### PR TITLE
chore: bump version to 0.8.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"


### PR DESCRIPTION
Version bump — TUI backend trait dispatch fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the crate version in `Cargo.toml` and does not change runtime code paths.
> 
> **Overview**
> Bumps the `crosstache` crate version from `0.8.2` to `0.8.3` in `Cargo.toml` for the next release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a5c6890488c65efae8678a2104242296c7b90b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->