### PR TITLE
chore: bump version to 0.4.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"


### PR DESCRIPTION
## Summary
- Bump version from 0.4.20 to 0.4.21

## Changes since v0.4.20
- feat: add client-side cache for listing operations (#107)
- feat: gen command (#105)
- docs: add cache feature design spec and review updates (#108)
- docs: update (#106)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the crate/package version in `Cargo.toml` and `Cargo.lock` with no functional code changes.
> 
> **Overview**
> Bumps the `crosstache` crate version from `0.4.20` to `0.4.21`, updating both `Cargo.toml` and the corresponding entry in `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efb905e6818e215fe26804ec496246132a50c62f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->