### PR TITLE
fix: history command shows 'unknown' for all versions

### DIFF
--- a/src/secret/manager.rs
+++ b/src/secret/manager.rs
@@ -1095,9 +1095,9 @@ impl SecretOperations for AzureSecretOperations {
                 for version_json in value_array {
                     let attributes = &version_json["attributes"];
 
-                    let version = version_json["kid"]
+                    let version = version_json["id"]
                         .as_str()
-                        .and_then(|kid| kid.split('/').next_back())
+                        .and_then(|id| id.split('/').next_back())
                         .unwrap_or("unknown")
                         .to_string();
 


### PR DESCRIPTION
## Bug

The `history` command displayed 'unknown' for every version ID.

## Root Cause

`get_secret_versions()` in `src/secret/manager.rs` was parsing the version ID from `version_json["kid"]` — a field that exists on **key** responses but is always `null` on secret version responses. The correct field is `"id"`, which contains the full secret URL with the version segment at the end.

## Fix

Changed `"kid"\ → `"id"` when extracting the version from the Azure Key Vault response.

## Testing

All 121 unit/integration tests pass. The single clipboard test failure is a pre-existing environment issue (clipboard unavailable in headless context).