### PR TITLE
fix: resolve version identifiers in xv get --version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.4.14"
+version = "0.4.16"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -4142,9 +4142,19 @@ async fn execute_secret_get(
     let mut context_manager = ContextManager::load().await.unwrap_or_default();
     let _ = context_manager.update_usage(&vault_name).await;
 
+    // Resolve user-friendly version (e.g. "v6") to Azure GUID
+    let resolved_version = match &version {
+        Some(ver) => {
+            let (guid, _display) =
+                resolve_version_to_guid(secret_manager, &vault_name, name, ver).await?;
+            Some(guid)
+        }
+        None => None,
+    };
+
     // Get the secret (specific version or current)
     let secret = secret_manager
-        .get_secret_with_version(&vault_name, name, version.as_deref(), true, true)
+        .get_secret_with_version(&vault_name, name, resolved_version.as_deref(), true, true)
         .await?;
 
     if raw {
@@ -4555,6 +4565,45 @@ async fn execute_secret_history(
     Ok(())
 }
 
+/// Resolve a user-friendly version identifier (e.g. "v6", "6") to the Azure Key Vault hex GUID.
+/// If the version string is already a hex GUID, it is returned as-is.
+async fn resolve_version_to_guid(
+    secret_manager: &crate::secret::manager::SecretManager,
+    vault_name: &str,
+    secret_name: &str,
+    version: &str,
+) -> Result<(String, String)> {
+    if let Ok(version_num) = version.trim_start_matches('v').parse::<u32>() {
+        if version_num == 0 {
+            return Err(crate::error::CrosstacheError::invalid_argument(
+                "Version number must be 1 or greater (v1 is the oldest version)",
+            ));
+        }
+        let versions_list = secret_manager
+            .secret_ops()
+            .get_secret_versions(vault_name, secret_name)
+            .await?;
+        let max_version = versions_list
+            .iter()
+            .filter_map(|v| v.version_number)
+            .max()
+            .unwrap_or(0);
+        let matched = versions_list
+            .into_iter()
+            .find(|v| v.version_number == Some(version_num));
+        match matched {
+            Some(v) => Ok((v.version, format!("v{version_num}"))),
+            None => Err(crate::error::CrosstacheError::invalid_argument(format!(
+                "Version v{version_num} not found for secret '{secret_name}'. \
+                 Available versions: v1–v{max_version} (use 'xv history {secret_name}' to list them)"
+            ))),
+        }
+    } else {
+        // Assume it's already a GUID
+        Ok((version.to_string(), version.to_string()))
+    }
+}
+
 async fn execute_secret_rollback(
     secret_manager: &crate::secret::manager::SecretManager,
     name: &str,
@@ -4573,44 +4622,9 @@ async fn execute_secret_rollback(
     let mut context_manager = ContextManager::load().await.unwrap_or_default();
     let _ = context_manager.update_usage(&vault_name).await;
 
-    // Resolve version: if the user passed an integer (e.g. "3"), look up the GUID
-    let resolved_version_guid: String;
-    let display_version: String;
-    if let Ok(version_num) = version.trim_start_matches('v').parse::<u32>() {
-        if version_num == 0 {
-            return Err(crate::error::CrosstacheError::invalid_argument(
-                "Version number must be 1 or greater (v1 is the oldest version)",
-            ));
-        }
-        let versions_list = secret_manager
-            .secret_ops()
-            .get_secret_versions(&vault_name, name)
-            .await?;
-        let max_version = versions_list
-            .iter()
-            .filter_map(|v| v.version_number)
-            .max()
-            .unwrap_or(0);
-        let matched = versions_list
-            .into_iter()
-            .find(|v| v.version_number == Some(version_num));
-        match matched {
-            Some(v) => {
-                display_version = format!("v{version_num}");
-                resolved_version_guid = v.version;
-            }
-            None => {
-                return Err(crate::error::CrosstacheError::invalid_argument(format!(
-                    "Version v{version_num} not found for secret '{name}'. \
-                     Available versions: v1–v{max_version} (use 'xv history {name}' to list them)"
-                )));
-            }
-        }
-    } else {
-        // Assume it's already a GUID
-        resolved_version_guid = version.to_string();
-        display_version = version.to_string();
-    }
+    // Resolve user-friendly version (e.g. "v6") to Azure GUID
+    let (resolved_version_guid, display_version) =
+        resolve_version_to_guid(secret_manager, &vault_name, name, version).await?;
 
     // Confirm rollback unless force flag is used
     if !force {


### PR DESCRIPTION
## Summary
- `xv get --version v6` was passing "v6" directly to the Azure Key Vault API URL, causing a 400 Bad Request ("Method GET does not allow operation 'v6'")
- Now resolves user-friendly version numbers (v1, v6, etc.) to Azure hex GUIDs before making the API call
- Extracts shared `resolve_version_to_guid()` helper used by both `get` and `rollback` commands, eliminating duplication
- Bumps version to 0.4.16

## Test plan
- [ ] `xv get --version v1 <secret>` retrieves the correct version
- [ ] `xv get --version <hex-guid> <secret>` still works with raw GUIDs
- [ ] `xv get --version v999 <secret>` gives clear error with available range
- [ ] `xv rollback` still works correctly with the refactored helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CLI behavior change limited to secret version resolution; main risk is incorrect mapping/edge cases when listing versions or handling unusual version strings.
> 
> **Overview**
> Fixes `xv get --version` so user-friendly version identifiers like `v6`/`6` are resolved to the Azure Key Vault version GUID before calling `get_secret_with_version`, avoiding invalid API requests.
> 
> Extracts a shared `resolve_version_to_guid()` helper (used by both `get` and `rollback`) that validates version numbers and returns clearer errors when a requested version is out of range. Bumps crate version to `0.4.16` (and updates `Cargo.lock`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 800c97f969e6bdf9e550d91e198411c49266d77c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->