### PR TITLE
chore(deps): update rand 0.8 -> 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 
 # Utilities
 uuid = { version = "1.0", features = ["v4", "serde"] }
-rand = "0.8"
+rand = "0.9"
 regex = "1.0"
 aho-corasick = "1.1"
 globset = "0.4"

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -258,7 +258,7 @@ pub(crate) fn generate_random_value(
         ));
     }
 
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
     let random_value: String = (0..length)
         .map(|_| {
             let idx = rng.gen_range(0..charset_bytes.len());


### PR DESCRIPTION
Updates `rand` from 0.8.5 to 0.9.x to unblock the dependabot PR #158.

### Changes
- `thread_rng()` -> `rand::rng()` (removed in rand 0.9)
- Only 1 call site in `src/cli/helpers.rs`

Once this merges, dependabot PR #158 can be rebased (or closed and re-triggered) since the breaking rand change will already be handled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump with a single, straightforward API migration in random-string generation. Main risk is subtle behavioral differences in RNG selection/output distribution across `rand` versions.
> 
> **Overview**
> Updates the `rand` dependency from `0.8` to `0.9` and adjusts the only call site impacted by the breaking change by replacing `thread_rng()` with `rand::rng()` in `generate_random_value`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79cfb90e141b3c8be5e949f813e3601dd129076d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->