### PR TITLE
fix: wire TUI to use backend traits for non-Azure backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "age",
  "aho-corasick",

--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -97,6 +97,15 @@ impl BackendRegistry {
         self.backends[self.default].as_ref()
     }
 
+    /// Get an `Arc` handle to the active backend (cloneable, `Send + Sync`).
+    ///
+    /// Useful when you need to move the backend into an async task (e.g. the
+    /// TUI data-loading spawns).
+    #[allow(dead_code)] // Used by the TUI feature gate; invisible to default builds.
+    pub fn active_arc(&self) -> Arc<dyn Backend> {
+        self.backends[self.default].clone()
+    }
+
     /// Get a backend by name.
     #[allow(dead_code)] // Infrastructure for Phase 2 pluggability — used for multi-backend dispatch.
     pub fn get(&self, name: &str) -> Option<&dyn Backend> {

--- a/src/tui/data.rs
+++ b/src/tui/data.rs
@@ -1,60 +1,96 @@
+use std::sync::Arc;
+
+use crate::backend::Backend;
 use crate::config::Config;
 use crate::error::CrosstacheError;
 use crate::tui::message::Message;
 use tokio::sync::mpsc::Sender;
 
-pub fn spawn_load_vaults(config: Config, tx: Sender<Message>) -> tokio::task::JoinHandle<()> {
+pub fn spawn_load_vaults(
+    config: Config,
+    tx: Sender<Message>,
+    backend: Option<Arc<dyn Backend>>,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        use crate::auth::provider::DefaultAzureCredentialProvider;
-        use crate::vault::manager::VaultManager;
-        let result: Result<_, CrosstacheError> = async {
-            let auth = std::sync::Arc::new(
-                DefaultAzureCredentialProvider::with_credential_priority(
-                    config.azure_credential_priority.clone(),
-                )
-                .map_err(|e| CrosstacheError::authentication(format!("auth: {e}")))?,
-            );
-            let vm = VaultManager::new(auth, config.subscription_id.clone(), config.no_color)?;
-            vm.vault_ops()
-                .list_vaults(Some(&config.subscription_id), None)
-                .await
+        if let Some(be) = backend {
+            // Trait-based path (local and future backends)
+            let result = match be.vaults() {
+                Some(vb) => vb.list_vaults().await.map_err(CrosstacheError::from),
+                None => Err(CrosstacheError::config(
+                    "active backend does not support vault listing",
+                )),
+            };
+            let msg = match result {
+                Ok(vaults) => Message::VaultsLoaded(vaults),
+                Err(e) => Message::Error(e),
+            };
+            let _ = tx.send(msg).await;
+        } else {
+            // Legacy Azure path
+            use crate::auth::provider::DefaultAzureCredentialProvider;
+            use crate::vault::manager::VaultManager;
+            let result: Result<_, CrosstacheError> = async {
+                let auth = std::sync::Arc::new(
+                    DefaultAzureCredentialProvider::with_credential_priority(
+                        config.azure_credential_priority.clone(),
+                    )
+                    .map_err(|e| CrosstacheError::authentication(format!("auth: {e}")))?,
+                );
+                let vm = VaultManager::new(auth, config.subscription_id.clone(), config.no_color)?;
+                vm.vault_ops()
+                    .list_vaults(Some(&config.subscription_id), None)
+                    .await
+            }
+            .await;
+            let msg = match result {
+                Ok(vaults) => Message::VaultsLoaded(vaults),
+                Err(e) => Message::Error(e),
+            };
+            let _ = tx.send(msg).await;
         }
-        .await;
-        let msg = match result {
-            Ok(vaults) => Message::VaultsLoaded(vaults),
-            Err(e) => Message::Error(e),
-        };
-        let _ = tx.send(msg).await;
     })
 }
-
-// STUBS — Tasks 5/6/10 replace each. They take the same parameters as the
-// real versions so the runtime in mod.rs can call them today.
 
 pub fn spawn_load_secrets(
     config: Config,
     vault: String,
     tx: Sender<Message>,
+    backend: Option<Arc<dyn Backend>>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        use crate::auth::provider::DefaultAzureCredentialProvider;
-        use crate::secret::manager::SecretManager;
-        let result: Result<_, CrosstacheError> = async {
-            let auth = std::sync::Arc::new(
-                DefaultAzureCredentialProvider::with_credential_priority(
-                    config.azure_credential_priority.clone(),
-                )
-                .map_err(|e| CrosstacheError::authentication(format!("auth: {e}")))?,
-            );
-            let sm = SecretManager::new(auth, config.no_color);
-            sm.secret_ops().list_secrets(&vault, None).await
+        if let Some(be) = backend {
+            // Trait-based path
+            let result = be
+                .secrets()
+                .list_secrets(&vault, None)
+                .await
+                .map_err(CrosstacheError::from);
+            let msg = match result {
+                Ok(secrets) => Message::SecretsLoaded { vault, secrets },
+                Err(e) => Message::Error(e),
+            };
+            let _ = tx.send(msg).await;
+        } else {
+            // Legacy Azure path
+            use crate::auth::provider::DefaultAzureCredentialProvider;
+            use crate::secret::manager::SecretManager;
+            let result: Result<_, CrosstacheError> = async {
+                let auth = std::sync::Arc::new(
+                    DefaultAzureCredentialProvider::with_credential_priority(
+                        config.azure_credential_priority.clone(),
+                    )
+                    .map_err(|e| CrosstacheError::authentication(format!("auth: {e}")))?,
+                );
+                let sm = SecretManager::new(auth, config.no_color);
+                sm.secret_ops().list_secrets(&vault, None).await
+            }
+            .await;
+            let msg = match result {
+                Ok(secrets) => Message::SecretsLoaded { vault, secrets },
+                Err(e) => Message::Error(e),
+            };
+            let _ = tx.send(msg).await;
         }
-        .await;
-        let msg = match result {
-            Ok(secrets) => Message::SecretsLoaded { vault, secrets },
-            Err(e) => Message::Error(e),
-        };
-        let _ = tx.send(msg).await;
     })
 }
 
