### PR TITLE
fix: read az CLI install prompt from /dev/tty instead of stdin

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -396,7 +396,7 @@ main() {
     if ! check_azure_cli; then
         warning "Azure CLI is not installed. crosstache requires Azure CLI for authentication."
         echo "Would you like to install Azure CLI now? (y/N)"
-        read -r response
+        read -r response </dev/tty
         case "$response" in
             [yY][eE][sS]|[yY])
                 install_azure_cli


### PR DESCRIPTION
When the installer is invoked via 'curl ... | bash', stdin is the pipe from curl, not the terminal. The 'read' command gets EOF immediately from the exhausted pipe, causing the prompt to exit without waiting for user input.

Fix by redirecting read's input from /dev/tty, which always refers to the controlling terminal regardless of stdin redirection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to input handling in `scripts/install.sh` that only affects the interactive Azure CLI install prompt.
> 
> **Overview**
> When Azure CLI is missing, the installer now reads the install confirmation prompt from `/dev/tty` instead of stdin, so `curl ... | bash` invocations still pause for user input rather than immediately hitting EOF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22973137eb98d3e2e83ba570682869b3bfbf5f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->