### PR TITLE
fix(tui): Windows arrow keys move once, not twice (v0.7.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -6,6 +6,12 @@ pub fn spawn_event_reader(tx: Sender<Message>) -> tokio::task::JoinHandle<()> {
         loop {
             match crossterm::event::read() {
                 Ok(crossterm::event::Event::Key(key)) => {
+                    // Windows emits Press, Repeat, AND Release for every
+                    // keystroke; Unix only emits Press. Without this guard,
+                    // each arrow press moved the cursor twice on Windows.
+                    if !matches!(key.kind, crossterm::event::KeyEventKind::Press) {
+                        continue;
+                    }
                     if tx.blocking_send(Message::KeyPress(key)).is_err() {
                         break;
                     }


### PR DESCRIPTION
## Summary
On Windows, every arrow / nav keypress moved the cursor twice. The crossterm event reader forwarded `KeyEventKind::Press`, `Repeat`, and `Release` events; Unix only emits `Press`, so the bug was Windows-only.

Filter to `KeyEventKind::Press` in the reader (`src/tui/event.rs`) so the input pipeline ignores release/repeat noise at the source. Bump `0.7.1` → `0.7.2`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --features tui --test tui_view_tests` — 7 pass
- [ ] Manual verification on Windows: arrow keys move one row per press

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts the TUI input pipeline to drop `Repeat`/`Release` key events, which could change key-hold/repeat behavior across terminals (though it fixes Windows double-navigation). Version bump is low risk.
> 
> **Overview**
> Fixes a Windows-only TUI navigation bug by filtering crossterm key events so only `KeyEventKind::Press` is forwarded from `spawn_event_reader`, preventing a single arrow key press from being handled multiple times.
> 
> Bumps the crate version from `0.7.1` to `0.7.2` (including `Cargo.lock` update).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc195e0a8d299051e6deef7caa30114b43df4b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->