@@ -63,35 +99,60 @@ pub fn spawn_load_value(
     vault: String,
     name: String,
     tx: Sender<Message>,
+    backend: Option<Arc<dyn Backend>>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        use crate::auth::provider::DefaultAzureCredentialProvider;
-        use crate::secret::manager::SecretManager;
-        let result: Result<_, CrosstacheError> = async {
-            let auth = std::sync::Arc::new(
-                DefaultAzureCredentialProvider::with_credential_priority(
-                    config.azure_credential_priority.clone(),
-                )
-                .map_err(|e| CrosstacheError::authentication(format!("auth: {e}")))?,
-            );
-            let sm = SecretManager::new(auth, config.no_color);
-            sm.secret_ops().get_secret(&vault, &name, true).await
-        }
-        .await;
-        let msg = match result {
-            Ok(props) => match props.value {
-                Some(v) => Message::ValueLoaded {
-                    vault,
-                    name,
-                    value: zeroize::Zeroizing::new(v.as_str().to_string()),
+        if let Some(be) = backend {
+            // Trait-based path
+            let result = be
+                .secrets()
+                .get_secret(&vault, &name, true)
+                .await
+                .map_err(CrosstacheError::from);
+            let msg = match result {
+                Ok(props) => match props.value {
+                    Some(v) => Message::ValueLoaded {
+                        vault,
+                        name,
+                        value: zeroize::Zeroizing::new(v.as_str().to_string()),
+                    },
+                    None => Message::Error(CrosstacheError::config(format!(
+                        "secret {name} has no value"
+                    ))),
                 },
-                None => Message::Error(CrosstacheError::config(format!(
-                    "secret {name} has no value"
-                ))),
-            },
-            Err(e) => Message::Error(e),
-        };
-        let _ = tx.send(msg).await;
+                Err(e) => Message::Error(e),
+            };
+            let _ = tx.send(msg).await;
+        } else {
+            // Legacy Azure path
+            use crate::auth::provider::DefaultAzureCredentialProvider;
+            use crate::secret::manager::SecretManager;
+            let result: Result<_, CrosstacheError> = async {
+                let auth = std::sync::Arc::new(
+                    DefaultAzureCredentialProvider::with_credential_priority(
+                        config.azure_credential_priority.clone(),
+                    )
+                    .map_err(|e| CrosstacheError::authentication(format!("auth: {e}")))?,
+                );
+                let sm = SecretManager::new(auth, config.no_color);
+                sm.secret_ops().get_secret(&vault, &name, true).await
+            }
+            .await;
+            let msg = match result {
+                Ok(props) => match props.value {
+                    Some(v) => Message::ValueLoaded {
+                        vault,
+                        name,
+                        value: zeroize::Zeroizing::new(v.as_str().to_string()),
+                    },
+                    None => Message::Error(CrosstacheError::config(format!(
+                        "secret {name} has no value"
+                    ))),
+                },
+                Err(e) => Message::Error(e),
+            };
+            let _ = tx.send(msg).await;
+        }
     })
 }
 
