### PR TITLE
fix: consistent table formatting in xv history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.4.16"
+version = "0.4.17"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -4511,6 +4511,7 @@ async fn execute_secret_history(
     config: &Config,
 ) -> Result<()> {
     use crate::config::ContextManager;
+    use crate::utils::format::format_table;
     use tabled::{Table, Tabled};
 
     // Determine vault name using context resolution
@@ -4557,10 +4558,10 @@ async fn execute_secret_history(
         })
         .collect();
 
-    let table = Table::new(&version_infos).to_string();
+    let table = Table::new(&version_infos);
     println!("Version history for secret '{name}' in vault '{vault_name}':");
     println!();
-    println!("{table}");
+    println!("{}", format_table(table, config.no_color));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- `xv history` used raw `Table::new().to_string()` producing plain unstyled output
- Now uses the shared `format_table()` utility for rounded borders, centered blue headers, and padding — matching `xv ls` and `xv share list`
- Bumps version to 0.4.17

## Test plan
- [ ] `xv history <secret>` shows styled table with rounded borders and blue headers
- [ ] `xv history <secret> | cat` falls back to plain text (no color)
- [ ] `xv history <secret> --no-color` suppresses color

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CLI output change plus a patch version bump; no changes to Azure interactions or data handling.
> 
> **Overview**
> `xv history` now renders its version-history table via the shared `format_table()` helper (respecting `--no-color`), instead of printing the raw `tabled::Table` string.
> 
> Also bumps the crate version from `0.4.16` to `0.4.17` in `Cargo.toml` and `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f182282af3efa182b235d623e27c1bd92849ce0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->