### PR TITLE
chore: Release crosstache version 0.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.4.2"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.4.2"
+version = "0.4.5"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"


### PR DESCRIPTION
Bumps `Cargo.toml` version from 0.4.2 to 0.4.5. Tag `v0.4.5` will be pushed after this merges to trigger the release workflow.