### PR TITLE
feat: implement Azure backend adapter behind new trait hierarchy

### DIFF
--- a/src/backend/azure/files.rs
+++ b/src/backend/azure/files.rs
@@ -12,8 +12,9 @@ use crate::backend::error::BackendError;
 use crate::backend::file::FileBackend;
 use crate::blob::manager::BlobManager;
 use crate::blob::models::{FileDownloadRequest, FileInfo, FileListRequest, FileUploadRequest};
-use crate::error::CrosstacheError;
 use crate::utils::progress::{NoopReporter, ProgressReporter};
+
+use super::map_error;
 
 /// Adapter that implements [`FileBackend`] by delegating to an existing
 /// [`BlobManager`] instance.
@@ -27,36 +28,6 @@ impl AzureFileBackend {
     #[allow(dead_code)]
     pub fn new(inner: Arc<BlobManager>) -> Self {
         Self { inner }
-    }
-}
-
-/// Map [`CrosstacheError`] → [`BackendError`].
-fn map_error(err: CrosstacheError) -> BackendError {
-    match err {
-        CrosstacheError::VaultNotFound { name, suggestion } => {
-            // BlobManager reuses VaultNotFound for "file not found"
-            BackendError::NotFound { name, suggestion }
-        }
-        CrosstacheError::SecretNotFound { name, suggestion } => {
-            BackendError::NotFound { name, suggestion }
-        }
-        CrosstacheError::AuthenticationError(msg) => BackendError::AuthenticationFailed(msg),
-        CrosstacheError::PermissionDenied(msg) => BackendError::PermissionDenied(msg),
-        CrosstacheError::Conflict(msg) => BackendError::Conflict(msg),
-        CrosstacheError::RateLimited(_msg) => BackendError::RateLimited {
-            retry_after_secs: None,
-        },
-        CrosstacheError::NetworkError(msg) => BackendError::Network(msg),
-        CrosstacheError::DnsResolutionError {
-            vault_name,
-            details,
-        } => BackendError::Network(format!(
-            "DNS resolution failed for '{vault_name}': {details}"
-        )),
-        CrosstacheError::ConnectionTimeout(msg) => BackendError::Network(msg),
-        CrosstacheError::ConnectionRefused(msg) => BackendError::Network(msg),
-        CrosstacheError::SslError(msg) => BackendError::Network(msg),
-        other => BackendError::Internal(other.to_string()),
     }
 }
 

