### PR TITLE
feat: list-style pagination (xv list / vault list / file list / share)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ xv find "api"                             # Fuzzy search by name pattern
 xv list                                   # List all secrets (alias: ls)
 xv list --group production                # Filter by group
 xv list --expiring 30d                    # Show secrets expiring soon
+xv list --page-size 50 --page 2           # Paginate list output
 xv update "api-key" --group prod --note "Frontend key"
 xv delete "api-key"                       # Soft-delete (alias: rm)
 xv delete --group legacy --force          # Bulk delete by group
@@ -151,6 +152,7 @@ xv rotate "api-key" --show-value          # Display the generated value
 ```bash
 xv vault create my-vault --resource-group my-rg --location eastus
 xv vault list
+xv vault list --page-size 25 --page 2
 xv vault info my-vault
 xv vault delete my-vault
 xv vault restore my-vault                 # Restore soft-deleted vault
@@ -211,6 +213,8 @@ Optional blob storage for files (requires setup via `xv init`):
 xv upload ./config.json
 xv download config.json
 xv file list
+xv file list --page-size 100 --page 3
+xv file list --limit 100                       # First page compatibility alias
 xv file info config.json                       # File metadata
 xv file upload ./docs --recursive              # Preserves directory structure
 xv file download "docs" --recursive --output ./local
@@ -231,6 +235,7 @@ xv info my-vault                          # Resource info (vault, secret, or fil
 xv share grant "api-key"                  # Grant access to a secret
 xv share revoke "api-key"                 # Revoke access to a secret
 xv share list "api-key"                   # List access permissions
+xv share list "api-key" --page-size 25    # Paginate access permissions
 xv audit "api-key"                        # Access/change history
 xv audit --vault my-vault                 # Vault-wide activity
 xv audit --vault my-vault --days 7        # Last 7 days only

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -10,7 +10,7 @@
 |---------|-------------|
 | `xv set <name>` | Create a secret (interactive prompt, `--stdin`, or bulk `K1=v1 K2=v2`) |
 | `xv get <name>` | Retrieve a secret (clipboard by default; `--raw` for stdout) |
-| `xv list` | List secrets (`--group`, `--all`, `--expiring <period>`, `--expired`) |
+| `xv list` | List secrets (`--group`, `--all`, `--expiring <period>`, `--expired`, `--page-size`, `--page`) |
 | `xv delete <name>` | Soft-delete a secret (`--force` to skip confirmation) |
 | `xv update <name>` | Update value, groups, folder, note, tags, expiry; supports `--rename` |
 | `xv purge <name>` | Permanently delete a soft-deleted secret |
@@ -49,7 +49,7 @@ Names are automatically sanitized for backend compatibility (Azure: alphanumeric
 | Command | Description |
 |---------|-------------|
 | `xv vault create <name>` | Create a new vault (`--resource-group`, `--location`) |
-| `xv vault list` | List vaults |
+| `xv vault list` | List vaults (`--page-size`, `--page`) |
 | `xv vault info <name>` | Show vault details |
 | `xv vault delete <name>` | Soft-delete a vault |
 | `xv vault restore <name>` | Restore a soft-deleted vault |
@@ -64,10 +64,10 @@ Names are automatically sanitized for backend compatibility (Azure: alphanumeric
 |---------|-------------|
 | `xv vault share grant` | Grant vault access (reader, contributor, admin) |
 | `xv vault share revoke` | Revoke vault access |
-| `xv vault share list` | List vault access assignments |
+| `xv vault share list` | List vault access assignments (`--page-size`, `--page`) |
 | `xv share grant` | Grant secret-level access |
 | `xv share revoke` | Revoke secret-level access |
-| `xv share list` | List secret permissions |
+| `xv share list` | List secret permissions (`--page-size`, `--page`) |
 
 ---
 
@@ -99,7 +99,7 @@ Requires blob storage setup via `xv init`. Gated behind the `file-ops` feature f
 | `xv download <file>` | Quick download (alias for `xv file download`) |
 | `xv file upload` | Upload files (`--recursive`, `--prefix`, `--flatten`) |
 | `xv file download` | Download files (`--recursive`, `--flatten`, `--output`, `--force`) |
-| `xv file list` | List files (hierarchical by default; `--recursive` for flat) |
+| `xv file list` | List files (hierarchical by default; `--recursive` for flat; `--page-size`, `--page`, `--limit`) |
 | `xv file delete` | Delete files (`-r`, `-f`, `-i`, `--dry-run`, `--verbose`, `--force`, `--continue-on-error`, glob patterns) |
 | `xv file info` | File metadata |
 | `xv file sync` | Sync local directory with blob prefix (`--direction` up/down/both, `--dry-run`, `--delete`) |

--- a/docs/plans/2026-04-28-list-pagination-plan.md
+++ b/docs/plans/2026-04-28-list-pagination-plan.md
@@ -1,0 +1,263 @@
+# List Commands Pagination — Implementation Plan
+
+**Goal:** Add user-visible pagination to `xv` list-style commands without changing default output or breaking machine-readable consumers.
+
+**Non-goals:**
+
+- Do not change Azure API traversal semantics. Secrets and vaults already follow Azure `nextLink`; blobs already stream SDK pages. This plan adds CLI result pagination after filtering/sorting.
+- Do not implement cursor/token pagination in the first pass.
+- Do not wrap existing JSON/YAML/CSV array outputs with metadata, because that would break scripts.
+
+**Assumptions from repo inspection:**
+
+- Top-level `xv list` is the secret list command in `src/cli/commands.rs` and dispatches to `execute_secret_list_direct()` in `src/cli/secret_ops.rs`.
+- `xv vault list` is in `VaultCommands::List` and dispatches through `src/cli/vault_ops.rs` to `VaultManager::list_vaults_formatted()`.
+- `xv file list` already has `--limit`, but truncation currently happens in `BlobManager::list_files_hierarchical()` via `FileListRequest.limit`; pagination should move to the CLI/display layer so page 2+ can work.
+- Access list commands also collect full result vectors before formatting: `xv share list <secret>` and `xv vault share list <vault>`.
+- Cache entries should continue storing full unpaginated list results, not page slices.
+
+---
+
+## Proposed CLI UX
+
+Add common flags to list commands:
+
+```text
+--page <N>          1-based page number; default 1 when --page-size/--limit is used
+--page-size <N>     number of rows per page
+```
+
+Behavior:
+
+- With no pagination flags: unchanged output.
+- With `--page-size N`: show only rows for page 1.
+- With `--page P --page-size N`: show rows for that page.
+- `--page` without `--page-size` should be rejected with a clear clap/config error.
+- Values must be positive integers.
+- Human formats (`table`, `plain`, `raw`) get a footer like:
+
+```text
+Showing 51-100 of 137 item(s) — page 2 of 3
+Next page: xv list --page 3 --page-size 50
+```
+
+- Machine formats (`json`, `yaml`, `csv`, `template`) output only the paged rows and no footer.
+- Existing `xv file list --limit N` remains supported as a backward-compatible alias for `--page-size N` on page 1. If both `--limit` and `--page-size` are provided, error.
+
+---
+
+## Task 1 — Add reusable pagination primitives
+
+**Files:**
+
+- Create `src/utils/pagination.rs`
+- Modify `src/utils/mod.rs`
+- Modify `src/cli/commands.rs` or a small `src/cli/pagination.rs` helper if keeping CLI args separate is cleaner
+
+Implementation shape:
+
+- Add a `PaginationArgs` clap struct with optional `page: Option<usize>` and `page_size: Option<usize>`.
+- Add a runtime `Pagination` struct with `page: usize` and `page_size: Option<usize>`.
+- Add `Pagination::from_args(page, page_size)` validation:
+  - `page == Some(0)` or `page_size == Some(0)` => error
+  - `page.is_some() && page_size.is_none()` => error
+  - no flags => disabled pagination
+- Add `paginate_slice<T: Clone>(items: &[T], pagination: Pagination) -> Page<T>`.
+- `Page<T>` should include:
+  - `items: Vec<T>`
+  - `total_items: usize`
+  - `page: usize`
+  - `page_size: Option<usize>`
+  - `total_pages: Option<usize>`
+  - `start_index_1_based: Option<usize>`
+  - `end_index_1_based: Option<usize>`
+
+Design note: keep this generic and output-format agnostic. Formatting footer text should live near CLI display code, not in the helper.
+
+Validation gate:
+
+- Unit tests for disabled pagination, first page, middle page, last partial page, page past end, zero values, and `--page` without `--page-size`.
+
+---
+
+## Task 2 — Wire pagination into secret list (`xv list`)
+
+**Files:**
+
+- `src/cli/commands.rs`
+- `src/cli/secret_ops.rs`
+
+Steps:
+
+1. Add `--page` and `--page-size` to `Commands::List`.
+2. Pass pagination args through `Cli::execute()` into `execute_secret_list_direct()` and then `execute_secret_list()`.
+3. In `execute_secret_list()`:
+   - keep fetching `all_secrets` exactly as today for cache correctness;
+   - apply existing `--all`, `--group`, `--expired`, and `--expiring` filters;
+   - paginate the filtered `secrets` vector immediately before formatting;
+   - format only `page.items`;
+   - return the original `all_secrets` for cache writes.
+4. In `display_cached_secret_list()`, apply the same filtering and pagination before formatting cached data.
+5. Add a human-only footer after the existing count line. For machine formats, print no extra metadata.
+
+Important compatibility point: the existing count line says e.g. `12 secret(s) in vault 'x'`. For paginated output, make it clear this is page count versus total, e.g. `Showing 10 of 137 secret(s) in vault 'x'` or use a separate footer.
+
+Validation gate:
+
+- Clap parse test for `xv list --page-size 25 --page 2`.
+- Unit/helper test that filtering happens before pagination.
+- Existing cache behavior remains: cache key is still `SecretsList { vault_name }`, and cache stores all secrets.
+
+---
+
+## Task 3 — Wire pagination into vault list (`xv vault list`)
+
+**Files:**
+
+- `src/cli/commands.rs`
+- `src/cli/vault_ops.rs`
+- Optionally `src/vault/manager.rs` if display responsibility stays there
+
+Recommended small refactor:
+
+- Keep `VaultManager::list_vaults_formatted()` available if other callers need it, but for `execute_vault_list()` prefer fetching raw vaults then formatting in CLI code so caching and pagination stay together.
+- Alternatively add a `pagination` parameter to `list_vaults_formatted()` and ensure it returns the full unpaginated `Vec<VaultSummary>`.
+
+Steps:
+
+1. Add `--page` and `--page-size` to `VaultCommands::List`.
+2. On cache hit, paginate cached `Vec<VaultSummary>` before formatting.
+3. On cache miss, fetch full vault list, write full list to cache, paginate only for display.
+4. Preserve `--format` behavior and current `auto` resolution.
+
+Validation gate:
+
+- Clap/help tests for `xv vault list --page-size 50 --page 2`.
+- Cache test or focused unit test proving cached data is not page-sliced.
+
+---
+
+## Task 4 — Convert file list `--limit` into page-size-compatible pagination
+
+**Files:**
+
+- `src/cli/file.rs`
+- `src/cli/file_ops.rs`
+- `src/blob/models.rs`
+- `src/blob/manager.rs`
+- `tests/file_commands_tests.rs`
+
+Steps:
+
+1. Add `--page` and `--page-size` to `FileCommands::List`.
+2. Keep existing `--limit` as compatibility syntax.
+3. Resolve file pagination rules in `execute_file_list()`:
+   - no pagination and no limit => unchanged;
+   - `--limit N` => `page_size=N`, `page=1`;
+   - `--page-size N` => `page_size=N`, `page=page.unwrap_or(1)`;
+   - both `--limit` and `--page-size` => error.
+4. Stop passing user pagination as `FileListRequest.limit` for normal display; fetch the full filtered/sorted list, then paginate in `file_ops`.
+5. Either remove `FileListRequest.limit` in a later cleanup or leave it unused for now with a comment; do not let it pre-truncate data needed for page 2+.
+6. Adjust cache logic:
+   - pagination-only flags should still allow cache use because the cached value is full list data;
+   - prefix/group/recursive still define the underlying result set.
+7. Apply pagination before `display_file_list_items()`.
+8. Add human-only footer after the existing file/directory count.
+
+Validation gate:
+
+- Update existing `tests/file_commands_tests.rs` to verify `limit`, `page`, and `page_size` parsing.
+- Add helper tests that page 2 for a synthetic list returns the expected files.
+- Verify `--limit` behavior remains page 1 truncation.
+
+---
+
+## Task 5 — Add pagination to access list commands
+
+**Files:**
+
+- `src/cli/commands.rs`
+- `src/cli/secret_ops.rs`
+- `src/cli/vault_ops.rs`
+
+Commands:
+
+- `xv share list <secret-name>`
+- `xv vault share list <vault-name>`
+
+Steps:
+
+1. Add `--page` and `--page-size` to `ShareCommands::List` and `VaultShareCommands::List`.
+2. After role resolution/filtering (`resolve_and_filter_roles()`), paginate roles before formatting.
+3. Use the common human-only footer.
+4. Keep service account filtering (`--all`) before pagination.
+
+Validation gate:
+
+- Clap parse/help tests for both commands.
+- Unit/helper tests over a synthetic `Vec<VaultRole>` if practical.
+
+---
+
+## Task 6 — Documentation and examples
+
+**Files:**
+
+- `README.md`
+- Possibly `docs/FEATURES.md`
+
+Add concise examples:
+
+```bash
+xv list --page-size 50
+xv list --page 2 --page-size 50
+xv vault list --page-size 25
+xv file list --page-size 100 --page 3
+xv file list --limit 100          # compatibility alias for first page
+```
+
+Document that pagination is applied after filters:
+
+```bash
+xv list --group prod --page-size 20 --page 2
+```
+
+Mention that machine formats return only selected rows and no footer.
+
+---
+
+## Task 7 — Tests and quality gates
+
+Preferred gates:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+```
+
+Focused tests if full suite is slow or Azure-dependent:
+
+```bash
+cargo test pagination
+cargo test --test cli_integration_tests -- --nocapture
+cargo test --test file_commands_tests -- --nocapture
+```
+
+Current local caveat from this planning session: `cargo` was not installed/available in PATH on the host, so implementation verification needs either Rust tooling installed or a dev environment/container with cargo.
+
+---
+
+## Risks and mitigations
+
+- **Breaking JSON/YAML/CSV consumers:** Do not add metadata wrappers by default. Keep machine output as arrays/rows only.
+- **Cache stores page slices by accident:** Always cache pre-pagination vectors.
+- **File page 2 impossible if blob manager truncates early:** Move limit/pagination out of `BlobManager` into `file_ops` display flow.
+- **Ambiguous `--limit` vs `--page-size`:** Keep `--limit` only for file list compatibility and reject combinations with `--page-size`.
+- **Large result sets still fetched fully:** This matches existing behavior. A later cursor/server-side pagination feature can optimize network/memory separately.
+
+---
+
+## Smallest useful first milestone
+
+Implement common pagination helper plus `xv list` secret pagination only. That exercises the cache, filtering-before-pagination, table footer, and machine-output compatibility patterns before applying the same structure to vault/file/access list commands.

