### PR TITLE
feat: implement xv file sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ Implemented features:
 - **Configurable Clipboard Timeout**: `clipboard_timeout` config key (default 30s, 0 to disable)
 
 Features partially implemented or stubbed:
-- **File Sync** (`xv file sync`): Command structure exists but prints "not yet implemented"
+- **File Sync** (`xv file sync`): Implemented (`--direction` up/down/both, `--dry-run`, `--delete`); see `src/blob/sync.rs` and `execute_file_sync` in `commands.rs`
 - **Vault Sharing**: Commands defined (grant/revoke/list) — implemented via RBAC
 - **Secret Backup/Restore**: Methods stubbed in `secret/manager.rs`
 - **Blob Metadata/Tags**: Stubbed with warnings ("not yet implemented for Azure SDK v0.21")

--- a/README.md
+++ b/README.md
@@ -216,7 +216,11 @@ xv file upload ./docs --recursive              # Preserves directory structure
 xv file download "docs" --recursive --output ./local
 xv file upload ./src --recursive --prefix "backup/2024-01-15"
 xv file delete config.json                     # Delete a file
-xv file sync                                   # Sync local and remote files
+xv file sync ./mydir --direction up            # Upload changed/missing files (default)
+xv file sync ./mydir --direction down          # Download changed/missing files
+xv file sync ./mydir --direction both          # Bidirectional (mtime + size)
+xv file sync ./mydir --dry-run                 # Show planned transfers
+xv file sync ./mydir --prefix backup/ --delete # Mirror local to remote; remove extra remote blobs
 ```
 
 ### Identity & Access

--- a/dev/MISSING-FEATURES.md
+++ b/dev/MISSING-FEATURES.md
@@ -32,9 +32,8 @@ Unsupported `--format` values print an error via `output::error()` but then retu
 
 ## P1 — High Priority (User-Facing Feature Gaps)
 
-### 6. File sync (`xv file sync`) — fully stubbed
-**File:** `src/cli/commands.rs:7941`
-Command struct is fully defined with `local_path`, `prefix`, `direction`, `dry_run`, and `delete` flags. The execute function discards all parameters and returns a hard error. 0% implemented.
+### 6. ~~File sync (`xv file sync`)~~ — implemented
+**Files:** `src/cli/commands.rs` (`execute_file_sync`), `src/blob/sync.rs` (change detection helpers).
 
 ### 7. Blob metadata and tags silently dropped on upload
 **File:** `src/blob/manager.rs:80–94`

--- a/dev/ROADMAP.md
+++ b/dev/ROADMAP.md
@@ -53,11 +53,8 @@ Features shipped and verified in the codebase.
 
 ## 🔜 Open — High Priority
 
-### 1. File Sync (`xv file sync`)
-**Impact:** Listed in `xv file --help` but prints "not yet implemented."
-**Current state:** Fully stubbed — no sync logic exists.
-**Effort:** Medium-High
-**Scope:** Start with one-way `sync up` and `sync down` before bidirectional.
+### 1. ~~File Sync (`xv file sync`)~~ — shipped
+**Current state:** Implemented: `up` / `down` / `both`, size + mtime comparison with epsilon, `--dry-run`, `--delete` (scoped; confirmation), cache invalidation. Helpers in `src/blob/sync.rs`.
 
 ### 2. Progress Indicators for File Operations
 **Impact:** Large file uploads/downloads give no feedback until completion.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -102,6 +102,7 @@ Requires blob storage setup via `xv init`. Gated behind the `file-ops` feature f
 | `xv file list` | List files (hierarchical by default; `--recursive` for flat) |
 | `xv file delete` | Delete files (`-r`, `-f`, `-i`, `--dry-run`, `--verbose`, `--force`, `--continue-on-error`, glob patterns) |
 | `xv file info` | File metadata |
+| `xv file sync` | Sync local directory with blob prefix (`--direction` up/down/both, `--dry-run`, `--delete`) |
 
 ---
 

--- a/src/blob/mod.rs
+++ b/src/blob/mod.rs
@@ -6,5 +6,6 @@
 pub mod manager;
 pub mod models;
 pub mod operations;
+pub mod sync;
 
 // Re-export commonly used types

--- a/src/blob/sync.rs
+++ b/src/blob/sync.rs
@@ -1,0 +1,147 @@
+//! Blob sync helpers: change detection and local path mapping for `xv file sync`.
+
+use crate::blob::models::FileInfo;
+use chrono::{DateTime, Duration, Utc};
+use std::path::{Path, PathBuf};
+
+/// Clock skew / filesystem rounding tolerance for comparing mtimes (seconds).
+pub const SYNC_MTIME_EPSILON_SECS: i64 = 2;
+
+/// Whether local file metadata matches remote closely enough to skip a transfer.
+#[must_use]
+pub fn is_unchanged(local_size: u64, local_mtime: DateTime<Utc>, remote: &FileInfo) -> bool {
+    if local_size != remote.size {
+        return false;
+    }
+    let diff = (local_mtime - remote.last_modified).num_seconds().abs();
+    diff <= SYNC_MTIME_EPSILON_SECS
+}
+
+#[must_use]
+fn local_mtime_clearly_newer(local_mtime: DateTime<Utc>, remote: &FileInfo) -> bool {
+    local_mtime > remote.last_modified + Duration::seconds(SYNC_MTIME_EPSILON_SECS)
+}
+
+#[must_use]
+fn remote_mtime_clearly_newer(local_mtime: DateTime<Utc>, remote: &FileInfo) -> bool {
+    remote.last_modified > local_mtime + Duration::seconds(SYNC_MTIME_EPSILON_SECS)
+}
+
+/// Resolve bidirectional sync when the blob exists both locally and remotely.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BothAction {
+    Upload,
+    Download,
+    Skip,
+}
+
+#[must_use]
+pub fn resolve_both(local_size: u64, local_mtime: DateTime<Utc>, remote: &FileInfo) -> BothAction {
+    if is_unchanged(local_size, local_mtime, remote) {
+        return BothAction::Skip;
+    }
+    if local_mtime_clearly_newer(local_mtime, remote) {
+        BothAction::Upload
+    } else if remote_mtime_clearly_newer(local_mtime, remote) {
+        BothAction::Download
+    } else if local_mtime >= remote.last_modified {
+        // Ambiguous (e.g. size differs but mtimes within epsilon): prefer newer mtime, then upload.
+        BothAction::Upload
+    } else {
+        BothAction::Download
+    }
+}
+
+/// Map a blob name back to a local path under `base_path`, inverting upload path rules
+/// when given the same optional `prefix` used during upload (`path_to_blob_name` in the CLI).
+#[must_use]
+pub fn local_path_from_blob(base_path: &Path, prefix: Option<&str>, blob_name: &str) -> PathBuf {
+    let rel = match prefix.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(p) => {
+            let p = p.trim_matches('/');
+            let head = format!("{p}/");
+            blob_name.strip_prefix(&head).unwrap_or(blob_name)
+        }
+        None => blob_name,
+    };
+    rel.split('/')
+        .fold(base_path.to_path_buf(), |acc, c| acc.join(c))
+}
+
+/// Longest shared prefix ending with `/` across blob names, if any.
+/// Used to scope `--delete` when `--prefix` is not set (only under this tree).
+#[must_use]
+pub fn common_directory_prefix(names: &std::collections::HashSet<String>) -> Option<String> {
+    if names.is_empty() {
+        return None;
+    }
+    let mut iter = names.iter();
+    let first = iter.next()?.as_str();
+    let mut prefix = first.to_string();
+    for n in iter {
+        while !n.starts_with(&prefix) {
+            if prefix.is_empty() {
+                return None;
+            }
+            prefix.pop();
+        }
+    }
+    prefix.rfind('/').map(|i| prefix[..=i].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn remote(size: u64, last_modified: DateTime<Utc>) -> FileInfo {
+        FileInfo {
+            name: "x".to_string(),
+            size,
+            content_type: "application/octet-stream".to_string(),
+            last_modified,
+            etag: "e".to_string(),
+            groups: vec![],
+            metadata: Default::default(),
+            tags: Default::default(),
+        }
+    }
+
+    #[test]
+    fn unchanged_same_size_close_mtime() {
+        let t = Utc::now();
+        let r = remote(10, t);
+        assert!(is_unchanged(10, t + Duration::seconds(1), &r));
+    }
+
+    #[test]
+    fn changed_size_differs() {
+        let t = Utc::now();
+        let r = remote(10, t);
+        assert!(!is_unchanged(11, t, &r));
+    }
+
+    #[test]
+    fn both_prefers_local_when_newer() {
+        let base = Utc::now();
+        let r = remote(100, base);
+        let local_mtime = base + Duration::seconds(10);
+        assert_eq!(resolve_both(100, local_mtime, &r), BothAction::Upload);
+    }
+
+    #[test]
+    fn both_prefers_remote_when_newer() {
+        let base = Utc::now();
+        let r = remote(100, base + Duration::seconds(10));
+        let local_mtime = base;
+        assert_eq!(resolve_both(100, local_mtime, &r), BothAction::Download);
+    }
+
+    #[test]
+    fn common_prefix_shared_dir() {
+        let mut s = HashSet::new();
+        s.insert("docs/a.txt".to_string());
+        s.insert("docs/b.txt".to_string());
+        assert_eq!(common_directory_prefix(&s), Some("docs/".to_string()));
+    }
+}

--- a/src/blob/sync.rs
+++ b/src/blob/sync.rs
@@ -1,13 +1,43 @@
 //! Blob sync helpers: change detection and local path mapping for `xv file sync`.
 
 use crate::blob::models::FileInfo;
+use crate::error::{CrosstacheError, Result};
 use chrono::{DateTime, Duration, Utc};
+use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
+use std::time::{Duration as StdDuration, UNIX_EPOCH};
 
 /// Clock skew / filesystem rounding tolerance for comparing mtimes (seconds).
 pub const SYNC_MTIME_EPSILON_SECS: i64 = 2;
 
+/// Set the local file's modification time to match the blob's `last_modified` so subsequent
+/// sync runs can compare mtimes without re-transferring the same content.
+pub fn set_file_mtime_utc(path: &Path, mtime: DateTime<Utc>) -> Result<()> {
+    let secs = mtime.timestamp();
+    let nanos = mtime.timestamp_subsec_nanos();
+    if secs < 0 {
+        return Err(CrosstacheError::config(
+            "blob last_modified cannot be represented as a local file timestamp",
+        ));
+    }
+    let st = UNIX_EPOCH + StdDuration::new(secs as u64, nanos);
+    let file = OpenOptions::new().write(true).open(path).map_err(|e| {
+        CrosstacheError::config(format!(
+            "Failed to open {} to set modification time: {e}",
+            path.display()
+        ))
+    })?;
+    file.set_modified(st).map_err(|e| {
+        CrosstacheError::config(format!(
+            "Failed to set modification time on {}: {e}",
+            path.display()
+        ))
+    })?;
+    Ok(())
+}
+
 /// Whether local file metadata matches remote closely enough to skip a transfer.
+/// Used after downloads (and uploads) when we align local mtime to the blob `last_modified`.
 #[must_use]
 pub fn is_unchanged(local_size: u64, local_mtime: DateTime<Utc>, remote: &FileInfo) -> bool {
     if local_size != remote.size {
@@ -15,6 +45,16 @@ pub fn is_unchanged(local_size: u64, local_mtime: DateTime<Utc>, remote: &FileIn
     }
     let diff = (local_mtime - remote.last_modified).num_seconds().abs();
     diff <= SYNC_MTIME_EPSILON_SECS
+}
+
+/// Whether sync **up** can skip this blob: same size and the remote version is at least as
+/// fresh as the local file (no local edits after the blob was written).
+#[must_use]
+pub fn should_skip_sync_up(local_size: u64, local_mtime: DateTime<Utc>, remote: &FileInfo) -> bool {
+    if local_size != remote.size {
+        return false;
+    }
+    remote.last_modified + Duration::seconds(SYNC_MTIME_EPSILON_SECS) >= local_mtime
 }
 
 #[must_use]
@@ -143,5 +183,21 @@ mod tests {
         s.insert("docs/a.txt".to_string());
         s.insert("docs/b.txt".to_string());
         assert_eq!(common_directory_prefix(&s), Some("docs/".to_string()));
+    }
+
+    #[test]
+    fn skip_sync_up_when_remote_newer_same_size() {
+        let local_t = Utc::now();
+        let remote_t = local_t + Duration::seconds(60);
+        let r = remote(100, remote_t);
+        assert!(should_skip_sync_up(100, local_t, &r));
+    }
+
+    #[test]
+    fn skip_sync_up_false_when_local_newer() {
+        let remote_t = Utc::now();
+        let local_t = remote_t + Duration::seconds(60);
+        let r = remote(100, remote_t);
+        assert!(!should_skip_sync_up(100, local_t, &r));
     }
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -8472,6 +8472,7 @@ async fn file_sync_delete_remote_not_local(
     local_set: &std::collections::HashSet<String>,
     dry_run: bool,
     delete_requested: bool,
+    quiet_stdout: bool,
     summary: &mut FileSyncSummary,
     mutated: &mut bool,
 ) -> Result<()> {
@@ -8514,8 +8515,10 @@ async fn file_sync_delete_remote_not_local(
     }
 
     if dry_run {
-        for n in &to_delete {
-            println!("delete (dry-run): {n}");
+        if !quiet_stdout {
+            for n in &to_delete {
+                println!("delete (dry-run): {n}");
+            }
         }
         summary.deleted += to_delete.len();
         return Ok(());
@@ -8536,7 +8539,9 @@ async fn file_sync_delete_remote_not_local(
     }
 
     for n in to_delete {
-        println!("Deleting remote: {n}");
+        if !quiet_stdout {
+            println!("Deleting remote: {n}");
+        }
         blob_manager.delete_file(&n).await?;
         summary.deleted += 1;
         *mutated = true;
@@ -8568,12 +8573,18 @@ async fn execute_file_sync(
         )));
     }
 
+    if delete && matches!(direction, SyncDirection::Down) {
+        output::warn(
+            "`--delete` applies to remote files not present locally and is ignored for sync down; use sync up or both.",
+        );
+    }
+
     let base_path = path.parent().unwrap_or(path);
     let prefix_ref = prefix.as_deref().map(str::trim).filter(|s| !s.is_empty());
 
     let local_files = collect_files_with_structure(path, base_path, prefix_ref, false)?;
 
-    if local_files.is_empty() {
+    if local_files.is_empty() && !config.output_json {
         output::info("No local files found to sync");
     }
 
@@ -8633,7 +8644,7 @@ async fn execute_file_sync(
                 let (size, mtime) = *local_meta.get(&blob_name).unwrap();
                 let need = match remote_by_name.get(&blob_name) {
                     None => true,
-                    Some(r) => !sync::is_unchanged(size, mtime, r),
+                    Some(r) => !sync::should_skip_sync_up(size, mtime, r),
                 };
                 if !need {
                     summary.skipped += 1;
@@ -8643,10 +8654,12 @@ async fn execute_file_sync(
                     continue;
                 }
                 if dry_run {
-                    println!(
-                        "upload (dry-run): {} → {blob_name}",
-                        info.local_path.display()
-                    );
+                    if !config.output_json {
+                        println!(
+                            "upload (dry-run): {} → {blob_name}",
+                            info.local_path.display()
+                        );
+                    }
                     summary.uploaded += 1;
                     continue;
                 }
@@ -8664,8 +8677,11 @@ async fn execute_file_sync(
                     metadata: std::collections::HashMap::new(),
                     tags: std::collections::HashMap::new(),
                 };
-                println!("upload: {} → {blob_name}", info.local_path.display());
-                blob_manager.upload_file(upload_request).await?;
+                if !config.output_json {
+                    println!("upload: {} → {blob_name}", info.local_path.display());
+                }
+                let uploaded_info = blob_manager.upload_file(upload_request).await?;
+                sync::set_file_mtime_utc(&info.local_path, uploaded_info.last_modified)?;
                 summary.uploaded += 1;
                 mutated = true;
             }
@@ -8677,6 +8693,7 @@ async fn execute_file_sync(
                 &local_names,
                 dry_run,
                 delete,
+                config.output_json,
                 &mut summary,
                 &mut mutated,
             )
@@ -8721,7 +8738,9 @@ async fn execute_file_sync(
                 }
 
                 if dry_run {
-                    println!("download (dry-run): {blob_name} → {}", target.display());
+                    if !config.output_json {
+                        println!("download (dry-run): {blob_name} → {}", target.display());
+                    }
                     summary.downloaded += 1;
                     continue;
                 }
@@ -8743,11 +8762,14 @@ async fn execute_file_sync(
                     output_path: Some(target.display().to_string()),
                     stream: false,
                 };
-                println!("download: {blob_name} → {}", target.display());
+                if !config.output_json {
+                    println!("download: {blob_name} → {}", target.display());
+                }
                 let content = blob_manager.download_file(download_request).await?;
                 fs::write(&target, content).map_err(|e| {
                     CrosstacheError::config(format!("Failed to write {}: {e}", target.display()))
                 })?;
+                sync::set_file_mtime_utc(&target, remote_info.last_modified)?;
                 summary.downloaded += 1;
                 mutated = true;
             }
@@ -8766,10 +8788,12 @@ async fn execute_file_sync(
                     (true, false) => {
                         let info = local_by_blob.get(&blob_name).unwrap();
                         if dry_run {
-                            println!(
-                                "upload (dry-run): {} → {blob_name}",
-                                info.local_path.display()
-                            );
+                            if !config.output_json {
+                                println!(
+                                    "upload (dry-run): {} → {blob_name}",
+                                    info.local_path.display()
+                                );
+                            }
                             summary.uploaded += 1;
                             continue;
                         }
@@ -8787,17 +8811,22 @@ async fn execute_file_sync(
                             metadata: std::collections::HashMap::new(),
                             tags: std::collections::HashMap::new(),
                         };
-                        println!("upload: {} → {blob_name}", info.local_path.display());
-                        blob_manager.upload_file(upload_request).await?;
+                        if !config.output_json {
+                            println!("upload: {} → {blob_name}", info.local_path.display());
+                        }
+                        let uploaded_info = blob_manager.upload_file(upload_request).await?;
+                        sync::set_file_mtime_utc(&info.local_path, uploaded_info.last_modified)?;
                         summary.uploaded += 1;
                         mutated = true;
                     }
                     (false, true) => {
-                        let _remote = remote_by_name.get(&blob_name).unwrap();
+                        let remote_info = remote_by_name.get(&blob_name).unwrap();
                         let target = sync::local_path_from_blob(base_path, prefix_ref, &blob_name);
                         sync_assert_safe_local_path(base_path, &target, &blob_name)?;
                         if dry_run {
-                            println!("download (dry-run): {blob_name} → {}", target.display());
+                            if !config.output_json {
+                                println!("download (dry-run): {blob_name} → {}", target.display());
+                            }
                             summary.downloaded += 1;
                             continue;
                         }
@@ -8817,7 +8846,9 @@ async fn execute_file_sync(
                             output_path: Some(target.display().to_string()),
                             stream: false,
                         };
-                        println!("download: {blob_name} → {}", target.display());
+                        if !config.output_json {
+                            println!("download: {blob_name} → {}", target.display());
+                        }
                         let content = blob_manager.download_file(download_request).await?;
                         fs::write(&target, content).map_err(|e| {
                             CrosstacheError::config(format!(
@@ -8825,6 +8856,7 @@ async fn execute_file_sync(
                                 target.display()
                             ))
                         })?;
+                        sync::set_file_mtime_utc(&target, remote_info.last_modified)?;
                         summary.downloaded += 1;
                         mutated = true;
                     }
@@ -8841,10 +8873,12 @@ async fn execute_file_sync(
                             }
                             BothAction::Upload => {
                                 if dry_run {
-                                    println!(
-                                        "upload (dry-run): {} → {blob_name}",
-                                        info.local_path.display()
-                                    );
+                                    if !config.output_json {
+                                        println!(
+                                            "upload (dry-run): {} → {blob_name}",
+                                            info.local_path.display()
+                                        );
+                                    }
                                     summary.uploaded += 1;
                                     continue;
                                 }
@@ -8862,8 +8896,15 @@ async fn execute_file_sync(
                                     metadata: std::collections::HashMap::new(),
                                     tags: std::collections::HashMap::new(),
                                 };
-                                println!("upload: {} → {blob_name}", info.local_path.display());
-                                blob_manager.upload_file(upload_request).await?;
+                                if !config.output_json {
+                                    println!("upload: {} → {blob_name}", info.local_path.display());
+                                }
+                                let uploaded_info =
+                                    blob_manager.upload_file(upload_request).await?;
+                                sync::set_file_mtime_utc(
+                                    &info.local_path,
+                                    uploaded_info.last_modified,
+                                )?;
                                 summary.uploaded += 1;
                                 mutated = true;
                             }
@@ -8872,10 +8913,12 @@ async fn execute_file_sync(
                                     sync::local_path_from_blob(base_path, prefix_ref, &blob_name);
                                 sync_assert_safe_local_path(base_path, &target, &blob_name)?;
                                 if dry_run {
-                                    println!(
-                                        "download (dry-run): {blob_name} → {}",
-                                        target.display()
-                                    );
+                                    if !config.output_json {
+                                        println!(
+                                            "download (dry-run): {blob_name} → {}",
+                                            target.display()
+                                        );
+                                    }
                                     summary.downloaded += 1;
                                     continue;
                                 }
@@ -8895,7 +8938,9 @@ async fn execute_file_sync(
                                     output_path: Some(target.display().to_string()),
                                     stream: false,
                                 };
-                                println!("download: {blob_name} → {}", target.display());
+                                if !config.output_json {
+                                    println!("download: {blob_name} → {}", target.display());
+                                }
                                 let content = blob_manager.download_file(download_request).await?;
                                 fs::write(&target, content).map_err(|e| {
                                     CrosstacheError::config(format!(
@@ -8903,6 +8948,7 @@ async fn execute_file_sync(
                                         target.display()
                                     ))
                                 })?;
+                                sync::set_file_mtime_utc(&target, remote_info.last_modified)?;
                                 summary.downloaded += 1;
                                 mutated = true;
                             }
@@ -8943,6 +8989,7 @@ async fn execute_file_sync(
                 &local_names_after,
                 dry_run,
                 delete,
+                config.output_json,
                 &mut summary,
                 &mut mutated,
             )

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -8549,6 +8549,86 @@ async fn file_sync_delete_remote_not_local(
     Ok(())
 }
 
+/// Ensure parent directories exist for a sync download target.
+#[cfg(feature = "file-ops")]
+fn file_sync_ensure_parent_dirs(target: &std::path::Path) -> Result<()> {
+    use std::fs;
+    if let Some(parent) = target.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent).map_err(|e| {
+                CrosstacheError::config(format!(
+                    "Failed to create directory {}: {e}",
+                    parent.display()
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Read local file, upload blob, align local mtime to server `last_modified`.
+#[cfg(feature = "file-ops")]
+async fn file_sync_perform_upload(
+    blob_manager: &BlobManager,
+    info: &FileUploadInfo,
+    blob_name: &str,
+    output_json: bool,
+) -> Result<()> {
+    use crate::blob::models::FileUploadRequest;
+    use crate::blob::sync;
+    use std::collections::HashMap;
+    use std::fs;
+    let content = fs::read(&info.local_path).map_err(|e| {
+        CrosstacheError::config(format!("Failed to read {}: {e}", info.local_path.display()))
+    })?;
+    let upload_request = FileUploadRequest {
+        name: blob_name.to_string(),
+        content,
+        content_type: None,
+        groups: vec![],
+        metadata: HashMap::new(),
+        tags: HashMap::new(),
+    };
+    if !output_json {
+        println!("upload: {} → {blob_name}", info.local_path.display());
+    }
+    let uploaded_info = blob_manager.upload_file(upload_request).await?;
+    sync::set_file_mtime_utc(&info.local_path, uploaded_info.last_modified)?;
+    Ok(())
+}
+
+/// Download blob to local path (with traversal check, parents, mtime).
+#[cfg(feature = "file-ops")]
+async fn file_sync_perform_download(
+    blob_manager: &BlobManager,
+    base_path: &std::path::Path,
+    prefix_ref: Option<&str>,
+    blob_name: &str,
+    remote_info: &crate::blob::models::FileInfo,
+    output_json: bool,
+) -> Result<()> {
+    use crate::blob::models::FileDownloadRequest;
+    use crate::blob::sync;
+    use std::fs;
+    let target = sync::local_path_from_blob(base_path, prefix_ref, blob_name);
+    sync_assert_safe_local_path(base_path, &target, blob_name)?;
+    file_sync_ensure_parent_dirs(&target)?;
+    if !output_json {
+        println!("download: {blob_name} → {}", target.display());
+    }
+    let download_request = FileDownloadRequest {
+        name: blob_name.to_string(),
+        output_path: Some(target.display().to_string()),
+        stream: false,
+    };
+    let content = blob_manager.download_file(download_request).await?;
+    fs::write(&target, content).map_err(|e| {
+        CrosstacheError::config(format!("Failed to write {}: {e}", target.display()))
+    })?;
+    sync::set_file_mtime_utc(&target, remote_info.last_modified)?;
+    Ok(())
+}
+
 #[cfg(feature = "file-ops")]
 async fn execute_file_sync(
     blob_manager: &BlobManager,
@@ -8559,7 +8639,7 @@ async fn execute_file_sync(
     delete: bool,
     config: &Config,
 ) -> Result<()> {
-    use crate::blob::models::{FileDownloadRequest, FileListRequest, FileUploadRequest};
+    use crate::blob::models::FileListRequest;
     use crate::blob::sync::{self, BothAction};
     use chrono::{DateTime, Utc};
     use std::collections::{HashMap, HashSet};
@@ -8663,25 +8743,8 @@ async fn execute_file_sync(
                     summary.uploaded += 1;
                     continue;
                 }
-                let content = fs::read(&info.local_path).map_err(|e| {
-                    CrosstacheError::config(format!(
-                        "Failed to read {}: {e}",
-                        info.local_path.display()
-                    ))
-                })?;
-                let upload_request = FileUploadRequest {
-                    name: blob_name.clone(),
-                    content,
-                    content_type: None,
-                    groups: vec![],
-                    metadata: std::collections::HashMap::new(),
-                    tags: std::collections::HashMap::new(),
-                };
-                if !config.output_json {
-                    println!("upload: {} → {blob_name}", info.local_path.display());
-                }
-                let uploaded_info = blob_manager.upload_file(upload_request).await?;
-                sync::set_file_mtime_utc(&info.local_path, uploaded_info.last_modified)?;
+                file_sync_perform_upload(blob_manager, info, &blob_name, config.output_json)
+                    .await?;
                 summary.uploaded += 1;
                 mutated = true;
             }
@@ -8745,31 +8808,15 @@ async fn execute_file_sync(
                     continue;
                 }
 
-                if let Some(parent) = target.parent() {
-                    if !parent.exists() {
-                        fs::create_dir_all(parent).map_err(|e| {
-                            CrosstacheError::config(format!(
-                                "Failed to create directory {}: {}",
-                                parent.display(),
-                                e
-                            ))
-                        })?;
-                    }
-                }
-
-                let download_request = FileDownloadRequest {
-                    name: blob_name.clone(),
-                    output_path: Some(target.display().to_string()),
-                    stream: false,
-                };
-                if !config.output_json {
-                    println!("download: {blob_name} → {}", target.display());
-                }
-                let content = blob_manager.download_file(download_request).await?;
-                fs::write(&target, content).map_err(|e| {
-                    CrosstacheError::config(format!("Failed to write {}: {e}", target.display()))
-                })?;
-                sync::set_file_mtime_utc(&target, remote_info.last_modified)?;
+                file_sync_perform_download(
+                    blob_manager,
+                    base_path,
+                    prefix_ref,
+                    &blob_name,
+                    remote_info,
+                    config.output_json,
+                )
+                .await?;
                 summary.downloaded += 1;
                 mutated = true;
             }
@@ -8797,25 +8844,13 @@ async fn execute_file_sync(
                             summary.uploaded += 1;
                             continue;
                         }
-                        let content = fs::read(&info.local_path).map_err(|e| {
-                            CrosstacheError::config(format!(
-                                "Failed to read {}: {e}",
-                                info.local_path.display()
-                            ))
-                        })?;
-                        let upload_request = FileUploadRequest {
-                            name: blob_name.clone(),
-                            content,
-                            content_type: None,
-                            groups: vec![],
-                            metadata: std::collections::HashMap::new(),
-                            tags: std::collections::HashMap::new(),
-                        };
-                        if !config.output_json {
-                            println!("upload: {} → {blob_name}", info.local_path.display());
-                        }
-                        let uploaded_info = blob_manager.upload_file(upload_request).await?;
-                        sync::set_file_mtime_utc(&info.local_path, uploaded_info.last_modified)?;
+                        file_sync_perform_upload(
+                            blob_manager,
+                            info,
+                            &blob_name,
+                            config.output_json,
+                        )
+                        .await?;
                         summary.uploaded += 1;
                         mutated = true;
                     }
@@ -8830,33 +8865,15 @@ async fn execute_file_sync(
                             summary.downloaded += 1;
                             continue;
                         }
-                        if let Some(parent) = target.parent() {
-                            if !parent.exists() {
-                                fs::create_dir_all(parent).map_err(|e| {
-                                    CrosstacheError::config(format!(
-                                        "Failed to create directory {}: {}",
-                                        parent.display(),
-                                        e
-                                    ))
-                                })?;
-                            }
-                        }
-                        let download_request = FileDownloadRequest {
-                            name: blob_name.clone(),
-                            output_path: Some(target.display().to_string()),
-                            stream: false,
-                        };
-                        if !config.output_json {
-                            println!("download: {blob_name} → {}", target.display());
-                        }
-                        let content = blob_manager.download_file(download_request).await?;
-                        fs::write(&target, content).map_err(|e| {
-                            CrosstacheError::config(format!(
-                                "Failed to write {}: {e}",
-                                target.display()
-                            ))
-                        })?;
-                        sync::set_file_mtime_utc(&target, remote_info.last_modified)?;
+                        file_sync_perform_download(
+                            blob_manager,
+                            base_path,
+                            prefix_ref,
+                            &blob_name,
+                            remote_info,
+                            config.output_json,
+                        )
+                        .await?;
                         summary.downloaded += 1;
                         mutated = true;
                     }
@@ -8882,29 +8899,13 @@ async fn execute_file_sync(
                                     summary.uploaded += 1;
                                     continue;
                                 }
-                                let content = fs::read(&info.local_path).map_err(|e| {
-                                    CrosstacheError::config(format!(
-                                        "Failed to read {}: {e}",
-                                        info.local_path.display()
-                                    ))
-                                })?;
-                                let upload_request = FileUploadRequest {
-                                    name: blob_name.clone(),
-                                    content,
-                                    content_type: None,
-                                    groups: vec![],
-                                    metadata: std::collections::HashMap::new(),
-                                    tags: std::collections::HashMap::new(),
-                                };
-                                if !config.output_json {
-                                    println!("upload: {} → {blob_name}", info.local_path.display());
-                                }
-                                let uploaded_info =
-                                    blob_manager.upload_file(upload_request).await?;
-                                sync::set_file_mtime_utc(
-                                    &info.local_path,
-                                    uploaded_info.last_modified,
-                                )?;
+                                file_sync_perform_upload(
+                                    blob_manager,
+                                    info,
+                                    &blob_name,
+                                    config.output_json,
+                                )
+                                .await?;
                                 summary.uploaded += 1;
                                 mutated = true;
                             }
@@ -8922,33 +8923,15 @@ async fn execute_file_sync(
                                     summary.downloaded += 1;
                                     continue;
                                 }
-                                if let Some(parent) = target.parent() {
-                                    if !parent.exists() {
-                                        fs::create_dir_all(parent).map_err(|e| {
-                                            CrosstacheError::config(format!(
-                                                "Failed to create directory {}: {}",
-                                                parent.display(),
-                                                e
-                                            ))
-                                        })?;
-                                    }
-                                }
-                                let download_request = FileDownloadRequest {
-                                    name: blob_name.clone(),
-                                    output_path: Some(target.display().to_string()),
-                                    stream: false,
-                                };
-                                if !config.output_json {
-                                    println!("download: {blob_name} → {}", target.display());
-                                }
-                                let content = blob_manager.download_file(download_request).await?;
-                                fs::write(&target, content).map_err(|e| {
-                                    CrosstacheError::config(format!(
-                                        "Failed to write {}: {e}",
-                                        target.display()
-                                    ))
-                                })?;
-                                sync::set_file_mtime_utc(&target, remote_info.last_modified)?;
+                                file_sync_perform_download(
+                                    blob_manager,
+                                    base_path,
+                                    prefix_ref,
+                                    &blob_name,
+                                    remote_info,
+                                    config.output_json,
+                                )
+                                .await?;
                                 summary.downloaded += 1;
                                 mutated = true;
                             }
@@ -8958,42 +8941,43 @@ async fn execute_file_sync(
                 }
             }
 
-            let local_names_after: HashSet<String> = if delete {
-                let path = Path::new(local_path);
-                let rescanned = collect_files_with_structure(path, base_path, prefix_ref, false)?;
-                rescanned.into_iter().map(|i| i.blob_name).collect()
-            } else {
-                local_names.clone()
-            };
+            if delete {
+                let local_names_after: HashSet<String> = {
+                    let path = Path::new(local_path);
+                    let rescanned =
+                        collect_files_with_structure(path, base_path, prefix_ref, false)?;
+                    rescanned.into_iter().map(|i| i.blob_name).collect()
+                };
 
-            let remote_after = blob_manager
-                .list_files(FileListRequest {
-                    prefix: list_prefix.clone(),
-                    groups: None,
-                    limit: None,
-                    delimiter: None,
-                    recursive: true,
-                })
+                let remote_after = blob_manager
+                    .list_files(FileListRequest {
+                        prefix: list_prefix.clone(),
+                        groups: None,
+                        limit: None,
+                        delimiter: None,
+                        recursive: true,
+                    })
+                    .await?;
+                let mut remote_map_after: HashMap<String, crate::blob::models::FileInfo> =
+                    HashMap::new();
+                for f in remote_after {
+                    remote_map_after.insert(f.name.clone(), f);
+                }
+
+                file_sync_delete_remote_not_local(
+                    blob_manager,
+                    direction,
+                    prefix_ref,
+                    &remote_map_after,
+                    &local_names_after,
+                    dry_run,
+                    delete,
+                    config.output_json,
+                    &mut summary,
+                    &mut mutated,
+                )
                 .await?;
-            let mut remote_map_after: HashMap<String, crate::blob::models::FileInfo> =
-                HashMap::new();
-            for f in remote_after {
-                remote_map_after.insert(f.name.clone(), f);
             }
-
-            file_sync_delete_remote_not_local(
-                blob_manager,
-                direction,
-                prefix_ref,
-                &remote_map_after,
-                &local_names_after,
-                dry_run,
-                delete,
-                config.output_json,
-                &mut summary,
-                &mut mutated,
-            )
-            .await?;
         }
     }
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -8424,6 +8424,127 @@ async fn execute_file_delete_multiple(
 }
 
 #[cfg(feature = "file-ops")]
+fn sync_assert_safe_local_path(
+    base: &std::path::Path,
+    target: &std::path::Path,
+    blob_name: &str,
+) -> Result<()> {
+    use std::path::Component;
+
+    let canonical_base = base.canonicalize().unwrap_or_else(|_| base.to_path_buf());
+    let mut resolved = canonical_base.clone();
+    for component in target.strip_prefix(base).unwrap_or(target).components() {
+        match component {
+            Component::ParentDir => {
+                resolved.pop();
+            }
+            Component::Normal(c) => {
+                resolved.push(c);
+            }
+            _ => {}
+        }
+    }
+    if !resolved.starts_with(&canonical_base) {
+        return Err(CrosstacheError::config(format!(
+            "Path traversal detected in blob name: {blob_name}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "file-ops")]
+#[derive(Default, serde::Serialize)]
+struct FileSyncSummary {
+    uploaded: usize,
+    downloaded: usize,
+    deleted: usize,
+    skipped: usize,
+    dry_run: bool,
+}
+
+#[cfg(feature = "file-ops")]
+#[allow(clippy::too_many_arguments)]
+async fn file_sync_delete_remote_not_local(
+    blob_manager: &BlobManager,
+    direction: &SyncDirection,
+    prefix_ref: Option<&str>,
+    remote_map: &std::collections::HashMap<String, crate::blob::models::FileInfo>,
+    local_set: &std::collections::HashSet<String>,
+    dry_run: bool,
+    delete_requested: bool,
+    summary: &mut FileSyncSummary,
+    mutated: &mut bool,
+) -> Result<()> {
+    use crate::blob::sync;
+
+    if !delete_requested {
+        return Ok(());
+    }
+    if matches!(direction, SyncDirection::Down) {
+        output::warn(
+            "`--delete` applies to remote files not present locally and is ignored for sync down; use sync up or both.",
+        );
+        return Ok(());
+    }
+
+    let scope = prefix_ref
+        .map(|p| {
+            let t = p.trim_matches('/');
+            format!("{t}/")
+        })
+        .or_else(|| sync::common_directory_prefix(local_set))
+        .filter(|s| !s.is_empty());
+
+    let Some(scope_prefix) = scope else {
+        output::warn(
+            "`--delete` skipped: set `--prefix` or sync a directory tree with a shared path prefix (e.g. docs/...).",
+        );
+        return Ok(());
+    };
+
+    let mut to_delete: Vec<String> = remote_map
+        .keys()
+        .filter(|name| name.starts_with(&scope_prefix) && !local_set.contains(*name))
+        .cloned()
+        .collect();
+    to_delete.sort();
+
+    if to_delete.is_empty() {
+        return Ok(());
+    }
+
+    if dry_run {
+        for n in &to_delete {
+            println!("delete (dry-run): {n}");
+        }
+        summary.deleted += to_delete.len();
+        return Ok(());
+    }
+
+    use crate::utils::interactive::InteractivePrompt;
+    let prompt = InteractivePrompt::new();
+    if !prompt.confirm(
+        &format!(
+            "Delete {} remote file(s) under '{}' that are not present locally?",
+            to_delete.len(),
+            scope_prefix.trim_end_matches('/')
+        ),
+        false,
+    )? {
+        output::info("Delete cancelled.");
+        return Ok(());
+    }
+
+    for n in to_delete {
+        println!("Deleting remote: {n}");
+        blob_manager.delete_file(&n).await?;
+        summary.deleted += 1;
+        *mutated = true;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "file-ops")]
 async fn execute_file_sync(
     blob_manager: &BlobManager,
     local_path: &str,
@@ -8433,17 +8554,462 @@ async fn execute_file_sync(
     delete: bool,
     config: &Config,
 ) -> Result<()> {
-    let _ = (
-        blob_manager,
-        local_path,
-        prefix,
-        direction,
+    use crate::blob::models::{FileDownloadRequest, FileListRequest, FileUploadRequest};
+    use crate::blob::sync::{self, BothAction};
+    use chrono::{DateTime, Utc};
+    use std::collections::{HashMap, HashSet};
+    use std::fs;
+    use std::path::Path;
+
+    let path = Path::new(local_path);
+    if !path.exists() {
+        return Err(CrosstacheError::config(format!(
+            "Path not found: {local_path}"
+        )));
+    }
+
+    let base_path = path.parent().unwrap_or(path);
+    let prefix_ref = prefix.as_deref().map(str::trim).filter(|s| !s.is_empty());
+
+    let local_files = collect_files_with_structure(path, base_path, prefix_ref, false)?;
+
+    if local_files.is_empty() {
+        output::info("No local files found to sync");
+    }
+
+    let mut local_by_blob: HashMap<String, FileUploadInfo> = HashMap::new();
+    let mut local_meta: HashMap<String, (u64, DateTime<Utc>)> = HashMap::new();
+
+    for info in &local_files {
+        let meta = fs::metadata(&info.local_path).map_err(|e| {
+            CrosstacheError::config(format!(
+                "Failed to read metadata for {}: {e}",
+                info.local_path.display()
+            ))
+        })?;
+        let size = meta.len();
+        let mtime_utc: DateTime<Utc> = meta
+            .modified()
+            .map_err(|e| {
+                CrosstacheError::config(format!(
+                    "Failed to read mtime for {}: {e}",
+                    info.local_path.display()
+                ))
+            })
+            .map(Into::into)?;
+        local_by_blob.insert(info.blob_name.clone(), info.clone());
+        local_meta.insert(info.blob_name.clone(), (size, mtime_utc));
+    }
+
+    let list_prefix = prefix_ref.map(|p| p.to_string());
+
+    let list_request = FileListRequest {
+        prefix: list_prefix.clone(),
+        groups: None,
+        limit: None,
+        delimiter: None,
+        recursive: true,
+    };
+    let remote_list = blob_manager.list_files(list_request).await?;
+    let mut remote_by_name: HashMap<String, crate::blob::models::FileInfo> = HashMap::new();
+    for f in remote_list {
+        remote_by_name.insert(f.name.clone(), f);
+    }
+
+    let local_names: HashSet<String> = local_by_blob.keys().cloned().collect();
+
+    let mut summary = FileSyncSummary {
         dry_run,
-        delete,
-        config,
-    );
-    output::error("File sync is not yet implemented. Track progress at: https://github.com/bziobnic/crosstache/issues");
-    Err(CrosstacheError::config("'xv file sync' is not yet available. Use 'xv file upload' and 'xv file download' for individual transfers.".to_string()))
+        ..Default::default()
+    };
+    let mut mutated = false;
+
+    match direction {
+        SyncDirection::Up => {
+            let mut sorted_names: Vec<String> = local_names.iter().cloned().collect();
+            sorted_names.sort();
+            for blob_name in sorted_names {
+                let info = local_by_blob.get(&blob_name).unwrap();
+                let (size, mtime) = *local_meta.get(&blob_name).unwrap();
+                let need = match remote_by_name.get(&blob_name) {
+                    None => true,
+                    Some(r) => !sync::is_unchanged(size, mtime, r),
+                };
+                if !need {
+                    summary.skipped += 1;
+                    if !config.output_json {
+                        println!("skip (up to date): {blob_name}");
+                    }
+                    continue;
+                }
+                if dry_run {
+                    println!(
+                        "upload (dry-run): {} → {blob_name}",
+                        info.local_path.display()
+                    );
+                    summary.uploaded += 1;
+                    continue;
+                }
+                let content = fs::read(&info.local_path).map_err(|e| {
+                    CrosstacheError::config(format!(
+                        "Failed to read {}: {e}",
+                        info.local_path.display()
+                    ))
+                })?;
+                let upload_request = FileUploadRequest {
+                    name: blob_name.clone(),
+                    content,
+                    content_type: None,
+                    groups: vec![],
+                    metadata: std::collections::HashMap::new(),
+                    tags: std::collections::HashMap::new(),
+                };
+                println!("upload: {} → {blob_name}", info.local_path.display());
+                blob_manager.upload_file(upload_request).await?;
+                summary.uploaded += 1;
+                mutated = true;
+            }
+            file_sync_delete_remote_not_local(
+                blob_manager,
+                direction,
+                prefix_ref,
+                &remote_by_name,
+                &local_names,
+                dry_run,
+                delete,
+                &mut summary,
+                &mut mutated,
+            )
+            .await?;
+        }
+        SyncDirection::Down => {
+            let mut remote_names: Vec<String> = remote_by_name.keys().cloned().collect();
+            remote_names.sort();
+            for blob_name in remote_names {
+                let remote_info = remote_by_name.get(&blob_name).unwrap();
+                let target = sync::local_path_from_blob(base_path, prefix_ref, &blob_name);
+                sync_assert_safe_local_path(base_path, &target, &blob_name)?;
+
+                let need = if !target.exists() {
+                    true
+                } else {
+                    let meta = fs::metadata(&target).map_err(|e| {
+                        CrosstacheError::config(format!(
+                            "Failed to read metadata for {}: {e}",
+                            target.display()
+                        ))
+                    })?;
+                    let size = meta.len();
+                    let mtime_utc: DateTime<Utc> = meta
+                        .modified()
+                        .map_err(|e| {
+                            CrosstacheError::config(format!(
+                                "Failed to read mtime for {}: {e}",
+                                target.display()
+                            ))
+                        })
+                        .map(Into::into)?;
+                    !sync::is_unchanged(size, mtime_utc, remote_info)
+                };
+
+                if !need {
+                    if !config.output_json {
+                        println!("skip (up to date): {blob_name}");
+                    }
+                    summary.skipped += 1;
+                    continue;
+                }
+
+                if dry_run {
+                    println!("download (dry-run): {blob_name} → {}", target.display());
+                    summary.downloaded += 1;
+                    continue;
+                }
+
+                if let Some(parent) = target.parent() {
+                    if !parent.exists() {
+                        fs::create_dir_all(parent).map_err(|e| {
+                            CrosstacheError::config(format!(
+                                "Failed to create directory {}: {}",
+                                parent.display(),
+                                e
+                            ))
+                        })?;
+                    }
+                }
+
+                let download_request = FileDownloadRequest {
+                    name: blob_name.clone(),
+                    output_path: Some(target.display().to_string()),
+                    stream: false,
+                };
+                println!("download: {blob_name} → {}", target.display());
+                let content = blob_manager.download_file(download_request).await?;
+                fs::write(&target, content).map_err(|e| {
+                    CrosstacheError::config(format!("Failed to write {}: {e}", target.display()))
+                })?;
+                summary.downloaded += 1;
+                mutated = true;
+            }
+        }
+        SyncDirection::Both => {
+            let remote_keys: HashSet<String> = remote_by_name.keys().cloned().collect();
+            let all_names: HashSet<String> = local_names.union(&remote_keys).cloned().collect();
+            let mut ordered: Vec<String> = all_names.into_iter().collect();
+            ordered.sort();
+
+            for blob_name in ordered {
+                let local_present = local_meta.contains_key(&blob_name);
+                let remote_present = remote_by_name.contains_key(&blob_name);
+
+                match (local_present, remote_present) {
+                    (true, false) => {
+                        let info = local_by_blob.get(&blob_name).unwrap();
+                        if dry_run {
+                            println!(
+                                "upload (dry-run): {} → {blob_name}",
+                                info.local_path.display()
+                            );
+                            summary.uploaded += 1;
+                            continue;
+                        }
+                        let content = fs::read(&info.local_path).map_err(|e| {
+                            CrosstacheError::config(format!(
+                                "Failed to read {}: {e}",
+                                info.local_path.display()
+                            ))
+                        })?;
+                        let upload_request = FileUploadRequest {
+                            name: blob_name.clone(),
+                            content,
+                            content_type: None,
+                            groups: vec![],
+                            metadata: std::collections::HashMap::new(),
+                            tags: std::collections::HashMap::new(),
+                        };
+                        println!("upload: {} → {blob_name}", info.local_path.display());
+                        blob_manager.upload_file(upload_request).await?;
+                        summary.uploaded += 1;
+                        mutated = true;
+                    }
+                    (false, true) => {
+                        let _remote = remote_by_name.get(&blob_name).unwrap();
+                        let target = sync::local_path_from_blob(base_path, prefix_ref, &blob_name);
+                        sync_assert_safe_local_path(base_path, &target, &blob_name)?;
+                        if dry_run {
+                            println!("download (dry-run): {blob_name} → {}", target.display());
+                            summary.downloaded += 1;
+                            continue;
+                        }
+                        if let Some(parent) = target.parent() {
+                            if !parent.exists() {
+                                fs::create_dir_all(parent).map_err(|e| {
+                                    CrosstacheError::config(format!(
+                                        "Failed to create directory {}: {}",
+                                        parent.display(),
+                                        e
+                                    ))
+                                })?;
+                            }
+                        }
+                        let download_request = FileDownloadRequest {
+                            name: blob_name.clone(),
+                            output_path: Some(target.display().to_string()),
+                            stream: false,
+                        };
+                        println!("download: {blob_name} → {}", target.display());
+                        let content = blob_manager.download_file(download_request).await?;
+                        fs::write(&target, content).map_err(|e| {
+                            CrosstacheError::config(format!(
+                                "Failed to write {}: {e}",
+                                target.display()
+                            ))
+                        })?;
+                        summary.downloaded += 1;
+                        mutated = true;
+                    }
+                    (true, true) => {
+                        let info = local_by_blob.get(&blob_name).unwrap();
+                        let (size, mtime) = *local_meta.get(&blob_name).unwrap();
+                        let remote_info = remote_by_name.get(&blob_name).unwrap();
+                        match sync::resolve_both(size, mtime, remote_info) {
+                            BothAction::Skip => {
+                                if !config.output_json {
+                                    println!("skip: {blob_name}");
+                                }
+                                summary.skipped += 1;
+                            }
+                            BothAction::Upload => {
+                                if dry_run {
+                                    println!(
+                                        "upload (dry-run): {} → {blob_name}",
+                                        info.local_path.display()
+                                    );
+                                    summary.uploaded += 1;
+                                    continue;
+                                }
+                                let content = fs::read(&info.local_path).map_err(|e| {
+                                    CrosstacheError::config(format!(
+                                        "Failed to read {}: {e}",
+                                        info.local_path.display()
+                                    ))
+                                })?;
+                                let upload_request = FileUploadRequest {
+                                    name: blob_name.clone(),
+                                    content,
+                                    content_type: None,
+                                    groups: vec![],
+                                    metadata: std::collections::HashMap::new(),
+                                    tags: std::collections::HashMap::new(),
+                                };
+                                println!("upload: {} → {blob_name}", info.local_path.display());
+                                blob_manager.upload_file(upload_request).await?;
+                                summary.uploaded += 1;
+                                mutated = true;
+                            }
+                            BothAction::Download => {
+                                let target =
+                                    sync::local_path_from_blob(base_path, prefix_ref, &blob_name);
+                                sync_assert_safe_local_path(base_path, &target, &blob_name)?;
+                                if dry_run {
+                                    println!(
+                                        "download (dry-run): {blob_name} → {}",
+                                        target.display()
+                                    );
+                                    summary.downloaded += 1;
+                                    continue;
+                                }
+                                if let Some(parent) = target.parent() {
+                                    if !parent.exists() {
+                                        fs::create_dir_all(parent).map_err(|e| {
+                                            CrosstacheError::config(format!(
+                                                "Failed to create directory {}: {}",
+                                                parent.display(),
+                                                e
+                                            ))
+                                        })?;
+                                    }
+                                }
+                                let download_request = FileDownloadRequest {
+                                    name: blob_name.clone(),
+                                    output_path: Some(target.display().to_string()),
+                                    stream: false,
+                                };
+                                println!("download: {blob_name} → {}", target.display());
+                                let content = blob_manager.download_file(download_request).await?;
+                                fs::write(&target, content).map_err(|e| {
+                                    CrosstacheError::config(format!(
+                                        "Failed to write {}: {e}",
+                                        target.display()
+                                    ))
+                                })?;
+                                summary.downloaded += 1;
+                                mutated = true;
+                            }
+                        }
+                    }
+                    (false, false) => {}
+                }
+            }
+
+            let local_names_after: HashSet<String> = if delete {
+                let path = Path::new(local_path);
+                let rescanned = collect_files_with_structure(path, base_path, prefix_ref, false)?;
+                rescanned.into_iter().map(|i| i.blob_name).collect()
+            } else {
+                local_names.clone()
+            };
+
+            let remote_after = blob_manager
+                .list_files(FileListRequest {
+                    prefix: list_prefix.clone(),
+                    groups: None,
+                    limit: None,
+                    delimiter: None,
+                    recursive: true,
+                })
+                .await?;
+            let mut remote_map_after: HashMap<String, crate::blob::models::FileInfo> =
+                HashMap::new();
+            for f in remote_after {
+                remote_map_after.insert(f.name.clone(), f);
+            }
+
+            file_sync_delete_remote_not_local(
+                blob_manager,
+                direction,
+                prefix_ref,
+                &remote_map_after,
+                &local_names_after,
+                dry_run,
+                delete,
+                &mut summary,
+                &mut mutated,
+            )
+            .await?;
+        }
+    }
+
+    if mutated && !dry_run {
+        let cache_manager = crate::cache::CacheManager::from_config(config);
+        if let Ok(vault_name) = config.resolve_vault_name(None).await {
+            cache_manager.invalidate(&crate::cache::CacheKey::FileList {
+                vault_name: vault_name.clone(),
+                recursive: true,
+            });
+            cache_manager.invalidate(&crate::cache::CacheKey::FileList {
+                vault_name,
+                recursive: false,
+            });
+        }
+    }
+
+    if config.output_json {
+        let json_output = serde_json::to_string_pretty(&summary).map_err(|e| {
+            CrosstacheError::serialization(format!("Failed to serialize sync summary: {e}"))
+        })?;
+        println!("{json_output}");
+    } else {
+        println!();
+        output::info("Sync summary:");
+        println!(
+            "  {}",
+            output::format_line(
+                output::Level::Info,
+                &format!("Uploaded: {}", summary.uploaded),
+                output::should_use_rich_stdout()
+            )
+        );
+        println!(
+            "  {}",
+            output::format_line(
+                output::Level::Info,
+                &format!("Downloaded: {}", summary.downloaded),
+                output::should_use_rich_stdout()
+            )
+        );
+        println!(
+            "  {}",
+            output::format_line(
+                output::Level::Info,
+                &format!("Deleted (remote): {}", summary.deleted),
+                output::should_use_rich_stdout()
+            )
+        );
+        println!(
+            "  {}",
+            output::format_line(
+                output::Level::Info,
+                &format!("Skipped: {}", summary.skipped),
+                output::should_use_rich_stdout()
+            )
+        );
+        if dry_run {
+            output::hint("Dry run: no changes were applied.");
+        }
+    }
+
+    Ok(())
 }
 
 /// Execute bulk secret set operation

--- a/tests/file_commands_tests.rs
+++ b/tests/file_commands_tests.rs
@@ -4,7 +4,7 @@
 //! with both the full command syntax and the quick aliases.
 
 use crosstache::{
-    cli::commands::{Commands, FileCommands},
+    cli::commands::{Commands, FileCommands, SyncDirection},
     config::{BlobConfig, Config},
     error::Result,
 };
@@ -50,7 +50,6 @@ async fn test_file_upload_command_basic() -> Result<()> {
         ],
         tag: vec![("environment".to_string(), "test".to_string())],
         content_type: Some("text/plain".to_string()),
-        progress: true,
         continue_on_error: false,
     };
 
@@ -65,7 +64,6 @@ async fn test_file_upload_command_basic() -> Result<()> {
             metadata,
             tag,
             content_type,
-            progress,
             continue_on_error,
         } => {
             assert_eq!(files, vec![temp_file.path().to_string_lossy().to_string()]);
@@ -75,7 +73,6 @@ async fn test_file_upload_command_basic() -> Result<()> {
             assert_eq!(metadata.len(), 2);
             assert_eq!(tag.len(), 1);
             assert_eq!(content_type, Some("text/plain".to_string()));
-            assert!(progress);
             assert!(!continue_on_error);
         }
         _ => panic!("Expected Upload command"),
@@ -110,7 +107,6 @@ async fn test_file_upload_command_with_multiple_groups() -> Result<()> {
             ("project".to_string(), "crosstache".to_string()),
         ],
         content_type: None,
-        progress: false,
         continue_on_error: false,
     };
 
@@ -125,7 +121,6 @@ async fn test_file_upload_command_with_multiple_groups() -> Result<()> {
             metadata,
             tag,
             content_type,
-            progress,
             continue_on_error: _,
         } => {
             assert_eq!(files, vec![temp_file.path().to_string_lossy().to_string()]);
@@ -137,7 +132,6 @@ async fn test_file_upload_command_with_multiple_groups() -> Result<()> {
             assert_eq!(metadata.len(), 2);
             assert_eq!(tag.len(), 2);
             assert!(content_type.is_none());
-            assert!(!progress);
         }
         _ => panic!("Expected Upload command"),
     }
@@ -156,7 +150,6 @@ async fn test_file_download_command_basic() -> Result<()> {
         rename: None,
         recursive: false,
         flatten: false,
-        stream: false,
         force: false,
         continue_on_error: false,
     };
@@ -168,14 +161,12 @@ async fn test_file_download_command_basic() -> Result<()> {
             rename,
             recursive: _,
             flatten: _,
-            stream,
             force,
             continue_on_error: _,
         } => {
             assert_eq!(files, vec!["test-file.txt"]);
             assert_eq!(output, Some(output_path.to_string_lossy().to_string()));
             assert!(rename.is_none());
-            assert!(!stream);
             assert!(!force);
         }
         _ => panic!("Expected Download command"),
@@ -185,14 +176,13 @@ async fn test_file_download_command_basic() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_file_download_command_with_streaming() -> Result<()> {
+async fn test_file_download_command_force_overwrite() -> Result<()> {
     let download_command = FileCommands::Download {
         files: vec!["large-file.bin".to_string()],
         output: None,
         rename: None,
         recursive: false,
         flatten: false,
-        stream: true,
         force: true,
         continue_on_error: false,
     };
@@ -204,13 +194,11 @@ async fn test_file_download_command_with_streaming() -> Result<()> {
             rename: _,
             recursive: _,
             flatten: _,
-            stream,
             force,
             continue_on_error: _,
         } => {
             assert_eq!(files, vec!["large-file.bin"]);
             assert!(output.is_none());
-            assert!(stream);
             assert!(force);
         }
         _ => panic!("Expected Download command"),
@@ -309,7 +297,6 @@ async fn test_file_upload_validation() -> Result<()> {
         metadata: vec![],
         tag: vec![],
         content_type: None,
-        progress: false,
         continue_on_error: false,
     };
 
@@ -324,7 +311,6 @@ async fn test_file_upload_validation() -> Result<()> {
             metadata,
             tag,
             content_type,
-            progress,
             continue_on_error,
         } => {
             assert_eq!(files, vec![non_existent_file]);
@@ -334,7 +320,6 @@ async fn test_file_upload_validation() -> Result<()> {
             assert!(metadata.is_empty());
             assert!(tag.is_empty());
             assert!(content_type.is_none());
-            assert!(!progress);
             assert!(!continue_on_error);
         }
         _ => panic!("Expected Upload command"),
@@ -364,7 +349,6 @@ async fn test_metadata_and_tag_parsing() -> Result<()> {
             ("project".to_string(), "crosstache".to_string()),
         ],
         content_type: Some("text/plain".to_string()),
-        progress: true,
         continue_on_error: false,
     };
 
@@ -379,7 +363,6 @@ async fn test_metadata_and_tag_parsing() -> Result<()> {
             metadata,
             tag,
             content_type: _,
-            progress: _,
             continue_on_error: _,
         } => {
             assert_eq!(metadata.len(), 2);
@@ -458,6 +441,36 @@ async fn test_file_info_command() -> Result<()> {
             assert_eq!(name, "info-file.txt");
         }
         _ => panic!("Expected Info command"),
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_file_sync_command() -> Result<()> {
+    let sync_command = FileCommands::Sync {
+        local_path: "./data".to_string(),
+        prefix: Some("backup/".to_string()),
+        direction: SyncDirection::Both,
+        dry_run: true,
+        delete: false,
+    };
+
+    match sync_command {
+        FileCommands::Sync {
+            local_path,
+            prefix,
+            direction,
+            dry_run,
+            delete,
+        } => {
+            assert_eq!(local_path, "./data");
+            assert_eq!(prefix, Some("backup/".to_string()));
+            assert!(matches!(direction, SyncDirection::Both));
+            assert!(dry_run);
+            assert!(!delete);
+        }
+        _ => panic!("Expected Sync command"),
     }
 
     Ok(())


### PR DESCRIPTION
- Add blob::sync helpers (mtime/size epsilon, both-way resolution, path mapping)
- Implement execute_file_sync: up/down/both, dry-run, delete with confirm
- Invalidate file list cache after mutations; JSON summary with --output-json
- Docs and roadmap updates; fix file_commands_tests for current FileCommands API

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new bidirectional local↔blob sync behavior including optional remote deletions, so mistakes in change detection/prefix scoping could cause unintended uploads/downloads or deletions despite confirmation prompts.
> 
> **Overview**
> **Implements `xv file sync` end-to-end** (was previously stubbed), supporting `--direction up|down|both`, size+mtime change detection with a small epsilon, and a `--dry-run` planning mode.
> 
> Adds safety/UX around syncing: path traversal protection for downloads, parent directory creation, aligning local mtimes to blob `last_modified`, optional **scoped** `--delete` of remote blobs not present locally (with interactive confirmation), and file-list cache invalidation plus a JSON/console sync summary.
> 
> Updates docs/roadmap to mark file sync as shipped, and adjusts tests to match the current `FileCommands` API while adding coverage for the new `FileCommands::Sync` variant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e8ab7aece19e3d916277bc55c21f5e475502a06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->