--- a/src/backend/azure/files.rs
+++ b/src/backend/azure/files.rs
@@ -1,0 +1,105 @@
+//! Azure file/blob backend adapter.
+//!
+//! Wraps the existing [`BlobManager`] behind the new [`FileBackend`] trait.
+//! Feature-gated behind `file-ops`.
+
+#[allow(unused_imports)]
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::backend::error::BackendError;
+use crate::backend::file::FileBackend;
+use crate::blob::manager::BlobManager;
+use crate::blob::models::{FileDownloadRequest, FileInfo, FileListRequest, FileUploadRequest};
+use crate::error::CrosstacheError;
+use crate::utils::progress::{NoopReporter, ProgressReporter};
+
+/// Adapter that implements [`FileBackend`] by delegating to an existing
+/// [`BlobManager`] instance.
+#[allow(dead_code)]
+pub struct AzureFileBackend {
+    inner: Arc<BlobManager>,
+}
+
+impl AzureFileBackend {
+    /// Wrap an existing `BlobManager`.
+    #[allow(dead_code)]
+    pub fn new(inner: Arc<BlobManager>) -> Self {
+        Self { inner }
+    }
+}
+
+/// Map [`CrosstacheError`] → [`BackendError`].
+fn map_error(err: CrosstacheError) -> BackendError {
+    match err {
+        CrosstacheError::VaultNotFound { name, suggestion } => {
+            // BlobManager reuses VaultNotFound for "file not found"
+            BackendError::NotFound { name, suggestion }
+        }
+        CrosstacheError::SecretNotFound { name, suggestion } => {
+            BackendError::NotFound { name, suggestion }
+        }
+        CrosstacheError::AuthenticationError(msg) => BackendError::AuthenticationFailed(msg),
+        CrosstacheError::PermissionDenied(msg) => BackendError::PermissionDenied(msg),
+        CrosstacheError::Conflict(msg) => BackendError::Conflict(msg),
+        CrosstacheError::RateLimited(_msg) => BackendError::RateLimited {
+            retry_after_secs: None,
+        },
+        CrosstacheError::NetworkError(msg) => BackendError::Network(msg),
+        CrosstacheError::DnsResolutionError {
+            vault_name,
+            details,
+        } => BackendError::Network(format!(
+            "DNS resolution failed for '{vault_name}': {details}"
+        )),
+        CrosstacheError::ConnectionTimeout(msg) => BackendError::Network(msg),
+        CrosstacheError::ConnectionRefused(msg) => BackendError::Network(msg),
+        CrosstacheError::SslError(msg) => BackendError::Network(msg),
+        other => BackendError::Internal(other.to_string()),
+    }
+}
+
+#[async_trait]
+impl FileBackend for AzureFileBackend {
+    async fn upload_file(
+        &self,
+        request: FileUploadRequest,
+        reporter: Option<&dyn ProgressReporter>,
+    ) -> Result<FileInfo, BackendError> {
+        let null = NoopReporter;
+        let reporter: &dyn ProgressReporter = reporter.unwrap_or(&null);
+        self.inner
+            .upload_file(request, reporter)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn download_file(
+        &self,
+        name: &str,
+        reporter: Option<&dyn ProgressReporter>,
+    ) -> Result<Vec<u8>, BackendError> {
+        let null = NoopReporter;
+        let reporter: &dyn ProgressReporter = reporter.unwrap_or(&null);
+        let request = FileDownloadRequest {
+            name: name.to_string(),
+        };
+        self.inner
+            .download_file(request, reporter)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn list_files(&self, request: FileListRequest) -> Result<Vec<FileInfo>, BackendError> {
+        self.inner.list_files(request).await.map_err(map_error)
+    }
+
+    async fn delete_file(&self, name: &str) -> Result<(), BackendError> {
+        self.inner.delete_file(name).await.map_err(map_error)
+    }
+
+    async fn get_file_info(&self, name: &str) -> Result<FileInfo, BackendError> {
+        self.inner.get_file_info(name).await.map_err(map_error)
+    }
+}

--- a/src/backend/azure/mod.rs
+++ b/src/backend/azure/mod.rs
@@ -22,8 +22,43 @@ use super::error::BackendError;
 use super::{Backend, BackendCapabilities, BackendKind, NameCharset, SecretBackend, VaultBackend};
 use crate::auth::provider::AzureAuthProvider;
 use crate::config::settings::Config;
+use crate::error::CrosstacheError;
 use crate::secret::manager::AzureSecretOperations;
 use crate::vault::operations::AzureVaultOperations;
+
+/// Map [`CrosstacheError`] → [`BackendError`].
+///
+/// This is a best-effort mapping; variants without a direct BackendError
+/// equivalent are mapped to `BackendError::Internal`.
+///
+/// Shared by all Azure sub-backends (secrets, vaults, files).
+pub fn map_error(err: CrosstacheError) -> BackendError {
+    match err {
+        CrosstacheError::SecretNotFound { name, suggestion } => {
+            BackendError::NotFound { name, suggestion }
+        }
+        CrosstacheError::VaultNotFound { name, suggestion } => {
+            BackendError::VaultNotFound { name, suggestion }
+        }
+        CrosstacheError::AuthenticationError(msg) => BackendError::AuthenticationFailed(msg),
+        CrosstacheError::PermissionDenied(msg) => BackendError::PermissionDenied(msg),
+        CrosstacheError::Conflict(msg) => BackendError::Conflict(msg),
+        CrosstacheError::RateLimited(_msg) => BackendError::RateLimited {
+            retry_after_secs: None,
+        },
+        CrosstacheError::NetworkError(msg) => BackendError::Network(msg),
+        CrosstacheError::DnsResolutionError {
+            vault_name,
+            details,
+        } => BackendError::Network(format!(
+            "DNS resolution failed for '{vault_name}': {details}"
+        )),
+        CrosstacheError::ConnectionTimeout(msg) => BackendError::Network(msg),
+        CrosstacheError::ConnectionRefused(msg) => BackendError::Network(msg),
+        CrosstacheError::SslError(msg) => BackendError::Network(msg),
+        other => BackendError::Internal(other.to_string()),
+    }
+}
 
 use self::secrets::AzureSecretBackend;
 use self::vaults::AzureVaultBackend;
@@ -114,7 +149,16 @@ impl Backend for AzureBackend {
     fn capabilities(&self) -> BackendCapabilities {
         BackendCapabilities {
             has_vaults: true,
-            has_file_storage: cfg!(feature = "file-ops"),
+            has_file_storage: {
+                #[cfg(feature = "file-ops")]
+                {
+                    self.file_backend.is_some()
+                }
+                #[cfg(not(feature = "file-ops"))]
+                {
+                    false
+                }
+            },
             has_rbac: true,
             has_audit: false,
             has_versioning: true,

--- a/src/backend/azure/mod.rs
+++ b/src/backend/azure/mod.rs
@@ -1,0 +1,154 @@
+//! Azure backend adapter.
+//!
+//! This module provides [`AzureBackend`], which implements the
+//! [`Backend`](super::Backend) trait by wrapping the existing Azure
+//! implementations (`AzureSecretOperations`, `AzureVaultOperations`,
+//! `BlobManager`) behind the new trait hierarchy.
+//!
+//! This is a *thin adapter layer* — no business logic is duplicated.
+
+#[allow(clippy::module_inception)]
+pub mod secrets;
+pub mod vaults;
+
+#[cfg(feature = "file-ops")]
+pub mod files;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::error::BackendError;
+use super::{Backend, BackendCapabilities, BackendKind, NameCharset, SecretBackend, VaultBackend};
+use crate::auth::provider::AzureAuthProvider;
+use crate::config::settings::Config;
+use crate::secret::manager::AzureSecretOperations;
+use crate::vault::operations::AzureVaultOperations;
+
+use self::secrets::AzureSecretBackend;
+use self::vaults::AzureVaultBackend;
+
+#[cfg(feature = "file-ops")]
+use self::files::AzureFileBackend;
+#[cfg(feature = "file-ops")]
+use super::FileBackend;
+#[cfg(feature = "file-ops")]
+use crate::blob::manager::BlobManager;
+
+/// Azure Key Vault backend — wraps all existing Azure implementations
+/// behind the new [`Backend`] trait.
+#[allow(dead_code)]
+pub struct AzureBackend {
+    secret_backend: AzureSecretBackend,
+    vault_backend: AzureVaultBackend,
+    #[cfg(feature = "file-ops")]
+    file_backend: Option<AzureFileBackend>,
+    auth_provider: Arc<dyn AzureAuthProvider>,
+}
+
+impl AzureBackend {
+    /// Create a new `AzureBackend` from a config and auth provider.
+    ///
+    /// This wires up the three sub-backends using the existing Azure
+    /// implementation types.
+    #[allow(dead_code)]
+    pub fn new(
+        config: &Config,
+        auth_provider: Arc<dyn AzureAuthProvider>,
+    ) -> Result<Self, BackendError> {
+        // Secret backend
+        let secret_ops = Arc::new(AzureSecretOperations::new(auth_provider.clone()));
+        let secret_backend = AzureSecretBackend::new(secret_ops);
+
+        // Vault backend
+        let vault_ops = Arc::new(
+            AzureVaultOperations::new(auth_provider.clone(), config.subscription_id.clone())
+                .map_err(|e| BackendError::Internal(e.to_string()))?,
+        );
+        let vault_backend = AzureVaultBackend::from_config(
+            vault_ops as Arc<dyn crate::vault::operations::VaultOperations>,
+            config,
+        );
+
+        // File backend (only when file-ops feature is enabled)
+        #[cfg(feature = "file-ops")]
+        let file_backend = {
+            let blob_config = config.get_blob_config();
+            if !blob_config.storage_account.is_empty() {
+                let blob_manager = BlobManager::new(
+                    auth_provider.clone(),
+                    blob_config.storage_account.clone(),
+                    blob_config.container_name.clone(),
+                )
+                .map_err(|e| BackendError::Internal(e.to_string()))?
+                .with_blob_config(
+                    blob_config.chunk_size_mb,
+                    blob_config.max_concurrent_uploads,
+                );
+                Some(AzureFileBackend::new(Arc::new(blob_manager)))
+            } else {
+                None
+            }
+        };
+
+        Ok(Self {
+            secret_backend,
+            vault_backend,
+            #[cfg(feature = "file-ops")]
+            file_backend,
+            auth_provider,
+        })
+    }
+}
+
+#[async_trait]
+impl Backend for AzureBackend {
+    fn name(&self) -> &'static str {
+        "azure"
+    }
+
+    fn kind(&self) -> BackendKind {
+        BackendKind::Azure
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            has_vaults: true,
+            has_file_storage: cfg!(feature = "file-ops"),
+            has_rbac: true,
+            has_audit: false,
+            has_versioning: true,
+            has_soft_delete: true,
+            has_secret_rotation: false,
+            has_groups: true,
+            has_folders: true,
+            has_notes: true,
+            has_expiry: true,
+            max_secret_size: Some(25 * 1024), // 25 KiB Azure limit
+            max_name_length: Some(127),       // Azure Key Vault name limit
+            name_charset: NameCharset::AlphanumericHyphen,
+        }
+    }
+
+    fn secrets(&self) -> &dyn SecretBackend {
+        &self.secret_backend
+    }
+
+    fn vaults(&self) -> Option<&dyn VaultBackend> {
+        Some(&self.vault_backend)
+    }
+
+    #[cfg(feature = "file-ops")]
+    fn files(&self) -> Option<&dyn FileBackend> {
+        self.file_backend.as_ref().map(|fb| fb as &dyn FileBackend)
+    }
+
+    async fn health_check(&self) -> Result<(), BackendError> {
+        // Verify we can obtain an Azure token (cheap connectivity check).
+        self.auth_provider
+            .get_token(&["https://vault.azure.net/.default"])
+            .await
+            .map_err(|e| BackendError::AuthenticationFailed(e.to_string()))?;
+        Ok(())
+    }
+}

--- a/src/backend/azure/secrets.rs
+++ b/src/backend/azure/secrets.rs
@@ -1,0 +1,226 @@
+//! Azure secret backend adapter.
+//!
+//! Wraps the existing [`AzureSecretOperations`] (which implements
+//! [`SecretOperations`]) behind the new [`SecretBackend`] trait.
+
+#[allow(unused_imports)]
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::backend::error::BackendError;
+use crate::backend::secret::SecretBackend;
+use crate::error::CrosstacheError;
+use crate::secret::manager::{
+    SecretOperations, SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest,
+};
+
+/// Adapter that implements [`SecretBackend`] by delegating to an existing
+/// [`SecretOperations`] implementation (i.e. `AzureSecretOperations`).
+#[allow(dead_code)]
+pub struct AzureSecretBackend {
+    inner: Arc<dyn SecretOperations>,
+}
+
+impl AzureSecretBackend {
+    /// Wrap an existing `SecretOperations` implementor.
+    #[allow(dead_code)]
+    pub fn new(inner: Arc<dyn SecretOperations>) -> Self {
+        Self { inner }
+    }
+}
+
+/// Map [`CrosstacheError`] → [`BackendError`].
+///
+/// This is a best-effort mapping; variants without a direct BackendError
+/// equivalent are mapped to `BackendError::Internal`.
+fn map_error(err: CrosstacheError) -> BackendError {
+    match err {
+        CrosstacheError::SecretNotFound { name, suggestion } => {
+            BackendError::NotFound { name, suggestion }
+        }
+        CrosstacheError::VaultNotFound { name, suggestion } => {
+            BackendError::VaultNotFound { name, suggestion }
+        }
+        CrosstacheError::AuthenticationError(msg) => BackendError::AuthenticationFailed(msg),
+        CrosstacheError::PermissionDenied(msg) => BackendError::PermissionDenied(msg),
+        CrosstacheError::Conflict(msg) => BackendError::Conflict(msg),
+        CrosstacheError::RateLimited(_msg) => BackendError::RateLimited {
+            retry_after_secs: None,
+        },
+        CrosstacheError::NetworkError(msg) => BackendError::Network(msg),
+        CrosstacheError::DnsResolutionError {
+            vault_name,
+            details,
+        } => BackendError::Network(format!(
+            "DNS resolution failed for '{vault_name}': {details}"
+        )),
+        CrosstacheError::ConnectionTimeout(msg) => BackendError::Network(msg),
+        CrosstacheError::ConnectionRefused(msg) => BackendError::Network(msg),
+        CrosstacheError::SslError(msg) => BackendError::Network(msg),
+        other => BackendError::Internal(other.to_string()),
+    }
+}
+
+#[async_trait]
+impl SecretBackend for AzureSecretBackend {
+    async fn set_secret(
+        &self,
+        vault: &str,
+        request: SecretRequest,
+    ) -> Result<SecretProperties, BackendError> {
+        self.inner
+            .set_secret(vault, &request)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn get_secret(
+        &self,
+        vault: &str,
+        name: &str,
+        include_value: bool,
+    ) -> Result<SecretProperties, BackendError> {
+        self.inner
+            .get_secret(vault, name, include_value)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn get_secret_version(
+        &self,
+        vault: &str,
+        name: &str,
+        version: &str,
+        include_value: bool,
+    ) -> Result<SecretProperties, BackendError> {
+        self.inner
+            .get_secret_version(vault, name, version, include_value)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn list_secrets(
+        &self,
+        vault: &str,
+        group_filter: Option<&str>,
+    ) -> Result<Vec<SecretSummary>, BackendError> {
+        self.inner
+            .list_secrets(vault, group_filter)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn delete_secret(&self, vault: &str, name: &str) -> Result<(), BackendError> {
+        self.inner
+            .delete_secret(vault, name)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn update_secret(
+        &self,
+        vault: &str,
+        name: &str,
+        request: SecretUpdateRequest,
+    ) -> Result<SecretProperties, BackendError> {
+        // The old SecretOperations::update_secret takes &SecretRequest, but
+        // the new trait takes SecretUpdateRequest. Translate by building a
+        // SecretRequest from the update request fields.
+        let compat_request = SecretRequest {
+            name: request.new_name.unwrap_or_else(|| request.name.clone()),
+            value: request
+                .value
+                .unwrap_or_else(|| zeroize::Zeroizing::new(String::new())),
+            content_type: request.content_type,
+            enabled: request.enabled,
+            expires_on: request.expires_on,
+            not_before: request.not_before,
+            tags: request.tags,
+            groups: request.groups,
+            note: request.note,
+            folder: request.folder,
+        };
+        self.inner
+            .update_secret(vault, name, &compat_request)
+            .await
+            .map_err(map_error)
+    }
+
+    // ------------------------------------------------------------------
+    // Optional operations — Azure supports all of these
+    // ------------------------------------------------------------------
+
+    async fn list_versions(
+        &self,
+        vault: &str,
+        name: &str,
+    ) -> Result<Vec<SecretProperties>, BackendError> {
+        self.inner
+            .get_secret_versions(vault, name)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn rollback(
+        &self,
+        vault: &str,
+        name: &str,
+        version: &str,
+    ) -> Result<SecretProperties, BackendError> {
+        self.inner
+            .rollback_secret(vault, name, version)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn restore_secret(
+        &self,
+        vault: &str,
+        name: &str,
+    ) -> Result<SecretProperties, BackendError> {
+        self.inner
+            .restore_secret(vault, name)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn purge_secret(&self, vault: &str, name: &str) -> Result<(), BackendError> {
+        self.inner
+            .purge_secret(vault, name)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn secret_exists(&self, vault: &str, name: &str) -> Result<bool, BackendError> {
+        self.inner
+            .secret_exists(vault, name)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn list_deleted_secrets(&self, vault: &str) -> Result<Vec<SecretSummary>, BackendError> {
+        self.inner
+            .list_deleted_secrets(vault)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn backup_secret(&self, vault: &str, name: &str) -> Result<Vec<u8>, BackendError> {
+        self.inner
+            .backup_secret(vault, name)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn restore_from_backup(
+        &self,
+        vault: &str,
+        backup: &[u8],
+    ) -> Result<SecretProperties, BackendError> {
+        self.inner
+            .restore_secret_from_backup(vault, backup)
+            .await
+            .map_err(map_error)
+    }
+}

--- a/src/backend/azure/secrets.rs
+++ b/src/backend/azure/secrets.rs
@@ -10,10 +10,11 @@ use async_trait::async_trait;
 
 use crate::backend::error::BackendError;
 use crate::backend::secret::SecretBackend;
-use crate::error::CrosstacheError;
 use crate::secret::manager::{
     SecretOperations, SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest,
 };
+
+use super::map_error;
 
 /// Adapter that implements [`SecretBackend`] by delegating to an existing
 /// [`SecretOperations`] implementation (i.e. `AzureSecretOperations`).
@@ -27,38 +28,6 @@ impl AzureSecretBackend {
     #[allow(dead_code)]
     pub fn new(inner: Arc<dyn SecretOperations>) -> Self {
         Self { inner }
-    }
-}
-
-/// Map [`CrosstacheError`] → [`BackendError`].
-///
-/// This is a best-effort mapping; variants without a direct BackendError
-/// equivalent are mapped to `BackendError::Internal`.
-fn map_error(err: CrosstacheError) -> BackendError {
-    match err {
-        CrosstacheError::SecretNotFound { name, suggestion } => {
-            BackendError::NotFound { name, suggestion }
-        }
-        CrosstacheError::VaultNotFound { name, suggestion } => {
-            BackendError::VaultNotFound { name, suggestion }
-        }
-        CrosstacheError::AuthenticationError(msg) => BackendError::AuthenticationFailed(msg),
-        CrosstacheError::PermissionDenied(msg) => BackendError::PermissionDenied(msg),
-        CrosstacheError::Conflict(msg) => BackendError::Conflict(msg),
-        CrosstacheError::RateLimited(_msg) => BackendError::RateLimited {
-            retry_after_secs: None,
-        },
-        CrosstacheError::NetworkError(msg) => BackendError::Network(msg),
-        CrosstacheError::DnsResolutionError {
-            vault_name,
-            details,
-        } => BackendError::Network(format!(
-            "DNS resolution failed for '{vault_name}': {details}"
-        )),
-        CrosstacheError::ConnectionTimeout(msg) => BackendError::Network(msg),
-        CrosstacheError::ConnectionRefused(msg) => BackendError::Network(msg),
-        CrosstacheError::SslError(msg) => BackendError::Network(msg),
-        other => BackendError::Internal(other.to_string()),
     }
 }
 
@@ -127,17 +96,76 @@ impl SecretBackend for AzureSecretBackend {
         // The old SecretOperations::update_secret takes &SecretRequest, but
         // the new trait takes SecretUpdateRequest. Translate by building a
         // SecretRequest from the update request fields.
+
+        // Determine whether we need to read the current secret.
+        // We need it when:
+        //  - value is None (to avoid overwriting with empty string)
+        //  - replace_tags is false and new tags are provided (to merge)
+        //  - replace_groups is false and new groups are provided (to merge)
+        let needs_current = request.value.is_none()
+            || (!request.replace_tags && request.tags.is_some())
+            || (!request.replace_groups && request.groups.is_some());
+
+        let current = if needs_current {
+            Some(
+                self.inner
+                    .get_secret(vault, name, true)
+                    .await
+                    .map_err(map_error)?,
+            )
+        } else {
+            None
+        };
+
+        // Resolve the value: use the provided value, or fall back to the current one.
+        let value = match request.value {
+            Some(v) => v,
+            None => current
+                .as_ref()
+                .and_then(|c| c.value.clone())
+                .unwrap_or_else(|| zeroize::Zeroizing::new(String::new())),
+        };
+
+        // Resolve tags: honor replace_tags semantics.
+        let tags = match request.tags {
+            Some(new_tags) if !request.replace_tags => {
+                // Merge: start with existing tags, then overlay new ones.
+                let mut merged = current.as_ref().map(|c| c.tags.clone()).unwrap_or_default();
+                merged.extend(new_tags);
+                Some(merged)
+            }
+            other => other,
+        };
+
+        // Resolve groups: honor replace_groups semantics.
+        let groups = match request.groups {
+            Some(new_groups) if !request.replace_groups => {
+                // Merge: start with existing groups (stored in tags as comma-separated),
+                // then add any new groups that aren't already present.
+                let mut existing: Vec<String> = current
+                    .as_ref()
+                    .and_then(|c| c.tags.get("groups"))
+                    .map(|g| g.split(',').map(|s| s.trim().to_string()).collect())
+                    .unwrap_or_default();
+                for g in new_groups {
+                    if !existing.contains(&g) {
+                        existing.push(g);
+                    }
+                }
+                Some(existing)
+            }
+            other => other,
+        };
+
         let compat_request = SecretRequest {
             name: request.new_name.unwrap_or_else(|| request.name.clone()),
-            value: request
-                .value
-                .unwrap_or_else(|| zeroize::Zeroizing::new(String::new())),
+            value,
             content_type: request.content_type,
             enabled: request.enabled,
             expires_on: request.expires_on,
             not_before: request.not_before,
-            tags: request.tags,
-            groups: request.groups,
+            tags,
+            groups,
             note: request.note,
             folder: request.folder,
         };

--- a/src/backend/azure/vaults.rs
+++ b/src/backend/azure/vaults.rs
@@ -1,0 +1,184 @@
+//! Azure vault backend adapter.
+//!
+//! Wraps the existing [`AzureVaultOperations`] (which implements
+//! [`VaultOperations`]) behind the new [`VaultBackend`] trait.
+
+#[allow(unused_imports)]
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::backend::error::BackendError;
+use crate::backend::vault::VaultBackend;
+use crate::config::settings::Config;
+use crate::error::CrosstacheError;
+use crate::vault::models::{
+    AccessLevel, VaultCreateRequest, VaultProperties, VaultRole, VaultSummary, VaultUpdateRequest,
+};
+use crate::vault::operations::VaultOperations;
+
+/// Adapter that implements [`VaultBackend`] by delegating to an existing
+/// [`VaultOperations`] implementation (i.e. `AzureVaultOperations`).
+///
+/// Because many old `VaultOperations` methods require a `resource_group`
+/// parameter that the new `VaultBackend` trait omits, the adapter stores
+/// a default resource group (from config) and uses it for every call.
+#[allow(dead_code)]
+pub struct AzureVaultBackend {
+    inner: Arc<dyn VaultOperations>,
+    /// Default resource group to use when the new trait API doesn't supply one.
+    default_resource_group: String,
+    /// Default subscription ID (needed by list_vaults).
+    subscription_id: String,
+    /// Default location (used for restore/purge).
+    default_location: String,
+}
+
+impl AzureVaultBackend {
+    /// Create a new adapter around an existing `VaultOperations` implementor.
+    #[allow(dead_code)]
+    pub fn new(
+        inner: Arc<dyn VaultOperations>,
+        default_resource_group: String,
+        subscription_id: String,
+        default_location: String,
+    ) -> Self {
+        Self {
+            inner,
+            default_resource_group,
+            subscription_id,
+            default_location,
+        }
+    }
+
+    /// Convenience constructor from config.
+    #[allow(dead_code)]
+    pub fn from_config(inner: Arc<dyn VaultOperations>, config: &Config) -> Self {
+        Self {
+            inner,
+            default_resource_group: config.default_resource_group.clone(),
+            subscription_id: config.subscription_id.clone(),
+            default_location: config.default_location.clone(),
+        }
+    }
+}
+
+/// Map [`CrosstacheError`] → [`BackendError`].
+fn map_error(err: CrosstacheError) -> BackendError {
+    match err {
+        CrosstacheError::VaultNotFound { name, suggestion } => {
+            BackendError::VaultNotFound { name, suggestion }
+        }
+        CrosstacheError::SecretNotFound { name, suggestion } => {
+            BackendError::NotFound { name, suggestion }
+        }
+        CrosstacheError::AuthenticationError(msg) => BackendError::AuthenticationFailed(msg),
+        CrosstacheError::PermissionDenied(msg) => BackendError::PermissionDenied(msg),
+        CrosstacheError::Conflict(msg) => BackendError::Conflict(msg),
+        CrosstacheError::RateLimited(_msg) => BackendError::RateLimited {
+            retry_after_secs: None,
+        },
+        CrosstacheError::NetworkError(msg) => BackendError::Network(msg),
+        CrosstacheError::DnsResolutionError {
+            vault_name,
+            details,
+        } => BackendError::Network(format!(
+            "DNS resolution failed for '{vault_name}': {details}"
+        )),
+        CrosstacheError::ConnectionTimeout(msg) => BackendError::Network(msg),
+        CrosstacheError::ConnectionRefused(msg) => BackendError::Network(msg),
+        CrosstacheError::SslError(msg) => BackendError::Network(msg),
+        other => BackendError::Internal(other.to_string()),
+    }
+}
+
+#[async_trait]
+impl VaultBackend for AzureVaultBackend {
+    async fn create_vault(
+        &self,
+        request: VaultCreateRequest,
+    ) -> Result<VaultProperties, BackendError> {
+        self.inner.create_vault(&request).await.map_err(map_error)
+    }
+
+    async fn get_vault(&self, name: &str) -> Result<VaultProperties, BackendError> {
+        // The old trait requires a resource_group; use the default.
+        self.inner
+            .get_vault(name, &self.default_resource_group)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn list_vaults(&self) -> Result<Vec<VaultSummary>, BackendError> {
+        self.inner
+            .list_vaults(Some(&self.subscription_id), None)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn delete_vault(&self, name: &str) -> Result<(), BackendError> {
+        self.inner
+            .delete_vault(name, &self.default_resource_group)
+            .await
+            .map_err(map_error)
+    }
+
+    // ------------------------------------------------------------------
+    // Optional operations
+    // ------------------------------------------------------------------
+
+    async fn update_vault(
+        &self,
+        name: &str,
+        request: VaultUpdateRequest,
+    ) -> Result<VaultProperties, BackendError> {
+        self.inner
+            .update_vault(name, &self.default_resource_group, &request)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn restore_vault(&self, name: &str) -> Result<VaultProperties, BackendError> {
+        self.inner
+            .restore_vault(name, &self.default_location)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn purge_vault(&self, name: &str) -> Result<(), BackendError> {
+        self.inner
+            .purge_vault(name, &self.default_location)
+            .await
+            .map_err(map_error)
+    }
+
+    // ------------------------------------------------------------------
+    // RBAC
+    // ------------------------------------------------------------------
+
+    async fn grant_access(
+        &self,
+        vault: &str,
+        principal: &str,
+        level: AccessLevel,
+    ) -> Result<(), BackendError> {
+        self.inner
+            .grant_access(vault, &self.default_resource_group, principal, level)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn revoke_access(&self, vault: &str, principal: &str) -> Result<(), BackendError> {
+        self.inner
+            .revoke_access(vault, &self.default_resource_group, principal)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn list_access(&self, vault: &str) -> Result<Vec<VaultRole>, BackendError> {
+        self.inner
+            .list_access(vault, &self.default_resource_group)
+            .await
+            .map_err(map_error)
+    }
+}

--- a/src/backend/azure/vaults.rs
+++ b/src/backend/azure/vaults.rs
@@ -11,11 +11,12 @@ use async_trait::async_trait;
 use crate::backend::error::BackendError;
 use crate::backend::vault::VaultBackend;
 use crate::config::settings::Config;
-use crate::error::CrosstacheError;
 use crate::vault::models::{
     AccessLevel, VaultCreateRequest, VaultProperties, VaultRole, VaultSummary, VaultUpdateRequest,
 };
 use crate::vault::operations::VaultOperations;
+
+use super::map_error;
 
 /// Adapter that implements [`VaultBackend`] by delegating to an existing
 /// [`VaultOperations`] implementation (i.e. `AzureVaultOperations`).
@@ -60,35 +61,6 @@ impl AzureVaultBackend {
             subscription_id: config.subscription_id.clone(),
             default_location: config.default_location.clone(),
         }
-    }
-}
-
-/// Map [`CrosstacheError`] → [`BackendError`].
-fn map_error(err: CrosstacheError) -> BackendError {
-    match err {
-        CrosstacheError::VaultNotFound { name, suggestion } => {
-            BackendError::VaultNotFound { name, suggestion }
-        }
-        CrosstacheError::SecretNotFound { name, suggestion } => {
-            BackendError::NotFound { name, suggestion }
-        }
-        CrosstacheError::AuthenticationError(msg) => BackendError::AuthenticationFailed(msg),
-        CrosstacheError::PermissionDenied(msg) => BackendError::PermissionDenied(msg),
-        CrosstacheError::Conflict(msg) => BackendError::Conflict(msg),
-        CrosstacheError::RateLimited(_msg) => BackendError::RateLimited {
-            retry_after_secs: None,
-        },
-        CrosstacheError::NetworkError(msg) => BackendError::Network(msg),
-        CrosstacheError::DnsResolutionError {
-            vault_name,
-            details,
-        } => BackendError::Network(format!(
-            "DNS resolution failed for '{vault_name}': {details}"
-        )),
-        CrosstacheError::ConnectionTimeout(msg) => BackendError::Network(msg),
-        CrosstacheError::ConnectionRefused(msg) => BackendError::Network(msg),
-        CrosstacheError::SslError(msg) => BackendError::Network(msg),
-        other => BackendError::Internal(other.to_string()),
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -15,6 +15,7 @@
 //! See also: [`BackendError`] for the backend-agnostic error type, and
 //! [`BackendRegistry`] for runtime backend resolution.
 
+pub mod azure;
 pub mod error;
 #[cfg(feature = "file-ops")]
 pub mod file;


### PR DESCRIPTION
Phase 2: Azure adapter layer wrapping existing implementations behind new backend traits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Azure `Backend` implementation and adapters for secrets/vaults/files, including new error-mapping and `update_secret` translation logic that could subtly change update/merge semantics. Also gates file storage behavior behind `file-ops` and config, so misconfiguration could affect capability detection.
> 
> **Overview**
> Adds a new `backend::azure` module that implements the new `Backend` trait via a thin adapter (`AzureBackend`) over existing Azure implementations, including a shared `CrosstacheError` → `BackendError` mapping and a token-based `health_check`.
> 
> Introduces sub-backend adapters for secrets and vaults (`AzureSecretBackend`, `AzureVaultBackend`), translating the new trait APIs onto the existing operation traits (notably translating `SecretUpdateRequest` into a compatible `SecretRequest`, and supplying default resource group/location/subscription from config for vault operations).
> 
> When `file-ops` is enabled, adds an `AzureFileBackend` wrapping `BlobManager` and conditionally exposes file storage capability based on blob config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa48938871e6854f9f46148fd04fb5310eaa2027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->