### PR TITLE
feat: add progress indicators for file operations

### DIFF
--- a/dev/ROADMAP.md
+++ b/dev/ROADMAP.md
@@ -54,15 +54,11 @@ Features shipped and verified in the codebase.
 - `xv audit` accepts `--resource-group` for vault-wide audits outside the default resource group
 - **Integration tests:** `tests/cli_integration_tests.rs` exercises the `xv` binary (help, version, config path/show, gen, format flags, completion) without Azure.
 - **Clipboard tests:** `tests/clipboard_tests.rs` uses read retries and graceful skips when the OS clipboard is unavailable (CI/headless).
+- **Progress indicators** for file operations (upload, download, sync): `ProgressReporter` trait with bar/spinner/noop implementations, configurable size threshold (`progress_threshold_mb`, default 5 MB), TTY-aware (suppressed when piped), `MultiProgressContext` for batch operations with per-file log + overall file-count bar
 
 ---
 
 ## 🔜 Open — High Priority
-
-### 1. Progress Indicators for File Operations
-**Impact:** Large file uploads/downloads give no feedback until completion.
-**Current state:** No progress bars or per-file status during recursive ops.
-**Effort:** Low-Medium (`indicatif` crate or similar).
 
 ### 2. Large File Chunked Upload
 **Impact:** Files over ~100MB may fail. Block-based upload with resume needed.

