### PR TITLE
fix(security): P1 hardening — env_clear, panic hook, file permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "age",
  "aho-corasick",

--- a/src/backend/local/crypto.rs
+++ b/src/backend/local/crypto.rs
@@ -11,6 +11,8 @@ use std::path::Path;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
+use crate::utils::helpers::write_private;
+
 use age::secrecy::ExposeSecret;
 use zeroize::Zeroizing;
 
@@ -30,6 +32,18 @@ pub fn encrypt_to_file(
     let encryptor = age::Encryptor::with_recipients(boxed_recipients)
         .ok_or_else(|| BackendError::Internal("no recipients provided".into()))?;
 
+    #[cfg(unix)]
+    let file = {
+        use std::os::unix::fs::OpenOptionsExt;
+        std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|e| BackendError::Internal(format!("create {}: {e}", path.display())))?
+    };
+    #[cfg(not(unix))]
     let file = File::create(path)
         .map_err(|e| BackendError::Internal(format!("create {}: {e}", path.display())))?;
 
@@ -192,7 +206,7 @@ pub fn generate_keypair(
     let identity = age::x25519::Identity::generate();
     let recipient = identity.to_public();
 
-    // Write private key
+    // Write private key with 0o600 permissions
     let secret_str = identity.to_string();
     let key_content = format!(
         "# created: {}\n# public key: {}\n{}\n",
@@ -200,15 +214,8 @@ pub fn generate_keypair(
         recipient,
         secret_str.expose_secret()
     );
-    fs::write(key_path, key_content.as_bytes())
+    write_private(key_path, key_content.as_bytes())
         .map_err(|e| BackendError::Internal(format!("write key: {e}")))?;
-
-    // Set key file permissions to 0600
-    #[cfg(unix)]
-    {
-        fs::set_permissions(key_path, fs::Permissions::from_mode(0o600))
-            .map_err(|e| BackendError::Internal(format!("chmod key: {e}")))?;
-    }
 
     // Write recipient (public key)
     let recipient_content = format!("{}\n", recipient);

--- a/src/backend/local/files.rs
+++ b/src/backend/local/files.rs
@@ -15,6 +15,7 @@ use chrono::Utc;
 use crate::backend::error::BackendError;
 use crate::backend::file::FileBackend;
 use crate::blob::models::{FileInfo, FileListRequest, FileUploadRequest};
+use crate::utils::helpers::create_private_dir;
 use crate::utils::progress::ProgressReporter;
 
 use super::crypto;
@@ -97,7 +98,7 @@ impl FileBackend for LocalFileBackend {
         _reporter: Option<&dyn ProgressReporter>,
     ) -> Result<FileInfo, BackendError> {
         let fdir = files_dir(&self.store_path, &self.vault);
-        fs::create_dir_all(&fdir)
+        create_private_dir(&fdir)
             .map_err(|e| BackendError::Internal(format!("mkdir files: {e}")))?;
 
         let original_size = request.content.len() as u64;

--- a/src/backend/local/mod.rs
+++ b/src/backend/local/mod.rs
@@ -30,6 +30,8 @@ pub mod vaults;
 
 use std::fs;
 
+use crate::utils::helpers::{create_private_dir, write_private};
+
 use async_trait::async_trait;
 
 use super::error::BackendError;
@@ -79,7 +81,7 @@ impl LocalBackend {
 
         // Ensure vaults directory exists
         let vaults_dir = config.store_path.join("vaults");
-        fs::create_dir_all(&vaults_dir).map_err(|e| {
+        create_private_dir(&vaults_dir).map_err(|e| {
             BackendError::Internal(format!(
                 "create vaults directory {}: {e}",
                 vaults_dir.display()
@@ -92,17 +94,18 @@ impl LocalBackend {
         // Create default vault if it doesn't exist
         let default_vault_dir = vaults_dir.join(&config.default_vault);
         if !default_vault_dir.join(".vault.json").exists() {
-            fs::create_dir_all(default_vault_dir.join("secrets"))
+            create_private_dir(default_vault_dir.join("secrets"))
                 .map_err(|e| BackendError::Internal(format!("create default vault: {e}")))?;
             let meta = serde_json::json!({
                 "name": config.default_vault,
                 "created_at": chrono::Utc::now().to_rfc3339(),
                 "tags": {}
             });
-            fs::write(
+            write_private(
                 default_vault_dir.join(".vault.json"),
                 serde_json::to_string_pretty(&meta)
-                    .map_err(|e| BackendError::Internal(format!("serialize vault meta: {e}")))?,
+                    .map_err(|e| BackendError::Internal(format!("serialize vault meta: {e}")))?
+                    .as_bytes(),
             )
             .map_err(|e| BackendError::Internal(format!("write default vault meta: {e}")))?;
         }

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -12,6 +12,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::utils::helpers::{create_private_dir, write_private};
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -159,7 +161,7 @@ fn read_meta(path: &Path) -> Result<SecretMeta, BackendError> {
 fn write_meta(path: &Path, meta: &SecretMeta) -> Result<(), BackendError> {
     let json = serde_json::to_string_pretty(meta)
         .map_err(|e| BackendError::Internal(format!("serialize meta: {e}")))?;
-    fs::write(path, json)
+    write_private(path, json.as_bytes())
         .map_err(|e| BackendError::Internal(format!("write meta {}: {e}", path.display())))
 }
 
@@ -257,7 +259,7 @@ impl SecretBackend for LocalSecretBackend {
         }
 
         let sdir = secrets_dir(&store, vault);
-        fs::create_dir_all(&sdir)
+        create_private_dir(&sdir)
             .map_err(|e| BackendError::Internal(format!("mkdir secrets: {e}")))?;
 
         let name = request.name.clone();
@@ -443,10 +445,11 @@ impl SecretBackend for LocalSecretBackend {
             "original_name": name,
         });
         let deleted_path = tdir.join(".deleted.json");
-        fs::write(
+        write_private(
             &deleted_path,
             serde_json::to_string_pretty(&deleted_meta)
-                .map_err(|e| BackendError::Internal(format!("serialize deleted meta: {e}")))?,
+                .map_err(|e| BackendError::Internal(format!("serialize deleted meta: {e}")))?
+                .as_bytes(),
         )
         .map_err(|e| BackendError::Internal(format!("write deleted meta: {e}")))?;
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -413,6 +413,9 @@ pub enum Commands {
         /// Disable masking of secret values in output
         #[arg(long)]
         no_masking: bool,
+        /// Inherit the parent process environment (default: child starts with a clean env)
+        #[arg(long)]
+        inherit_env: bool,
         /// Command and arguments to run
         #[arg(last = true, required = true)]
         command: Vec<String>,
@@ -1239,10 +1242,16 @@ impl Cli {
             Commands::Run {
                 group,
                 no_masking,
+                inherit_env,
                 command,
             } => {
                 crate::cli::secret_ops::execute_secret_run_direct(
-                    group, no_masking, command, config, registry,
+                    group,
+                    no_masking,
+                    inherit_env,
+                    command,
+                    config,
+                    registry,
                 )
                 .await
             }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -694,6 +694,7 @@ pub(crate) async fn execute_secret_rotate_direct(
 pub(crate) async fn execute_secret_run_direct(
     group: Vec<String>,
     no_masking: bool,
+    inherit_env: bool,
     command: Vec<String>,
     config: Config,
     registry: Option<&BackendRegistry>,
@@ -703,7 +704,16 @@ pub(crate) async fn execute_secret_run_direct(
     // Create secret manager
     let secret_manager = SecretManager::new(auth_provider, config.no_color);
 
-    execute_secret_run(&secret_manager, None, group, no_masking, command, &config).await
+    execute_secret_run(
+        &secret_manager,
+        None,
+        group,
+        no_masking,
+        inherit_env,
+        command,
+        &config,
+    )
+    .await
 }
 
 pub(crate) async fn execute_secret_inject_direct(
@@ -2015,6 +2025,7 @@ async fn execute_secret_run(
     vault: Option<String>,
     groups: Vec<String>,
     no_masking: bool,
+    inherit_env: bool,
     command: Vec<String>,
     config: &Config,
 ) -> Result<()> {
@@ -2174,6 +2185,9 @@ async fn execute_secret_run(
     }
 
     // Set environment variables from vault secrets
+    if !inherit_env {
+        cmd.env_clear();
+    }
     cmd.envs(&env_vars);
 
     // Resolve URI references in existing environment variables

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -39,6 +39,12 @@ pub async fn run_tui(
         }
     });
 
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        reset_terminal_sync();
+        previous_hook(panic_info);
+    }));
+
     let mut terminal = setup_terminal()?;
     let result = run_loop(&mut terminal, config, backend).await;
     teardown_terminal(&mut terminal)?;
@@ -56,9 +62,13 @@ fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
         .map_err(|e| crate::error::CrosstacheError::config(format!("terminal: {e}")))
 }
 
-fn teardown_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
+fn reset_terminal_sync() {
     disable_raw_mode().ok();
-    execute!(terminal.backend_mut(), LeaveAlternateScreen).ok();
+    execute!(io::stdout(), LeaveAlternateScreen).ok();
+}
+
+fn teardown_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
+    reset_terminal_sync();
     terminal.show_cursor().ok();
     Ok(())
 }

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -9,16 +9,49 @@ use std::collections::HashMap;
 use std::path::Path;
 use uuid::Uuid;
 
-/// Write content to a file with restricted permissions (0600 on Unix).
-/// Use for any file that may contain secrets, tokens, or sensitive config.
-pub fn write_sensitive_file(path: &Path, content: &[u8]) -> std::io::Result<()> {
-    std::fs::write(path, content)?;
+/// Write bytes to a file with mode 0o600 (owner read/write only).
+pub fn write_private(
+    path: impl AsRef<std::path::Path>,
+    bytes: impl AsRef<[u8]>,
+) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path.as_ref())?;
+        file.write_all(bytes.as_ref())?;
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path.as_ref(), bytes.as_ref())?;
+        let mut perms = std::fs::metadata(path.as_ref())?.permissions();
+        perms.set_readonly(true);
+        std::fs::set_permissions(path.as_ref(), perms)?;
+        Ok(())
+    }
+}
+
+/// Create a directory (and parents) with mode 0o700 (owner only).
+pub fn create_private_dir(path: impl AsRef<std::path::Path>) -> std::io::Result<()> {
+    std::fs::create_dir_all(path.as_ref())?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        std::fs::set_permissions(path.as_ref(), std::fs::Permissions::from_mode(0o700))?;
     }
     Ok(())
+}
+
+/// Write content to a file with restricted permissions (0600 on Unix).
+/// Use for any file that may contain secrets, tokens, or sensitive config.
+pub fn write_sensitive_file(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    write_private(path, content)
 }
 
 /// Async version of write_sensitive_file.

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -55,14 +55,15 @@ pub fn write_sensitive_file(path: &Path, content: &[u8]) -> std::io::Result<()> 
 }
 
 /// Async version of write_sensitive_file.
+///
+/// Delegates to the synchronous `write_private` on a blocking thread so that
+/// the atomic `OpenOptions::mode(0o600)` path is used (no TOCTOU window).
 pub async fn write_sensitive_file_async(path: &Path, content: &[u8]) -> std::io::Result<()> {
-    tokio::fs::write(path, content).await?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await?;
-    }
-    Ok(())
+    let path = path.to_path_buf();
+    let content = content.to_vec();
+    tokio::task::spawn_blocking(move || write_private(&path, &content))
+        .await
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
 }
 
 /// Check if a string is a valid GUID/UUID


### PR DESCRIPTION
## Summary

Three P1 fixes from the deep-dive code review (`dev/CODE_REVIEW.md`).

### Fix 1: `xv run` clears parent environment before injecting secrets
- **File:** `src/cli/secret_ops.rs`
- **Problem:** `cmd.envs(&env_vars)` was called without `cmd.env_clear()`. Child processes inherited the operator's full environment (cloud credentials, tokens, history-related env, etc.) alongside the injected vault secrets.
- **Fix:** Added `cmd.env_clear()` before `cmd.envs(&env_vars)`. Added `--inherit-env` flag for backward compatibility when the parent environment is needed.

### Fix 2: TUI panic hook restores terminal on panic
- **File:** `src/tui/mod.rs`
- **Problem:** `setup_terminal()` enables raw mode + alternate screen. A panic in any TUI view code left the terminal unusable.
- **Fix:** Installed `std::panic::set_hook` that calls `reset_terminal_sync()` (disable raw mode, leave alternate screen) then delegates to the previous hook. Extracted `reset_terminal_sync()` helper used by both the panic hook and `teardown_terminal()`.

### Fix 3: `write_private`/`create_private_dir` helpers for sensitive files
- **Files:** `src/utils/helpers.rs`, `src/backend/local/crypto.rs`, `secrets.rs`, `mod.rs`, `files.rs`
- **Problem:** Multiple sites used `fs::write` or `File::create` with default umask for sensitive files (age keys, encrypted payloads, plaintext metadata sidecars, vault.json). On multi-user systems, these files were world-readable. The age key file had a write→chmod TOCTOU race.
- **Fix:** Added `write_private(path, bytes)` that atomically creates files with `mode(0o600)` on Unix via `OpenOptions`, and `create_private_dir(path)` that creates directories with `0o700`. Applied at all sensitive file write sites. Rewired `write_sensitive_file()` to delegate to `write_private()`.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo check --all-features` — compiles (only pre-existing dead_code warning)
- [ ] Verify `xv run` with and without `--inherit-env`
- [ ] Verify TUI panic recovery (inject a deliberate panic)
- [ ] Verify file permissions on newly created secrets/keys (`stat -c %a`)

Addresses: P1 items 1–5 from `dev/CODE_REVIEW.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes in `xv run` (environment inheritance) and filesystem permission handling could break workflows on some platforms, but changes are localized and aimed at tightening security defaults.
> 
> **Overview**
> Improves security defaults across CLI, TUI, and the local backend.
> 
> `xv run` now starts child processes with a **clean environment** by default via `env_clear()`, with a new `--inherit-env` flag to preserve the previous behavior when needed.
> 
> Local backend writes/creates sensitive artifacts (age ciphertext files, key material, vault metadata, secret metadata, and storage directories) using new `write_private`/`create_private_dir` helpers to enforce *owner-only* permissions (0o600/0o700) and avoid Unix TOCTOU chmod races. The TUI installs a panic hook to restore the terminal (raw mode/alt screen) on panic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b34613cf68cba1ec8e0d95c57b78781b245803d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->