### PR TITLE
fix: cargo fmt + clippy lint (v0.2.3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -5,4 +5,3 @@
 //! DefaultAzureCredential, client secrets, and Graph API integration.
 
 pub mod provider;
-

--- a/src/blob/models.rs
+++ b/src/blob/models.rs
@@ -27,10 +27,7 @@ pub enum BlobListItem {
     #[serde(rename = "file")]
     File(FileInfo),
     #[serde(rename = "directory")]
-    Directory {
-        name: String,
-        full_path: String,
-    },
+    Directory { name: String, full_path: String },
 }
 
 /// Request for uploading a file
@@ -64,4 +61,3 @@ pub struct FileListRequest {
     #[allow(dead_code)]
     pub recursive: bool,
 }
-

--- a/src/blob/operations.rs
+++ b/src/blob/operations.rs
@@ -15,12 +15,12 @@ impl BlobManager {
         requests: Vec<FileUploadRequest>,
     ) -> Result<Vec<Result<FileInfo>>> {
         let mut results = Vec::new();
-        
+
         for request in requests {
             let result = self.upload_file(request).await;
             results.push(result);
         }
-        
+
         Ok(results)
     }
 
@@ -28,12 +28,12 @@ impl BlobManager {
     #[allow(dead_code)]
     pub async fn batch_delete_files(&self, names: Vec<String>) -> Result<Vec<Result<()>>> {
         let mut results = Vec::new();
-        
+
         for name in names {
             let result = self.delete_file(&name).await;
             results.push(result);
         }
-        
+
         Ok(results)
     }
 
@@ -45,17 +45,17 @@ impl BlobManager {
         progress_callback: Option<Box<dyn Fn(u64, u64) + Send + Sync>>,
     ) -> Result<FileInfo> {
         let file_size = request.content.len() as u64;
-        
+
         if let Some(ref callback) = progress_callback {
             callback(0, file_size);
         }
-        
+
         let result = self.upload_file(request).await?;
-        
+
         if let Some(ref callback) = progress_callback {
             callback(file_size, file_size);
         }
-        
+
         Ok(result)
     }
 
@@ -79,10 +79,10 @@ impl BlobManager {
             delimiter: None,
             recursive: true,
         };
-        
+
         let files = self.list_files(list_request).await?;
         let total_size = files.iter().map(|f| f.size).sum();
-        
+
         Ok(total_size)
     }
 

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -75,8 +75,7 @@ impl VaultContext {
 }
 
 /// Manages vault contexts with local and global persistence
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ContextManager {
     /// Current active context
     pub current: Option<VaultContext>,
@@ -89,7 +88,6 @@ pub struct ContextManager {
     #[serde(skip)]
     pub is_local: bool,
 }
-
 
 impl ContextManager {
     /// Load context from local directory or global config
@@ -302,7 +300,7 @@ impl ContextManager {
             };
             Ok(config_dir.join("xv").join("context"))
         }
-        
+
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {
             // Use platform-appropriate config directory for other platforms

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ async fn run(cli: Cli) -> Result<()> {
 
 async fn load_config_without_validation() -> Result<crate::config::Config> {
     use crate::config::load_config_no_validation;
-    
+
     // Use the config module's function but without validation
     load_config_no_validation().await
 }

--- a/src/secret/manager.rs
+++ b/src/secret/manager.rs
@@ -316,7 +316,6 @@ impl AzureSecretOperations {
     fn get_folder(&self, tags: &HashMap<String, String>) -> Option<String> {
         tags.get("folder").cloned()
     }
-
 }
 
 #[async_trait]
@@ -519,7 +518,7 @@ impl SecretOperations for AzureSecretOperations {
             .get("exp")
             .and_then(|v| v.as_i64())
             .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0));
-        
+
         let not_before = attributes
             .get("nbf")
             .and_then(|v| v.as_i64())
@@ -644,7 +643,7 @@ impl SecretOperations for AzureSecretOperations {
             .get("exp")
             .and_then(|v| v.as_i64())
             .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0));
-        
+
         let not_before = attributes
             .get("nbf")
             .and_then(|v| v.as_i64())
@@ -779,9 +778,7 @@ impl SecretOperations for AzureSecretOperations {
                         }
                         Err(e) => {
                             // If we can't get details, add with basic info
-                            eprintln!(
-                                "Warning: Failed to get details for secret '{name}': {e}"
-                            );
+                            eprintln!("Warning: Failed to get details for secret '{name}': {e}");
                             let summary = SecretSummary {
                                 name: name.clone(),
                                 original_name: name,
@@ -865,9 +862,8 @@ impl SecretOperations for AzureSecretOperations {
 
         // Use REST API to restore a deleted secret
         let vault_url = format!("https://{vault_name}.vault.azure.net");
-        let restore_url = format!(
-            "{vault_url}/deletedsecrets/{sanitized_name}/recover?api-version=7.4"
-        );
+        let restore_url =
+            format!("{vault_url}/deletedsecrets/{sanitized_name}/recover?api-version=7.4");
 
         // Get an access token for Key Vault
         let token = self
@@ -985,9 +981,8 @@ impl SecretOperations for AzureSecretOperations {
 
         // Use REST API to permanently purge a deleted secret
         let vault_url = format!("https://{vault_name}.vault.azure.net");
-        let purge_url = format!(
-            "{vault_url}/deletedsecrets/{sanitized_name}/purge?api-version=7.4"
-        );
+        let purge_url =
+            format!("{vault_url}/deletedsecrets/{sanitized_name}/purge?api-version=7.4");
 
         // Get an access token for Key Vault
         let token = self
@@ -1101,7 +1096,7 @@ impl SecretOperations for AzureSecretOperations {
         if let Some(value_array) = json["value"].as_array() {
             for version_json in value_array {
                 let attributes = &version_json["attributes"];
-                
+
                 let version = version_json["kid"]
                     .as_str()
                     .and_then(|kid| kid.split('/').next_back())
@@ -1340,22 +1335,22 @@ impl SecretManager {
     }
 
     /// Get detailed secret information without the secret value
-    pub async fn get_secret_info(
-        &self,
-        vault_name: &str,
-        secret_name: &str,
-    ) -> Result<SecretInfo> {
+    pub async fn get_secret_info(&self, vault_name: &str, secret_name: &str) -> Result<SecretInfo> {
         // Use the existing get_secret method to fetch properties
-        let secret_props = self.secret_ops
+        let secret_props = self
+            .secret_ops
             .get_secret(vault_name, secret_name, false)
             .await?;
-        
+
         // Build the vault URI
         let vault_uri = format!("https://{vault_name}.vault.azure.net");
-        
+
         // Build the secret ID (simulated since we don't have it from SecretProperties)
-        let id = format!("{}/secrets/{}/{}", vault_uri, secret_props.name, secret_props.version);
-        
+        let id = format!(
+            "{}/secrets/{}/{}",
+            vault_uri, secret_props.name, secret_props.version
+        );
+
         // Extract metadata from tags
         let tags = secret_props.tags.clone();
         let groups = SecretInfo::extract_groups(&tags);
@@ -1363,7 +1358,7 @@ impl SecretManager {
         let note = SecretInfo::extract_note(&tags);
         let original_name = SecretInfo::extract_original_name(&tags)
             .or_else(|| Some(secret_props.original_name.clone()));
-        
+
         // Parse timestamps from the string formats
         let created = if !secret_props.created_on.is_empty() {
             DateTime::parse_from_rfc3339(&secret_props.created_on)
@@ -1372,7 +1367,7 @@ impl SecretManager {
         } else {
             None
         };
-        
+
         let updated = if !secret_props.updated_on.is_empty() {
             DateTime::parse_from_rfc3339(&secret_props.updated_on)
                 .ok()
@@ -1380,7 +1375,7 @@ impl SecretManager {
         } else {
             None
         };
-        
+
         // Build SecretInfo
         let info = SecretInfo {
             name: secret_props.name.clone(),
@@ -1405,7 +1400,7 @@ impl SecretManager {
             vault_uri,
             version_count: None, // Could be populated by calling list versions endpoint
         };
-        
+
         Ok(info)
     }
 

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -6,4 +6,3 @@
 pub mod manager;
 pub mod models;
 pub mod name_manager;
-

--- a/src/secret/models.rs
+++ b/src/secret/models.rs
@@ -11,52 +11,52 @@ use std::collections::HashMap;
 pub struct SecretInfo {
     /// Secret name (sanitized)
     pub name: String,
-    
+
     /// Original name (before sanitization)
     pub original_name: Option<String>,
-    
+
     /// Secret identifier (full URI)
     pub id: String,
-    
+
     /// Current version identifier
     pub version: Option<String>,
-    
+
     /// Whether the secret is enabled
     pub enabled: bool,
-    
+
     /// Creation timestamp
     pub created: Option<DateTime<Utc>>,
-    
+
     /// Last updated timestamp
     pub updated: Option<DateTime<Utc>>,
-    
+
     /// Expiration date (if set)
     pub expires: Option<DateTime<Utc>>,
-    
+
     /// Not-before date (if set)
     pub not_before: Option<DateTime<Utc>>,
-    
+
     /// Recovery level (e.g., "Recoverable+Purgeable")
     pub recovery_level: Option<String>,
-    
+
     /// Content type (if specified)
     pub content_type: Option<String>,
-    
+
     /// Tags associated with the secret
     pub tags: HashMap<String, String>,
-    
+
     /// Groups extracted from tags
     pub groups: Vec<String>,
-    
+
     /// Folder extracted from tags
     pub folder: Option<String>,
-    
+
     /// Note extracted from tags
     pub note: Option<String>,
-    
+
     /// Key Vault URI
     pub vault_uri: String,
-    
+
     /// Number of versions (if available)
     pub version_count: Option<usize>,
 }
@@ -65,23 +65,25 @@ impl SecretInfo {
     /// Extract groups from tags
     pub fn extract_groups(tags: &HashMap<String, String>) -> Vec<String> {
         tags.get("groups")
-            .map(|g| g.split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect())
+            .map(|g| {
+                g.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
             .unwrap_or_default()
     }
-    
+
     /// Extract folder from tags
     pub fn extract_folder(tags: &HashMap<String, String>) -> Option<String> {
         tags.get("folder").cloned()
     }
-    
+
     /// Extract note from tags
     pub fn extract_note(tags: &HashMap<String, String>) -> Option<String> {
         tags.get("note").cloned()
     }
-    
+
     /// Extract original name from tags
     pub fn extract_original_name(tags: &HashMap<String, String>) -> Option<String> {
         tags.get("original_name").cloned()
@@ -92,74 +94,83 @@ impl std::fmt::Display for SecretInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Secret Information:")?;
         writeln!(f, "  Name: {}", self.name)?;
-        
+
         if let Some(original) = &self.original_name {
             if original != &self.name {
                 writeln!(f, "  Original Name: {original}")?;
             }
         }
-        
+
         writeln!(f, "  Vault: {}", self.vault_uri)?;
         writeln!(f, "  Enabled: {}", if self.enabled { "Yes" } else { "No" })?;
-        
+
         if let Some(version) = &self.version {
             writeln!(f, "  Current Version: {version}")?;
         }
-        
+
         if let Some(created) = self.created {
             writeln!(f, "  Created: {}", created.format("%Y-%m-%d %H:%M:%S UTC"))?;
         }
-        
+
         if let Some(updated) = self.updated {
-            writeln!(f, "  Last Updated: {}", updated.format("%Y-%m-%d %H:%M:%S UTC"))?;
+            writeln!(
+                f,
+                "  Last Updated: {}",
+                updated.format("%Y-%m-%d %H:%M:%S UTC")
+            )?;
         }
-        
+
         if let Some(expires) = self.expires {
             writeln!(f, "  Expires: {}", expires.format("%Y-%m-%d %H:%M:%S UTC"))?;
         }
-        
+
         if let Some(not_before) = self.not_before {
-            writeln!(f, "  Not Before: {}", not_before.format("%Y-%m-%d %H:%M:%S UTC"))?;
+            writeln!(
+                f,
+                "  Not Before: {}",
+                not_before.format("%Y-%m-%d %H:%M:%S UTC")
+            )?;
         }
-        
+
         if let Some(content_type) = &self.content_type {
             writeln!(f, "  Content Type: {content_type}")?;
         }
-        
+
         if let Some(recovery_level) = &self.recovery_level {
             writeln!(f, "  Recovery Level: {recovery_level}")?;
         }
-        
+
         if !self.groups.is_empty() {
             writeln!(f, "  Groups: {}", self.groups.join(", "))?;
         }
-        
+
         if let Some(folder) = &self.folder {
             writeln!(f, "  Folder: {folder}")?;
         }
-        
+
         if let Some(note) = &self.note {
             writeln!(f, "  Note: {note}")?;
         }
-        
+
         if let Some(count) = self.version_count {
             writeln!(f, "  Total Versions: {count}")?;
         }
-        
+
         // Display other tags (excluding system tags)
         let system_tags = ["groups", "folder", "note", "original_name", "created_by"];
-        let other_tags: HashMap<_, _> = self.tags
+        let other_tags: HashMap<_, _> = self
+            .tags
             .iter()
             .filter(|(k, _)| !system_tags.contains(&k.as_str()))
             .collect();
-        
+
         if !other_tags.is_empty() {
             writeln!(f, "  Additional Tags:")?;
             for (key, value) in other_tags {
                 writeln!(f, "    {key}: {value}")?;
             }
         }
-        
+
         Ok(())
     }
 }

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -374,5 +374,4 @@ mod tests {
         assert!(result.contains("Name"));
         assert!(result.contains("Test Vault"));
     }
-
 }

--- a/src/utils/interactive.rs
+++ b/src/utils/interactive.rs
@@ -43,7 +43,7 @@ impl InteractivePrompt {
     #[allow(dead_code)]
     pub fn input_text(&self, message: &str, default: Option<&str>) -> Result<String> {
         let mut input = Input::with_theme(&self.theme).with_prompt(message);
-        
+
         if let Some(default_value) = default {
             input = input.default(default_value.to_string());
         }
@@ -51,19 +51,24 @@ impl InteractivePrompt {
         let result = input
             .interact_text()
             .map_err(|e| CrosstacheError::config(format!("Failed to get user input: {e}")))?;
-        
+
         Ok(result)
     }
 
     /// Prompt for text input with validation function
-    pub fn input_text_validated<F>(&self, message: &str, default: Option<&str>, validator: F) -> Result<String>
+    pub fn input_text_validated<F>(
+        &self,
+        message: &str,
+        default: Option<&str>,
+        validator: F,
+    ) -> Result<String>
     where
         F: Fn(&str) -> std::result::Result<(), String> + 'static,
     {
         let mut input = Input::with_theme(&self.theme)
             .with_prompt(message)
             .validate_with(|input: &String| validator(input.as_str()));
-        
+
         if let Some(default_value) = default {
             input = input.default(default_value.to_string());
         }
@@ -71,12 +76,17 @@ impl InteractivePrompt {
         let result = input
             .interact_text()
             .map_err(|e| CrosstacheError::config(format!("Failed to get user input: {e}")))?;
-        
+
         Ok(result)
     }
 
     /// Prompt for selection from a list of options
-    pub fn select(&self, message: &str, options: &[String], default: Option<usize>) -> Result<usize> {
+    pub fn select(
+        &self,
+        message: &str,
+        options: &[String],
+        default: Option<usize>,
+    ) -> Result<usize> {
         let mut select = Select::with_theme(&self.theme)
             .with_prompt(message)
             .items(options)
@@ -89,7 +99,7 @@ impl InteractivePrompt {
         let result = select
             .interact()
             .map_err(|e| CrosstacheError::config(format!("Failed to get user selection: {e}")))?;
-        
+
         Ok(result)
     }
 
@@ -150,7 +160,7 @@ impl ProgressIndicator {
         );
         bar.set_message(message.to_string());
         bar.enable_steady_tick(Duration::from_millis(100));
-        
+
         Self { bar }
     }
 
@@ -184,34 +194,40 @@ impl SetupHelper {
         if subscription_id.trim().is_empty() {
             return Err("Subscription ID cannot be empty".to_string());
         }
-        
+
         // Basic GUID format validation
-        let guid_pattern = regex::Regex::new(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
-            .map_err(|_| "Invalid regex pattern".to_string())?;
-        
+        let guid_pattern = regex::Regex::new(
+            r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        )
+        .map_err(|_| "Invalid regex pattern".to_string())?;
+
         if !guid_pattern.is_match(subscription_id.trim()) {
             return Err("Subscription ID must be a valid GUID format".to_string());
         }
-        
+
         Ok(())
     }
 
     /// Validate resource group name
     pub fn validate_resource_group_name(name: &str) -> std::result::Result<(), String> {
         let name = name.trim();
-        
+
         if name.is_empty() {
             return Err("Resource group name cannot be empty".to_string());
         }
-        
+
         if name.len() > 90 {
             return Err("Resource group name cannot exceed 90 characters".to_string());
         }
-        
-        if name.starts_with('.') || name.starts_with('-') || name.ends_with('.') || name.ends_with('-') {
+
+        if name.starts_with('.')
+            || name.starts_with('-')
+            || name.ends_with('.')
+            || name.ends_with('-')
+        {
             return Err("Resource group name cannot start or end with '.' or '-'".to_string());
         }
-        
+
         // Check for valid characters and no consecutive periods/hyphens
         let mut prev_char = ' ';
         for ch in name.chars() {
@@ -219,43 +235,47 @@ impl SetupHelper {
                 return Err("Resource group name can only contain alphanumeric characters, periods, hyphens, and underscores".to_string());
             }
             if (ch == '.' && prev_char == '.') || (ch == '-' && prev_char == '-') {
-                return Err("Resource group name cannot contain consecutive periods or hyphens".to_string());
+                return Err(
+                    "Resource group name cannot contain consecutive periods or hyphens".to_string(),
+                );
             }
             prev_char = ch;
         }
-        
+
         Ok(())
     }
 
     /// Validate vault name according to Azure Key Vault requirements
     pub fn validate_vault_name(name: &str) -> std::result::Result<(), String> {
         let name = name.trim();
-        
+
         if name.is_empty() {
             return Err("Vault name cannot be empty".to_string());
         }
-        
+
         if name.len() < 3 || name.len() > 24 {
             return Err("Vault name must be between 3 and 24 characters".to_string());
         }
-        
+
         if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
-            return Err("Vault name can only contain alphanumeric characters and hyphens".to_string());
+            return Err(
+                "Vault name can only contain alphanumeric characters and hyphens".to_string(),
+            );
         }
-        
+
         if name.starts_with('-') || name.ends_with('-') {
             return Err("Vault name cannot start or end with a hyphen".to_string());
         }
-        
+
         if name.contains("--") {
             return Err("Vault name cannot contain consecutive hyphens".to_string());
         }
-        
+
         // Must start with a letter
         if !name.chars().next().unwrap_or(' ').is_ascii_alphabetic() {
             return Err("Vault name must start with a letter".to_string());
         }
-        
+
         Ok(())
     }
 
@@ -268,7 +288,7 @@ impl SetupHelper {
             .chars()
             .filter(|c| c.is_ascii_alphanumeric())
             .collect::<String>();
-        
+
         let timestamp = chrono::Utc::now().format("%m%d").to_string();
         format!("kv-{username}-{timestamp}")
     }
@@ -282,7 +302,7 @@ impl SetupHelper {
             .chars()
             .filter(|c| c.is_ascii_alphanumeric())
             .collect::<String>();
-        
+
         format!("rg-{username}-keyvaults")
     }
 
@@ -295,10 +315,10 @@ impl SetupHelper {
             .chars()
             .filter(|c| c.is_ascii_alphanumeric())
             .collect::<String>();
-        
+
         let timestamp = chrono::Utc::now().format("%m%d%H%M").to_string();
         let generated_name = format!("st{username}{timestamp}");
-        
+
         // Ensure it's not too long (max 24 characters)
         if generated_name.len() > 24 {
             format!("st{username}{timestamp}")
@@ -310,54 +330,65 @@ impl SetupHelper {
     /// Validate storage account name according to Azure Storage requirements
     pub fn validate_storage_account_name(name: &str) -> std::result::Result<(), String> {
         let name = name.trim();
-        
+
         if name.is_empty() {
             return Err("Storage account name cannot be empty".to_string());
         }
-        
+
         if name.len() < 3 || name.len() > 24 {
             return Err("Storage account name must be between 3 and 24 characters".to_string());
         }
-        
-        if !name.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()) {
-            return Err("Storage account name can only contain lowercase letters and numbers".to_string());
+
+        if !name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        {
+            return Err(
+                "Storage account name can only contain lowercase letters and numbers".to_string(),
+            );
         }
-        
+
         if !name.chars().next().unwrap_or(' ').is_ascii_alphabetic() {
             return Err("Storage account name must start with a letter".to_string());
         }
-        
+
         Ok(())
     }
 
     /// Validate container name according to Azure Storage requirements
     pub fn validate_container_name(name: &str) -> std::result::Result<(), String> {
         let name = name.trim();
-        
+
         if name.is_empty() {
             return Err("Container name cannot be empty".to_string());
         }
-        
+
         if name.len() < 3 || name.len() > 63 {
             return Err("Container name must be between 3 and 63 characters".to_string());
         }
-        
-        if !name.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-') {
-            return Err("Container name can only contain lowercase letters, numbers, and hyphens".to_string());
+
+        if !name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        {
+            return Err(
+                "Container name can only contain lowercase letters, numbers, and hyphens"
+                    .to_string(),
+            );
         }
-        
+
         if name.starts_with('-') || name.ends_with('-') {
             return Err("Container name cannot start or end with a hyphen".to_string());
         }
-        
+
         if name.contains("--") {
             return Err("Container name cannot contain consecutive hyphens".to_string());
         }
-        
+
         if !name.chars().next().unwrap_or(' ').is_ascii_alphabetic() {
             return Err("Container name must start with a letter".to_string());
         }
-        
+
         Ok(())
     }
 }
@@ -369,12 +400,16 @@ mod tests {
     #[test]
     fn test_validate_subscription_id() {
         // Valid GUID
-        assert!(SetupHelper::validate_subscription_id("12345678-1234-1234-1234-123456789012").is_ok());
-        
+        assert!(
+            SetupHelper::validate_subscription_id("12345678-1234-1234-1234-123456789012").is_ok()
+        );
+
         // Invalid format
         assert!(SetupHelper::validate_subscription_id("not-a-guid").is_err());
         assert!(SetupHelper::validate_subscription_id("").is_err());
-        assert!(SetupHelper::validate_subscription_id("12345678-1234-1234-1234-12345678901").is_err());
+        assert!(
+            SetupHelper::validate_subscription_id("12345678-1234-1234-1234-12345678901").is_err()
+        );
     }
 
     #[test]
@@ -382,7 +417,7 @@ mod tests {
         // Valid names
         assert!(SetupHelper::validate_resource_group_name("my-resource-group").is_ok());
         assert!(SetupHelper::validate_resource_group_name("rg_test_123").is_ok());
-        
+
         // Invalid names
         assert!(SetupHelper::validate_resource_group_name("").is_err());
         assert!(SetupHelper::validate_resource_group_name(".invalid").is_err());
@@ -396,7 +431,7 @@ mod tests {
         // Valid names
         assert!(SetupHelper::validate_vault_name("myvault123").is_ok());
         assert!(SetupHelper::validate_vault_name("my-vault").is_ok());
-        
+
         // Invalid names
         assert!(SetupHelper::validate_vault_name("").is_err());
         assert!(SetupHelper::validate_vault_name("ab").is_err());
@@ -412,7 +447,7 @@ mod tests {
         let vault_name = SetupHelper::generate_default_vault_name();
         assert!(vault_name.starts_with("kv-"));
         assert!(SetupHelper::validate_vault_name(&vault_name).is_ok());
-        
+
         let rg_name = SetupHelper::generate_default_resource_group();
         assert!(rg_name.starts_with("rg-"));
         assert!(rg_name.ends_with("-keyvaults"));

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,4 +12,3 @@ pub mod network;
 pub mod resource_detector;
 pub mod retry;
 pub mod sanitizer;
-

--- a/src/utils/resource_detector.rs
+++ b/src/utils/resource_detector.rs
@@ -10,7 +10,7 @@ pub struct ResourceDetector;
 
 impl ResourceDetector {
     /// Detect resource type based on various heuristics
-    /// 
+    ///
     /// Priority order:
     /// 1. Explicit type hint (if provided)
     /// 2. Context clues (resource group implies vault)
@@ -25,42 +25,41 @@ impl ResourceDetector {
         if let Some(resource_type) = hint {
             return resource_type;
         }
-        
+
         // Priority 2: If resource group is provided, it's likely a vault
         if has_resource_group {
             return ResourceType::Vault;
         }
-        
+
         // Priority 3: Pattern matching
-        
+
         // Check for file patterns (has extension)
         #[cfg(feature = "file-ops")]
         if Self::looks_like_file(resource) {
             return ResourceType::File;
         }
-        
+
         // Check for vault naming patterns
         if Self::looks_like_vault(resource) {
             return ResourceType::Vault;
         }
-        
+
         // Default: Assume it's a secret (most common operation)
         ResourceType::Secret
     }
-    
+
     /// Check if the resource name looks like a file
     fn looks_like_file(name: &str) -> bool {
         // Files typically have extensions
         if name.contains('.') {
             // Check if it's a common file extension
             let common_extensions = [
-                "txt", "json", "xml", "csv", "pdf", "doc", "docx",
-                "xls", "xlsx", "zip", "tar", "gz", "jpg", "jpeg",
-                "png", "gif", "mp4", "avi", "mov", "log", "conf",
-                "yaml", "yml", "toml", "ini", "cfg", "env", "pem",
-                "key", "crt", "cer", "pfx", "p12", "jks", "keystore",
+                "txt", "json", "xml", "csv", "pdf", "doc", "docx", "xls", "xlsx", "zip", "tar",
+                "gz", "jpg", "jpeg", "png", "gif", "mp4", "avi", "mov", "log", "conf", "yaml",
+                "yml", "toml", "ini", "cfg", "env", "pem", "key", "crt", "cer", "pfx", "p12",
+                "jks", "keystore",
             ];
-            
+
             if let Some(extension) = name.split('.').next_back() {
                 let ext_lower = extension.to_lowercase();
                 if common_extensions.contains(&ext_lower.as_str()) {
@@ -68,15 +67,15 @@ impl ResourceDetector {
                 }
             }
         }
-        
+
         // Check for path-like patterns
         if name.contains('/') || name.contains('\\') {
             return true;
         }
-        
+
         false
     }
-    
+
     /// Check if the resource name looks like a vault
     fn looks_like_vault(name: &str) -> bool {
         // Azure Key Vault naming rules:
@@ -85,7 +84,7 @@ impl ResourceDetector {
         // - Must start with a letter
         // - Must end with a letter or digit
         // - No consecutive hyphens
-        
+
         let len = name.len();
         if !(3..=24).contains(&len) {
             return false;
@@ -97,17 +96,21 @@ impl ResourceDetector {
         }
 
         // Check if it ends with a letter or digit
-        if !name.chars().last().is_some_and(|c| c.is_ascii_alphanumeric()) {
+        if !name
+            .chars()
+            .last()
+            .is_some_and(|c| c.is_ascii_alphanumeric())
+        {
             return false;
         }
-        
+
         // Check for valid characters (alphanumeric and hyphens)
         let mut prev_hyphen = false;
         for c in name.chars() {
             if !c.is_ascii_alphanumeric() && c != '-' {
                 return false;
             }
-            
+
             // Check for consecutive hyphens
             if c == '-' {
                 if prev_hyphen {
@@ -118,24 +121,22 @@ impl ResourceDetector {
                 prev_hyphen = false;
             }
         }
-        
+
         // Common vault naming patterns
-        let vault_patterns = [
-            "vault", "kv", "keyvault", "akv", "-kv-", "-vault-",
-        ];
-        
+        let vault_patterns = ["vault", "kv", "keyvault", "akv", "-kv-", "-vault-"];
+
         let name_lower = name.to_lowercase();
         for pattern in &vault_patterns {
             if name_lower.contains(pattern) {
                 return true;
             }
         }
-        
+
         // If it passes all vault naming rules, it might be a vault
         // but we'll still default to secret since that's more common
         false
     }
-    
+
     /// Check if a name is a valid vault name
     #[allow(dead_code)]
     pub fn is_valid_vault_name(name: &str) -> bool {
@@ -144,26 +145,26 @@ impl ResourceDetector {
         if !(3..=24).contains(&len) {
             return false;
         }
-        
+
         // Must start with a letter
         let first_char = name.chars().next().unwrap();
         if !first_char.is_ascii_alphabetic() {
             return false;
         }
-        
+
         // Must end with a letter or digit
         let last_char = name.chars().last().unwrap();
         if !last_char.is_ascii_alphanumeric() {
             return false;
         }
-        
+
         // Check all characters and no consecutive hyphens
         let mut prev_hyphen = false;
         for c in name.chars() {
             if !c.is_ascii_alphanumeric() && c != '-' {
                 return false;
             }
-            
+
             if c == '-' {
                 if prev_hyphen {
                     return false;
@@ -173,47 +174,47 @@ impl ResourceDetector {
                 prev_hyphen = false;
             }
         }
-        
+
         true
     }
-    
+
     /// Check if a name is a valid secret name
     #[allow(dead_code)]
     pub fn is_valid_secret_name(name: &str) -> bool {
         // Azure Key Vault secret naming rules:
         // - 1-127 characters
         // - Alphanumeric and hyphens
-        
+
         let len = name.len();
         if len == 0 || len > 127 {
             return false;
         }
-        
+
         // Check for valid characters
         for c in name.chars() {
             if !c.is_ascii_alphanumeric() && c != '-' {
                 return false;
             }
         }
-        
+
         true
     }
-    
+
     /// Check if a name is a valid file name
     #[allow(dead_code)]
     pub fn is_valid_file_name(name: &str) -> bool {
         // Basic file name validation
         // Azure Blob Storage naming rules are quite permissive
-        
+
         if name.is_empty() || name.len() > 1024 {
             return false;
         }
-        
+
         // Check for invalid characters in blob names
         // Blob names can contain any URL-safe characters
         true
     }
-    
+
     /// Get a user-friendly description of why a resource was detected as a certain type
     pub fn get_detection_reason(
         resource: &str,
@@ -240,7 +241,10 @@ impl ResourceDetector {
             #[cfg(feature = "file-ops")]
             ResourceType::File => {
                 if resource.contains('.') {
-                    format!("Has file extension: .{}", resource.split('.').next_back().unwrap_or(""))
+                    format!(
+                        "Has file extension: .{}",
+                        resource.split('.').next_back().unwrap_or("")
+                    )
                 } else if resource.contains('/') || resource.contains('\\') {
                     "Contains path separators".to_string()
                 } else {
@@ -254,7 +258,7 @@ impl ResourceDetector {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_file_detection() {
         assert!(ResourceDetector::looks_like_file("document.pdf"));
@@ -264,7 +268,7 @@ mod tests {
         assert!(!ResourceDetector::looks_like_file("my-secret"));
         assert!(!ResourceDetector::looks_like_file("my-vault"));
     }
-    
+
     #[test]
     fn test_vault_detection() {
         assert!(ResourceDetector::looks_like_vault("my-key-vault"));
@@ -273,9 +277,11 @@ mod tests {
         assert!(!ResourceDetector::looks_like_vault("-vault")); // starts with hyphen
         assert!(!ResourceDetector::looks_like_vault("vault-")); // ends with hyphen
         assert!(!ResourceDetector::looks_like_vault("v")); // too short
-        assert!(!ResourceDetector::looks_like_vault("this-is-a-very-long-vault-name-that-exceeds-limit")); // too long
+        assert!(!ResourceDetector::looks_like_vault(
+            "this-is-a-very-long-vault-name-that-exceeds-limit"
+        )); // too long
     }
-    
+
     #[test]
     fn test_resource_type_detection() {
         // Explicit hint takes priority
@@ -283,27 +289,27 @@ mod tests {
             ResourceDetector::detect_resource_type("anything", Some(ResourceType::Vault), false),
             ResourceType::Vault
         );
-        
+
         // Resource group implies vault
         assert_eq!(
             ResourceDetector::detect_resource_type("my-resource", None, true),
             ResourceType::Vault
         );
-        
+
         // File detection by extension
         #[cfg(feature = "file-ops")]
         assert_eq!(
             ResourceDetector::detect_resource_type("data.json", None, false),
             ResourceType::File
         );
-        
+
         // Default to secret
         assert_eq!(
             ResourceDetector::detect_resource_type("my-secret-name", None, false),
             ResourceType::Secret
         );
     }
-    
+
     #[test]
     fn test_valid_names() {
         // Valid vault names
@@ -311,13 +317,13 @@ mod tests {
         assert!(ResourceDetector::is_valid_vault_name("my-vault-123"));
         assert!(!ResourceDetector::is_valid_vault_name("my_vault")); // underscore not allowed
         assert!(!ResourceDetector::is_valid_vault_name("123vault")); // must start with letter
-        
+
         // Valid secret names
         assert!(ResourceDetector::is_valid_secret_name("my-secret"));
         assert!(ResourceDetector::is_valid_secret_name("secret123"));
         assert!(!ResourceDetector::is_valid_secret_name("my_secret")); // underscore not allowed
         assert!(!ResourceDetector::is_valid_secret_name("")); // empty not allowed
-        
+
         // File names are generally valid
         assert!(ResourceDetector::is_valid_file_name("file.txt"));
         assert!(ResourceDetector::is_valid_file_name("my-file"));

--- a/src/vault/manager.rs
+++ b/src/vault/manager.rs
@@ -6,9 +6,7 @@
 
 use std::sync::Arc;
 
-use super::models::{
-    AccessLevel, VaultCreateRequest, VaultProperties, VaultRole, VaultSummary,
-};
+use super::models::{AccessLevel, VaultCreateRequest, VaultProperties, VaultRole, VaultSummary};
 use super::operations::{AzureVaultOperations, VaultOperations};
 use crate::auth::provider::AzureAuthProvider;
 use crate::error::Result;
@@ -361,5 +359,4 @@ impl VaultManager {
 
         Ok(())
     }
-
 }

--- a/src/vault/models.rs
+++ b/src/vault/models.rs
@@ -360,6 +360,4 @@ impl AccessPolicy {
             user_email,
         }
     }
-
 }
-

--- a/src/vault/operations.rs
+++ b/src/vault/operations.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use super::models::{
-    AccessLevel, AccessPolicy, VaultCreateRequest,
-    VaultProperties, VaultRole, VaultSummary, VaultUpdateRequest,
+    AccessLevel, AccessPolicy, VaultCreateRequest, VaultProperties, VaultRole, VaultSummary,
+    VaultUpdateRequest,
 };
 use crate::auth::provider::AzureAuthProvider;
 use crate::error::{CrosstacheError, Result};
@@ -71,7 +71,6 @@ pub trait VaultOperations: Send + Sync {
 
     /// List vault access assignments
     async fn list_access(&self, vault_name: &str, resource_group: &str) -> Result<Vec<VaultRole>>;
-
 }
 
 /// Azure vault operations implementation
@@ -617,7 +616,6 @@ impl VaultOperations for AzureVaultOperations {
 
         self.execute_with_retry(operation).await
     }
-
 }
 
 impl AzureVaultOperations {

--- a/tests/auth_tests.rs
+++ b/tests/auth_tests.rs
@@ -117,7 +117,6 @@ mod graph_api_tests {
 
 #[cfg(test)]
 mod authentication_flow_tests {
-    
 
     #[test]
     fn test_azure_scope_validation() {
@@ -152,30 +151,35 @@ mod authentication_flow_tests {
         let _secret = std::env::var(secret_var).unwrap_or_default();
         let _priority = std::env::var(priority_var).unwrap_or_default();
     }
-    
+
     #[test]
-    fn test_credential_priority_parsing() {        
+    fn test_credential_priority_parsing() {
         // Test parsing of credential priority values
         let valid_priorities = vec!["cli", "managed_identity", "environment", "default"];
         let invalid_priorities = vec!["invalid", "unknown", ""];
-        
+
         for priority in valid_priorities {
             // This would normally use AzureCredentialType::from_str
             // but we're just testing the string values here
             assert!(!priority.is_empty());
-            assert!(matches!(priority, "cli" | "managed_identity" | "environment" | "default"));
+            assert!(matches!(
+                priority,
+                "cli" | "managed_identity" | "environment" | "default"
+            ));
         }
-        
+
         for priority in invalid_priorities {
             // Invalid priorities should be caught
-            assert!(!matches!(priority, "cli" | "managed_identity" | "environment" | "default"));
+            assert!(!matches!(
+                priority,
+                "cli" | "managed_identity" | "environment" | "default"
+            ));
         }
     }
 }
 
 #[cfg(test)]
 mod error_handling_tests {
-    
 
     #[test]
     fn test_error_message_formatting() {
@@ -213,7 +217,6 @@ mod error_handling_tests {
 
 #[cfg(test)]
 mod integration_tests {
-    
 
     #[test]
     fn test_authentication_configuration() {

--- a/tests/azure_recursive_upload_tests.rs
+++ b/tests/azure_recursive_upload_tests.rs
@@ -103,12 +103,7 @@ fn test_recursive_upload_preserves_structure() {
     cleanup_test_blobs("test-structure/");
 
     // Execute: Upload with structure preservation (default)
-    let output = run_xv_command(&[
-        "file",
-        "upload",
-        test_dir.to_str().unwrap(),
-        "--recursive",
-    ]);
+    let output = run_xv_command(&["file", "upload", test_dir.to_str().unwrap(), "--recursive"]);
 
     // Verify command succeeded
     assert!(
@@ -296,12 +291,7 @@ fn test_hidden_files_are_skipped() {
     cleanup_test_blobs("hidden-test/");
 
     // Execute: Upload recursively
-    let output = run_xv_command(&[
-        "file",
-        "upload",
-        test_dir.to_str().unwrap(),
-        "--recursive",
-    ]);
+    let output = run_xv_command(&["file", "upload", test_dir.to_str().unwrap(), "--recursive"]);
 
     // Verify command succeeded
     assert!(

--- a/tests/file_commands_tests.rs
+++ b/tests/file_commands_tests.rs
@@ -5,7 +5,7 @@
 
 use crosstache::{
     cli::commands::{Commands, FileCommands},
-    config::{Config, BlobConfig},
+    config::{BlobConfig, Config},
     error::Result,
 };
 use std::fs;
@@ -48,9 +48,7 @@ async fn test_file_upload_command_basic() -> Result<()> {
             ("author".to_string(), "test-user".to_string()),
             ("version".to_string(), "1.0".to_string()),
         ],
-        tag: vec![
-            ("environment".to_string(), "test".to_string()),
-        ],
+        tag: vec![("environment".to_string(), "test".to_string())],
         content_type: Some("text/plain".to_string()),
         progress: true,
         continue_on_error: false,
@@ -164,7 +162,16 @@ async fn test_file_download_command_basic() -> Result<()> {
     };
 
     match download_command {
-        FileCommands::Download { files, output, rename, recursive: _, flatten: _, stream, force, continue_on_error: _ } => {
+        FileCommands::Download {
+            files,
+            output,
+            rename,
+            recursive: _,
+            flatten: _,
+            stream,
+            force,
+            continue_on_error: _,
+        } => {
             assert_eq!(files, vec!["test-file.txt"]);
             assert_eq!(output, Some(output_path.to_string_lossy().to_string()));
             assert!(rename.is_none());
@@ -191,7 +198,16 @@ async fn test_file_download_command_with_streaming() -> Result<()> {
     };
 
     match download_command {
-        FileCommands::Download { files, output, rename: _, recursive: _, flatten: _, stream, force, continue_on_error: _ } => {
+        FileCommands::Download {
+            files,
+            output,
+            rename: _,
+            recursive: _,
+            flatten: _,
+            stream,
+            force,
+            continue_on_error: _,
+        } => {
             assert_eq!(files, vec!["large-file.bin"]);
             assert!(output.is_none());
             assert!(stream);
@@ -213,14 +229,16 @@ async fn test_quick_upload_command() -> Result<()> {
         file_path: temp_file.path().to_string_lossy().to_string(),
         name: Some("quick-upload.txt".to_string()),
         groups: Some("quick,test".to_string()),
-        metadata: vec![
-            "type=quick-test".to_string(),
-            "method=cli".to_string(),
-        ],
+        metadata: vec!["type=quick-test".to_string(), "method=cli".to_string()],
     };
 
     match quick_upload_command {
-        Commands::Upload { file_path, name, groups, metadata } => {
+        Commands::Upload {
+            file_path,
+            name,
+            groups,
+            metadata,
+        } => {
             assert_eq!(file_path, temp_file.path().to_string_lossy().to_string());
             assert_eq!(name, Some("quick-upload.txt".to_string()));
             assert_eq!(groups, Some("quick,test".to_string()));
@@ -389,7 +407,13 @@ async fn test_file_list_command() -> Result<()> {
     };
 
     match list_command {
-        FileCommands::List { prefix, group, metadata, limit, recursive: _ } => {
+        FileCommands::List {
+            prefix,
+            group,
+            metadata,
+            limit,
+            recursive: _,
+        } => {
             assert_eq!(prefix, Some("config/".to_string()));
             assert_eq!(group, Some("production".to_string()));
             assert!(metadata);
@@ -410,7 +434,11 @@ async fn test_file_delete_command() -> Result<()> {
     };
 
     match delete_command {
-        FileCommands::Delete { files, force, continue_on_error: _ } => {
+        FileCommands::Delete {
+            files,
+            force,
+            continue_on_error: _,
+        } => {
             assert_eq!(files, vec!["old-file.txt"]);
             assert!(force);
         }


### PR DESCRIPTION
Runs cargo fmt across the codebase and fixes one remaining clippy lint (redundant closure). All three CI checks pass locally.