### PR TITLE
fix: skip Azure config validation when backend is local

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -219,12 +219,15 @@ impl Config {
     }
 
     pub fn validate(&self) -> Result<()> {
-        if self.subscription_id.is_empty() {
-            return Err(CrosstacheError::config("Subscription ID is required"));
-        }
+        // Azure-specific fields are only required when using the Azure backend.
+        if self.effective_backend_name() == "azure" {
+            if self.subscription_id.is_empty() {
+                return Err(CrosstacheError::config("Subscription ID is required"));
+            }
 
-        if self.tenant_id.is_empty() {
-            return Err(CrosstacheError::config("Tenant ID is required"));
+            if self.tenant_id.is_empty() {
+                return Err(CrosstacheError::config("Tenant ID is required"));
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Fixes a bug where `xv ls` (and all commands) fail with 'Subscription ID is required' when `backend = "local"` is set in config.

The `Config::validate()` method unconditionally required Azure-specific fields. Now it checks `effective_backend_name()` and only validates Azure fields when the backend is actually Azure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrows config validation to the Azure backend, reducing false failures for `backend = "local"` with minimal impact on other code paths.
> 
> **Overview**
> Fixes config validation so Azure-only requirements (`subscription_id`, `tenant_id`) are enforced *only* when `effective_backend_name()` resolves to `"azure"`.
> 
> This prevents commands from failing on startup when users select the `local` backend and don’t have Azure credentials configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae0c5261fb452b4b5a6f8f9a6d8bdfdac032b2b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->