### PR TITLE
feat: local backend init wizard, integration tests, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ xv scan install                        # block secret leaks before commit
 ## Table of contents
 
 - [Quick start](#quick-start)
+- [Local Backend (age-encrypted files)](#local-backend-age-encrypted-files)
 - [Installation](#installation)
 - [Common workflows](#common-workflows) — end-to-end recipes
 - [Secrets — CRUD](#secrets--crud)
@@ -63,6 +64,73 @@ xv tui
 ```
 
 That's the 5-minute path. The rest of this doc shows what's possible once you've got the basics.
+
+---
+
+## Local Backend (age-encrypted files)
+
+The local backend stores secrets as age-encrypted files on your machine — no cloud account needed.
+
+### Quick start
+
+```bash
+# Initialize with local backend
+xv init
+# → Choose "Local" when prompted
+
+# Or set backend via env
+export XV_BACKEND=local
+
+# Basic secret operations
+xv set DB_PASSWORD
+xv get DB_PASSWORD --raw
+xv list
+```
+
+### How it works
+
+Secrets are encrypted with [age](https://age-encryption.org/) and stored as individual files:
+
+```
+~/.xv/
+├── key.txt              # Your age private key (0600 permissions)
+├── recipients.txt       # Public key for encryption
+└── store/
+    └── vaults/
+        └── default/
+            ├── .vault.json
+            └── secrets/
+                ├── DB_PASSWORD.age          # Encrypted value
+                └── DB_PASSWORD.meta.json    # Metadata (name, groups, tags)
+```
+
+### Migrating between backends
+
+```bash
+# Copy all secrets from Azure to local
+xv migrate --from azure --to local
+
+# Copy from local to Azure
+xv migrate --from local --to azure --vault my-keyvault
+
+# Preview what would be migrated
+xv migrate --from azure --to local --dry-run
+
+# Filter by pattern
+xv migrate --from azure --to local --filter "db-*"
+```
+
+### Configuration
+
+```toml
+# ~/.config/xv/xv.conf
+backend = "local"
+
+[local]
+store_path = "~/.xv/store"
+key_file = "~/.xv/key.txt"
+default_vault = "default"
+```
 
 ---
 

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -4,7 +4,7 @@
 //! including Azure environment detection, configuration building, and vault creation.
 
 use crate::auth::provider::{AzureAuthProvider, DefaultAzureCredentialProvider};
-use crate::config::settings::Config;
+use crate::config::settings::{Config, LocalConfig};
 use crate::error::{CrosstacheError, Result};
 use crate::utils::azure_detect::{AzureDetector, AzureEnvironment, AzureSubscription};
 use crate::utils::interactive::{InteractivePrompt, ProgressIndicator, SetupHelper};
@@ -45,6 +45,25 @@ impl ConfigInitializer {
     /// Run the complete interactive initialization process
     pub async fn run_interactive_setup(&self) -> Result<Config> {
         self.prompt.welcome()?;
+
+        // Step 0: Choose backend
+        println!();
+        output::step("Backend Selection");
+        let backend_options = vec![
+            "Azure Key Vault (cloud-based, requires Azure subscription)".to_string(),
+            "Local (age-encrypted files, offline, no cloud account needed)".to_string(),
+        ];
+        let backend_index = self.prompt.select(
+            "Which secrets backend would you like to use?",
+            &backend_options,
+            Some(0),
+        )?;
+
+        if backend_index == 1 {
+            return self.run_local_setup().await;
+        }
+
+        // Azure flow (unchanged)
 
         // Step 1: Detect Azure environment
         println!();
@@ -119,6 +138,100 @@ impl ConfigInitializer {
 
         output::success("Setup completed successfully!");
         output::info("You can now start using crosstache with your configured defaults.");
+
+        Ok(config)
+    }
+
+    /// Run the simplified local backend setup (3 steps).
+    async fn run_local_setup(&self) -> Result<Config> {
+        // Step 1: Store path
+        println!();
+        output::step("Step 1/3: Store Location");
+        let default_store = dirs::home_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("."))
+            .join(".xv")
+            .join("store");
+        let store_path = self.prompt.input_text(
+            "Store path for encrypted secrets",
+            Some(&default_store.to_string_lossy()),
+        )?;
+
+        // Step 2: Key file path
+        println!();
+        output::step("Step 2/3: Key File");
+        let default_key = dirs::home_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("."))
+            .join(".xv")
+            .join("key.txt");
+        let key_file = self
+            .prompt
+            .input_text("Age key file path", Some(&default_key.to_string_lossy()))?;
+
+        // Step 3: Default vault name
+        println!();
+        output::step("Step 3/3: Default Vault");
+        let default_vault = self
+            .prompt
+            .input_text("Default vault name", Some("default"))?;
+
+        // Create the local backend (generates keys and directories automatically)
+        let local_config = LocalConfig {
+            store_path: Some(store_path.clone()),
+            key_file: Some(key_file.clone()),
+            default_vault: Some(default_vault.clone()),
+        };
+
+        let progress = ProgressIndicator::new("Setting up local backend...");
+        crate::backend::local::LocalBackend::new(Some(&local_config))
+            .map_err(|e| CrosstacheError::config(format!("Failed to create local backend: {e}")))?;
+        progress.finish_success("Local backend initialized");
+
+        // Read the public key for the summary
+        let resolved =
+            crate::backend::local::config::ResolvedLocalConfig::from_raw(Some(&local_config));
+        let public_key = if resolved.recipients_file.exists() {
+            std::fs::read_to_string(&resolved.recipients_file)
+                .unwrap_or_default()
+                .trim()
+                .to_string()
+        } else {
+            String::new()
+        };
+
+        // Build and save config
+        let config = Config {
+            backend: Some("local".to_string()),
+            local: Some(local_config),
+            // Azure fields get sensible empty defaults
+            subscription_id: String::new(),
+            tenant_id: String::new(),
+            default_vault: default_vault.clone(),
+            default_resource_group: String::new(),
+            default_location: String::new(),
+            output_json: false,
+            runtime_output_format: crate::utils::format::OutputFormat::Auto,
+            template: None,
+            no_color: false,
+            debug: false,
+            cache_enabled: true,
+            cache_ttl_secs: 900,
+            blob_config: None,
+            azure_credential_priority: crate::config::settings::AzureCredentialType::Default,
+            clipboard_timeout: 30,
+            gen_default_charset: None,
+            env_flag: None,
+        };
+
+        self.save_config(&config).await?;
+
+        output::success("Local backend setup completed!");
+        println!();
+        println!("  Store path:    {store_path}");
+        println!("  Key file:      {key_file}");
+        println!("  Default vault: {default_vault}");
+        if !public_key.is_empty() {
+            println!("  Public key:    {public_key}");
+        }
 
         Ok(config)
     }
@@ -842,6 +955,17 @@ impl ConfigInitializer {
 
     /// Show setup summary
     pub fn show_setup_summary(&self, config: &Config) -> Result<()> {
+        // Local backend shows its own summary in run_local_setup()
+        if config.backend.as_deref() == Some("local") {
+            println!();
+            output::info("Next steps:");
+            output::hint("Set a secret: xv set my-secret");
+            output::hint("Get a secret: xv get my-secret --raw");
+            output::hint("List secrets: xv list");
+            output::hint("Get help: xv --help");
+            return Ok(());
+        }
+
         println!();
         output::success("Setup Summary");
         println!();

--- a/tests/local_backend_integration.rs
+++ b/tests/local_backend_integration.rs
@@ -1,0 +1,514 @@
+//! Integration tests for the local age-encrypted file backend.
+//!
+//! These tests exercise the full `LocalBackend` through the backend trait
+//! interfaces, verifying end-to-end secret lifecycle, versioning,
+//! soft-delete, file storage, and error handling.
+
+use std::collections::HashMap;
+
+use crosstache::backend::error::BackendError;
+use crosstache::backend::Backend;
+use crosstache::config::settings::LocalConfig;
+use crosstache::secret::manager::SecretRequest;
+use crosstache::vault::models::VaultCreateRequest;
+use tempfile::TempDir;
+use zeroize::Zeroizing;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Create a `LocalBackend` rooted in a fresh temp directory.
+fn make_backend(tmp: &TempDir) -> crosstache::backend::local::LocalBackend {
+    let cfg = LocalConfig {
+        store_path: Some(tmp.path().join("store").to_string_lossy().to_string()),
+        key_file: Some(tmp.path().join("key.txt").to_string_lossy().to_string()),
+        default_vault: Some("default".into()),
+    };
+    crosstache::backend::local::LocalBackend::new(Some(&cfg)).expect("create backend")
+}
+
+fn secret_req(name: &str, value: &str) -> SecretRequest {
+    SecretRequest {
+        name: name.to_string(),
+        value: Zeroizing::new(value.to_string()),
+        content_type: None,
+        enabled: None,
+        expires_on: None,
+        not_before: None,
+        tags: None,
+        groups: None,
+        note: None,
+        folder: None,
+    }
+}
+
+fn vault_req(name: &str) -> VaultCreateRequest {
+    VaultCreateRequest {
+        name: name.to_string(),
+        location: "local".to_string(),
+        resource_group: String::new(),
+        subscription_id: String::new(),
+        sku: None,
+        enabled_for_deployment: None,
+        enabled_for_disk_encryption: None,
+        enabled_for_template_deployment: None,
+        soft_delete_retention_in_days: None,
+        purge_protection: None,
+        tags: None,
+        access_policies: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_full_secret_lifecycle() {
+    let tmp = TempDir::new().unwrap();
+    let backend = make_backend(&tmp);
+
+    // Create vault (default already exists, use it)
+    let vaults = backend.vaults().unwrap();
+    let vault_list = vaults.list_vaults().await.unwrap();
+    assert_eq!(vault_list.len(), 1);
+    assert_eq!(vault_list[0].name, "default");
+
+    // Set secret
+    let secrets = backend.secrets();
+    let props = secrets
+        .set_secret("default", secret_req("DB_PASSWORD", "hunter2"))
+        .await
+        .unwrap();
+    assert_eq!(props.name, "DB_PASSWORD");
+    assert_eq!(props.version, "v1");
+
+    // List secrets
+    let list = secrets.list_secrets("default", None).await.unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].name, "DB_PASSWORD");
+
+    // Get secret (with value)
+    let got = secrets
+        .get_secret("default", "DB_PASSWORD", true)
+        .await
+        .unwrap();
+    assert_eq!(&*got.value.unwrap(), "hunter2");
+
+    // Update secret (new value via set_secret)
+    let updated = secrets
+        .set_secret("default", secret_req("DB_PASSWORD", "new-password"))
+        .await
+        .unwrap();
+    assert_eq!(updated.version, "v2");
+
+    // Get updated value
+    let got = secrets
+        .get_secret("default", "DB_PASSWORD", true)
+        .await
+        .unwrap();
+    assert_eq!(&*got.value.unwrap(), "new-password");
+
+    // Delete secret
+    secrets
+        .delete_secret("default", "DB_PASSWORD")
+        .await
+        .unwrap();
+
+    // Verify gone from active list
+    let list = secrets.list_secrets("default", None).await.unwrap();
+    assert!(list.is_empty());
+
+    // Get should return NotFound
+    let err = secrets.get_secret("default", "DB_PASSWORD", false).await;
+    assert!(matches!(err, Err(BackendError::NotFound { .. })));
+}
+
+#[tokio::test]
+async fn test_version_history_and_rollback() {
+    let tmp = TempDir::new().unwrap();
+    let backend = make_backend(&tmp);
+    let secrets = backend.secrets();
+
+    // Set secret v1
+    secrets
+        .set_secret("default", secret_req("API_KEY", "v1-value"))
+        .await
+        .unwrap();
+
+    // Update to v2
+    secrets
+        .set_secret("default", secret_req("API_KEY", "v2-value"))
+        .await
+        .unwrap();
+
+    // Update to v3
+    secrets
+        .set_secret("default", secret_req("API_KEY", "v3-value"))
+        .await
+        .unwrap();
+
+    // List versions — should have 3
+    let versions = secrets.list_versions("default", "API_KEY").await.unwrap();
+    assert_eq!(versions.len(), 3);
+    assert_eq!(versions[0].version_number, Some(1));
+    assert_eq!(versions[1].version_number, Some(2));
+    assert_eq!(versions[2].version_number, Some(3));
+
+    // Rollback to v1
+    let rolled = secrets.rollback("default", "API_KEY", "v1").await.unwrap();
+    assert!(rolled.version.starts_with('v'));
+
+    // Get current value — should be v1's content
+    let got = secrets
+        .get_secret("default", "API_KEY", true)
+        .await
+        .unwrap();
+    assert_eq!(&*got.value.unwrap(), "v1-value");
+}
+
+#[tokio::test]
+async fn test_soft_delete_restore_purge() {
+    let tmp = TempDir::new().unwrap();
+    let backend = make_backend(&tmp);
+    let secrets = backend.secrets();
+
+    // Set secret
+    secrets
+        .set_secret("default", secret_req("TEMP_KEY", "secret-value"))
+        .await
+        .unwrap();
+
+    // Delete (soft)
+    secrets.delete_secret("default", "TEMP_KEY").await.unwrap();
+
+    // Should appear in deleted list
+    let deleted = secrets.list_deleted_secrets("default").await.unwrap();
+    assert_eq!(deleted.len(), 1);
+    assert_eq!(deleted[0].name, "TEMP_KEY");
+
+    // Get should return NotFound
+    let err = secrets.get_secret("default", "TEMP_KEY", false).await;
+    assert!(matches!(err, Err(BackendError::NotFound { .. })));
+
+    // Restore
+    let restored = secrets.restore_secret("default", "TEMP_KEY").await.unwrap();
+    assert_eq!(restored.name, "TEMP_KEY");
+
+    // Get should work now
+    let got = secrets
+        .get_secret("default", "TEMP_KEY", true)
+        .await
+        .unwrap();
+    assert_eq!(&*got.value.unwrap(), "secret-value");
+
+    // Delete again
+    secrets.delete_secret("default", "TEMP_KEY").await.unwrap();
+
+    // Purge permanently
+    secrets.purge_secret("default", "TEMP_KEY").await.unwrap();
+
+    // Deleted list should be empty
+    let deleted = secrets.list_deleted_secrets("default").await.unwrap();
+    assert!(deleted.is_empty());
+}
+
+#[cfg(feature = "file-ops")]
+#[tokio::test]
+async fn test_file_storage_roundtrip() {
+    use crosstache::blob::models::{FileListRequest, FileUploadRequest};
+
+    let tmp = TempDir::new().unwrap();
+    let backend = make_backend(&tmp);
+    let files = backend.files().expect("file-ops feature should be enabled");
+
+    let content = b"-----BEGIN RSA PRIVATE KEY-----\ntest content\n-----END RSA PRIVATE KEY-----";
+
+    // Upload file
+    let upload_req = FileUploadRequest {
+        name: "certs/server.pem".into(),
+        content: content.to_vec(),
+        content_type: Some("application/x-pem-file".into()),
+        groups: vec!["infra".into()],
+        metadata: HashMap::from([("env".into(), "prod".into())]),
+        tags: HashMap::from([("purpose".into(), "tls".into())]),
+    };
+    let info = files.upload_file(upload_req, None).await.unwrap();
+    assert_eq!(info.name, "certs/server.pem");
+    assert_eq!(info.size, content.len() as u64);
+
+    // List files
+    let list = files
+        .list_files(FileListRequest {
+            prefix: None,
+            groups: None,
+            limit: None,
+            delimiter: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].name, "certs/server.pem");
+
+    // Download and verify content matches
+    let downloaded = files.download_file("certs/server.pem", None).await.unwrap();
+    assert_eq!(downloaded, content);
+
+    // Get file info
+    let file_info = files.get_file_info("certs/server.pem").await.unwrap();
+    assert_eq!(file_info.name, "certs/server.pem");
+    assert_eq!(file_info.content_type, "application/x-pem-file");
+
+    // Delete
+    files.delete_file("certs/server.pem").await.unwrap();
+
+    // Verify gone
+    let list = files
+        .list_files(FileListRequest {
+            prefix: None,
+            groups: None,
+            limit: None,
+            delimiter: None,
+        })
+        .await
+        .unwrap();
+    assert!(list.is_empty());
+
+    // Download should fail
+    let err = files.download_file("certs/server.pem", None).await;
+    assert!(matches!(err, Err(BackendError::NotFound { .. })));
+}
+
+#[tokio::test]
+async fn test_special_characters_in_names() {
+    let tmp = TempDir::new().unwrap();
+    let backend = make_backend(&tmp);
+    let secrets = backend.secrets();
+
+    // Secret with slashes and @ symbols
+    secrets
+        .set_secret("default", secret_req("my/secret@test", "slash-value"))
+        .await
+        .unwrap();
+    let got = secrets
+        .get_secret("default", "my/secret@test", true)
+        .await
+        .unwrap();
+    assert_eq!(&*got.value.unwrap(), "slash-value");
+    assert_eq!(got.name, "my/secret@test");
+
+    // Secret with spaces
+    secrets
+        .set_secret("default", secret_req("has spaces", "space-value"))
+        .await
+        .unwrap();
+    let got = secrets
+        .get_secret("default", "has spaces", true)
+        .await
+        .unwrap();
+    assert_eq!(&*got.value.unwrap(), "space-value");
+    assert_eq!(got.name, "has spaces");
+
+    // Secret with unicode/emoji
+    secrets
+        .set_secret("default", secret_req("key-🔑", "emoji-value"))
+        .await
+        .unwrap();
+    let got = secrets.get_secret("default", "key-🔑", true).await.unwrap();
+    assert_eq!(&*got.value.unwrap(), "emoji-value");
+
+    // List should show all three
+    let list = secrets.list_secrets("default", None).await.unwrap();
+    assert_eq!(list.len(), 3);
+}
+
+#[tokio::test]
+async fn test_multiple_vaults() {
+    let tmp = TempDir::new().unwrap();
+    let backend = make_backend(&tmp);
+    let vaults = backend.vaults().unwrap();
+    let secrets = backend.secrets();
+
+    // Create additional vaults
+    vaults.create_vault(vault_req("prod")).await.unwrap();
+    vaults.create_vault(vault_req("staging")).await.unwrap();
+
+    // Set secret in prod
+    secrets
+        .set_secret("prod", secret_req("DB_URL", "prod-db.example.com"))
+        .await
+        .unwrap();
+
+    // Set secret in staging
+    secrets
+        .set_secret("staging", secret_req("DB_URL", "staging-db.example.com"))
+        .await
+        .unwrap();
+
+    // List prod — should only see prod's secrets
+    let prod_secrets = secrets.list_secrets("prod", None).await.unwrap();
+    assert_eq!(prod_secrets.len(), 1);
+    assert_eq!(prod_secrets[0].name, "DB_URL");
+
+    // List staging — should only see staging's secrets
+    let staging_secrets = secrets.list_secrets("staging", None).await.unwrap();
+    assert_eq!(staging_secrets.len(), 1);
+    assert_eq!(staging_secrets[0].name, "DB_URL");
+
+    // Values should be different (vault isolation)
+    let prod_val = secrets.get_secret("prod", "DB_URL", true).await.unwrap();
+    assert_eq!(&*prod_val.value.unwrap(), "prod-db.example.com");
+
+    let staging_val = secrets.get_secret("staging", "DB_URL", true).await.unwrap();
+    assert_eq!(&*staging_val.value.unwrap(), "staging-db.example.com");
+
+    // Default vault should be empty (no secrets set there)
+    let default_secrets = secrets.list_secrets("default", None).await.unwrap();
+    assert!(default_secrets.is_empty());
+
+    // List vaults — should have 3
+    let vault_list = vaults.list_vaults().await.unwrap();
+    assert_eq!(vault_list.len(), 3);
+}
+
+#[tokio::test]
+async fn test_error_cases() {
+    let tmp = TempDir::new().unwrap();
+    let backend = make_backend(&tmp);
+    let secrets = backend.secrets();
+    let vaults = backend.vaults().unwrap();
+
+    // Get non-existent secret → NotFound
+    let err = secrets.get_secret("default", "nonexistent", false).await;
+    assert!(matches!(err, Err(BackendError::NotFound { .. })));
+
+    // Delete non-existent secret → NotFound
+    let err = secrets.delete_secret("default", "nonexistent").await;
+    assert!(matches!(err, Err(BackendError::NotFound { .. })));
+
+    // Set secret in non-existent vault → VaultNotFound
+    let err = secrets
+        .set_secret("no-such-vault", secret_req("key", "val"))
+        .await;
+    assert!(matches!(err, Err(BackendError::VaultNotFound { .. })));
+
+    // Delete non-existent vault → VaultNotFound
+    let err = vaults.delete_vault("no-such-vault").await;
+    assert!(matches!(err, Err(BackendError::VaultNotFound { .. })));
+
+    // Create duplicate vault → Conflict
+    vaults.create_vault(vault_req("dup-test")).await.unwrap();
+    let err = vaults.create_vault(vault_req("dup-test")).await;
+    assert!(matches!(err, Err(BackendError::Conflict(_))));
+
+    // Rollback to non-existent version → NotFound
+    secrets
+        .set_secret("default", secret_req("rb-err", "val"))
+        .await
+        .unwrap();
+    let err = secrets.rollback("default", "rb-err", "v99").await;
+    assert!(matches!(err, Err(BackendError::NotFound { .. })));
+
+    // Restore non-deleted secret → NotFound
+    let err = secrets.restore_secret("default", "rb-err").await;
+    assert!(matches!(err, Err(BackendError::NotFound { .. })));
+}
+
+#[tokio::test]
+async fn test_backend_metadata() {
+    let tmp = TempDir::new().unwrap();
+    let backend = make_backend(&tmp);
+
+    assert_eq!(backend.name(), "local");
+    assert_eq!(backend.kind(), crosstache::backend::BackendKind::Local);
+
+    let caps = backend.capabilities();
+    assert!(caps.has_vaults);
+    assert!(caps.has_versioning);
+    assert!(caps.has_soft_delete);
+    assert!(caps.has_groups);
+    assert!(caps.has_notes);
+    assert!(!caps.has_rbac);
+    assert!(!caps.has_audit);
+}
+
+#[tokio::test]
+async fn test_health_check() {
+    let tmp = TempDir::new().unwrap();
+    let backend = make_backend(&tmp);
+
+    backend.health_check().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_empty_and_large_values() {
+    let tmp = TempDir::new().unwrap();
+    let backend = make_backend(&tmp);
+    let secrets = backend.secrets();
+
+    // Empty value
+    secrets
+        .set_secret("default", secret_req("empty-secret", ""))
+        .await
+        .unwrap();
+    let got = secrets
+        .get_secret("default", "empty-secret", true)
+        .await
+        .unwrap();
+    assert_eq!(&*got.value.unwrap(), "");
+
+    // Large value (64KB)
+    let large = "x".repeat(65536);
+    secrets
+        .set_secret("default", secret_req("large-secret", &large))
+        .await
+        .unwrap();
+    let got = secrets
+        .get_secret("default", "large-secret", true)
+        .await
+        .unwrap();
+    assert_eq!(got.value.unwrap().len(), 65536);
+}
+
+#[tokio::test]
+async fn test_secret_with_metadata() {
+    let tmp = TempDir::new().unwrap();
+    let backend = make_backend(&tmp);
+    let secrets = backend.secrets();
+
+    let req = SecretRequest {
+        name: "tagged-secret".into(),
+        value: Zeroizing::new("val".into()),
+        content_type: Some("application/json".into()),
+        enabled: Some(true),
+        expires_on: None,
+        not_before: None,
+        tags: Some(HashMap::from([
+            ("env".into(), "prod".into()),
+            ("team".into(), "platform".into()),
+        ])),
+        groups: Some(vec!["databases".into(), "critical".into()]),
+        note: Some("Production database credential".into()),
+        folder: Some("infra/db".into()),
+    };
+
+    let props = secrets.set_secret("default", req).await.unwrap();
+    assert_eq!(props.content_type, "application/json");
+    assert!(props.enabled);
+
+    // List with group filter
+    let filtered = secrets
+        .list_secrets("default", Some("databases"))
+        .await
+        .unwrap();
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].name, "tagged-secret");
+
+    // Non-matching group filter
+    let empty = secrets
+        .list_secrets("default", Some("nonexistent-group"))
+        .await
+        .unwrap();
+    assert!(empty.is_empty());
+}


### PR DESCRIPTION
## PR 9: Tests, docs, and init wizard update (Phase 2 finale)

This is the final PR in the Phase 2 backend pluggability series.

### Part 1: `xv init` wizard — backend selection

- Adds a backend selection step at the beginning of `run_interactive_setup()`
- Users choose between **Azure Key Vault** (existing 6-step flow, unchanged) and **Local** (new 3-step flow)
- Local init flow:
  1. Ask for store path (default `~/.xv/store`)
  2. Ask for key file path (default `~/.xv/key.txt`)
  3. Ask for default vault name (default `default`)
  4. Auto-generate age keypair, create store directories and default vault
  5. Save config with `backend = "local"` and `[local]` section
  6. Show summary with paths and public key
- Uses `InteractivePrompt` (select/input_text) for consistent UX
- `show_setup_summary()` updated to handle local backend configs

### Part 2: Integration tests (`tests/local_backend_integration.rs`)

11 comprehensive tests exercising `LocalBackend` through the backend trait interfaces:

| Test | Coverage |
|------|----------|
| `test_full_secret_lifecycle` | create vault → set → list → get → update → delete → verify gone |
| `test_version_history_and_rollback` | v1 → v2 → v3 → list_versions → rollback to v1 → verify value |
| `test_soft_delete_restore_purge` | set → delete → list_deleted → restore → verify → delete → purge |
| `test_file_storage_roundtrip` | upload → list → download → verify → get_file_info → delete |
| `test_special_characters_in_names` | slashes, @, spaces, emoji in secret names |
| `test_multiple_vaults` | prod + staging vault isolation, separate secrets |
| `test_error_cases` | NotFound, VaultNotFound, Conflict, rollback non-existent version |
| `test_backend_metadata` | name, kind, capabilities checks |
| `test_health_check` | health_check() passes after init |
| `test_empty_and_large_values` | empty string, 64KB values |
| `test_secret_with_metadata` | tags, groups, content_type, note, folder, group filtering |

### Part 3: README documentation

- New **Local Backend (age-encrypted files)** section with:
  - Quick start commands
  - Storage layout diagram
  - Migration between backends
  - Configuration reference
- Added to table of contents

### Quality gates

- `cargo check` ✅
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features` ✅ (no new warnings)
- `cargo test` ✅ (all existing + 11 new integration tests pass)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the interactive `xv init` flow to support selecting and initializing a new local (age-encrypted) backend, which can affect first-run configuration behavior and persisted config output. Adds a large integration test suite that may increase CI time but is otherwise low risk.
> 
> **Overview**
> `xv init` now starts with a **backend selection** step and adds a new 3-step local setup path that initializes the local store/key/vault, writes `backend = "local"` plus `[local]` config, and prints a local-specific next-steps summary (Azure setup remains the existing flow).
> 
> Adds comprehensive integration coverage for the local backend in `tests/local_backend_integration.rs`, exercising secret lifecycle/versioning/soft-delete, multi-vault isolation, error cases, and (behind `file-ops`) file upload/download roundtrips.
> 
> Updates `README.md` with a new **Local Backend (age-encrypted files)** section including quick start, on-disk layout, migration examples, and configuration reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bab598e8b9ef2c71133083b40986080364ec9220. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->