### PR TITLE
chore: bump version to v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"


### PR DESCRIPTION
Version bump for v0.7.3 release.

## Changes since v0.7.2

- **feat:** Progress indicators for file operations (#163) — ProgressReporter trait, bar/spinner/noop implementations, wired into upload/download/sync
- **fix:** Read az CLI install prompt from /dev/tty instead of stdin (#157)
- **chore:** Remove Claude auto-review workflow (#159)
- **chore(deps):** Bump rand 0.8 → 0.9 (#161, #162)
- **chore(deps):** Bump cargo dependency group (#158)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a package version bump in `Cargo.toml` and the corresponding `Cargo.lock` entry, with no code or dependency logic modifications.
> 
> **Overview**
> Bumps the crate version from `0.7.2` to `0.7.3` in `Cargo.toml` and updates the matching `crosstache` package version in `Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d42091e1b37fea7f78f78593e63d921331f05230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->