### PR TITLE
chore(deps): update rand 0.8 -> 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ dependencies = [
  "mockall",
  "nucleo",
  "opener",
- "rand 0.8.5",
+ "rand 0.9.1",
  "ratatui",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 
 # Utilities
 uuid = { version = "1.0", features = ["v4", "serde"] }
-rand = "0.8"
+rand = "0.9"
 regex = "1.0"
 aho-corasick = "1.1"
 globset = "0.4"

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -258,10 +258,10 @@ pub(crate) fn generate_random_value(
         ));
     }
 
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
     let random_value: String = (0..length)
         .map(|_| {
-            let idx = rng.gen_range(0..charset_bytes.len());
+            let idx = rng.random_range(0..charset_bytes.len());
             charset_bytes[idx] as char
         })
         .collect();


### PR DESCRIPTION
Updates `rand` from 0.8.5 to 0.9.x.

### Changes
- `thread_rng()` -> `rand::rng()` (removed in 0.9)
- `gen_range()` -> `random_range()` (deprecated in 0.9)
- Only 1 call site in `src/cli/helpers.rs`
- Cargo.lock updated
- All 22 tests pass locally

Once merged, dependabot PR #158 can be closed/re-triggered since the breaking rand change will be handled.

Closes #160 (supersedes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret/random generation in `generate_random_value`, so any behavioral change in RNG seeding or range selection could affect generated outputs. Scope is small (one call site plus lockfile/dependency bump).
> 
> **Overview**
> Bumps the `rand` dependency from `0.8` to `0.9` (including `Cargo.lock` updates).
> 
> Updates the CLI random generator in `src/cli/helpers.rs` to use the `rand` 0.9 API (`rand::rng()` and `random_range()`), replacing removed/deprecated `thread_rng()` and `gen_range()` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 700a0452fa2e189ec42305afb39aea38c7c6b661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->