### PR TITLE
fix(tui): quit keys + ship TUI in release binaries (v0.7.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
           sudo apt-get install -y libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev pkg-config
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --features tui --target ${{ matrix.target }}
 
       - name: Create archive (Windows)
         if: matrix.os == 'windows-latest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/src/tui/update.rs
+++ b/src/tui/update.rs
@@ -1,6 +1,6 @@
 use crate::tui::app::{App, Overlay, Pane};
 use crate::tui::message::Message;
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 #[derive(Debug)]
 pub enum Command {
@@ -79,6 +79,14 @@ pub fn update(app: &mut App, msg: Message) -> Vec<Command> {
 
 fn handle_key(app: &mut App, key: KeyEvent) -> Vec<Command> {
     let mut cmds = Vec::new();
+    // Ctrl+C is a universal quit shortcut and must take precedence over
+    // any per-character handler (including the reserved-key 'c' toast and
+    // filter-mode character capture).
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        app.quit = true;
+        cmds.push(Command::Quit);
+        return cmds;
+    }
     // Filter mode intercepts most keys.
     if app.secret_filter_active {
         match key.code {
@@ -110,7 +118,10 @@ fn handle_key(app: &mut App, key: KeyEvent) -> Vec<Command> {
         return cmds;
     }
     match key.code {
-        KeyCode::Char('q') | KeyCode::Esc => cmds.push(Command::Quit),
+        KeyCode::Char('q') | KeyCode::Esc => {
+            app.quit = true;
+            cmds.push(Command::Quit);
+        }
         KeyCode::Char('?') => app.overlay = Overlay::Help,
         KeyCode::Char('/') => {
             if app.pane == crate::tui::app::Pane::Secrets {
@@ -156,7 +167,7 @@ fn handle_key(app: &mut App, key: KeyEvent) -> Vec<Command> {
                 }
             }
         },
-        KeyCode::Char(c) if matches!(c, 'c' | 'd' | 'r') => {
+        KeyCode::Char(c) if matches!(c, 'c' | 'd' | 'r') && key.modifiers.is_empty() => {
             app.toast = Some(crate::tui::app::Toast {
                 message: format!("'{c}' is reserved for v0.8 write mode"),
                 code: None,

--- a/tests/tui_view_tests.rs
+++ b/tests/tui_view_tests.rs
@@ -12,6 +12,64 @@ fn empty_app() -> App {
     app
 }
 
+fn key(code: crossterm::event::KeyCode) -> crossterm::event::KeyEvent {
+    crossterm::event::KeyEvent::new(code, crossterm::event::KeyModifiers::NONE)
+}
+
+fn ctrl_key(c: char) -> crossterm::event::KeyEvent {
+    crossterm::event::KeyEvent::new(
+        crossterm::event::KeyCode::Char(c),
+        crossterm::event::KeyModifiers::CONTROL,
+    )
+}
+
+#[test]
+fn pressing_q_sets_quit_flag() {
+    let mut app = empty_app();
+    let _ = crosstache::tui::update::update(
+        &mut app,
+        crosstache::tui::message::Message::KeyPress(key(crossterm::event::KeyCode::Char('q'))),
+    );
+    assert!(app.quit, "'q' must set app.quit so the main loop exits");
+}
+
+#[test]
+fn pressing_esc_sets_quit_flag() {
+    let mut app = empty_app();
+    let _ = crosstache::tui::update::update(
+        &mut app,
+        crosstache::tui::message::Message::KeyPress(key(crossterm::event::KeyCode::Esc)),
+    );
+    assert!(app.quit, "Esc must set app.quit so the main loop exits");
+}
+
+#[test]
+fn ctrl_c_sets_quit_flag_and_does_not_show_reserved_toast() {
+    let mut app = empty_app();
+    let _ = crosstache::tui::update::update(
+        &mut app,
+        crosstache::tui::message::Message::KeyPress(ctrl_key('c')),
+    );
+    assert!(app.quit, "Ctrl+C must set app.quit");
+    assert!(
+        app.toast.is_none(),
+        "Ctrl+C must not surface the v0.8 reserved-key toast"
+    );
+}
+
+#[test]
+fn plain_c_still_shows_reserved_toast() {
+    // Regression guard: Ctrl-C exception must not unintentionally suppress
+    // the reserved-key feedback for unmodified 'c'.
+    let mut app = empty_app();
+    let _ = crosstache::tui::update::update(
+        &mut app,
+        crosstache::tui::message::Message::KeyPress(key(crossterm::event::KeyCode::Char('c'))),
+    );
+    let toast = app.toast.expect("plain 'c' should still toast");
+    assert!(toast.message.contains("reserved"));
+}
+
 #[test]
 fn empty_app_renders_three_panes_and_status() {
     let backend = TestBackend::new(80, 20);


### PR DESCRIPTION
## Summary
- **`q` / `Esc` actually quit now.** The key handler pushed `Command::Quit`, but `handle_command` is a no-op for `Quit` — the main loop only exits when `app.quit = true`. Set the flag directly in the key handler.
- **Ctrl+C quits instead of showing the v0.8 toast.** Caught up-front before any per-character handler. Also guarded the `'c' | 'd' | 'r'` reserved-keys match so any modifier (Ctrl, Alt, …) bypasses the toast.
- **Release binaries now include TUI.** Added `--features tui` to the release-build step so v0.7.x platform binaries actually expose `xv tui`.
- Bump version `0.7.0` → `0.7.1`.

## Test plan
- [x] 4 new regression tests in `tests/tui_view_tests.rs` covering `q`, `Esc`, `Ctrl+C`, and the plain-`c` toast still firing
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` — 297 pass
- [x] `cargo test --features tui --test tui_view_tests` — 7 pass
- [ ] CI green
- [ ] After merge: tag `v0.7.1` against the merge commit, verify release workflow attaches platform binaries, sanity-check that the macOS / Linux / Windows tarballs contain a TUI-enabled `xv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TUI input handling and the GitHub release build flags; regressions could affect quitting behavior or produce release artifacts without expected features, but changes are localized and covered by new tests.
> 
> **Overview**
> Fixes TUI quitting semantics by setting `app.quit` directly on `q`/`Esc`, and adds a high-priority `Ctrl+C` handler that quits without triggering the reserved-key toast (reserved `'c'|'d'|'r'` toast now only fires with no modifiers).
> 
> Updates the release workflow to build with `--features tui` so published binaries include `xv tui`, and bumps the crate version to `0.7.1` (including lockfile update). Adds regression tests covering quit keys and the `Ctrl+C` vs plain-`c` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae0372b63297735f6a3f01d38c781a63d79f9e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->