### PR TITLE
chore: bump version to 0.8.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.7.3"
+version = "0.8.0-rc.1"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"


### PR DESCRIPTION
Bump Cargo.toml version to match the v0.8.0-rc.1 tag. Release workflow requires version match.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the crate version in `Cargo.toml` and does not change runtime code or dependencies.
> 
> **Overview**
> Updates the `Cargo.toml` package version from `0.7.3` to `0.8.0-rc.1` to align the crate metadata with the `v0.8.0-rc.1` release tag/workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e05d5cb4e785cee328e54a5554fca09d75ba665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->