### PR TITLE
v0.4.0 — Sharing, diff, pagination, and more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -6031,7 +6031,7 @@ async fn execute_vault_update(
     };
 
     let vault = vault_manager
-        .update_vault(&name, &resource_group, &update_request)
+        .update_vault(name, &resource_group, &update_request)
         .await?;
 
     println!("Successfully updated vault '{}'", vault.name);


### PR DESCRIPTION
## New Features

### Vault & Secret Sharing
- `xv vault share grant/revoke/list` — fully functional with user email resolution (Graph API)
- `xv share grant/revoke/list` — new secret-level RBAC using Azure role assignments

### `xv diff` (new command)
```bash
xv diff vault-a vault-b [--show-values] [--group production]
```

### `xv vault update` — now functional (was stubbed)

### Pagination — large vaults no longer truncate

### Configurable clipboard timeout — `clipboard_timeout_secs` in config

### CI — slimmed to check/lint/test only on PRs