### PR TITLE
bump version to 0.4.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"


### PR DESCRIPTION
## Summary
- Bump version to 0.4.13 for release tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure version/lockfile metadata change with no functional code modifications.
> 
> **Overview**
> Bumps the `crosstache` crate version from `0.4.12` to `0.4.13` in `Cargo.toml` and updates `Cargo.lock` accordingly for release tagging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95b3a674a28a9099863f4c81f5b8782c10adfd13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->