### PR TITLE
fix: update test suite for current API + bump to v0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/src/utils/datetime.rs
+++ b/src/utils/datetime.rs
@@ -3,7 +3,7 @@
 //! This module provides functionality to parse various date/time formats
 //! including ISO dates, relative durations, and Azure Key Vault timestamps.
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Datelike, Duration, Utc};
 use regex::Regex;
 use crate::error::{CrosstacheError, Result};
 


### PR DESCRIPTION
Test suite was out of date with FileCommands enum changes (missing flatten, prefix, recursive fields). Also adds missing chrono::Datelike import. All 143 tests passing.