@@ -100,30 +161,50 @@ pub fn spawn_load_history(
     vault: String,
     name: String,
     tx: Sender<Message>,
+    backend: Option<Arc<dyn Backend>>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        use crate::auth::provider::DefaultAzureCredentialProvider;
-        use crate::secret::manager::SecretManager;
-        let result: Result<_, CrosstacheError> = async {
-            let auth = std::sync::Arc::new(
-                DefaultAzureCredentialProvider::with_credential_priority(
-                    config.azure_credential_priority.clone(),
-                )
-                .map_err(|e| CrosstacheError::authentication(format!("auth: {e}")))?,
-            );
-            let sm = SecretManager::new(auth, config.no_color);
-            sm.secret_ops().get_secret_versions(&vault, &name).await
+        if let Some(be) = backend {
+            // Trait-based path
+            let result = be
+                .secrets()
+                .list_versions(&vault, &name)
+                .await
+                .map_err(CrosstacheError::from);
+            let msg = match result {
+                Ok(versions) => Message::HistoryLoaded {
+                    vault,
+                    name,
+                    versions,
+                },
+                Err(e) => Message::Error(e),
+            };
+            let _ = tx.send(msg).await;
+        } else {
+            // Legacy Azure path
+            use crate::auth::provider::DefaultAzureCredentialProvider;
+            use crate::secret::manager::SecretManager;
+            let result: Result<_, CrosstacheError> = async {
+                let auth = std::sync::Arc::new(
+                    DefaultAzureCredentialProvider::with_credential_priority(
+                        config.azure_credential_priority.clone(),
+                    )
+                    .map_err(|e| CrosstacheError::authentication(format!("auth: {e}")))?,
+                );
+                let sm = SecretManager::new(auth, config.no_color);
+                sm.secret_ops().get_secret_versions(&vault, &name).await
+            }
+            .await;
+            let msg = match result {
+                Ok(versions) => Message::HistoryLoaded {
+                    vault,
+                    name,
+                    versions,
+                },
+                Err(e) => Message::Error(e),
+            };
+            let _ = tx.send(msg).await;
         }
-        .await;
-        let msg = match result {
-            Ok(versions) => Message::HistoryLoaded {
-                vault,
-                name,
-                versions,
-            },
-            Err(e) => Message::Error(e),
-        };
-        let _ = tx.send(msg).await;
     })
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -10,6 +10,7 @@ pub mod overlays;
 pub mod update;
 pub mod view;
 
+use crate::backend::Backend;
 use crate::config::Config;
 use crate::error::Result;
 use app::App;
@@ -21,14 +22,25 @@ use message::Message;
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use std::io::{self, Stdout};
+use std::sync::Arc;
 use update::Command;
 
 pub async fn run_tui(
     config: Config,
-    _registry: Option<&crate::backend::BackendRegistry>,
+    registry: Option<&crate::backend::BackendRegistry>,
 ) -> Result<()> {
+    // For non-Azure backends, extract a cloneable Arc so the TUI data-loading
+    // tasks can use the backend trait layer instead of hard-coded Azure auth.
+    let backend: Option<Arc<dyn Backend>> = registry.and_then(|r| {
+        if r.active().kind() != crate::backend::BackendKind::Azure {
+            Some(r.active_arc())
+        } else {
+            None
+        }
+    });
+
     let mut terminal = setup_terminal()?;
-    let result = run_loop(&mut terminal, config).await;
+    let result = run_loop(&mut terminal, config, backend).await;
     teardown_terminal(&mut terminal)?;
     result
 }
@@ -51,13 +63,17 @@ fn teardown_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Resul
     Ok(())
 }
 
