### PR TITLE
feat: implement BackendRegistry with config and CLI backend selection

### DIFF
--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -20,6 +20,15 @@ pub struct BackendRegistry {
     default: &'static str,
 }
 
+impl std::fmt::Debug for BackendRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BackendRegistry")
+            .field("default", &self.default)
+            .field("backends", &self.backends.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
 impl BackendRegistry {
     /// Build a registry from the loaded [`Config`].
     ///

--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -1,13 +1,15 @@
 //! Backend registry — runtime backend resolution.
 //!
 //! [`BackendRegistry`] holds instantiated backends and dispatches
-//! operations to the active one. This is a skeleton for now; actual
-//! backend instantiation will be added in a later PR.
+//! operations to the active one.  Created once at startup from the
+//! application [`Config`](crate::config::Config).
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::Backend;
+use super::error::BackendError;
+use super::{Backend, BackendKind};
+use crate::config::settings::Config;
 
 /// Maps backend names to live [`Backend`] instances.
 ///
@@ -19,6 +21,45 @@ pub struct BackendRegistry {
 }
 
 impl BackendRegistry {
+    /// Build a registry from the loaded [`Config`].
+    ///
+    /// The active backend is determined by `config.backend` (defaulting to
+    /// `"azure"` when absent). For Azure, an [`AzureBackend`] is created
+    /// using the existing auth provider. For Local, an error is returned
+    /// because the local backend is not yet implemented.
+    ///
+    /// [`AzureBackend`]: super::azure::AzureBackend
+    pub fn from_config(config: &Config) -> Result<Self, BackendError> {
+        let kind: BackendKind = config
+            .effective_backend_name()
+            .parse()
+            .map_err(|e: String| BackendError::Internal(e))?;
+
+        match kind {
+            BackendKind::Azure => {
+                let auth_provider = Self::create_azure_auth_provider(config)?;
+                let backend = super::azure::AzureBackend::new(config, auth_provider)?;
+                Ok(Self::new(Arc::new(backend)))
+            }
+            BackendKind::Local => Err(BackendError::Unsupported(
+                "local backend is not yet implemented — coming in a future release".into(),
+            )),
+        }
+    }
+
+    /// Create an Azure auth provider from the config's credential priority.
+    fn create_azure_auth_provider(
+        config: &Config,
+    ) -> Result<Arc<dyn crate::auth::provider::AzureAuthProvider>, BackendError> {
+        use crate::auth::provider::DefaultAzureCredentialProvider;
+
+        let provider = DefaultAzureCredentialProvider::with_credential_priority(
+            config.azure_credential_priority.clone(),
+        )
+        .map_err(|e| BackendError::AuthenticationFailed(e.to_string()))?;
+        Ok(Arc::new(provider))
+    }
+
     /// Create a new registry with a single backend.
     pub fn new(backend: Arc<dyn Backend>) -> Self {
         let name = backend.name();
@@ -48,5 +89,35 @@ impl BackendRegistry {
     /// The name of the default (active) backend.
     pub fn default_name(&self) -> &'static str {
         self.default
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_config_local_returns_unsupported() {
+        let config = Config {
+            backend: Some("local".to_string()),
+            ..Default::default()
+        };
+        let result = BackendRegistry::from_config(&config);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, BackendError::Unsupported(_)),
+            "expected Unsupported, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn from_config_unknown_backend_returns_error() {
+        let config = Config {
+            backend: Some("nosuchbackend".to_string()),
+            ..Default::default()
+        };
+        let result = BackendRegistry::from_config(&config);
+        assert!(result.is_err());
     }
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -98,6 +98,17 @@ pub struct Cli {
     #[arg(long, global = true, hide = should_hide_options())]
     pub env: Option<String>,
 
+    /// Secrets backend to use (overrides config file and XV_BACKEND env var).
+    /// Valid values: azure, local.
+    #[arg(
+        long,
+        global = true,
+        value_name = "BACKEND",
+        env = "XV_BACKEND",
+        hide = should_hide_options()
+    )]
+    pub backend: Option<String>,
+
     /// Custom template string for template format
     #[arg(long, global = true, hide = should_hide_options())]
     pub template: Option<String>,

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -791,6 +791,7 @@ impl ConfigInitializer {
         };
 
         Ok(Config {
+            backend: None,
             subscription_id: init_config.subscription_id,
             tenant_id: init_config.tenant_id,
             default_vault: init_config.default_vault.unwrap_or_default(),
@@ -805,6 +806,7 @@ impl ConfigInitializer {
             cache_ttl_secs: 900,
             blob_config,
             azure_credential_priority: crate::config::settings::AzureCredentialType::Default,
+            local: None,
             clipboard_timeout: 30,
             gen_default_charset: None,
             env_flag: None,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -10,6 +10,30 @@ use std::fmt;
 use std::path::PathBuf;
 use tabled::Tabled;
 
+// ---------------------------------------------------------------------------
+// Local backend configuration (Phase 2)
+// ---------------------------------------------------------------------------
+
+/// Configuration for the local age-encrypted file backend.
+///
+/// Lives under `[local]` in `xv.conf`. Only relevant when `backend = "local"`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LocalConfig {
+    /// Root directory for the encrypted secret store.
+    /// Defaults to `$XDG_DATA_HOME/xv/store` (or `~/.local/share/xv/store`).
+    #[serde(default)]
+    pub store_path: Option<String>,
+
+    /// Path to the age identity (private key) file.
+    /// Defaults to `$XDG_CONFIG_HOME/xv/age-key.txt`.
+    #[serde(default)]
+    pub key_file: Option<String>,
+
+    /// Default vault name used when no `--vault` / context is set.
+    #[serde(default)]
+    pub default_vault: Option<String>,
+}
+
 /// Azure credential type priority for authentication
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -82,6 +106,12 @@ impl Default for BlobConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Tabled)]
 pub struct Config {
+    /// Active backend: `"azure"` (default) or `"local"`.
+    /// Missing / `None` is treated as `"azure"` for backward compatibility.
+    #[tabled(skip)]
+    #[serde(default)]
+    pub backend: Option<String>,
+
     #[tabled(rename = "Debug")]
     pub debug: bool,
     #[tabled(rename = "Subscription ID")]
@@ -121,6 +151,11 @@ pub struct Config {
     #[tabled(rename = "Credential Priority")]
     #[serde(default)]
     pub azure_credential_priority: AzureCredentialType,
+    /// Configuration for the local age-encrypted file backend.
+    /// Only relevant when `backend = "local"`.
+    #[tabled(skip)]
+    #[serde(default)]
+    pub local: Option<LocalConfig>,
     /// Seconds before clipboard is automatically cleared (0 to disable)
     #[tabled(rename = "Clipboard Timeout")]
     #[serde(default = "default_clipboard_timeout")]
@@ -154,6 +189,7 @@ fn default_cache_ttl_secs() -> u64 {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            backend: None,
             debug: false,
             subscription_id: String::new(),
             default_vault: String::new(),
@@ -168,6 +204,7 @@ impl Default for Config {
             no_color: false,
             blob_config: None,
             azure_credential_priority: AzureCredentialType::Default,
+            local: None,
             clipboard_timeout: default_clipboard_timeout(),
             gen_default_charset: None,
             env_flag: None,
@@ -225,6 +262,15 @@ impl Config {
 
     pub async fn save(&self) -> Result<()> {
         save_config(self).await
+    }
+
+    /// Return the effective backend name as a string.
+    ///
+    /// Resolves `self.backend` (an `Option<String>`) to a definite value.
+    /// `None` is treated as `"azure"` for backward compatibility.
+    #[allow(dead_code)]
+    pub fn effective_backend_name(&self) -> &str {
+        self.backend.as_deref().unwrap_or("azure")
     }
 
     /// Resolve vault name with context awareness
@@ -433,6 +479,11 @@ async fn load_from_file(path: &PathBuf) -> Result<Config> {
 }
 
 fn load_from_env(config: &mut Config) {
+    // Backend override from environment variable
+    if let Ok(value) = std::env::var("XV_BACKEND") {
+        config.backend = Some(value);
+    }
+
     if let Ok(value) = std::env::var("DEBUG") {
         config.debug = value.to_lowercase() == "true" || value == "1";
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,11 @@ async fn run(cli: Cli) -> Result<()> {
     // resolve_resource_group when consulting .xv.toml).
     config.env_flag = cli.env.clone();
 
+    // Apply CLI --backend flag to config (overrides config file and env var).
+    if let Some(ref backend) = cli.backend {
+        config.backend = Some(backend.clone());
+    }
+
     // Execute the command
     cli.execute(config).await?;
 


### PR DESCRIPTION
## PR 3: BackendRegistry + Config + CLI Flag

Implements the backend registry and configuration layer for Phase 2 backend pluggability.

### Changes
- **BackendRegistry**: Full implementation in `src/backend/registry.rs` - `from_config()` creates the right backend based on config
- **Config**: Added `backend` field (Option<String>, None = azure for backward compat) and `LocalConfig` struct
- **CLI**: Added `--backend <name>` global flag that overrides config
- **main.rs**: Wires CLI flag into config override

Local backend returns Unsupported error - actual implementation comes in PR 6.

Part of Phase 2: Backend Pluggability (design spec: docs/superpowers/specs/2026-05-03-backend-pluggability-phase-2-design.md §5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the runtime backend is chosen and instantiated (config/env/CLI overrides) and introduces new config surface area for a future local backend, which could affect startup/command execution paths if misconfigured.
> 
> **Overview**
> Implements `BackendRegistry::from_config` to instantiate the active backend from `Config`, including Azure auth-provider construction based on `azure_credential_priority`, and returns a clear `Unsupported` error for the not-yet-implemented local backend.
> 
> Adds a `backend` selector to config (defaulting to Azure for backward compatibility), introduces a `[local]` `LocalConfig` section placeholder, and wires overrides via `XV_BACKEND` and a new global CLI `--backend` flag (applied in `main.rs`).
> 
> Includes basic unit tests for unknown/local backend selection errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6be268594d8eff4b5f764df5b9cc4c65ae0283c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->