--- a/src/blob/manager.rs
+++ b/src/blob/manager.rs
@@ -580,6 +580,7 @@ impl BlobManager {
     /// After the commit, blob properties are fetched so that the returned
     /// [`FileInfo`] contains the real server-side `size`, `etag`, and
     /// `last_modified` values.
+    #[allow(dead_code)]
     pub async fn upload_large_file<R: tokio::io::AsyncRead + Unpin>(
         &self,
         name: &str,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -9,4 +9,5 @@ pub mod models;
 pub mod refresh;
 
 pub use manager::CacheManager;
+#[allow(unused_imports)]
 pub use models::{CacheEntry, CacheEntryType, CacheKey, CacheStatus};

--- a/src/cache/models.rs
+++ b/src/cache/models.rs
@@ -5,7 +5,7 @@
 use chrono::{DateTime, Utc};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// A cached response stored on disk as JSON.
 #[derive(Debug, Serialize, Deserialize)]
@@ -19,6 +19,7 @@ pub struct CacheEntry<T: Serialize + DeserializeOwned> {
 }
 
 /// The type of listing operation that produced this cache entry.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum CacheEntryType {
     SecretsList,
@@ -27,6 +28,7 @@ pub enum CacheEntryType {
 }
 
 /// Identifies a cache entry and determines its file path.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
 pub enum CacheKey {
     SecretsList { vault_name: String },
@@ -36,7 +38,7 @@ pub enum CacheKey {
 
 impl CacheKey {
     /// Resolve this key to its file path under the given cache directory.
-    pub fn to_path(&self, cache_dir: &PathBuf) -> PathBuf {
+    pub fn to_path(&self, cache_dir: &Path) -> PathBuf {
         match self {
             CacheKey::SecretsList { vault_name } => {
                 cache_dir.join(vault_name).join("secrets-list.json")
@@ -151,6 +153,7 @@ pub struct CacheEntryInfo {
     pub key: String,
     pub created_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
+    #[allow(dead_code)]
     pub size_bytes: u64,
     pub is_stale: bool,
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -161,10 +161,16 @@ impl CharsetType {
     /// Get the character set string for this type
     pub fn chars(&self) -> &'static str {
         match self {
-            CharsetType::Alphanumeric => "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
-            CharsetType::AlphanumericSymbols => "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+-=[]{}|;:,.<>?",
+            CharsetType::Alphanumeric => {
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+            }
+            CharsetType::AlphanumericSymbols => {
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+-=[]{}|;:,.<>?"
+            }
             CharsetType::Hex => "0123456789ABCDEF",
-            CharsetType::Base64 => "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",
+            CharsetType::Base64 => {
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+            }
             CharsetType::Numeric => "0123456789",
             CharsetType::Uppercase => "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
             CharsetType::Lowercase => "abcdefghijklmnopqrstuvwxyz",
@@ -268,6 +274,15 @@ pub enum Commands {
         /// Bypass the local cache and fetch fresh data
         #[arg(long)]
         no_cache: bool,
+        /// Page number to display (requires --page-size)
+        #[arg(long)]
+        page: Option<usize>,
+        /// Number of rows per page
+        #[arg(long)]
+        page_size: Option<usize>,
+        /// Use an interactive pager for TTY output
+        #[arg(long)]
+        pager: bool,
     },
     /// Delete a secret from the current vault context (alias: rm)
     #[command(alias = "rm")]
@@ -619,6 +634,15 @@ pub enum VaultCommands {
         /// Bypass the local cache and fetch fresh data
         #[arg(long)]
         no_cache: bool,
+        /// Page number to display (requires --page-size)
+        #[arg(long)]
+        page: Option<usize>,
+        /// Number of rows per page
+        #[arg(long)]
+        page_size: Option<usize>,
+        /// Use an interactive pager for TTY output
+        #[arg(long)]
+        pager: bool,
     },
     /// Delete a vault
     Delete {
@@ -784,6 +808,15 @@ pub enum VaultShareCommands {
         /// Include service accounts in output
         #[arg(long)]
         all: bool,
+        /// Page number to display (requires --page-size)
+        #[arg(long)]
+        page: Option<usize>,
+        /// Number of rows per page
+        #[arg(long)]
+        page_size: Option<usize>,
+        /// Use an interactive pager for TTY output
+        #[arg(long)]
+        pager: bool,
     },
 }
 
@@ -813,6 +846,15 @@ pub enum ShareCommands {
         /// Include service accounts in output
         #[arg(long)]
         all: bool,
+        /// Page number to display (requires --page-size)
+        #[arg(long)]
+        page: Option<usize>,
+        /// Number of rows per page
+        #[arg(long)]
+        page_size: Option<usize>,
+        /// Use an interactive pager for TTY output
+        #[arg(long)]
+        pager: bool,
     },
 }
 
@@ -1003,9 +1045,13 @@ impl Cli {
                 expiring,
                 expired,
                 no_cache,
+                page,
+                page_size,
+                pager,
             } => {
+                let pagination = crate::utils::pagination::Pagination::from_args(page, page_size)?;
                 crate::cli::secret_ops::execute_secret_list_direct(
-                    group, all, expiring, expired, no_cache, config,
+                    group, all, expiring, expired, no_cache, pagination, pager, config,
                 )
                 .await
             }
@@ -1312,6 +1358,133 @@ mod tests {
         assert!("alpha".parse::<CharsetType>().is_err());
         assert!("unknown".parse::<CharsetType>().is_err());
         assert!("".parse::<CharsetType>().is_err());
+    }
+
+    #[test]
+    fn test_secret_list_pagination_args_parse() {
+        let cli =
+            Cli::try_parse_from(["xv", "list", "--page-size", "25", "--page", "2", "--pager"])
+                .unwrap();
+
+        match cli.command {
+            Commands::List {
+                page,
+                page_size,
+                pager,
+                ..
+            } => {
+                assert_eq!(page, Some(2));
+                assert_eq!(page_size, Some(25));
+                assert!(pager);
+            }
+            _ => panic!("Expected List command"),
+        }
+    }
+
+    #[test]
+    fn test_vault_list_pagination_args_parse() {
+        let cli = Cli::try_parse_from([
+            "xv",
+            "vault",
+            "list",
+            "--page-size",
+            "50",
+            "--page",
+            "3",
+            "--pager",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Vault {
+                command:
+                    VaultCommands::List {
+                        page,
+                        page_size,
+                        pager,
+                        ..
+                    },
+            } => {
+                assert_eq!(page, Some(3));
+                assert_eq!(page_size, Some(50));
+                assert!(pager);
+            }
+            _ => panic!("Expected vault list command"),
+        }
+    }
+
+    #[test]
+    fn test_share_list_pagination_args_parse() {
+        let cli = Cli::try_parse_from([
+            "xv",
+            "share",
+            "list",
+            "api-key",
+            "--page-size",
+            "10",
+            "--page",
+            "2",
+            "--pager",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Share {
+                command:
+                    ShareCommands::List {
+                        secret_name,
+                        page,
+                        page_size,
+                        pager,
+                        ..
+                    },
+            } => {
+                assert_eq!(secret_name, "api-key");
+                assert_eq!(page, Some(2));
+                assert_eq!(page_size, Some(10));
+                assert!(pager);
+            }
+            _ => panic!("Expected share list command"),
+        }
+    }
+
+    #[test]
+    fn test_vault_share_list_pagination_args_parse() {
+        let cli = Cli::try_parse_from([
+            "xv",
+            "vault",
+            "share",
+            "list",
+            "prod-vault",
+            "--page-size",
+            "10",
+            "--page",
+            "2",
+            "--pager",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Vault {
+                command:
+                    VaultCommands::Share {
+                        command:
+                            VaultShareCommands::List {
+                                vault_name,
+                                page,
+                                page_size,
+                                pager,
+                                ..
+                            },
+                    },
+            } => {
+                assert_eq!(vault_name, "prod-vault");
+                assert_eq!(page, Some(2));
+                assert_eq!(page_size, Some(10));
+                assert!(pager);
+            }
+            _ => panic!("Expected vault share list command"),
+        }
     }
 
     // ── gen command unit tests ───────────────────────────────────────────────

--- a/src/cli/file.rs
+++ b/src/cli/file.rs
@@ -80,6 +80,15 @@ pub enum FileCommands {
         /// Maximum number of results
         #[arg(long)]
         limit: Option<usize>,
+        /// Page number to display (requires --page-size)
+        #[arg(long)]
+        page: Option<usize>,
+        /// Number of rows per page
+        #[arg(long)]
+        page_size: Option<usize>,
+        /// Use an interactive pager for TTY output
+        #[arg(long)]
+        pager: bool,
         /// List all files recursively (show all nested files instead of directory structure)
         #[arg(short, long)]
         recursive: bool,

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -8,6 +8,7 @@ use crate::config::Config;
 use crate::error::{CrosstacheError, Result};
 use crate::utils::format::OutputFormat;
 use crate::utils::output;
+use crate::utils::pagination::Pagination;
 use std::path::{Path, PathBuf};
 
 pub(crate) async fn execute_file_command(command: FileCommands, config: Config) -> Result<()> {
@@ -167,14 +168,38 @@ pub(crate) async fn execute_file_command(command: FileCommands, config: Config) 
             prefix,
             group,
             limit,
+            page,
+            page_size,
+            pager,
             recursive,
             no_cache,
         } => {
+            use crate::utils::pagination::Pagination;
+
+            if limit.is_some() && page_size.is_some() {
+                return Err(CrosstacheError::invalid_argument(
+                    "--limit cannot be combined with --page-size; use --page-size instead",
+                ));
+            }
+
+            if limit.is_some() && page.is_some() {
+                return Err(CrosstacheError::invalid_argument(
+                    "--limit shows the first page only and cannot be combined with --page",
+                ));
+            }
+
+            let pagination = if limit.is_some() {
+                Pagination::first_page_with_size(limit)?
+            } else {
+                Pagination::from_args(page, page_size)?
+            };
+
             execute_file_list(
                 &blob_manager,
                 prefix,
                 group,
-                limit,
+                pagination,
+                pager,
                 recursive,
                 no_cache,
                 &config,
@@ -409,19 +434,21 @@ fn display_file_list_items(
     items: &[crate::blob::models::BlobListItem],
     recursive: bool,
     config: &Config,
-) -> Result<()> {
+) -> Result<String> {
     use crate::blob::manager::format_size;
     use crate::blob::models::BlobListItem;
     use crate::utils::format::TableFormatter;
     use serde::Serialize;
+    use std::fmt::Write as _;
     use tabled::Tabled;
 
     if items.is_empty() {
         output::info("No files found");
-        return Ok(());
+        return Ok(String::new());
     }
 
     let fmt = config.runtime_output_format.resolve_for_stdout();
+    let mut output = String::new();
 
     // Rows for `--format csv`: machine-oriented fields (not `format_size()` / joined strings).
     #[derive(Tabled, Serialize)]
@@ -463,13 +490,13 @@ fn display_file_list_items(
             let json_output = serde_json::to_string_pretty(items).map_err(|e| {
                 CrosstacheError::serialization(format!("Failed to serialize items: {e}"))
             })?;
-            println!("{json_output}");
+            output.push_str(&json_output);
         }
         OutputFormat::Yaml => {
             let yaml_output = serde_yaml::to_string(items).map_err(|e| {
                 CrosstacheError::serialization(format!("Failed to serialize items: {e}"))
             })?;
-            println!("{yaml_output}");
+            output.push_str(&yaml_output);
         }
         OutputFormat::Csv => {
             let csv_rows: Vec<FileListCsvRow> = items
@@ -503,7 +530,7 @@ fn display_file_list_items(
                 })
                 .collect();
             let formatter = TableFormatter::new(fmt, config.no_color, config.template.clone());
-            println!("{}", formatter.format_table(&csv_rows)?);
+            output.push_str(&formatter.format_table(&csv_rows)?);
         }
         OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw => {
             let display_items: Vec<ListItem> = items
@@ -527,7 +554,7 @@ fn display_file_list_items(
                 .collect();
 
             let formatter = TableFormatter::new(fmt, config.no_color, config.template.clone());
-            println!("{}", formatter.format_table(&display_items)?);
+            output.push_str(&formatter.format_table(&display_items)?);
 
             let file_count = items
                 .iter()
@@ -539,11 +566,18 @@ fn display_file_list_items(
                 .count();
 
             if recursive {
-                println!("\nTotal files: {}", file_count);
+                output.push('\n');
+                let _ = writeln!(output, "Total files: {}", file_count);
             } else if dir_count > 0 {
-                println!("\nTotal: {} directories, {} files", dir_count, file_count);
+                output.push('\n');
+                let _ = writeln!(
+                    output,
+                    "Total: {} directories, {} files",
+                    dir_count, file_count
+                );
             } else {
-                println!("\nTotal files: {}", file_count);
+                output.push('\n');
+                let _ = writeln!(output, "Total files: {}", file_count);
             }
         }
         OutputFormat::Template => {
@@ -567,25 +601,27 @@ fn display_file_list_items(
                 })
                 .collect();
             let formatter = TableFormatter::new(fmt, config.no_color, config.template.clone());
-            println!("{}", formatter.format_table(&display_items)?);
+            output.push_str(&formatter.format_table(&display_items)?);
         }
         OutputFormat::Auto => unreachable!("resolve_for_stdout must not return Auto"),
     }
 
-    Ok(())
+    Ok(output.trim_end_matches('\n').to_string())
 }
 
 async fn execute_file_list(
     blob_manager: &BlobManager,
     prefix: Option<String>,
     group: Option<String>,
-    limit: Option<usize>,
+    pagination: Pagination,
+    pager: bool,
     recursive: bool,
     no_cache: bool,
     config: &Config,
 ) -> Result<()> {
     use crate::blob::models::{BlobListItem, FileListRequest};
     use crate::cache::{CacheKey, CacheManager};
+    use crate::utils::pagination::{paginate_slice, pagination_footer_text};
 
     let cache_manager = CacheManager::from_config(config);
     let vault_name = config.resolve_vault_name(None).await.unwrap_or_default();
@@ -595,11 +631,22 @@ async fn execute_file_list(
     };
     let use_cache = cache_manager.is_enabled() && !no_cache;
 
-    let is_unfiltered = prefix.is_none() && group.is_none() && limit.is_none();
+    let is_unfiltered = prefix.is_none() && group.is_none();
 
     if use_cache && is_unfiltered {
         if let Some(cached) = cache_manager.get::<Vec<BlobListItem>>(&cache_key) {
-            return display_file_list_items(&cached, recursive, config);
+            let page = paginate_slice(&cached, pagination);
+            let mut output = display_file_list_items(&page.items, recursive, config)?;
+            if !output.is_empty() {
+                output.push('\n');
+                if let Some(footer) =
+                    pagination_footer_text(&page, "item", config.runtime_output_format)
+                {
+                    output.push_str(&footer);
+                }
+                crate::utils::pager::print_output(&output, pager)?;
+            }
+            return Ok(());
         }
     }
 
@@ -607,7 +654,7 @@ async fn execute_file_list(
     let list_request = FileListRequest {
         prefix: prefix.clone(),
         groups: group.map(|g| vec![g]),
-        limit,
+        limit: None,
         delimiter: if recursive {
             None
         } else {
@@ -632,7 +679,16 @@ async fn execute_file_list(
         cache_manager.set(&cache_key, &items);
     }
 
-    display_file_list_items(&items, recursive, config)
+    let page = paginate_slice(&items, pagination);
+    let mut output = display_file_list_items(&page.items, recursive, config)?;
+    if !output.is_empty() {
+        output.push('\n');
+        if let Some(footer) = pagination_footer_text(&page, "item", config.runtime_output_format) {
+            output.push_str(&footer);
+        }
+        crate::utils::pager::print_output(&output, pager)?;
+    }
+    Ok(())
 }
 
 async fn execute_file_delete(

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -10,6 +10,7 @@ use crate::error::{CrosstacheError, Result};
 use crate::secret::manager::SecretManager;
 use crate::utils::format::OutputFormat;
 use crate::utils::output;
+use crate::utils::pagination::Pagination;
 use std::sync::Arc;
 use zeroize::Zeroizing;
 
@@ -97,14 +98,47 @@ pub(crate) async fn execute_secret_get_direct(
     execute_secret_get(&secret_manager, name, None, raw, version, &config).await
 }
 
+fn secret_summary_matches_group(
+    secret: &crate::secret::manager::SecretSummary,
+    group: &str,
+) -> bool {
+    secret
+        .groups
+        .as_ref()
+        .map(|groups| groups.split(',').any(|grp| grp.trim() == group))
+        .unwrap_or(false)
+}
+
+fn secret_count_label(
+    displayed: usize,
+    total: usize,
+    qualifier: Option<&str>,
+    paginated: bool,
+) -> String {
+    let noun = match qualifier {
+        Some(q) => format!("{q} secret(s)"),
+        None => "secret(s)".to_string(),
+    };
+
+    if paginated {
+        format!("Showing {displayed} of {total} {noun}")
+    } else {
+        format!("{displayed} {noun}")
+    }
+}
+
 pub(crate) fn display_cached_secret_list(
     secrets: Vec<crate::secret::manager::SecretSummary>,
     group: Option<String>,
     all: bool,
+    pagination: Pagination,
+    pager: bool,
     vault_name: &str,
     config: &Config,
 ) -> Result<()> {
     use crate::utils::format::TableFormatter;
+    use crate::utils::pagination::{paginate_slice, pagination_footer_text};
+    use std::fmt::Write as _;
 
     let mut filtered = secrets;
 
@@ -112,13 +146,10 @@ pub(crate) fn display_cached_secret_list(
         filtered.retain(|s| s.enabled);
     }
     if let Some(ref g) = group {
-        filtered.retain(|s| {
-            s.groups
-                .as_ref()
-                .map(|groups| groups.contains(g))
-                .unwrap_or(false)
-        });
+        filtered.retain(|s| secret_summary_matches_group(s, g));
     }
+
+    let page = paginate_slice(&filtered, pagination);
 
     let fmt = config.runtime_output_format;
     let human_table_like = matches!(
@@ -127,32 +158,56 @@ pub(crate) fn display_cached_secret_list(
     );
 
     if human_table_like {
-        println!();
+        let mut output = String::new();
+        output.push('\n');
         // Color only for styled table; plain/raw must not emit ANSI escapes
         if !config.no_color && fmt == OutputFormat::Table {
-            println!("\x1b[36mVault: {}\x1b[0m", vault_name);
+            let _ = writeln!(output, "\x1b[36mVault: {}\x1b[0m", vault_name);
         } else {
-            println!("Vault: {}", vault_name);
+            let _ = writeln!(output, "Vault: {}", vault_name);
         }
-        println!();
+        output.push('\n');
 
-        if filtered.is_empty() {
-            output::info(if all {
+        if page.total_items == 0 {
+            let msg = if all {
                 "No secrets found in vault."
             } else {
                 "No enabled secrets found in vault. Use --all to show disabled secrets."
-            });
+            };
+            output.push_str(&output::format_line(
+                output::Level::Info,
+                msg,
+                output::should_use_rich_stdout(),
+            ));
+            crate::utils::pager::print_output(&output, pager)?;
             return Ok(());
         }
 
         let formatter = TableFormatter::new(fmt, config.no_color, config.template.clone());
-        println!("{}", formatter.format_table(&filtered)?);
-        println!("\n{} secret(s) in vault '{}'", filtered.len(), vault_name);
+        output.push_str(&formatter.format_table(&page.items)?);
+        output.push('\n');
+        let _ = writeln!(
+            output,
+            "{} in vault '{}'",
+            secret_count_label(
+                page.items.len(),
+                page.total_items,
+                None,
+                page.page_size.is_some(),
+            ),
+            vault_name
+        );
+        if let Some(footer) = pagination_footer_text(&page, "secret", fmt) {
+            output.push('\n');
+            output.push_str(&footer);
+        }
+        crate::utils::pager::print_output(&output, pager)?;
         return Ok(());
     }
 
     let formatter = TableFormatter::new(fmt, config.no_color, config.template.clone());
-    println!("{}", formatter.format_table(&filtered)?);
+    let output = formatter.format_table(&page.items)?;
+    crate::utils::pager::print_output(&output, pager)?;
 
     Ok(())
 }
@@ -163,6 +218,8 @@ pub(crate) async fn execute_secret_list_direct(
     expiring: Option<String>,
     expired: bool,
     no_cache: bool,
+    pagination: Pagination,
+    pager: bool,
     config: Config,
 ) -> Result<()> {
     use crate::cache::{CacheKey, CacheManager};
@@ -179,7 +236,15 @@ pub(crate) async fn execute_secret_list_direct(
         if let Some(cached) =
             cache_manager.get::<Vec<crate::secret::manager::SecretSummary>>(&cache_key)
         {
-            return display_cached_secret_list(cached, group, all, &vault_name, &config);
+            return display_cached_secret_list(
+                cached,
+                group,
+                all,
+                pagination,
+                pager,
+                &vault_name,
+                &config,
+            );
         }
     }
 
@@ -197,11 +262,12 @@ pub(crate) async fn execute_secret_list_direct(
 
     let secrets = execute_secret_list(
         &secret_manager,
-        None,
         group,
         all,
         expiring,
         expired,
+        pagination,
+        pager,
         &config,
     )
     .await?;
@@ -1927,17 +1993,20 @@ async fn execute_secret_inject(
 
 async fn execute_secret_list(
     secret_manager: &crate::secret::manager::SecretManager,
-    vault: Option<String>,
     group: Option<String>,
     show_all: bool,
     expiring: Option<String>,
     expired: bool,
+    pagination: Pagination,
+    pager: bool,
     config: &Config,
 ) -> Result<Vec<crate::secret::manager::SecretSummary>> {
     use crate::config::ContextManager;
     use crate::utils::format::TableFormatter;
+    use crate::utils::pagination::{paginate_slice, pagination_footer_text};
+    use std::fmt::Write as _;
 
-    let vault_name = config.resolve_vault_name(vault).await?;
+    let vault_name = config.resolve_vault_name(None).await?;
 
     let mut context_manager = ContextManager::load().await.unwrap_or_default();
     let _ = context_manager.update_usage(&vault_name).await;
@@ -1961,12 +2030,7 @@ async fn execute_secret_list(
         secrets.retain(|s| s.enabled);
     }
     if let Some(ref g) = group {
-        secrets.retain(|s| {
-            s.groups
-                .as_ref()
-                .map(|groups| groups.split(',').any(|grp| grp.trim() == g))
-                .unwrap_or(false)
-        });
+        secrets.retain(|s| secret_summary_matches_group(s, g));
     }
 
     // Apply expiry filtering if requested (requires per-secret API calls)
@@ -2011,16 +2075,20 @@ async fn execute_secret_list(
         secrets = filtered_secrets;
     }
 
+    let paged = paginate_slice(&secrets, pagination);
+    let display_secrets = paged.items.clone();
+
     // Display results
     if human_table_like {
-        println!();
+        let mut output = String::new();
+        output.push('\n');
         // Color only for styled table; plain/raw must not emit ANSI escapes
         if !config.no_color && fmt == OutputFormat::Table {
-            println!("\x1b[36mVault: {}\x1b[0m", vault_name);
+            let _ = writeln!(output, "\x1b[36mVault: {}\x1b[0m", vault_name);
         } else {
-            println!("Vault: {}", vault_name);
+            let _ = writeln!(output, "Vault: {}", vault_name);
         }
-        println!();
+        output.push('\n');
 
         if secrets.is_empty() {
             let msg = if expired || expiring.is_some() {
@@ -2034,23 +2102,61 @@ async fn execute_secret_list(
             } else {
                 "No enabled secrets found in vault. Use --all to show disabled secrets.".to_string()
             };
-            output::info(&msg);
+            output.push_str(&output::format_line(
+                output::Level::Info,
+                &msg,
+                output::should_use_rich_stdout(),
+            ));
+            crate::utils::pager::print_output(&output, pager)?;
         } else {
             let formatter = TableFormatter::new(fmt, config.no_color, config.template.clone());
-            println!("{}", formatter.format_table(&secrets)?);
+            output.push_str(&formatter.format_table(&display_secrets)?);
 
-            let count_label = if expired {
-                format!("{} expired secret(s)", secrets.len())
-            } else if let Some(ref duration) = expiring {
-                format!("{} secret(s) expiring within {}", secrets.len(), duration)
+            let qualifier = if expired {
+                Some("expired".to_string())
             } else {
-                format!("{} secret(s)", secrets.len())
+                expiring
+                    .as_ref()
+                    .map(|duration| format!("secret(s) expiring within {duration}"))
             };
-            println!("\n{} in vault '{}'", count_label, vault_name);
+            let count_label = if let Some(ref q) = qualifier {
+                if expired {
+                    secret_count_label(
+                        display_secrets.len(),
+                        paged.total_items,
+                        Some(q),
+                        paged.page_size.is_some(),
+                    )
+                } else if paged.page_size.is_some() {
+                    format!(
+                        "Showing {} of {} {}",
+                        display_secrets.len(),
+                        paged.total_items,
+                        q
+                    )
+                } else {
+                    format!("{} {}", display_secrets.len(), q)
+                }
+            } else {
+                secret_count_label(
+                    display_secrets.len(),
+                    paged.total_items,
+                    None,
+                    paged.page_size.is_some(),
+                )
+            };
+            output.push('\n');
+            let _ = writeln!(output, "{} in vault '{}'", count_label, vault_name);
+            if let Some(footer) = pagination_footer_text(&paged, "secret", fmt) {
+                output.push('\n');
+                output.push_str(&footer);
+            }
+            crate::utils::pager::print_output(&output, pager)?;
         }
     } else {
         let formatter = TableFormatter::new(fmt, config.no_color, config.template.clone());
-        println!("{}", formatter.format_table(&secrets)?);
+        let output = formatter.format_table(&display_secrets)?;
+        crate::utils::pager::print_output(&output, pager)?;
     }
 
     Ok(all_secrets)
@@ -2160,7 +2266,7 @@ async fn execute_secret_update(
         && !clear_not_before
     {
         return Err(CrosstacheError::invalid_argument(
-            "No updates specified. Use 'secret update' to modify metadata (groups, tags, folder, note, expiry) or rename secrets. Use 'secret set' to update secret values."
+            "No updates specified. Use 'secret update' to modify metadata (groups, tags, folder, note, expiry) or rename secrets. Use 'secret set' to update secret values.",
         ));
     }
 
@@ -2603,7 +2709,7 @@ async fn execute_secret_share(
                 _ => {
                     return Err(CrosstacheError::invalid_argument(format!(
                         "Invalid access level: {level}"
-                    )))
+                    )));
                 }
             };
 
@@ -2637,7 +2743,16 @@ async fn execute_secret_share(
                 secret_name, user, vault_name
             );
         }
-        ShareCommands::List { secret_name, all } => {
+        ShareCommands::List {
+            secret_name,
+            all,
+            page,
+            page_size,
+            pager,
+        } => {
+            use crate::utils::pagination::{paginate_slice, pagination_footer_text, Pagination};
+            use std::fmt::Write as _;
+
             let mut roles = vault_manager
                 .list_secret_access(&vault_name, &resource_group, &secret_name)
                 .await?;
@@ -2646,13 +2761,18 @@ async fn execute_secret_share(
                 .resolve_and_filter_roles(&mut roles, all)
                 .await?;
 
+            let pagination = Pagination::from_args(page, page_size)?;
+            let paged = paginate_slice(&roles, pagination);
+
             if roles.is_empty() {
                 println!(
                     "No access assignments found for secret '{}' in vault '{}'",
                     secret_name, vault_name
                 );
             } else {
-                println!(
+                let mut output = String::new();
+                let _ = writeln!(
+                    output,
                     "Access assignments for secret '{}' in vault '{}':",
                     secret_name, vault_name
                 );
@@ -2661,8 +2781,17 @@ async fn execute_secret_share(
                     config.no_color,
                     None,
                 );
-                let table_output = formatter.format_table(&roles)?;
-                println!("{table_output}");
+                let table_output = formatter.format_table(&paged.items)?;
+                output.push_str(&table_output);
+                if let Some(footer) = pagination_footer_text(
+                    &paged,
+                    "assignment",
+                    crate::utils::format::OutputFormat::Table,
+                ) {
+                    output.push('\n');
+                    output.push_str(&footer);
+                }
+                crate::utils::pager::print_output(&output, pager)?;
             }
         }
     }
@@ -2994,6 +3123,7 @@ mod tests {
         let stdout_thread = std::thread::spawn(move || {
             let mut out = OpenOptions::new()
                 .create(true)
+                .truncate(true)
                 .write(true)
                 .truncate(true)
                 .open(&stdout_path)
@@ -3011,6 +3141,7 @@ mod tests {
         let stderr_thread = std::thread::spawn(move || {
             let mut out = OpenOptions::new()
                 .create(true)
+                .truncate(true)
                 .write(true)
                 .truncate(true)
                 .open(&stderr_path)
@@ -3029,6 +3160,48 @@ mod tests {
         let _ = stdout_thread.join();
         let _ = stderr_thread.join();
         status.code().unwrap_or(1)
+    }
+
+    fn summary_with_groups(groups: Option<&str>) -> crate::secret::manager::SecretSummary {
+        crate::secret::manager::SecretSummary {
+            name: "secret".to_string(),
+            original_name: "secret".to_string(),
+            note: None,
+            folder: None,
+            groups: groups.map(str::to_string),
+            updated_on: "2026-04-28".to_string(),
+            enabled: true,
+            content_type: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_secret_summary_group_filter_is_exact_comma_separated_match() {
+        assert!(secret_summary_matches_group(
+            &summary_with_groups(Some("prod, infra")),
+            "prod"
+        ));
+        assert!(secret_summary_matches_group(
+            &summary_with_groups(Some("prod, infra")),
+            "infra"
+        ));
+        assert!(!secret_summary_matches_group(
+            &summary_with_groups(Some("production")),
+            "prod"
+        ));
+        assert!(!secret_summary_matches_group(
+            &summary_with_groups(None),
+            "prod"
+        ));
+    }
+
+    #[test]
+    fn test_secret_count_label_distinguishes_paginated_total() {
+        assert_eq!(
+            secret_count_label(10, 137, None, true),
+            "Showing 10 of 137 secret(s)"
+        );
+        assert_eq!(secret_count_label(137, 137, None, false), "137 secret(s)");
     }
 
     #[test]

--- a/src/cli/system_ops.rs
+++ b/src/cli/system_ops.rs
@@ -73,7 +73,12 @@ impl AzureActivityLogClient {
         // Build the Azure Activity Log API URL
         let activity_url = format!(
             "https://management.azure.com/subscriptions/{}/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&$filter=eventTimestamp ge '{}' and eventTimestamp le '{}' and resourceUri eq '/subscriptions/{}/resourceGroups/{}/providers/Microsoft.KeyVault/vaults/{}'",
-            subscription_id, start_time_str, end_time_str, subscription_id, resource_group, vault_name
+            subscription_id,
+            start_time_str,
+            end_time_str,
+            subscription_id,
+            resource_group,
+            vault_name
         );
 
         // Get access token from auth provider
@@ -154,7 +159,7 @@ impl AzureActivityLogClient {
         }
 
         // Sort by timestamp (newest first)
-        entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.timestamp));
 
         Ok(entries)
     }

--- a/src/cli/vault_ops.rs
+++ b/src/cli/vault_ops.rs
@@ -43,8 +43,21 @@ pub(crate) async fn execute_vault_command(command: VaultCommands, config: Config
             resource_group,
             format,
             no_cache,
+            page,
+            page_size,
+            pager,
         } => {
-            execute_vault_list(&vault_manager, resource_group, format, no_cache, &config).await?;
+            execute_vault_list(
+                &vault_manager,
+                resource_group,
+                format,
+                no_cache,
+                page,
+                page_size,
+                pager,
+                &config,
+            )
+            .await?;
         }
         VaultCommands::Delete {
             name,
@@ -205,41 +218,61 @@ async fn execute_vault_list(
     resource_group: Option<String>,
     format: OutputFormat,
     no_cache: bool,
+    page: Option<usize>,
+    page_size: Option<usize>,
+    pager: bool,
     config: &Config,
 ) -> Result<()> {
     use crate::cache::{CacheKey, CacheManager};
     use crate::utils::format::TableFormatter;
+    use crate::utils::pagination::{paginate_slice, pagination_footer_text, Pagination};
     use crate::vault::models::VaultSummary;
 
     let cache_manager = CacheManager::from_config(config);
     let cache_key = CacheKey::VaultList;
     let use_cache = cache_manager.is_enabled() && !no_cache;
     let output_format = format.resolve_for_stdout();
+    let pagination = Pagination::from_args(page, page_size)?;
 
     if use_cache && resource_group.is_none() {
         if let Some(cached) = cache_manager.get::<Vec<VaultSummary>>(&cache_key) {
             if cached.is_empty() {
                 output::info("No vaults found.");
             } else {
+                let page = paginate_slice(&cached, pagination);
                 let formatter =
                     TableFormatter::new(output_format, config.no_color, config.template.clone());
-                println!("{}", formatter.format_table(&cached)?);
+                let mut output = formatter.format_table(&page.items)?;
+                if let Some(footer) = pagination_footer_text(&page, "vault", output_format) {
+                    output.push('\n');
+                    output.push_str(&footer);
+                }
+                crate::utils::pager::print_output(&output, pager)?;
             }
             return Ok(());
         }
     }
 
     let vaults = vault_manager
-        .list_vaults_formatted(
-            Some(&config.subscription_id),
-            resource_group.as_deref(),
-            output_format,
-            config.template.clone(),
-        )
+        .list_vaults(Some(&config.subscription_id), resource_group.as_deref())
         .await?;
 
     if use_cache && resource_group.is_none() {
         cache_manager.set(&cache_key, &vaults);
+    }
+
+    if vaults.is_empty() {
+        output::info("No vaults found.");
+    } else {
+        let page = paginate_slice(&vaults, pagination);
+        let formatter =
+            TableFormatter::new(output_format, config.no_color, config.template.clone());
+        let mut output = formatter.format_table(&page.items)?;
+        if let Some(footer) = pagination_footer_text(&page, "vault", output_format) {
+            output.push('\n');
+            output.push_str(&footer);
+        }
+        crate::utils::pager::print_output(&output, pager)?;
     }
 
     Ok(())
@@ -922,7 +955,7 @@ async fn execute_vault_share(
                 _ => {
                     return Err(CrosstacheError::invalid_argument(format!(
                         "Invalid access level: {level}"
-                    )))
+                    )));
                 }
             };
 
@@ -960,7 +993,13 @@ async fn execute_vault_share(
             resource_group,
             format,
             all,
+            page,
+            page_size,
+            pager,
         } => {
+            use crate::utils::pagination::{paginate_slice, pagination_footer_text, Pagination};
+            use std::fmt::Write as _;
+
             let resource_group =
                 resource_group.unwrap_or_else(|| config.default_resource_group.clone());
 
@@ -974,21 +1013,30 @@ async fn execute_vault_share(
                 .resolve_and_filter_roles(&mut roles, all)
                 .await?;
 
+            let pagination = Pagination::from_args(page, page_size)?;
+            let paged = paginate_slice(&roles, pagination);
+
             if roles.is_empty() {
                 output::info(&format!(
                     "No access assignments found for vault '{vault_name}'"
                 ));
             } else {
-                if format.resolve_for_stdout() == crate::utils::format::OutputFormat::Table {
-                    println!("Access assignments for vault '{vault_name}':");
-                }
                 let formatter = crate::utils::format::TableFormatter::new(
                     format,
                     config.no_color,
                     config.template.clone(),
                 );
-                let table_output = formatter.format_table(&roles)?;
-                println!("{table_output}");
+                let table_output = formatter.format_table(&paged.items)?;
+                let mut output = String::new();
+                if format.resolve_for_stdout() == crate::utils::format::OutputFormat::Table {
+                    let _ = writeln!(output, "Access assignments for vault '{vault_name}':");
+                }
+                output.push_str(&table_output);
+                if let Some(footer) = pagination_footer_text(&paged, "assignment", format) {
+                    output.push('\n');
+                    output.push_str(&footer);
+                }
+                crate::utils::pager::print_output(&output, pager)?;
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -169,6 +169,7 @@ impl CrosstacheError {
         Self::ConfigError(msg.into())
     }
 
+    #[allow(dead_code)]
     pub fn secret_not_found<S: Into<String>>(name: S) -> Self {
         Self::SecretNotFound {
             name: name.into(),

--- a/src/secret/manager.rs
+++ b/src/secret/manager.rs
@@ -1196,7 +1196,7 @@ impl SecretOperations for AzureSecretOperations {
             v.version_number = Some((i + 1) as u32);
         }
         // Re-sort newest first for display
-        versions.sort_by(|a, b| b.created_timestamp.cmp(&a.created_timestamp));
+        versions.sort_by_key(|version| std::cmp::Reverse(version.created_timestamp));
         Ok(versions)
     }
 
@@ -1738,7 +1738,7 @@ impl SecretManager {
                 group_secrets.len()
             ))?;
 
-            let formatter = TableFormatter::new(output_format.clone(), self.no_color, None);
+            let formatter = TableFormatter::new(output_format, self.no_color, None);
             let table_output = formatter.format_table(&group_secrets)?;
             println!("{table_output}");
 

--- a/src/utils/datetime.rs
+++ b/src/utils/datetime.rs
@@ -60,14 +60,14 @@ pub fn parse_relative_duration(input: &str) -> Result<DateTime<Utc>> {
                 return Err(CrosstacheError::invalid_argument(format!(
                     "Unknown duration unit: {}",
                     unit
-                )))
+                )));
             }
         };
 
         Ok(future_time)
     } else {
         Err(CrosstacheError::invalid_argument(format!(
-            "Invalid relative duration format: '{}'. Expected format like '30d', '7d', '1h', '30min', '1y'", 
+            "Invalid relative duration format: '{}'. Expected format like '30d', '7d', '1h', '30min', '1y'",
             input
         )))
     }
@@ -106,7 +106,7 @@ pub fn parse_iso_datetime(input: &str) -> Result<DateTime<Utc>> {
     }
 
     Err(CrosstacheError::invalid_argument(format!(
-        "Invalid date format: '{}'. Expected ISO 8601 format (YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, or YYYY-MM-DDTHH:MM:SSZ) or relative duration (30d, 7d, 1h, etc.)", 
+        "Invalid date format: '{}'. Expected ISO 8601 format (YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, or YYYY-MM-DDTHH:MM:SSZ) or relative duration (30d, 7d, 1h, etc.)",
         input
     )))
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,6 +11,8 @@ pub mod helpers;
 pub mod interactive;
 pub mod network;
 pub mod output;
+pub mod pager;
+pub mod pagination;
 pub mod resource_detector;
 pub mod retry;
 pub mod sanitizer;

--- a/src/utils/network.rs
+++ b/src/utils/network.rs
@@ -47,7 +47,9 @@ pub fn classify_network_error(error: &reqwest::Error, url: &str) -> CrosstacheEr
         if is_dns_resolution_error(error) {
             return CrosstacheError::dns_resolution(
                 vault_name.clone(),
-                format!("Unable to resolve vault hostname. Please check if the vault name '{vault_name}' is correct and the vault exists.")
+                format!(
+                    "Unable to resolve vault hostname. Please check if the vault name '{vault_name}' is correct and the vault exists."
+                ),
             );
         }
 
@@ -87,12 +89,16 @@ pub fn classify_network_error(error: &reqwest::Error, url: &str) -> CrosstacheEr
     // Check for specific HTTP status codes that indicate network issues
     if let Some(status) = error.status() {
         match status.as_u16() {
-            503 => return CrosstacheError::network(format!(
-                "Azure Key Vault '{vault_name}' service is temporarily unavailable. Please try again later."
-            )),
-            502 | 504 => return CrosstacheError::network(format!(
-                "Gateway error when accessing vault '{vault_name}'. The Azure service may be experiencing issues."
-            )),
+            503 => {
+                return CrosstacheError::network(format!(
+                    "Azure Key Vault '{vault_name}' service is temporarily unavailable. Please try again later."
+                ));
+            }
+            502 | 504 => {
+                return CrosstacheError::network(format!(
+                    "Gateway error when accessing vault '{vault_name}'. The Azure service may be experiencing issues."
+                ));
+            }
             _ => {}
         }
     }

--- a/src/utils/pager.rs
+++ b/src/utils/pager.rs
@@ -1,0 +1,105 @@
+//! Interactive TTY pager for long human-facing CLI output.
+
+use crate::error::Result;
+use crossterm::event::{read, Event, KeyCode, KeyEventKind};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode, size};
+use std::io::{self, IsTerminal, Write};
+
+const MORE_PROMPT: &str = "--More-- (space=next, q=quit)";
+
+struct RawModeGuard;
+
+impl RawModeGuard {
+    fn new() -> Result<Self> {
+        enable_raw_mode()?;
+        Ok(Self)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+    }
+}
+
+fn can_page() -> bool {
+    io::stdout().is_terminal() && io::stdin().is_terminal()
+}
+
+fn page_text(text: &str) -> Result<()> {
+    let _guard = RawModeGuard::new()?;
+    let mut stdout = io::stdout().lock();
+    let screen_height = size().map(|(_, h)| h as usize).unwrap_or(24).max(2);
+    let lines_per_page = screen_height.saturating_sub(1).max(1);
+    let lines: Vec<&str> = text.lines().collect();
+
+    if lines.is_empty() {
+        return Ok(());
+    }
+
+    let mut index = 0;
+    while index < lines.len() {
+        let end = usize::min(index + lines_per_page, lines.len());
+        for line in &lines[index..end] {
+            write!(stdout, "{line}\r\n")?;
+        }
+        index = end;
+
+        if index < lines.len() {
+            write!(stdout, "{MORE_PROMPT}")?;
+            stdout.flush()?;
+
+            loop {
+                match read()? {
+                    Event::Key(key)
+                        if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+                    {
+                        match key.code {
+                            KeyCode::Char('q') | KeyCode::Esc => {
+                                write!(stdout, "\r\n")?;
+                                stdout.flush()?;
+                                return Ok(());
+                            }
+                            KeyCode::Char(' ') | KeyCode::Enter | KeyCode::PageDown => {
+                                write!(stdout, "\r\n")?;
+                                break;
+                            }
+                            _ => {}
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    stdout.flush()?;
+    Ok(())
+}
+
+/// Print text directly, or page it interactively when `pager` is enabled.
+pub fn print_output(text: &str, pager: bool) -> Result<()> {
+    if pager && can_page() {
+        page_text(text)
+    } else {
+        println!("{text}");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_page_requires_terminals() {
+        // We can't reliably assert the runtime terminal state in tests, but the
+        // helper should compile and be callable without side effects.
+        let _ = can_page();
+    }
+
+    #[test]
+    fn direct_print_helper_is_callable() {
+        let _ = print_output("hello\nworld", false);
+    }
+}

--- a/src/utils/pagination.rs
+++ b/src/utils/pagination.rs
@@ -1,0 +1,203 @@
+//! Shared pagination helpers for CLI list commands.
+
+use crate::error::{CrosstacheError, Result};
+use crate::utils::format::OutputFormat;
+
+/// Runtime pagination settings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Pagination {
+    pub page: usize,
+    pub page_size: Option<usize>,
+}
+
+impl Pagination {
+    pub fn from_args(page: Option<usize>, page_size: Option<usize>) -> Result<Self> {
+        if matches!(page, Some(0)) {
+            return Err(CrosstacheError::invalid_argument(
+                "--page must be greater than zero",
+            ));
+        }
+
+        if matches!(page_size, Some(0)) {
+            return Err(CrosstacheError::invalid_argument(
+                "--page-size must be greater than zero",
+            ));
+        }
+
+        if page.is_some() && page_size.is_none() {
+            return Err(CrosstacheError::invalid_argument(
+                "--page requires --page-size",
+            ));
+        }
+
+        Ok(Self {
+            page: page.unwrap_or(1),
+            page_size,
+        })
+    }
+
+    pub fn first_page_with_size(page_size: Option<usize>) -> Result<Self> {
+        Self::from_args(None, page_size)
+    }
+}
+
+/// A paginated result slice plus display metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Page<T> {
+    pub items: Vec<T>,
+    pub total_items: usize,
+    pub page: usize,
+    pub page_size: Option<usize>,
+    pub total_pages: Option<usize>,
+    pub start_index_1_based: Option<usize>,
+    pub end_index_1_based: Option<usize>,
+}
+
+impl<T> Page<T> {
+    pub fn human_summary(&self, noun: &str) -> Option<String> {
+        let page_size = self.page_size?;
+        let total_pages = self.total_pages.unwrap_or(0);
+
+        if self.total_items == 0 || self.items.is_empty() {
+            return Some(format!(
+                "Showing 0 of {} {}(s) — page {} of {}",
+                self.total_items, noun, self.page, total_pages
+            ));
+        }
+
+        Some(format!(
+            "Showing {}-{} of {} {}(s) — page {} of {} (page size {})",
+            self.start_index_1_based.unwrap_or(0),
+            self.end_index_1_based.unwrap_or(0),
+            self.total_items,
+            noun,
+            self.page,
+            total_pages,
+            page_size
+        ))
+    }
+}
+
+/// Return a page of `items`. When pagination is disabled, all items are returned.
+pub fn paginate_slice<T: Clone>(items: &[T], pagination: Pagination) -> Page<T> {
+    let total_items = items.len();
+
+    let Some(page_size) = pagination.page_size else {
+        return Page {
+            items: items.to_vec(),
+            total_items,
+            page: 1,
+            page_size: None,
+            total_pages: None,
+            start_index_1_based: if total_items == 0 { None } else { Some(1) },
+            end_index_1_based: if total_items == 0 {
+                None
+            } else {
+                Some(total_items)
+            },
+        };
+    };
+
+    let total_pages = if total_items == 0 {
+        0
+    } else {
+        total_items.div_ceil(page_size)
+    };
+
+    let start = (pagination.page - 1).saturating_mul(page_size);
+    let end = usize::min(start.saturating_add(page_size), total_items);
+    let page_items = if start >= total_items {
+        Vec::new()
+    } else {
+        items[start..end].to_vec()
+    };
+
+    Page {
+        start_index_1_based: if page_items.is_empty() {
+            None
+        } else {
+            Some(start + 1)
+        },
+        end_index_1_based: if page_items.is_empty() {
+            None
+        } else {
+            Some(end)
+        },
+        items: page_items,
+        total_items,
+        page: pagination.page,
+        page_size: Some(page_size),
+        total_pages: Some(total_pages),
+    }
+}
+
+#[allow(dead_code)]
+pub fn print_pagination_footer<T>(page: &Page<T>, noun: &str, output_format: OutputFormat) {
+    if let Some(text) = pagination_footer_text(page, noun, output_format) {
+        println!("\n{text}");
+    }
+}
+
+/// Return footer text for human-readable output formats.
+pub fn pagination_footer_text<T>(
+    page: &Page<T>,
+    noun: &str,
+    output_format: OutputFormat,
+) -> Option<String> {
+    let human_output = matches!(
+        output_format.resolve_for_stdout(),
+        OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+    );
+
+    human_output.then(|| page.human_summary(noun)).flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_pagination_returns_all_items() {
+        let page = paginate_slice(&[1, 2, 3], Pagination::from_args(None, None).unwrap());
+        assert_eq!(page.items, vec![1, 2, 3]);
+        assert!(page.page_size.is_none());
+    }
+
+    #[test]
+    fn first_page_returns_expected_items() {
+        let page = paginate_slice(
+            &[1, 2, 3, 4, 5],
+            Pagination::from_args(None, Some(2)).unwrap(),
+        );
+        assert_eq!(page.items, vec![1, 2]);
+        assert_eq!(page.total_pages, Some(3));
+        assert_eq!(page.start_index_1_based, Some(1));
+        assert_eq!(page.end_index_1_based, Some(2));
+    }
+
+    #[test]
+    fn middle_page_returns_expected_items() {
+        let page = paginate_slice(
+            &[1, 2, 3, 4, 5],
+            Pagination::from_args(Some(2), Some(2)).unwrap(),
+        );
+        assert_eq!(page.items, vec![3, 4]);
+        assert_eq!(page.start_index_1_based, Some(3));
+        assert_eq!(page.end_index_1_based, Some(4));
+    }
+
+    #[test]
+    fn page_past_end_returns_empty_items_with_total_metadata() {
+        let page = paginate_slice(&[1, 2, 3], Pagination::from_args(Some(3), Some(2)).unwrap());
+        assert!(page.items.is_empty());
+        assert_eq!(page.total_items, 3);
+        assert_eq!(page.total_pages, Some(2));
+    }
+
+    #[test]
+    fn validates_page_and_page_size() {
+        assert!(Pagination::from_args(Some(0), Some(10)).is_err());
+        assert!(Pagination::from_args(Some(1), Some(0)).is_err());
+        assert!(Pagination::from_args(Some(1), None).is_err());
+    }
+}

--- a/src/vault/manager.rs
+++ b/src/vault/manager.rs
@@ -102,6 +102,17 @@ impl VaultManager {
     }
 
     /// List vaults with formatted output
+    pub async fn list_vaults(
+        &self,
+        subscription_id: Option<&str>,
+        resource_group: Option<&str>,
+    ) -> Result<Vec<VaultSummary>> {
+        self.vault_ops
+            .list_vaults(subscription_id, resource_group)
+            .await
+    }
+
+    /// List vaults with formatted output
     pub async fn list_vaults_formatted(
         &self,
         subscription_id: Option<&str>,

--- a/tests/cache_tests.rs
+++ b/tests/cache_tests.rs
@@ -42,7 +42,7 @@ fn test_cache_no_cache_flag_behavior() {
         vault_name: "test-vault".to_string(),
     };
     mgr.set(&key, &vec!["data".to_string()]);
-    let path = key.to_path(&dir.path().to_path_buf());
+    let path = key.to_path(dir.path());
     assert!(path.exists());
 }
 
@@ -54,7 +54,7 @@ fn test_cache_disabled_behavior() {
         vault_name: "test-vault".to_string(),
     };
     mgr.set(&key, &vec!["data".to_string()]);
-    let path = key.to_path(&dir.path().to_path_buf());
+    let path = key.to_path(dir.path());
     assert!(!path.exists());
     let result: Option<Vec<String>> = mgr.get(&key);
     assert!(result.is_none());

--- a/tests/clipboard_tests.rs
+++ b/tests/clipboard_tests.rs
@@ -5,8 +5,11 @@
 //! concurrent clipboard access:
 //!   cargo test --test clipboard_tests -- --test-threads=1
 
+#[cfg(target_os = "macos")]
 use std::process::Command;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(target_os = "macos")]
+use std::time::Instant;
 
 /// Helper: read current clipboard text via pbcopy/pbpaste (macOS).
 /// Returns None if clipboard access fails.
@@ -275,8 +278,10 @@ fn test_config_clipboard_timeout_zero_disables() {
 
 #[test]
 fn test_config_clipboard_timeout_serialization_roundtrip() {
-    let mut config = crosstache::config::settings::Config::default();
-    config.clipboard_timeout = 45;
+    let config = crosstache::config::settings::Config {
+        clipboard_timeout: 45,
+        ..Default::default()
+    };
 
     let serialized = serde_json::to_string(&config).expect("should serialize");
     assert!(

--- a/tests/file_commands_tests.rs
+++ b/tests/file_commands_tests.rs
@@ -386,6 +386,9 @@ async fn test_file_list_command() -> Result<()> {
         prefix: Some("config/".to_string()),
         group: Some("production".to_string()),
         limit: Some(50),
+        page: None,
+        page_size: None,
+        pager: false,
         recursive: false,
         no_cache: false,
     };
@@ -395,12 +398,18 @@ async fn test_file_list_command() -> Result<()> {
             prefix,
             group,
             limit,
+            page,
+            page_size,
+            pager,
             recursive: _,
             no_cache: _,
         } => {
             assert_eq!(prefix, Some("config/".to_string()));
             assert_eq!(group, Some("production".to_string()));
             assert_eq!(limit, Some(50));
+            assert_eq!(page, None);
+            assert_eq!(page_size, None);
+            assert!(!pager);
         }
         _ => panic!("Expected List command"),
     }


### PR DESCRIPTION
## Summary

Adds opt-in pagination to `xv` list-style commands: secrets list, vaults list, file list, secret share list, vault share list. Strict backward-compatible: omitting the new flags reproduces the existing output byte-for-byte; machine formats (`json`/`yaml`/`csv`/`template`) get only the paged rows with no extra metadata.

- **New flags** (where applicable):
  - `--page <N>` — 1-based page number (default 1 when `--page-size` is set)
  - `--page-size <N>` — rows per page
  - `--pager <auto|always|never>` — route table output through a pager
- **Reusable primitives** in `src/utils/pagination.rs` and `src/utils/pager.rs` so future list commands can opt in without re-inventing.
- **Cache layer untouched** — entries continue to store full unpaginated results; pagination is applied at the CLI/display layer.
- **Footer for human formats** — `Showing 51-100 of 137 item(s) — page 2 of 3` plus a copy-pasteable next-page command.

## Constraints honored

- `--page` without `--page-size` errors at clap parse.
- `xv file list --limit N` stays as a back-compat alias for `--page-size N` on page 1; combining `--limit` and `--page-size` errors.
- Default output for every existing command is unchanged.
- JSON/YAML/CSV consumers see exactly the paged rows; no envelope, no footer, no schema change.

## Plan

`docs/plans/2026-04-28-list-pagination-plan.md` (added in this PR).

## Test plan

- [x] `cargo test` — 257 lib + all integration suites green
- [x] `cargo build` — clean
- [ ] Manual: `xv list --page-size 10` paginates secrets; footer shows correctly
- [ ] Manual: `xv list --page 2 --page-size 10` jumps to page 2
- [ ] Manual: `xv list --page 3` (without --page-size) errors at parse with a helpful clap message
- [ ] Manual: `xv list --format json --page-size 10` emits a JSON array of exactly 10 items, no footer, no envelope
- [ ] Manual: `xv vault list --page-size 5` works
- [ ] Manual: `xv file list --limit 20` (legacy flag) still works on page 1
- [ ] Manual: `xv file list --limit 20 --page-size 20` errors with "cannot combine --limit and --page-size"
- [ ] Manual: `xv share list <secret> --page-size 5` works
- [ ] Manual: `xv vault share list <vault> --page-size 5` works
- [ ] Manual: `xv list --pager always` pipes table output through the pager

## Notes

- This branch was reconciled out of pre-existing in-flight work that predated v0.6.0-rc.1 and v0.6.0-rc.2. Local main was rebased onto `origin/main` and the working-tree changes were merged with 4 conflict regions resolved by hand:
  - `src/error.rs` (×2) — kept upstream's `{ ref name, .. }` patterns (rc.1 added `suggestion` field to `SecretNotFound`/`VaultNotFound`)
  - `src/cli/vault_ops.rs` (×2) — kept this branch's pagination integration; one upstream version was a stale duplicate-formatter that ignored the pagination prep.
  - `src/cli/commands.rs` (×1) — kept this branch's `Commands::List` destructure that adds `page`/`page_size`/`pager`.
- Cargo.lock was regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple user-facing list commands and their output formatting (including cached paths), so regressions could affect CLI UX and scripting expectations despite attempts to keep machine formats stable.
> 
> **Overview**
> Adds opt-in pagination to list-style commands (`xv list`, `xv vault list`, `xv file list`, `xv share list`, `xv vault share list`) via new `--page`/`--page-size` flags, plus a `--pager` option to view long human output interactively.
> 
> Introduces shared utilities `utils/pagination.rs` (validation + `paginate_slice` + human-only footer) and `utils/pager.rs` (TTY paging), and wires them so pagination is applied *after* filtering and *before* formatting; cache entries still store full unpaginated vectors.
> 
> Updates `xv file list` so legacy `--limit` acts as a page-1 alias (and can’t be combined with `--page`/`--page-size`), moves file truncation out of the blob request path, and refreshes docs/tests accordingly (including a new pagination implementation plan doc).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccd84b1748f1ca3a34bf55d9b919229b859abf51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->