### PR TITLE
fix: increase select prompt page size (v0.2.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/src/utils/interactive.rs
+++ b/src/utils/interactive.rs
@@ -78,7 +78,8 @@ impl InteractivePrompt {
     pub fn select(&self, message: &str, options: &[String], default: Option<usize>) -> Result<usize> {
         let mut select = Select::with_theme(&self.theme)
             .with_prompt(message)
-            .items(options);
+            .items(options)
+            .max_length(20);
 
         if let Some(default_index) = default {
             select = select.default(default_index);


### PR DESCRIPTION
Fixes truncated selection lists in `xv init` — dialoguer's Select widget was only showing ~4 items by default, hiding resource groups like 'Vaults'. Bumped to 20 visible items. Version bump to 0.2.1.