### PR TITLE
release: v0.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Run tests
         run: cargo test --verbose
+
+      - name: Test (with TUI feature)
+        run: cargo test --features tui --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.7.0-rc.2"
+version = "0.7.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.7.0-rc.2"
+version = "0.7.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"


### PR DESCRIPTION
## Summary
- Bump `Cargo.toml` / `Cargo.lock` from `0.7.0-rc.2` → `0.7.0` (Phase-1 GA).
- Pull in the missing `cargo test --features tui` step in CI that was supposed to ride along with #151 but didn't make the squash.

## What's in 0.7.0
The Phase-1 strategic improvement arc has soaked through rc.1 and rc.2 and shipped via #146 (pagination), #147 (fuzzy find), #148 (leak scanner), #149 (TUI), #150 (README rewrite), #151 (hermetic E2E harness), and #152 (fmt+clippy cleanup):

- Structured exit codes & JSON error envelopes — `docs/exit-codes.md`
- `.xv.toml` env profiles with walk-up resolution — `docs/env-profiles.md`
- Ranked nucleo fuzzy `xv find` — `docs/find.md`
- List pagination across `secret`, `vault`, `file`
- Pre-commit secret-leak scanner — `docs/scan.md`
- Ratatui terminal UI behind the `tui` feature
- Hermetic E2E test harness — `docs/testing.md`
- Comprehensive README rewrite

## Test plan
- [x] `cargo build` clean on the release version
- [x] `xv version` reports `0.7.0`
- [ ] CI green on this PR
- [ ] After merge, tag `v0.7.0` against the merge commit and push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a version bump and adding an extra CI test run with the `tui` feature enabled; primary risk is CI breakage due to feature-specific compile/test issues.
> 
> **Overview**
> Promotes the crate from `0.7.0-rc.2` to **`0.7.0`** by updating `Cargo.toml` and `Cargo.lock`.
> 
> Updates CI to also run `cargo test --features tui` in addition to the default test suite, ensuring the optional TUI build path stays covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4383e8ddb4bb665ea207c3de51c4bd25af90b703. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->