--- a/docs/superpowers/plans/2026-04-01-progress-indicators.md
+++ b/docs/superpowers/plans/2026-04-01-progress-indicators.md
@@ -1,0 +1,750 @@
+# Progress Indicators for File Operations — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add progress bars and spinners to blob file operations so users get visual feedback during uploads, downloads, and sync.
+
+**Architecture:** A `ProgressReporter` trait in `src/utils/progress.rs` abstracts progress reporting. Three implementations: `BarReporter` (bytes bar for large files), `SpinnerReporter` (for small files), `NoopReporter` (non-TTY). A `MultiProgressContext` wraps `indicatif::MultiProgress` for batch operations with an overall file-count bar and per-file reporters. The blob manager methods accept `&dyn ProgressReporter` but never create reporters — the CLI layer handles that.
+
+**Tech Stack:** `indicatif 0.17` (already a dependency), `std::io::IsTerminal` for TTY detection.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/utils/progress.rs` | Create | ProgressReporter trait, BarReporter, SpinnerReporter, NoopReporter, MultiProgressContext, factory function |
+| `src/utils/mod.rs` | Modify (line 8) | Add `pub mod progress;` |
+| `src/config/settings.rs` | Modify (lines 54-73) | Add `progress_threshold_mb` to BlobConfig |
+| `src/blob/manager.rs` | Modify (lines 58-124, 343-384, 505-571, 583-707) | Add `reporter` parameter to upload/download methods |
+| `src/cli/file_ops.rs` | Modify (lines 290-366, 368-402, 831-958, 1081-1293, 1508-1564, 1566-1975) | Create reporters, pass to blob manager, wire up MultiProgress for batch ops |
+
+---
+
+### Task 1: ProgressReporter Trait and Implementations
+
+**Files:**
+- Create: `src/utils/progress.rs`
+- Modify: `src/utils/mod.rs`
+
+- [ ] **Step 1: Create `src/utils/progress.rs` with the trait and all implementations**
+
+```rust
+//! Progress reporting for file operations.
+//!
+//! Provides a trait-based abstraction over `indicatif` so the blob manager
+//! stays UI-free while the CLI layer controls progress rendering.
+
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+/// Trait for reporting progress during file operations.
+/// All methods are no-ops by default so that callers can pass a `NoopReporter`
+/// when progress display is unwanted (e.g., non-TTY or tests).
+pub trait ProgressReporter: Send + Sync {
+    fn set_total(&self, total: u64);
+    fn advance(&self, amount: u64);
+    fn set_message(&self, msg: String);
+    fn finish_with_message(&self, msg: String);
+    fn finish_clear(&self);
+}
+
+// ---------------------------------------------------------------------------
+// NoopReporter
+// ---------------------------------------------------------------------------
+
+/// Does nothing. Used when stdout is not a TTY.
+pub struct NoopReporter;
+
+impl ProgressReporter for NoopReporter {
+    fn set_total(&self, _total: u64) {}
+    fn advance(&self, _amount: u64) {}
+    fn set_message(&self, _msg: String) {}
+    fn finish_with_message(&self, _msg: String) {}
+    fn finish_clear(&self) {}
+}
+
+// ---------------------------------------------------------------------------
+// BarReporter
+// ---------------------------------------------------------------------------
+
+/// Bytes-level progress bar for large files.
+pub struct BarReporter {
+    bar: ProgressBar,
+}
+
+impl BarReporter {
+    pub fn new(total: u64) -> Self {
+        let bar = ProgressBar::new(total);
+        bar.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner:.green} [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+                .expect("valid template")
+                .progress_chars("#>-"),
+        );
+        Self { bar }
+    }
+
+    /// Create a BarReporter managed by a `MultiProgress`.
+    pub fn new_in(mp: &MultiProgress, total: u64) -> Self {
+        let bar = mp.add(ProgressBar::new(total));
+        bar.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner:.green} [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+                .expect("valid template")
+                .progress_chars("#>-"),
+        );
+        Self { bar }
+    }
+}
+
+impl ProgressReporter for BarReporter {
+    fn set_total(&self, total: u64) {
+        self.bar.set_length(total);
+    }
+    fn advance(&self, amount: u64) {
+        self.bar.inc(amount);
+    }
+    fn set_message(&self, msg: String) {
+        self.bar.set_message(msg);
+    }
+    fn finish_with_message(&self, msg: String) {
+        self.bar.finish_with_message(msg);
+    }
+    fn finish_clear(&self) {
+        self.bar.finish_and_clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SpinnerReporter
+// ---------------------------------------------------------------------------
+
+/// Spinner for small files — shows activity without byte-level tracking.
+pub struct SpinnerReporter {
+    bar: ProgressBar,
+}
+
+impl SpinnerReporter {
+    pub fn new(message: &str) -> Self {
+        let bar = ProgressBar::new_spinner();
+        bar.set_style(
+            ProgressStyle::default_spinner()
+                .template("{spinner:.green} {msg}")
+                .expect("valid template"),
+        );
+        bar.set_message(message.to_string());
+        bar.enable_steady_tick(std::time::Duration::from_millis(100));
+        Self { bar }
+    }
+
+    /// Create a SpinnerReporter managed by a `MultiProgress`.
+    pub fn new_in(mp: &MultiProgress, message: &str) -> Self {
+        let bar = mp.add(ProgressBar::new_spinner());
+        bar.set_style(
+            ProgressStyle::default_spinner()
+                .template("{spinner:.green} {msg}")
+                .expect("valid template"),
+        );
+        bar.set_message(message.to_string());
+        bar.enable_steady_tick(std::time::Duration::from_millis(100));
+        Self { bar }
+    }
+}
+
+impl ProgressReporter for SpinnerReporter {
+    fn set_total(&self, _total: u64) {}
+    fn advance(&self, _amount: u64) {}
+    fn set_message(&self, msg: String) {
+        self.bar.set_message(msg);
+    }
+    fn finish_with_message(&self, msg: String) {
+        self.bar.finish_with_message(msg);
+    }
+    fn finish_clear(&self) {
+        self.bar.finish_and_clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/// Create the appropriate reporter for a single-file operation.
+pub fn create_file_reporter(
+    file_size: u64,
+    threshold_bytes: u64,
+    is_tty: bool,
+) -> Box<dyn ProgressReporter> {
+    if !is_tty {
+        return Box::new(NoopReporter);
+    }
+    if file_size >= threshold_bytes {
+        Box::new(BarReporter::new(file_size))
+    } else {
+        Box::new(SpinnerReporter::new(""))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MultiProgressContext
+// ---------------------------------------------------------------------------
+
+/// Manages an overall file-count bar plus per-file child reporters for batch operations.
+pub struct MultiProgressContext {
+    mp: MultiProgress,
+    overall: ProgressBar,
+    threshold_bytes: u64,
+    is_tty: bool,
+}
+
+impl MultiProgressContext {
+    pub fn new(total_files: u64, threshold_bytes: u64, is_tty: bool) -> Self {
+        if !is_tty {
+            return Self {
+                mp: MultiProgress::new(),
+                overall: ProgressBar::hidden(),
+                threshold_bytes,
+                is_tty,
+            };
+        }
+        let mp = MultiProgress::new();
+        let overall = mp.add(ProgressBar::new(total_files));
+        overall.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} files  {msg}")
+                .expect("valid template")
+                .progress_chars("#>-"),
+        );
+        Self {
+            mp,
+            overall,
+            threshold_bytes,
+            is_tty,
+        }
+    }
+
+    /// Create a per-file reporter inserted above the overall bar.
+    pub fn create_child(&self, file_size: u64, name: &str) -> Box<dyn ProgressReporter> {
+        if !self.is_tty {
+            return Box::new(NoopReporter);
+        }
+        if file_size >= self.threshold_bytes {
+            Box::new(BarReporter::new_in(&self.mp, file_size))
+        } else {
+            Box::new(SpinnerReporter::new_in(&self.mp, name))
+        }
+    }
+
+    /// Log a line above the progress bars (completed file status).
+    pub fn log(&self, msg: &str) {
+        if self.is_tty {
+            let _ = self.mp.println(msg);
+        }
+    }
+
+    /// Advance the overall bar by one file and set the current file message.
+    pub fn advance_overall(&self, current_file: &str) {
+        self.overall.inc(1);
+        self.overall.set_message(current_file.to_string());
+    }
+
+    /// Finish and clear all bars.
+    pub fn finish(&self) {
+        self.overall.finish_and_clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_reporter_does_not_panic() {
+        let r = NoopReporter;
+        r.set_total(100);
+        r.advance(50);
+        r.set_message("hello".into());
+        r.finish_with_message("done".into());
+        r.finish_clear();
+    }
+
+    #[test]
+    fn factory_returns_noop_when_not_tty() {
+        // is_tty = false should always return NoopReporter regardless of size
+        let r = create_file_reporter(100_000_000, 5_000_000, false);
+        // Just verify it doesn't panic
+        r.set_total(100);
+        r.advance(50);
+        r.finish_clear();
+    }
+
+    #[test]
+    fn factory_returns_bar_for_large_file_on_tty() {
+        // We can't easily check the concrete type, but we can verify it works
+        let r = create_file_reporter(10_000_000, 5_000_000, true);
+        r.set_total(10_000_000);
+        r.advance(1_000_000);
+        r.finish_clear();
+    }
+
+    #[test]
+    fn factory_returns_spinner_for_small_file_on_tty() {
+        let r = create_file_reporter(1_000, 5_000_000, true);
+        r.set_total(0);
+        r.advance(0);
+        r.finish_clear();
+    }
+
+    #[test]
+    fn multi_progress_noop_when_not_tty() {
+        let ctx = MultiProgressContext::new(10, 5_000_000, false);
+        let child = ctx.create_child(100, "test.txt");
+        child.set_total(100);
+        child.advance(100);
+        child.finish_clear();
+        ctx.advance_overall("test.txt");
+        ctx.log("done: test.txt");
+        ctx.finish();
+    }
+}
+```
+
+- [ ] **Step 2: Add module export in `src/utils/mod.rs`**
+
+Add `pub mod progress;` to the module list. Insert it alphabetically between `output` and `resource_detector`:
+
+In `src/utils/mod.rs`, add after the `pub mod output;` line:
+```rust
+pub mod progress;
+```
+
+- [ ] **Step 3: Run tests to verify**
+
+Run: `cargo test --lib utils::progress`
+Expected: All 5 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/progress.rs src/utils/mod.rs
+git commit -m "feat: add ProgressReporter trait and implementations for file operations"
+```
+
+---
+
+### Task 2: Add `progress_threshold_mb` Config Setting
+
+**Files:**
+- Modify: `src/config/settings.rs:54-73` (BlobConfig struct and Default impl)
+- Modify: `src/config/settings.rs:441-453` (load_from_env)
+
+- [ ] **Step 1: Add field to BlobConfig struct**
+
+In `src/config/settings.rs`, add after line 60 (`pub max_concurrent_uploads: usize,`):
+
+```rust
+    pub progress_threshold_mb: usize,
+```
+
+- [ ] **Step 2: Add default value in BlobConfig::default()**
+
+In the `Default` impl (lines 63-73), add after `max_concurrent_uploads: 3,`:
+
+```rust
+            progress_threshold_mb: 5,
+```
+
+- [ ] **Step 3: Add environment variable loading**
+
+In `load_from_env()`, add after the `BLOB_MAX_CONCURRENT_UPLOADS` block (after line 453):
+
+```rust
+    if let Ok(value) = std::env::var("PROGRESS_THRESHOLD_MB") {
+        if let Ok(threshold) = value.parse::<usize>() {
+            blob_config.progress_threshold_mb = threshold;
+            blob_config_updated = true;
+        }
+    }
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo check`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/settings.rs
+git commit -m "feat: add progress_threshold_mb config setting (default 5MB)"
+```
+
+---
+
+### Task 3: Wire ProgressReporter into BlobManager Methods
+
+**Files:**
+- Modify: `src/blob/manager.rs:58-124` (upload_file)
+- Modify: `src/blob/manager.rs:343-384` (download_file)
+- Modify: `src/blob/manager.rs:583-707` (upload_large_file)
+
+- [ ] **Step 1: Add import at top of `src/blob/manager.rs`**
+
+Add after line 20 (`use tokio::io::AsyncWrite;`):
+
+```rust
+use crate::utils::progress::ProgressReporter;
+```
+
+- [ ] **Step 2: Add `reporter` parameter to `upload_file`**
+
+Change the signature at line 58 from:
+
+```rust
+    pub async fn upload_file(&self, request: FileUploadRequest) -> Result<FileInfo> {
+```
+
+to:
+
+```rust
+    pub async fn upload_file(&self, request: FileUploadRequest, reporter: &dyn ProgressReporter) -> Result<FileInfo> {
+```
+
+Add progress calls. After line 86 (`let content_length = request.content.len() as u64;`), add:
+
+```rust
+        reporter.set_total(content_length);
+```
+
+After the `put_block_blob` call succeeds (after line 103), add:
+
+```rust
+        reporter.advance(content_length);
+        reporter.finish_clear();
+```
+
+- [ ] **Step 3: Add `reporter` parameter to `download_file`**
+
+Change the signature at line 343 from:
+
+```rust
+    pub async fn download_file(&self, request: FileDownloadRequest) -> Result<Vec<u8>> {
+```
+
+to:
+
+```rust
+    pub async fn download_file(&self, request: FileDownloadRequest, reporter: &dyn ProgressReporter) -> Result<Vec<u8>> {
+```
+
+After line 371 (`let content_length = properties.blob.properties.content_length;`), add:
+
+```rust
+        reporter.set_total(content_length);
+```
+
+After the `get_content()` call succeeds (after line 381), add:
+
+```rust
+        reporter.advance(content_length);
+        reporter.finish_clear();
+```
+
+Also add progress finish for the empty file early return. Change line 374 from:
+
+```rust
+            return Ok(Vec::new());
+```
+
+to:
+
+```rust
+            reporter.finish_clear();
+            return Ok(Vec::new());
+```
+
+- [ ] **Step 4: Add `reporter` parameter to `upload_large_file`**
+
+Change the signature at line 583 from:
+
+```rust
+    pub async fn upload_large_file<R: tokio::io::AsyncRead + Unpin>(
+        &self,
+        name: &str,
+        mut reader: R,
+        _file_size: u64,
+        metadata: HashMap<String, String>,
+        tags: HashMap<String, String>,
+    ) -> Result<FileInfo> {
+```
+
+to:
+
+```rust
+    pub async fn upload_large_file<R: tokio::io::AsyncRead + Unpin>(
+        &self,
+        name: &str,
+        mut reader: R,
+        file_size: u64,
+        metadata: HashMap<String, String>,
+        tags: HashMap<String, String>,
+        reporter: &dyn ProgressReporter,
+    ) -> Result<FileInfo> {
+```
+
+Note: `_file_size` becomes `file_size` (remove the underscore prefix since we now use it).
+
+After line 596 (`let chunk_size = self.chunk_size_mb * 1024 * 1024;`), add:
+
+```rust
+        reporter.set_total(file_size);
+```
+
+In the upload task spawn block (lines 632-641), we need to report progress after each block completes. Since the reporter is behind `&dyn`, we can't move it into the spawned task. Instead, report after the task completes. Replace the task-wait loop (lines 644-649):
+
+```rust
+        // Wait for all block uploads to finish.
+        for task in upload_tasks {
+            task.await
+                .map_err(|e| CrosstacheError::unknown(format!("Upload task panicked: {e}")))?
+                .map_err(|e: CrosstacheError| e)?;
+        }
+```
+
+with:
+
+```rust
+        // Wait for all block uploads to finish and report progress.
+        for task in upload_tasks {
+            task.await
+                .map_err(|e| CrosstacheError::unknown(format!("Upload task panicked: {e}")))?
+                .map_err(|e: CrosstacheError| e)?;
+            reporter.advance(chunk_size as u64);
+        }
+        reporter.finish_clear();
+```
+
+Note: The last chunk may be smaller, so the bar might overshoot briefly — indicatif clamps at 100% automatically. The `finish_clear()` cleans up regardless.
+
+- [ ] **Step 5: Fix all call sites that now need a reporter argument**
+
+Search for all existing calls to `upload_file`, `download_file`, and `upload_large_file` and add `&NoopReporter` temporarily so the code compiles. These will be replaced with real reporters in Task 4.
+
+In `src/cli/file_ops.rs`, add at the top:
+
+```rust
+use crate::utils::progress::NoopReporter;
+```
+
+Then update every call site:
+
+1. `execute_file_upload` line 357: `blob_manager.upload_file(upload_request).await?` → `blob_manager.upload_file(upload_request, &NoopReporter).await?`
+2. `execute_file_download` line 396: `blob_manager.download_file(download_request).await?` → `blob_manager.download_file(download_request, &NoopReporter).await?`
+3. `file_sync_perform_upload` line 1532: `blob_manager.upload_file(upload_request).await?` → `blob_manager.upload_file(upload_request, &NoopReporter).await?`
+4. `file_sync_perform_download` line 1558: `blob_manager.download_file(download_request).await?` → `blob_manager.download_file(download_request, &NoopReporter).await?`
+
+Also check for calls in `execute_file_download_recursive` — those call `execute_file_download` which already has the `NoopReporter`, so they're fine.
+
+Search for any other call sites of `upload_large_file` and `download_file` outside of `file_ops.rs`:
+
+Run: `grep -rn 'upload_large_file\|\.upload_file(\|\.download_file(' src/ --include='*.rs' | grep -v 'fn \|//\|test'`
+
+Update any additional call sites found with `&NoopReporter`.
+
+- [ ] **Step 6: Verify it compiles**
+
+Run: `cargo check`
+Expected: No errors.
+
+- [ ] **Step 7: Run all tests**
+
+Run: `cargo test`
+Expected: All tests pass (existing tests now go through NoopReporter path).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/blob/manager.rs src/cli/file_ops.rs
+git commit -m "feat: add ProgressReporter parameter to blob manager upload/download methods"
+```
+
+---
+
+### Task 4: Wire Real Reporters into CLI File Operations
+
+**Files:**
+- Modify: `src/cli/file_ops.rs` (execute_file_upload, execute_file_download, execute_file_upload_recursive, execute_file_download_recursive, execute_file_sync, file_sync_perform_upload, file_sync_perform_download)
+
+- [ ] **Step 1: Add imports and helper for TTY detection and threshold**
+
+Replace the `use crate::utils::progress::NoopReporter;` import added in Task 3 with:
+
+```rust
+use crate::utils::progress::{self, MultiProgressContext, NoopReporter};
+```
+
+Add a helper function near the top of the file (after the existing imports):
+
+```rust
+fn progress_threshold_bytes(config: &Config) -> u64 {
+    let blob_config = config.get_blob_config();
+    (blob_config.progress_threshold_mb as u64) * 1024 * 1024
+}
+
+fn is_tty() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdout().is_terminal()
+}
+```
+
+- [ ] **Step 2: Wire reporter into `execute_file_upload`**
+
+In `execute_file_upload` (line 290), after the file content is read (after line 314, where `content` is assigned), add:
+
+```rust
+    let file_size = content.len() as u64;
+```
+
+Replace line 355 (`println!("Uploading file '{file_path}' as '{remote_name}'...");`) and the upload call at line 357 with:
+
+```rust
+    let threshold = progress_threshold_bytes(_config);
+    let tty = is_tty();
+    if !tty {
+        println!("Uploading file '{file_path}' as '{remote_name}'...");
+    }
+    let reporter = progress::create_file_reporter(file_size, threshold, tty);
+    reporter.set_message(format!("Uploading '{remote_name}'..."));
+
+    let file_info = blob_manager.upload_file(upload_request, reporter.as_ref()).await?;
+```
+
+- [ ] **Step 3: Wire reporter into `execute_file_download`**
+
+In `execute_file_download` (line 368), we need the file size before downloading. The blob manager's `download_file` already fetches properties internally, but we need the size before creating the reporter.
+
+Add a properties fetch before the download. Replace lines 394-396:
+
+```rust
+    println!("Downloading file '{name}' to '{output_path}'...");
+
+    let content = blob_manager.download_file(download_request).await?;
+```
+
+with:
+
+```rust
+    let threshold = progress_threshold_bytes(_config);
+    let tty = is_tty();
+    if !tty {
+        println!("Downloading file '{name}' to '{output_path}'...");
+    }
+    let reporter = progress::create_file_reporter(0, threshold, tty);
+    reporter.set_message(format!("Downloading '{name}'..."));
+
+    let content = blob_manager.download_file(download_request, reporter.as_ref()).await?;
+```
+
+Note: We pass `0` as file_size to `create_file_reporter` here because we don't know the remote size yet. The blob manager's `download_file` calls `reporter.set_total(content_length)` after fetching properties, which will upgrade the display. For the initial creation, this means we get a spinner (since 0 < threshold), and the spinner works fine for single downloads since they're single-shot anyway. This is acceptable — the spinner provides feedback while the download happens.
+
+- [ ] **Step 4: Wire MultiProgress into `execute_file_upload_recursive`**
+
+In `execute_file_upload_recursive`, after the file count is known (after collecting files), create a MultiProgressContext and use it around the upload loop.
+
+Find the loop that iterates over files and calls `execute_file_upload`. Before the loop starts, add:
+
+```rust
+    let threshold = progress_threshold_bytes(config);
+    let tty = is_tty();
+    let mp = MultiProgressContext::new(file_count as u64, threshold, tty);
+```
+
+Where `file_count` is the total number of files collected (this variable should already exist — it's printed as "Found N file(s) to upload").
+
+Inside the loop, before each `execute_file_upload` call, log via the MultiProgress instead of println, and after each call advance the overall bar:
+
+```rust
+    mp.log(&format!("Uploaded: {blob_name}"));
+    mp.advance_overall(&next_blob_name_or_empty);
+```
+
+At the end, before the summary:
+```rust
+    mp.finish();
+```
+
+The exact integration depends on the loop structure — the implementing agent should read the full function and wire the MultiProgress around the existing per-file loop, replacing direct `println!` calls with `mp.log()` when `is_tty` is true.
+
+- [ ] **Step 5: Wire MultiProgress into `execute_file_download_recursive`**
+
+Same pattern as Step 4 but for downloads. After the blob list is fetched and the total count is known, create a `MultiProgressContext`. Use `mp.log()` for per-file status and `mp.advance_overall()` after each download. Call `mp.finish()` before the summary.
+
+- [ ] **Step 6: Wire MultiProgress into `execute_file_sync`**
+
+In `execute_file_sync`, after the comparison phase determines the list of actions (uploads + downloads + deletes), create a `MultiProgressContext` with the total action count. Skip progress entirely when `dry_run` is true.
+
+Before the direction match (around line 1650):
+
+```rust
+    let threshold = progress_threshold_bytes(config);
+    let tty = is_tty() && !dry_run;
+```
+
+The sync function has three direction branches (Up, Down, Both). In each branch's loop:
+- Replace `println!("upload: ...")` and `println!("download: ...")` with `mp.log(...)` when `tty` is true
+- Call `mp.advance_overall(blob_name)` after each action
+- Call `mp.finish()` before the summary output
+
+For sync, calculating the total action count upfront requires knowing how many files need action before the loop runs. The simplest approach: don't create the MultiProgress until the loop starts — instead, use a deferred creation where the total is set to the total number of items being iterated (which is already known: it's the length of `sorted_names` or `remote_names` or `ordered`). Skipped items still advance the overall bar (they're just fast).
+
+Update `file_sync_perform_upload` and `file_sync_perform_download` to accept a `reporter: &dyn ProgressReporter` parameter and pass it through to `blob_manager.upload_file()` / `blob_manager.download_file()`. The caller in `execute_file_sync` creates a child reporter from the MultiProgressContext for each file that needs upload/download.
+
+- [ ] **Step 7: Verify it compiles**
+
+Run: `cargo check`
+Expected: No errors.
+
+- [ ] **Step 8: Run all tests**
+
+Run: `cargo test`
+Expected: All tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/cli/file_ops.rs
+git commit -m "feat: wire progress reporters into file upload, download, and sync commands"
+```
+
+---
+
+### Task 5: Update Roadmap and Final Verification
+
+**Files:**
+- Modify: `dev/ROADMAP.md`
+
+- [ ] **Step 1: Move the progress indicators item to Completed in `dev/ROADMAP.md`**
+
+Remove the "Progress Indicators for File Operations" section from "Open — High Priority" and add it to the Completed section under the latest version heading:
+
+```markdown
+- **Progress indicators** for file operations (upload, download, sync): configurable size threshold (`progress_threshold_mb`), TTY-aware, batch MultiProgress with per-file reporters
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cargo test`
+Expected: All tests pass.
+
+- [ ] **Step 3: Run clippy**
+
+Run: `cargo clippy --all-targets`
+Expected: No warnings related to progress changes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dev/ROADMAP.md
+git commit -m "docs: mark progress indicators as completed in roadmap"
+```

--- a/docs/superpowers/specs/2026-04-01-progress-indicators-design.md
+++ b/docs/superpowers/specs/2026-04-01-progress-indicators-design.md
@@ -1,0 +1,134 @@
+# Progress Indicators for File Operations
+
+> Date: 2026-04-01 | Status: Approved
+
+## Overview
+
+Add progress bars and spinners to blob/file operations so users get visual feedback during uploads, downloads, recursive operations, and sync. Uses `indicatif` (already a dependency) with a `ProgressReporter` trait to keep UI concerns out of the blob manager.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Single-file treatment | Bytes bar for large files, spinner for small | Avoids visual noise for quick operations |
+| Batch display | Scrolling log + sticky overall bar | Shows per-file completion while tracking overall progress |
+| Non-TTY behavior | Suppress progress entirely | Matches existing `auto` format behavior; scripts get clean output |
+| Size threshold | Configurable, 5 MB default | Consistent with other tunables (`blob_chunk_size_mb`) |
+| Architecture | ProgressReporter trait injection | Clean separation; blob manager stays UI-free |
+
+## Architecture
+
+### ProgressReporter Trait
+
+Located in `src/utils/progress.rs`:
+
+```rust
+pub trait ProgressReporter: Send + Sync {
+    fn set_total(&self, total: u64);
+    fn advance(&self, amount: u64);
+    fn set_message(&self, msg: String);
+    fn finish_with_message(&self, msg: String);
+    fn finish_clear(&self);
+}
+```
+
+### Implementations
+
+- **`BarReporter`** — wraps `indicatif::ProgressBar`. Bytes-style template: `{spinner} [{bar:40}] {bytes}/{total_bytes} ({eta})`. Used on TTY when file size >= threshold.
+- **`SpinnerReporter`** — wraps `indicatif::ProgressBar` in spinner mode. Shows filename and spinner. Used on TTY when file size < threshold.
+- **`NoopReporter`** — all methods are no-ops. Used when stdout is not a TTY.
+
+### Factory Function
+
+```rust
+pub fn create_file_reporter(file_size: u64, threshold: u64, is_tty: bool) -> Box<dyn ProgressReporter>
+```
+
+Returns `BarReporter` if `is_tty && file_size >= threshold`, `SpinnerReporter` if `is_tty && file_size < threshold`, `NoopReporter` otherwise.
+
+### MultiProgressContext
+
+Wraps `indicatif::MultiProgress` for batch operations:
+
+- An overall file-count bar (sticky at bottom), template: `{spinner} [{bar:40}] {pos}/{len} files  {msg}` where `{msg}` is the current filename
+- A method to create per-file reporters (bar or spinner based on size vs threshold)
+- Completed files log above the bars via `println!` through the MultiProgress
+
+## Configuration
+
+New config key: `progress_threshold_mb`
+
+- **Config file:** `progress_threshold_mb = 5`
+- **Environment variable:** `PROGRESS_THRESHOLD_MB`
+- **Default:** 5 (MB), converted to bytes internally (`value * 1024 * 1024`)
+- **No CLI flag** — display preference, not per-command
+
+Follows the existing pattern of `blob_chunk_size_mb` and `clipboard_timeout`.
+
+## Blob Manager Integration
+
+Methods gain a `reporter: &dyn ProgressReporter` parameter. The manager calls trait methods but never creates reporters.
+
+### Methods Affected
+
+- **`upload_file()`** — `set_total(data.len())`, then `advance()` after the PUT completes (single-shot).
+- **`upload_large_file()`** — `set_total(file_size)` upfront, `advance(chunk_size)` after each `put_block()`. Thread-safe via indicatif's built-in atomic counters.
+- **`download_file()`** — `set_total(content_length)` from response headers, `advance(bytes.len())` after download completes (single-shot; true streaming is out of scope).
+- **`download_file_stream()`** — same advance-after-write pattern.
+
+### Methods NOT Affected
+
+`list_files()`, `delete_file()`, `get_properties()` — fast API calls that don't need progress.
+
+## CLI Layer Integration (file_ops.rs)
+
+TTY detection via `std::io::IsTerminal` on stdout (stable since Rust 1.70).
+
+### Single File Operations
+
+`execute_file_upload` and `execute_file_download`:
+- Get file size (local fs for upload, blob properties for download)
+- Call `create_file_reporter(file_size, threshold, is_tty)`
+- Pass reporter to blob manager method
+- Reporter finishes; existing success/error messages print after
+
+### Recursive Upload (`execute_file_upload_recursive`)
+
+- Create `MultiProgressContext` with total file count
+- For each file: create per-file reporter from multi-progress, pass to upload, log completion above the bar
+- Overall bar advances by 1 after each file
+- On finish, clear multi-progress and print existing summary
+
+### Recursive Download (`execute_file_download_recursive`)
+
+Same pattern as recursive upload but with download operations.
+
+### Sync (`execute_file_sync`)
+
+- After comparison phase determines action list, create `MultiProgressContext` with total action count
+- Each action (upload/download/delete) advances overall bar
+- Upload/download actions get per-file reporters for large files
+- `--dry-run` skips progress bars entirely (prints existing dry-run output)
+
+### Non-TTY
+
+`create_file_reporter` returns `NoopReporter`. All existing `println!` output continues unchanged.
+
+## Testing
+
+### Unit Tests (in `src/utils/progress.rs`)
+
+- `NoopReporter` doesn't panic on any method call
+- `create_file_reporter` returns correct type based on size/threshold/TTY
+- `MultiProgressContext` creates child reporters and tracks overall count
+
+### Integration
+
+- Existing CLI integration tests run without TTY, exercising `NoopReporter` path automatically
+- No need to test indicatif rendering; trust the library
+
+## Out of Scope
+
+- True streaming downloads (chunked byte-by-byte for single downloads) — current impl buffers full response
+- Progress for `list_files()` pagination
+- Progress for delete operations within sync (fast API calls)

--- a/src/blob/manager.rs
+++ b/src/blob/manager.rs
@@ -615,7 +615,7 @@ impl BlobManager {
         let semaphore = Arc::new(Semaphore::new(self.max_concurrent_uploads));
         let mut block_list = BlockList::default();
         let mut block_idx: u32 = 0;
-        let mut upload_tasks: Vec<tokio::task::JoinHandle<Result<()>>> = Vec::new();
+        let mut upload_tasks: Vec<(tokio::task::JoinHandle<Result<()>>, u64)> = Vec::new();
 
         // Read chunks and spawn concurrent block uploads.
         loop {
@@ -638,9 +638,10 @@ impl BlobManager {
                 .await
                 .map_err(|e| CrosstacheError::unknown(format!("Semaphore error: {e}")))?;
             let blob_client = blob_client.clone();
+            let actual_chunk_size = chunk.len() as u64;
             let chunk_bytes = chunk; // Vec<u8> satisfies Into<azure_core::Body>
 
-            upload_tasks.push(tokio::spawn(async move {
+            upload_tasks.push((tokio::spawn(async move {
                 let _permit = permit; // held for the duration of the upload
                 blob_client
                     .put_block(block_id, chunk_bytes)
@@ -649,15 +650,15 @@ impl BlobManager {
                         CrosstacheError::azure_api(format!("Failed to upload block: {e}"))
                     })?;
                 Ok(())
-            }));
+            }), actual_chunk_size));
         }
 
-        // Wait for all block uploads to finish.
-        for task in upload_tasks {
+        // Wait for all block uploads to finish and report progress.
+        for (task, bytes) in upload_tasks {
             task.await
                 .map_err(|e| CrosstacheError::unknown(format!("Upload task panicked: {e}")))?
                 .map_err(|e: CrosstacheError| e)?;
-            reporter.advance(chunk_size as u64);
+            reporter.advance(bytes);
         }
         reporter.finish_clear();
 

--- a/src/blob/manager.rs
+++ b/src/blob/manager.rs
@@ -19,6 +19,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::io::AsyncWrite;
 
+use crate::utils::progress::ProgressReporter;
+
 /// Core blob storage manager
 pub struct BlobManager {
     storage_account: String,
@@ -55,7 +57,7 @@ impl BlobManager {
     }
 
     /// Upload a file to blob storage
-    pub async fn upload_file(&self, request: FileUploadRequest) -> Result<FileInfo> {
+    pub async fn upload_file(&self, request: FileUploadRequest, reporter: &dyn ProgressReporter) -> Result<FileInfo> {
         // Determine content type
         let content_type = request.content_type.unwrap_or_else(|| {
             mime_guess::from_path(&request.name)
@@ -84,6 +86,7 @@ impl BlobManager {
 
         // Store content length before moving request.content
         let content_length = request.content.len() as u64;
+        reporter.set_total(content_length);
 
         // Build SDK Metadata from our HashMap
         let mut sdk_metadata = Metadata::new();
@@ -101,6 +104,8 @@ impl BlobManager {
             .metadata(sdk_metadata)
             .await
             .map_err(|e| CrosstacheError::azure_api(format!("Failed to upload blob: {e}")))?;
+        reporter.advance(content_length);
+        reporter.finish_clear();
 
         // Extract response data and build FileInfo
         let etag = response.etag.to_string();
@@ -340,7 +345,7 @@ impl BlobManager {
     }
 
     /// Download a file from blob storage
-    pub async fn download_file(&self, request: FileDownloadRequest) -> Result<Vec<u8>> {
+    pub async fn download_file(&self, request: FileDownloadRequest, reporter: &dyn ProgressReporter) -> Result<Vec<u8>> {
         // Validate download request parameters
         if request.name.trim().is_empty() {
             return Err(CrosstacheError::config(
@@ -369,8 +374,10 @@ impl BlobManager {
         // Handle empty files specially to avoid HTTP 416 error
         // Azure's get_content() fails with 416 Range Not Satisfiable for 0-byte blobs
         let content_length = properties.blob.properties.content_length;
+        reporter.set_total(content_length);
         if content_length == 0 {
             // Return empty vec for 0-byte files
+            reporter.finish_clear();
             return Ok(Vec::new());
         }
 
@@ -379,6 +386,8 @@ impl BlobManager {
             .get_content()
             .await
             .map_err(|e| CrosstacheError::azure_api(format!("Failed to download blob: {e}")))?;
+        reporter.advance(content_length);
+        reporter.finish_clear();
 
         Ok(blob_content)
     }
@@ -584,9 +593,10 @@ impl BlobManager {
         &self,
         name: &str,
         mut reader: R,
-        _file_size: u64,
+        file_size: u64,
         metadata: HashMap<String, String>,
         tags: HashMap<String, String>,
+        reporter: &dyn ProgressReporter,
     ) -> Result<FileInfo> {
         use tokio::sync::Semaphore;
 
@@ -594,6 +604,7 @@ impl BlobManager {
             .first_or_octet_stream()
             .to_string();
         let chunk_size = self.chunk_size_mb * 1024 * 1024;
+        reporter.set_total(file_size);
 
         // Build blob client.
         let token_credential = self.auth_provider.get_token_credential();
@@ -646,7 +657,9 @@ impl BlobManager {
             task.await
                 .map_err(|e| CrosstacheError::unknown(format!("Upload task panicked: {e}")))?
                 .map_err(|e: CrosstacheError| e)?;
+            reporter.advance(chunk_size as u64);
         }
+        reporter.finish_clear();
 
         if block_list.blocks.is_empty() {
             // Zero-byte file: fall back to a simple put_block_blob so the blob

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -929,17 +929,31 @@ async fn execute_file_upload_recursive(
                 println!("Uploading: {}", local_path_str);
             }
         }
-        let result = execute_file_upload(
-            blob_manager,
-            &local_path_str,
-            Some(file_info.blob_name.clone()), // Use the calculated blob name
-            group.clone(),
-            metadata.clone(),
-            tag.clone(),
-            None, // No content type override for batch uploads
-            config,
-        )
-        .await;
+
+        // Call blob manager directly (not execute_file_upload) to avoid
+        // per-file output that conflicts with MultiProgress rendering.
+        let result = {
+            use crate::blob::models::FileUploadRequest;
+            use std::collections::HashMap;
+
+            let content = std::fs::read(&file_info.local_path).map_err(|e| {
+                CrosstacheError::config(format!(
+                    "Failed to read {}: {e}",
+                    file_info.local_path.display()
+                ))
+            })?;
+            let upload_request = FileUploadRequest {
+                name: file_info.blob_name.clone(),
+                content,
+                content_type: None,
+                groups: group.clone(),
+                metadata: metadata.iter().cloned().collect::<HashMap<_, _>>(),
+                tags: tag.iter().cloned().collect::<HashMap<_, _>>(),
+            };
+            blob_manager
+                .upload_file(upload_request, &NoopReporter)
+                .await
+        };
 
         match result {
             Ok(_) => {
@@ -1275,15 +1289,21 @@ async fn execute_file_download_recursive(
             }
         }
 
-        // Download the file
-        let result = execute_file_download(
-            blob_manager,
-            blob_name,
-            Some(local_path_str.clone()),
-            force,
-            config,
-        )
-        .await;
+        // Call blob manager directly (not execute_file_download) to avoid
+        // per-file output that conflicts with MultiProgress rendering.
+        let result = {
+            use crate::blob::models::FileDownloadRequest;
+
+            let download_request = FileDownloadRequest {
+                name: blob_name.to_string(),
+            };
+            let content = blob_manager
+                .download_file(download_request, &NoopReporter)
+                .await?;
+            std::fs::write(&local_path, content).map_err(|e| {
+                CrosstacheError::config(format!("Failed to write file {}: {e}", local_path_str))
+            })
+        };
 
         match result {
             Ok(_) => {

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -8,6 +8,7 @@ use crate::config::Config;
 use crate::error::{CrosstacheError, Result};
 use crate::utils::format::OutputFormat;
 use crate::utils::output;
+use crate::utils::progress::NoopReporter;
 use std::path::{Path, PathBuf};
 
 pub(crate) async fn execute_file_command(command: FileCommands, config: Config) -> Result<()> {
@@ -354,7 +355,7 @@ async fn execute_file_upload(
     // Upload file
     println!("Uploading file '{file_path}' as '{remote_name}'...");
 
-    let file_info = blob_manager.upload_file(upload_request).await?;
+    let file_info = blob_manager.upload_file(upload_request, &NoopReporter).await?;
     output::success(&format!("Successfully uploaded file '{}'", file_info.name));
     println!("   Size: {} bytes", file_info.size);
     println!("   Content-Type: {}", file_info.content_type);
@@ -393,7 +394,7 @@ async fn execute_file_download(
 
     println!("Downloading file '{name}' to '{output_path}'...");
 
-    let content = blob_manager.download_file(download_request).await?;
+    let content = blob_manager.download_file(download_request, &NoopReporter).await?;
     fs::write(&output_path, content)
         .map_err(|e| CrosstacheError::config(format!("Failed to write file {output_path}: {e}")))?;
     output::success(&format!("Successfully downloaded file '{name}'"));
@@ -1529,7 +1530,7 @@ async fn file_sync_perform_upload(
     if !output_json {
         println!("upload: {} → {blob_name}", info.local_path.display());
     }
-    let uploaded_info = blob_manager.upload_file(upload_request).await?;
+    let uploaded_info = blob_manager.upload_file(upload_request, &NoopReporter).await?;
     sync::set_file_mtime_utc(&info.local_path, uploaded_info.last_modified)?;
     Ok(())
 }
@@ -1555,7 +1556,7 @@ async fn file_sync_perform_download(
     let download_request = FileDownloadRequest {
         name: blob_name.to_string(),
     };
-    let content = blob_manager.download_file(download_request).await?;
+    let content = blob_manager.download_file(download_request, &NoopReporter).await?;
     fs::write(&target, content).map_err(|e| {
         CrosstacheError::config(format!("Failed to write {}: {e}", target.display()))
     })?;

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -8,8 +8,18 @@ use crate::config::Config;
 use crate::error::{CrosstacheError, Result};
 use crate::utils::format::OutputFormat;
 use crate::utils::output;
-use crate::utils::progress::NoopReporter;
+use crate::utils::progress::{self, MultiProgressContext, NoopReporter};
 use std::path::{Path, PathBuf};
+
+fn progress_threshold_bytes(config: &Config) -> u64 {
+    let blob_config = config.get_blob_config();
+    (blob_config.progress_threshold_mb as u64) * 1024 * 1024
+}
+
+fn is_tty() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdout().is_terminal()
+}
 
 pub(crate) async fn execute_file_command(command: FileCommands, config: Config) -> Result<()> {
     // Create blob manager
@@ -296,7 +306,7 @@ async fn execute_file_upload(
     metadata: Vec<(String, String)>,
     tags: Vec<(String, String)>,
     content_type: Option<String>,
-    _config: &Config,
+    config: &Config,
 ) -> Result<()> {
     use crate::blob::models::FileUploadRequest;
     use std::collections::HashMap;
@@ -313,6 +323,7 @@ async fn execute_file_upload(
     // Read file content
     let content = fs::read(file_path)
         .map_err(|e| CrosstacheError::config(format!("Failed to read file {file_path}: {e}")))?;
+    let file_size = content.len() as u64;
 
     if content.is_empty() {
         output::warn(&format!(
@@ -353,9 +364,15 @@ async fn execute_file_upload(
     };
 
     // Upload file
-    println!("Uploading file '{file_path}' as '{remote_name}'...");
+    let threshold = progress_threshold_bytes(config);
+    let tty = is_tty();
+    if !tty {
+        println!("Uploading file '{file_path}' as '{remote_name}'...");
+    }
+    let reporter = progress::create_file_reporter(file_size, threshold, tty);
+    reporter.set_message(format!("Uploading '{remote_name}'..."));
 
-    let file_info = blob_manager.upload_file(upload_request, &NoopReporter).await?;
+    let file_info = blob_manager.upload_file(upload_request, reporter.as_ref()).await?;
     output::success(&format!("Successfully uploaded file '{}'", file_info.name));
     println!("   Size: {} bytes", file_info.size);
     println!("   Content-Type: {}", file_info.content_type);
@@ -371,7 +388,7 @@ async fn execute_file_download(
     name: &str,
     output: Option<String>,
     force: bool,
-    _config: &Config,
+    config: &Config,
 ) -> Result<()> {
     use crate::blob::models::FileDownloadRequest;
     use std::fs;
@@ -392,9 +409,15 @@ async fn execute_file_download(
         name: name.to_string(),
     };
 
-    println!("Downloading file '{name}' to '{output_path}'...");
+    let threshold = progress_threshold_bytes(config);
+    let tty = is_tty();
+    if !tty {
+        println!("Downloading file '{name}' to '{output_path}'...");
+    }
+    let reporter = progress::create_file_reporter(0, threshold, tty);
+    reporter.set_message(format!("Downloading '{name}'..."));
 
-    let content = blob_manager.download_file(download_request, &NoopReporter).await?;
+    let content = blob_manager.download_file(download_request, reporter.as_ref()).await?;
     fs::write(&output_path, content)
         .map_err(|e| CrosstacheError::config(format!("Failed to write file {output_path}: {e}")))?;
     output::success(&format!("Successfully downloaded file '{name}'"));
@@ -874,6 +897,9 @@ async fn execute_file_upload_recursive(
 
     let mut success_count = 0;
     let mut failure_count = 0;
+    let threshold = progress_threshold_bytes(config);
+    let tty = is_tty();
+    let mp = MultiProgressContext::new(all_files.len() as u64, threshold, tty);
 
     // Validate blob name lengths
     for file_info in &all_files {
@@ -896,10 +922,12 @@ async fn execute_file_upload_recursive(
     for file_info in &all_files {
         let local_path_str = file_info.local_path.to_string_lossy();
 
-        if !flatten {
-            println!("Uploading: {} → {}", local_path_str, file_info.blob_name);
-        } else {
-            println!("Uploading: {}", local_path_str);
+        if !tty {
+            if !flatten {
+                println!("Uploading: {} → {}", local_path_str, file_info.blob_name);
+            } else {
+                println!("Uploading: {}", local_path_str);
+            }
         }
         let result = execute_file_upload(
             blob_manager,
@@ -916,16 +944,21 @@ async fn execute_file_upload_recursive(
         match result {
             Ok(_) => {
                 success_count += 1;
+                mp.log(&format!("Uploaded: {}", file_info.blob_name));
+                mp.advance_overall(&file_info.blob_name);
             }
             Err(e) => {
                 output::error(&format!("Failed to upload '{}': {}", local_path_str, e));
                 failure_count += 1;
+                mp.advance_overall(&file_info.blob_name);
                 if !continue_on_error {
                     return Err(e);
                 }
             }
         }
     }
+
+    mp.finish();
 
     // Print summary
     println!();
@@ -1143,6 +1176,9 @@ async fn execute_file_download_recursive(
 
     let mut success_count = 0;
     let mut failure_count = 0;
+    let threshold = progress_threshold_bytes(config);
+    let tty = is_tty();
+    let mp = MultiProgressContext::new(all_files_to_download.len() as u64, threshold, tty);
 
     for file_info in &all_files_to_download {
         let blob_name = &file_info.name;
@@ -1231,10 +1267,12 @@ async fn execute_file_download_recursive(
             continue;
         }
 
-        if !flatten {
-            println!("Downloading: {} → {}", blob_name, local_path_str);
-        } else {
-            println!("Downloading: {}", blob_name);
+        if !tty {
+            if !flatten {
+                println!("Downloading: {} → {}", blob_name, local_path_str);
+            } else {
+                println!("Downloading: {}", blob_name);
+            }
         }
 
         // Download the file
@@ -1250,16 +1288,21 @@ async fn execute_file_download_recursive(
         match result {
             Ok(_) => {
                 success_count += 1;
+                mp.log(&format!("Downloaded: {}", blob_name));
+                mp.advance_overall(blob_name);
             }
             Err(e) => {
                 output::error(&format!("Failed to download '{}': {}", blob_name, e));
                 failure_count += 1;
+                mp.advance_overall(blob_name);
                 if !continue_on_error {
                     return Err(e);
                 }
             }
         }
     }
+
+    mp.finish();
 
     // Print summary
     println!();
@@ -1511,6 +1554,7 @@ async fn file_sync_perform_upload(
     info: &FileUploadInfo,
     blob_name: &str,
     output_json: bool,
+    reporter: &dyn crate::utils::progress::ProgressReporter,
 ) -> Result<()> {
     use crate::blob::models::FileUploadRequest;
     use crate::blob::sync;
@@ -1530,7 +1574,7 @@ async fn file_sync_perform_upload(
     if !output_json {
         println!("upload: {} → {blob_name}", info.local_path.display());
     }
-    let uploaded_info = blob_manager.upload_file(upload_request, &NoopReporter).await?;
+    let uploaded_info = blob_manager.upload_file(upload_request, reporter).await?;
     sync::set_file_mtime_utc(&info.local_path, uploaded_info.last_modified)?;
     Ok(())
 }
@@ -1543,6 +1587,7 @@ async fn file_sync_perform_download(
     blob_name: &str,
     remote_info: &crate::blob::models::FileInfo,
     output_json: bool,
+    reporter: &dyn crate::utils::progress::ProgressReporter,
 ) -> Result<()> {
     use crate::blob::models::FileDownloadRequest;
     use crate::blob::sync;
@@ -1556,7 +1601,7 @@ async fn file_sync_perform_download(
     let download_request = FileDownloadRequest {
         name: blob_name.to_string(),
     };
-    let content = blob_manager.download_file(download_request, &NoopReporter).await?;
+    let content = blob_manager.download_file(download_request, reporter).await?;
     fs::write(&target, content).map_err(|e| {
         CrosstacheError::config(format!("Failed to write {}: {e}", target.display()))
     })?;
@@ -1647,23 +1692,29 @@ async fn execute_file_sync(
         ..Default::default()
     };
     let mut mutated = false;
+    let threshold = progress_threshold_bytes(config);
+    let tty = is_tty() && !dry_run;
 
     match direction {
         SyncDirection::Up => {
             let mut sorted_names: Vec<String> = local_names.iter().cloned().collect();
             sorted_names.sort();
-            for blob_name in sorted_names {
-                let info = local_by_blob.get(&blob_name).unwrap();
-                let (size, mtime) = *local_meta.get(&blob_name).unwrap();
-                let need = match remote_by_name.get(&blob_name) {
+            let mp = MultiProgressContext::new(sorted_names.len() as u64, threshold, tty);
+            for blob_name in &sorted_names {
+                let info = local_by_blob.get(blob_name).unwrap();
+                let (size, mtime) = *local_meta.get(blob_name).unwrap();
+                let need = match remote_by_name.get(blob_name) {
                     None => true,
                     Some(r) => !sync::should_skip_sync_up(size, mtime, r),
                 };
                 if !need {
                     summary.skipped += 1;
-                    if !config.output_json {
+                    if tty {
+                        mp.log(&format!("skip (up to date): {blob_name}"));
+                    } else if !config.output_json {
                         println!("skip (up to date): {blob_name}");
                     }
+                    mp.advance_overall(blob_name);
                     continue;
                 }
                 if dry_run {
@@ -1674,13 +1725,17 @@ async fn execute_file_sync(
                         );
                     }
                     summary.uploaded += 1;
+                    mp.advance_overall(blob_name);
                     continue;
                 }
-                file_sync_perform_upload(blob_manager, info, &blob_name, config.output_json)
+                file_sync_perform_upload(blob_manager, info, blob_name, config.output_json, &NoopReporter)
                     .await?;
                 summary.uploaded += 1;
+                mp.log(&format!("upload: {} → {blob_name}", info.local_path.display()));
+                mp.advance_overall(blob_name);
                 mutated = true;
             }
+            mp.finish();
             file_sync_delete_remote_not_local(
                 blob_manager,
                 direction,
@@ -1698,10 +1753,11 @@ async fn execute_file_sync(
         SyncDirection::Down => {
             let mut remote_names: Vec<String> = remote_by_name.keys().cloned().collect();
             remote_names.sort();
-            for blob_name in remote_names {
-                let remote_info = remote_by_name.get(&blob_name).unwrap();
-                let target = sync::local_path_from_blob(base_path, prefix_ref, &blob_name);
-                sync_assert_safe_local_path(base_path, &target, &blob_name)?;
+            let mp = MultiProgressContext::new(remote_names.len() as u64, threshold, tty);
+            for blob_name in &remote_names {
+                let remote_info = remote_by_name.get(blob_name).unwrap();
+                let target = sync::local_path_from_blob(base_path, prefix_ref, blob_name);
+                sync_assert_safe_local_path(base_path, &target, blob_name)?;
 
                 let need = if !target.exists() {
                     true
@@ -1726,10 +1782,13 @@ async fn execute_file_sync(
                 };
 
                 if !need {
-                    if !config.output_json {
+                    if tty {
+                        mp.log(&format!("skip (up to date): {blob_name}"));
+                    } else if !config.output_json {
                         println!("skip (up to date): {blob_name}");
                     }
                     summary.skipped += 1;
+                    mp.advance_overall(blob_name);
                     continue;
                 }
 
@@ -1738,6 +1797,7 @@ async fn execute_file_sync(
                         println!("download (dry-run): {blob_name} → {}", target.display());
                     }
                     summary.downloaded += 1;
+                    mp.advance_overall(blob_name);
                     continue;
                 }
 
@@ -1745,28 +1805,33 @@ async fn execute_file_sync(
                     blob_manager,
                     base_path,
                     prefix_ref,
-                    &blob_name,
+                    blob_name,
                     remote_info,
                     config.output_json,
+                    &NoopReporter,
                 )
                 .await?;
                 summary.downloaded += 1;
+                mp.log(&format!("download: {blob_name} → {}", target.display()));
+                mp.advance_overall(blob_name);
                 mutated = true;
             }
+            mp.finish();
         }
         SyncDirection::Both => {
             let remote_keys: HashSet<String> = remote_by_name.keys().cloned().collect();
             let all_names: HashSet<String> = local_names.union(&remote_keys).cloned().collect();
             let mut ordered: Vec<String> = all_names.into_iter().collect();
             ordered.sort();
+            let mp = MultiProgressContext::new(ordered.len() as u64, threshold, tty);
 
-            for blob_name in ordered {
-                let local_present = local_meta.contains_key(&blob_name);
-                let remote_present = remote_by_name.contains_key(&blob_name);
+            for blob_name in &ordered {
+                let local_present = local_meta.contains_key(blob_name);
+                let remote_present = remote_by_name.contains_key(blob_name);
 
                 match (local_present, remote_present) {
                     (true, false) => {
-                        let info = local_by_blob.get(&blob_name).unwrap();
+                        let info = local_by_blob.get(blob_name).unwrap();
                         if dry_run {
                             if !config.output_json {
                                 println!(
@@ -1775,51 +1840,62 @@ async fn execute_file_sync(
                                 );
                             }
                             summary.uploaded += 1;
+                            mp.advance_overall(blob_name);
                             continue;
                         }
                         file_sync_perform_upload(
                             blob_manager,
                             info,
-                            &blob_name,
+                            blob_name,
                             config.output_json,
+                            &NoopReporter,
                         )
                         .await?;
                         summary.uploaded += 1;
+                        mp.log(&format!("upload: {} → {blob_name}", info.local_path.display()));
+                        mp.advance_overall(blob_name);
                         mutated = true;
                     }
                     (false, true) => {
-                        let remote_info = remote_by_name.get(&blob_name).unwrap();
-                        let target = sync::local_path_from_blob(base_path, prefix_ref, &blob_name);
-                        sync_assert_safe_local_path(base_path, &target, &blob_name)?;
+                        let remote_info = remote_by_name.get(blob_name).unwrap();
+                        let target = sync::local_path_from_blob(base_path, prefix_ref, blob_name);
+                        sync_assert_safe_local_path(base_path, &target, blob_name)?;
                         if dry_run {
                             if !config.output_json {
                                 println!("download (dry-run): {blob_name} → {}", target.display());
                             }
                             summary.downloaded += 1;
+                            mp.advance_overall(blob_name);
                             continue;
                         }
                         file_sync_perform_download(
                             blob_manager,
                             base_path,
                             prefix_ref,
-                            &blob_name,
+                            blob_name,
                             remote_info,
                             config.output_json,
+                            &NoopReporter,
                         )
                         .await?;
                         summary.downloaded += 1;
+                        mp.log(&format!("download: {blob_name} → {}", target.display()));
+                        mp.advance_overall(blob_name);
                         mutated = true;
                     }
                     (true, true) => {
-                        let info = local_by_blob.get(&blob_name).unwrap();
-                        let (size, mtime) = *local_meta.get(&blob_name).unwrap();
-                        let remote_info = remote_by_name.get(&blob_name).unwrap();
+                        let info = local_by_blob.get(blob_name).unwrap();
+                        let (size, mtime) = *local_meta.get(blob_name).unwrap();
+                        let remote_info = remote_by_name.get(blob_name).unwrap();
                         match sync::resolve_both(size, mtime, remote_info) {
                             BothAction::Skip => {
-                                if !config.output_json {
+                                if tty {
+                                    mp.log(&format!("skip: {blob_name}"));
+                                } else if !config.output_json {
                                     println!("skip: {blob_name}");
                                 }
                                 summary.skipped += 1;
+                                mp.advance_overall(blob_name);
                             }
                             BothAction::Upload => {
                                 if dry_run {
@@ -1830,22 +1906,26 @@ async fn execute_file_sync(
                                         );
                                     }
                                     summary.uploaded += 1;
+                                    mp.advance_overall(blob_name);
                                     continue;
                                 }
                                 file_sync_perform_upload(
                                     blob_manager,
                                     info,
-                                    &blob_name,
+                                    blob_name,
                                     config.output_json,
+                                    &NoopReporter,
                                 )
                                 .await?;
                                 summary.uploaded += 1;
+                                mp.log(&format!("upload: {} → {blob_name}", info.local_path.display()));
+                                mp.advance_overall(blob_name);
                                 mutated = true;
                             }
                             BothAction::Download => {
                                 let target =
-                                    sync::local_path_from_blob(base_path, prefix_ref, &blob_name);
-                                sync_assert_safe_local_path(base_path, &target, &blob_name)?;
+                                    sync::local_path_from_blob(base_path, prefix_ref, blob_name);
+                                sync_assert_safe_local_path(base_path, &target, blob_name)?;
                                 if dry_run {
                                     if !config.output_json {
                                         println!(
@@ -1854,18 +1934,22 @@ async fn execute_file_sync(
                                         );
                                     }
                                     summary.downloaded += 1;
+                                    mp.advance_overall(blob_name);
                                     continue;
                                 }
                                 file_sync_perform_download(
                                     blob_manager,
                                     base_path,
                                     prefix_ref,
-                                    &blob_name,
+                                    blob_name,
                                     remote_info,
                                     config.output_json,
+                                    &NoopReporter,
                                 )
                                 .await?;
                                 summary.downloaded += 1;
+                                mp.log(&format!("download: {blob_name} → {}", target.display()));
+                                mp.advance_overall(blob_name);
                                 mutated = true;
                             }
                         }
@@ -1873,6 +1957,7 @@ async fn execute_file_sync(
                     (false, false) => {}
                 }
             }
+            mp.finish();
 
             if delete {
                 let local_names_after: HashSet<String> = {

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -782,6 +782,7 @@ impl ConfigInitializer {
                 enable_large_file_support: true,
                 chunk_size_mb: 4,
                 max_concurrent_uploads: 3,
+                progress_threshold_mb: 5,
             })
         } else {
             None

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -51,6 +51,7 @@ impl std::str::FromStr for AzureCredentialType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct BlobConfig {
     pub storage_account: String,
     pub container_name: String,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -58,6 +58,7 @@ pub struct BlobConfig {
     pub enable_large_file_support: bool,
     pub chunk_size_mb: usize,
     pub max_concurrent_uploads: usize,
+    pub progress_threshold_mb: usize,
 }
 
 impl Default for BlobConfig {
@@ -69,6 +70,7 @@ impl Default for BlobConfig {
             enable_large_file_support: true,
             chunk_size_mb: 4,
             max_concurrent_uploads: 3,
+            progress_threshold_mb: 5,
         }
     }
 }
@@ -448,6 +450,13 @@ fn load_from_env(config: &mut Config) {
     if let Ok(value) = std::env::var("BLOB_MAX_CONCURRENT_UPLOADS") {
         if let Ok(max_uploads) = value.parse::<usize>() {
             blob_config.max_concurrent_uploads = max_uploads;
+            blob_config_updated = true;
+        }
+    }
+
+    if let Ok(value) = std::env::var("PROGRESS_THRESHOLD_MB") {
+        if let Ok(threshold) = value.parse::<usize>() {
+            blob_config.progress_threshold_mb = threshold;
             blob_config_updated = true;
         }
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,6 +10,7 @@ pub mod helpers;
 pub mod interactive;
 pub mod network;
 pub mod output;
+pub mod progress;
 pub mod resource_detector;
 pub mod retry;
 pub mod sanitizer;

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -25,6 +25,7 @@ fn spinner_style() -> ProgressStyle {
 /// Trait for reporting progress during file operations.
 /// All methods are no-ops by default so that callers can pass a `NoopReporter`
 /// when progress display is unwanted (e.g., non-TTY or tests).
+#[allow(dead_code)]
 pub trait ProgressReporter: Send + Sync {
     fn set_total(&self, total: u64);
     fn advance(&self, amount: u64);
@@ -191,6 +192,8 @@ impl MultiProgressContext {
     }
 
     /// Create a per-file reporter inserted above the overall bar.
+    /// Currently unused — reserved for future per-file byte-level progress in batch ops.
+    #[allow(dead_code)]
     pub fn create_child(&self, file_size: u64, name: &str) -> Box<dyn ProgressReporter> {
         if !self.is_tty {
             return Box::new(NoopReporter);

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -1,0 +1,274 @@
+//! Progress reporting for file operations.
+//!
+//! Provides a trait-based abstraction over `indicatif` so the blob manager
+//! stays UI-free while the CLI layer controls progress rendering.
+
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+/// Trait for reporting progress during file operations.
+/// All methods are no-ops by default so that callers can pass a `NoopReporter`
+/// when progress display is unwanted (e.g., non-TTY or tests).
+pub trait ProgressReporter: Send + Sync {
+    fn set_total(&self, total: u64);
+    fn advance(&self, amount: u64);
+    fn set_message(&self, msg: String);
+    fn finish_with_message(&self, msg: String);
+    fn finish_clear(&self);
+}
+
+// ---------------------------------------------------------------------------
+// NoopReporter
+// ---------------------------------------------------------------------------
+
+/// Does nothing. Used when stdout is not a TTY.
+pub struct NoopReporter;
+
+impl ProgressReporter for NoopReporter {
+    fn set_total(&self, _total: u64) {}
+    fn advance(&self, _amount: u64) {}
+    fn set_message(&self, _msg: String) {}
+    fn finish_with_message(&self, _msg: String) {}
+    fn finish_clear(&self) {}
+}
+
+// ---------------------------------------------------------------------------
+// BarReporter
+// ---------------------------------------------------------------------------
+
+/// Bytes-level progress bar for large files.
+pub struct BarReporter {
+    bar: ProgressBar,
+}
+
+impl BarReporter {
+    pub fn new(total: u64) -> Self {
+        let bar = ProgressBar::new(total);
+        bar.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner:.green} [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+                .expect("valid template")
+                .progress_chars("#>-"),
+        );
+        Self { bar }
+    }
+
+    /// Create a BarReporter managed by a `MultiProgress`.
+    pub fn new_in(mp: &MultiProgress, total: u64) -> Self {
+        let bar = mp.add(ProgressBar::new(total));
+        bar.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner:.green} [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+                .expect("valid template")
+                .progress_chars("#>-"),
+        );
+        Self { bar }
+    }
+}
+
+impl ProgressReporter for BarReporter {
+    fn set_total(&self, total: u64) {
+        self.bar.set_length(total);
+    }
+    fn advance(&self, amount: u64) {
+        self.bar.inc(amount);
+    }
+    fn set_message(&self, msg: String) {
+        self.bar.set_message(msg);
+    }
+    fn finish_with_message(&self, msg: String) {
+        self.bar.finish_with_message(msg);
+    }
+    fn finish_clear(&self) {
+        self.bar.finish_and_clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SpinnerReporter
+// ---------------------------------------------------------------------------
+
+/// Spinner for small files — shows activity without byte-level tracking.
+pub struct SpinnerReporter {
+    bar: ProgressBar,
+}
+
+impl SpinnerReporter {
+    pub fn new(message: &str) -> Self {
+        let bar = ProgressBar::new_spinner();
+        bar.set_style(
+            ProgressStyle::default_spinner()
+                .template("{spinner:.green} {msg}")
+                .expect("valid template"),
+        );
+        bar.set_message(message.to_string());
+        bar.enable_steady_tick(std::time::Duration::from_millis(100));
+        Self { bar }
+    }
+
+    /// Create a SpinnerReporter managed by a `MultiProgress`.
+    pub fn new_in(mp: &MultiProgress, message: &str) -> Self {
+        let bar = mp.add(ProgressBar::new_spinner());
+        bar.set_style(
+            ProgressStyle::default_spinner()
+                .template("{spinner:.green} {msg}")
+                .expect("valid template"),
+        );
+        bar.set_message(message.to_string());
+        bar.enable_steady_tick(std::time::Duration::from_millis(100));
+        Self { bar }
+    }
+}
+
+impl ProgressReporter for SpinnerReporter {
+    fn set_total(&self, _total: u64) {}
+    fn advance(&self, _amount: u64) {}
+    fn set_message(&self, msg: String) {
+        self.bar.set_message(msg);
+    }
+    fn finish_with_message(&self, msg: String) {
+        self.bar.finish_with_message(msg);
+    }
+    fn finish_clear(&self) {
+        self.bar.finish_and_clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/// Create the appropriate reporter for a single-file operation.
+pub fn create_file_reporter(
+    file_size: u64,
+    threshold_bytes: u64,
+    is_tty: bool,
+) -> Box<dyn ProgressReporter> {
+    if !is_tty {
+        return Box::new(NoopReporter);
+    }
+    if file_size >= threshold_bytes {
+        Box::new(BarReporter::new(file_size))
+    } else {
+        Box::new(SpinnerReporter::new(""))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MultiProgressContext
+// ---------------------------------------------------------------------------
+
+/// Manages an overall file-count bar plus per-file child reporters for batch operations.
+pub struct MultiProgressContext {
+    mp: MultiProgress,
+    overall: ProgressBar,
+    threshold_bytes: u64,
+    is_tty: bool,
+}
+
+impl MultiProgressContext {
+    pub fn new(total_files: u64, threshold_bytes: u64, is_tty: bool) -> Self {
+        if !is_tty {
+            return Self {
+                mp: MultiProgress::new(),
+                overall: ProgressBar::hidden(),
+                threshold_bytes,
+                is_tty,
+            };
+        }
+        let mp = MultiProgress::new();
+        let overall = mp.add(ProgressBar::new(total_files));
+        overall.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} files  {msg}")
+                .expect("valid template")
+                .progress_chars("#>-"),
+        );
+        Self {
+            mp,
+            overall,
+            threshold_bytes,
+            is_tty,
+        }
+    }
+
+    /// Create a per-file reporter inserted above the overall bar.
+    pub fn create_child(&self, file_size: u64, name: &str) -> Box<dyn ProgressReporter> {
+        if !self.is_tty {
+            return Box::new(NoopReporter);
+        }
+        if file_size >= self.threshold_bytes {
+            Box::new(BarReporter::new_in(&self.mp, file_size))
+        } else {
+            Box::new(SpinnerReporter::new_in(&self.mp, name))
+        }
+    }
+
+    /// Log a line above the progress bars (completed file status).
+    pub fn log(&self, msg: &str) {
+        if self.is_tty {
+            let _ = self.mp.println(msg);
+        }
+    }
+
+    /// Advance the overall bar by one file and set the current file message.
+    pub fn advance_overall(&self, current_file: &str) {
+        self.overall.inc(1);
+        self.overall.set_message(current_file.to_string());
+    }
+
+    /// Finish and clear all bars.
+    pub fn finish(&self) {
+        self.overall.finish_and_clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_reporter_does_not_panic() {
+        let r = NoopReporter;
+        r.set_total(100);
+        r.advance(50);
+        r.set_message("hello".into());
+        r.finish_with_message("done".into());
+        r.finish_clear();
+    }
+
+    #[test]
+    fn factory_returns_noop_when_not_tty() {
+        let r = create_file_reporter(100_000_000, 5_000_000, false);
+        r.set_total(100);
+        r.advance(50);
+        r.finish_clear();
+    }
+
+    #[test]
+    fn factory_returns_bar_for_large_file_on_tty() {
+        let r = create_file_reporter(10_000_000, 5_000_000, true);
+        r.set_total(10_000_000);
+        r.advance(1_000_000);
+        r.finish_clear();
+    }
+
+    #[test]
+    fn factory_returns_spinner_for_small_file_on_tty() {
+        let r = create_file_reporter(1_000, 5_000_000, true);
+        r.set_total(0);
+        r.advance(0);
+        r.finish_clear();
+    }
+
+    #[test]
+    fn multi_progress_noop_when_not_tty() {
+        let ctx = MultiProgressContext::new(10, 5_000_000, false);
+        let child = ctx.create_child(100, "test.txt");
+        child.set_total(100);
+        child.advance(100);
+        child.finish_clear();
+        ctx.advance_overall("test.txt");
+        ctx.log("done: test.txt");
+        ctx.finish();
+    }
+}

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -5,6 +5,23 @@
 
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
+// ---------------------------------------------------------------------------
+// Private style helpers
+// ---------------------------------------------------------------------------
+
+fn bar_style() -> ProgressStyle {
+    ProgressStyle::default_bar()
+        .template("{spinner:.green} [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+        .expect("valid template")
+        .progress_chars("#>-")
+}
+
+fn spinner_style() -> ProgressStyle {
+    ProgressStyle::default_spinner()
+        .template("{spinner:.green} {msg}")
+        .expect("valid template")
+}
+
 /// Trait for reporting progress during file operations.
 /// All methods are no-ops by default so that callers can pass a `NoopReporter`
 /// when progress display is unwanted (e.g., non-TTY or tests).
@@ -43,24 +60,14 @@ pub struct BarReporter {
 impl BarReporter {
     pub fn new(total: u64) -> Self {
         let bar = ProgressBar::new(total);
-        bar.set_style(
-            ProgressStyle::default_bar()
-                .template("{spinner:.green} [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
-                .expect("valid template")
-                .progress_chars("#>-"),
-        );
+        bar.set_style(bar_style());
         Self { bar }
     }
 
     /// Create a BarReporter managed by a `MultiProgress`.
     pub fn new_in(mp: &MultiProgress, total: u64) -> Self {
         let bar = mp.add(ProgressBar::new(total));
-        bar.set_style(
-            ProgressStyle::default_bar()
-                .template("{spinner:.green} [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
-                .expect("valid template")
-                .progress_chars("#>-"),
-        );
+        bar.set_style(bar_style());
         Self { bar }
     }
 }
@@ -95,11 +102,7 @@ pub struct SpinnerReporter {
 impl SpinnerReporter {
     pub fn new(message: &str) -> Self {
         let bar = ProgressBar::new_spinner();
-        bar.set_style(
-            ProgressStyle::default_spinner()
-                .template("{spinner:.green} {msg}")
-                .expect("valid template"),
-        );
+        bar.set_style(spinner_style());
         bar.set_message(message.to_string());
         bar.enable_steady_tick(std::time::Duration::from_millis(100));
         Self { bar }
@@ -108,11 +111,7 @@ impl SpinnerReporter {
     /// Create a SpinnerReporter managed by a `MultiProgress`.
     pub fn new_in(mp: &MultiProgress, message: &str) -> Self {
         let bar = mp.add(ProgressBar::new_spinner());
-        bar.set_style(
-            ProgressStyle::default_spinner()
-                .template("{spinner:.green} {msg}")
-                .expect("valid template"),
-        );
+        bar.set_style(spinner_style());
         bar.set_message(message.to_string());
         bar.enable_steady_tick(std::time::Duration::from_millis(100));
         Self { bar }

--- a/tests/file_commands_tests.rs
+++ b/tests/file_commands_tests.rs
@@ -25,6 +25,7 @@ fn create_test_config() -> Config {
             enable_large_file_support: true,
             chunk_size_mb: 4,
             max_concurrent_uploads: 3,
+            progress_threshold_mb: 5,
         }),
         ..Default::default()
     }


### PR DESCRIPTION
## Summary

- Add `ProgressReporter` trait with bar/spinner/noop implementations for file operation progress feedback
- Configurable size threshold (`progress_threshold_mb`, default 5 MB) determines bar vs spinner
- TTY-aware: progress bars on interactive terminals, suppressed when piped
- `MultiProgressContext` for batch operations (recursive upload/download, sync) with overall file-count bar and per-file log lines
- Wire reporters into blob manager's `upload_file`, `download_file`, and `upload_large_file` methods

### What users see

| Operation | TTY | Non-TTY |
|-----------|-----|---------|
| Single upload (large) | Bytes progress bar | "Uploading..." text |
| Single upload (small) | Spinner | "Uploading..." text |
| Recursive upload | Overall file-count bar + per-file log | Per-file println (unchanged) |
| Sync | Overall action-count bar + per-action log | Per-action println (unchanged) |

### Files changed

- **New:** `src/utils/progress.rs` — ProgressReporter trait, BarReporter, SpinnerReporter, NoopReporter, MultiProgressContext
- **Modified:** `src/config/settings.rs` — `progress_threshold_mb` in BlobConfig with `#[serde(default)]`
- **Modified:** `src/blob/manager.rs` — reporter parameter on upload/download methods
- **Modified:** `src/cli/file_ops.rs` — real reporters in single ops, MultiProgress in batch/sync ops

## Test plan

- [x] All 211 unit tests pass
- [x] `cargo clippy --all-targets` clean (no new warnings)
- [ ] Manual test: `xv file upload` large file shows bytes progress bar
- [ ] Manual test: `xv file upload -r` shows overall file-count bar with per-file log
- [ ] Manual test: `xv file sync` shows progress for each direction
- [ ] Manual test: pipe output (`xv file upload ... | cat`) suppresses progress bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core file operation code paths and changes `BlobManager` method signatures, so regressions could impact uploads/downloads or CLI output behavior. Progress display is suppressed on non-TTY, reducing risk for scripted usage.
> 
> **Overview**
> Adds a new `utils::progress` module that introduces a `ProgressReporter` abstraction (bar/spinner/noop) plus `MultiProgressContext` for batch-style progress rendering.
> 
> Wires progress reporting through the blob layer by adding a `reporter: &dyn ProgressReporter` parameter to `BlobManager`’s `upload_file`, `download_file`, and `upload_large_file`, and emitting `set_total`/`advance`/`finish_clear` calls.
> 
> Updates `xv file` CLI operations to create reporters based on stdout TTY detection and a new `progress_threshold_mb` blob config (default 5MB, env `PROGRESS_THRESHOLD_MB`), and uses an overall file-count progress bar for recursive upload/download and sync while keeping non-TTY output largely unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 156290445cac35449b93243cacb0414e1bd476b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->