-async fn run_loop(terminal: &mut Terminal<CrosstermBackend<Stdout>>, config: Config) -> Result<()> {
+async fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    config: Config,
+    backend: Option<Arc<dyn Backend>>,
+) -> Result<()> {
     let (tx, mut rx) = tokio::sync::mpsc::channel(64);
     let mut app = App::new(config.clone());
 
     let _evt = event::spawn_event_reader(tx.clone());
     let _tick = event::spawn_tick_timer(tx.clone());
-    let _initial = data::spawn_load_vaults(config, tx.clone());
+    let _initial = data::spawn_load_vaults(config, tx.clone(), backend.clone());
 
     while !app.quit {
         terminal
@@ -66,26 +82,44 @@ async fn run_loop(terminal: &mut Terminal<CrosstermBackend<Stdout>>, config: Con
         let Some(msg) = rx.recv().await else { break };
         let cmds = update::update(&mut app, msg);
         for cmd in cmds {
-            handle_command(&app, &tx, cmd).await;
+            handle_command(&app, &tx, cmd, &backend).await;
         }
     }
     Ok(())
 }
 
-async fn handle_command(app: &App, tx: &tokio::sync::mpsc::Sender<Message>, cmd: Command) {
+async fn handle_command(
+    app: &App,
+    tx: &tokio::sync::mpsc::Sender<Message>,
+    cmd: Command,
+    backend: &Option<Arc<dyn Backend>>,
+) {
     match cmd {
         Command::Quit => {}
         Command::LoadVaults => {
-            let _ = data::spawn_load_vaults(app.config.clone(), tx.clone());
+            let _ = data::spawn_load_vaults(app.config.clone(), tx.clone(), backend.clone());
         }
         Command::LoadSecrets { vault } => {
-            let _ = data::spawn_load_secrets(app.config.clone(), vault, tx.clone());
+            let _ =
+                data::spawn_load_secrets(app.config.clone(), vault, tx.clone(), backend.clone());
         }
         Command::LoadValue { vault, name } => {
-            let _ = data::spawn_load_value(app.config.clone(), vault, name, tx.clone());
+            let _ = data::spawn_load_value(
+                app.config.clone(),
+                vault,
+                name,
+                tx.clone(),
+                backend.clone(),
+            );
         }
         Command::LoadHistory { vault, name } => {
-            let _ = data::spawn_load_history(app.config.clone(), vault, name, tx.clone());
+            let _ = data::spawn_load_history(
+                app.config.clone(),
+                vault,
+                name,
+                tx.clone(),
+                backend.clone(),
+            );
         }
         Command::LoadAudit { vault, name } => {
             let _ = data::spawn_load_audit(app.config.clone(), vault, name, tx.clone());


### PR DESCRIPTION
## Summary

The TUI data-loading functions (`spawn_load_vaults`, `spawn_load_secrets`, `spawn_load_value`, `spawn_load_history`) hardcoded Azure auth via `DefaultAzureCredentialProvider`, causing failures when `backend = "local"`.

## Changes

### 1. `BackendRegistry::active_arc()` (src/backend/registry.rs)
Added a method to get a cloneable `Arc<dyn Backend>`, enabling the TUI to move the backend into async spawn tasks.

### 2. `run_tui` wiring (src/tui/mod.rs)
- Extracts `Option<Arc<dyn Backend>>` from the registry for non-Azure backends
- Threads it through `run_loop` → `handle_command` → all spawn functions

### 3. Trait-based dispatch (src/tui/data.rs)
Each of the 4 spawn functions now accepts `Option<Arc<dyn Backend>>`:
- **`spawn_load_vaults`**: Uses `backend.vaults().unwrap().list_vaults()` when available
- **`spawn_load_secrets`**: Uses `backend.secrets().list_secrets(&vault, None)`
- **`spawn_load_value`**: Uses `backend.secrets().get_secret(&vault, &name, true)`
- **`spawn_load_history`**: Uses `backend.secrets().list_versions(&vault, &name)`

If backend is `None` (Azure), falls through to existing legacy Azure code path.

## Verification
- `cargo check` ✅ (default features)
- `cargo check --features tui` ✅
- `cargo test` ✅ (356 passed, 0 failed)
- `cargo fmt --check` ✅
- `cargo clippy` ✅ (no new warnings)
- `cargo clippy --features tui` ✅ (no new warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how the TUI loads vaults/secrets by introducing conditional trait-based dispatch and passing `Arc<dyn Backend>` through async tasks; regressions would show up as missing/failed loads in the TUI, especially around capability checks (`vaults()` optional) and backend selection.
> 
> **Overview**
> The TUI data-loading tasks are rewired to use the backend trait layer when running against non-Azure backends, avoiding hard-coded Azure credential setup.
> 
> This introduces `BackendRegistry::active_arc()` to hand out a cloneable `Arc<dyn Backend>`, threads an optional backend handle through `run_tui`/`run_loop`/`handle_command`, and updates the `spawn_load_*` functions to either call `Backend`/sub-backends (`vaults()`, `secrets()`) or fall back to the existing legacy Azure-specific code path when no backend is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a93856287ddde9b5117bfc905d9b3babe60143d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->