### PR TITLE
fix(security): P1/P2 hardening batch 2 — injection, panics, symlinks, error fidelity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "urlencoding",
  "uuid",
  "zeroize",
  "zip",
@@ -4701,6 +4702,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ time = { version = "0.3", features = ["macros"] }
 
 # Additional utilities
 url = "2.0"
+urlencoding = "2"
 base64 = "0.22"
 sha2 = "0.10"
 hex = "0.4"

--- a/src/backend/azure/auth.rs
+++ b/src/backend/azure/auth.rs
@@ -419,7 +419,8 @@ impl AzureAuthProvider for DefaultAzureCredentialProvider {
         let token = self
             .get_token(&["https://graph.microsoft.com/.default"])
             .await?;
-        let graph_url = format!("https://graph.microsoft.com/v1.0/users/{user}");
+        let graph_url =
+            crate::utils::url_helpers::graph_url("https://graph.microsoft.com/v1.0/users", &[user]);
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert(
             "Authorization",

--- a/src/backend/azure/detect.rs
+++ b/src/backend/azure/detect.rs
@@ -229,7 +229,8 @@ impl AzureDetector {
                 "GET",
                 "--url",
                 &format!(
-                    "https://graph.microsoft.com/v1.0/organization?$filter=id eq '{tenant_id}'"
+                    "https://graph.microsoft.com/v1.0/organization?$filter={}",
+                    crate::utils::url_helpers::odata_eq("id", tenant_id)
                 ),
             ])
             .output()

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -321,10 +321,33 @@ impl SecretBackend for LocalSecretBackend {
             });
         }
 
+        // Reject symlinks to prevent attackers from redirecting reads to
+        // arbitrary files on the filesystem.
+        if fs::symlink_metadata(&mp)
+            .map(|m| m.is_symlink())
+            .unwrap_or(false)
+        {
+            return Err(BackendError::Internal(format!(
+                "refusing to read metadata file: {} is a symlink",
+                mp.display()
+            )));
+        }
+
         let meta = read_meta(&mp)?;
 
         let value = if include_value {
             let ap = age_path(&self.store_path, vault, name);
+
+            if fs::symlink_metadata(&ap)
+                .map(|m| m.is_symlink())
+                .unwrap_or(false)
+            {
+                return Err(BackendError::Internal(format!(
+                    "refusing to decrypt secret file: {} is a symlink",
+                    ap.display()
+                )));
+            }
+
             Some(crypto::decrypt_from_file(&ap, &self.identity)?)
         } else {
             None
@@ -359,10 +382,31 @@ impl SecretBackend for LocalSecretBackend {
             });
         }
 
+        if fs::symlink_metadata(&meta_file)
+            .map(|m| m.is_symlink())
+            .unwrap_or(false)
+        {
+            return Err(BackendError::Internal(format!(
+                "refusing to read metadata file: {} is a symlink",
+                meta_file.display()
+            )));
+        }
+
         let meta = read_meta(&meta_file)?;
 
         let value = if include_value {
             let age_file = vdir.join(format!("{version}.age"));
+
+            if fs::symlink_metadata(&age_file)
+                .map(|m| m.is_symlink())
+                .unwrap_or(false)
+            {
+                return Err(BackendError::Internal(format!(
+                    "refusing to decrypt secret file: {} is a symlink",
+                    age_file.display()
+                )));
+            }
+
             Some(crypto::decrypt_from_file(&age_file, &self.identity)?)
         } else {
             None

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -1284,29 +1284,16 @@ async fn execute_file_download_recursive(
             output_path.join(blob_name)
         };
 
-        // Security: prevent path traversal via malicious blob names (e.g. "../../etc/passwd")
+        // Security: prevent path traversal via malicious blob names (e.g. "../../etc/passwd").
+        // We inspect each component of the blob name BEFORE joining it with the
+        // destination directory so no filesystem call is required and there is no
+        // TOCTOU window.  Any ParentDir (`..`) component is an unambiguous sign of
+        // a traversal attempt and is rejected immediately.
         {
-            let canonical_output = output_path
-                .canonicalize()
-                .unwrap_or_else(|_| output_path.to_path_buf());
-            // Resolve what we can — parent dirs may not exist yet, so normalize components
-            let mut resolved = canonical_output.clone();
-            for component in local_path
-                .strip_prefix(output_path)
-                .unwrap_or(&local_path)
+            let has_traversal = Path::new(blob_name)
                 .components()
-            {
-                match component {
-                    std::path::Component::ParentDir => {
-                        resolved.pop();
-                    }
-                    std::path::Component::Normal(c) => {
-                        resolved.push(c);
-                    }
-                    _ => {}
-                }
-            }
-            if !resolved.starts_with(&canonical_output) {
+                .any(|c| c == std::path::Component::ParentDir);
+            if has_traversal {
                 output::warn(&format!(
                     "Skipping '{}': path traversal detected in blob name",
                     blob_name

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2237,7 +2237,7 @@ async fn execute_secret_run(
 
         // secret_values is moved into stream_and_mask, which wraps it in Arc.
         // After threads join, Arc drop triggers Zeroizing::drop on each secret.
-        let exit_code = stream_and_mask(child, secret_values);
+        let exit_code = stream_and_mask(child, secret_values)?;
         std::process::exit(exit_code);
     }
 }
@@ -2248,11 +2248,18 @@ async fn execute_secret_run(
 /// `secret_values` is moved into an `Arc` and shared across two reader threads.
 /// After both threads join, this function holds the last `Arc` reference —
 /// dropping it triggers `Zeroizing::drop` on each secret value.
-fn stream_and_mask(mut child: std::process::Child, secret_values: Vec<Zeroizing<String>>) -> i32 {
+fn stream_and_mask(
+    mut child: std::process::Child,
+    secret_values: Vec<Zeroizing<String>>,
+) -> Result<i32> {
     use std::io::{BufRead, BufReader, Write};
 
-    let stdout = child.stdout.take().expect("stdout was piped");
-    let stderr = child.stderr.take().expect("stderr was piped");
+    let stdout = child.stdout.take().ok_or_else(|| {
+        CrosstacheError::config("failed to capture child stdout: pipe was not set")
+    })?;
+    let stderr = child.stderr.take().ok_or_else(|| {
+        CrosstacheError::config("failed to capture child stderr: pipe was not set")
+    })?;
 
     // Move secret_values into Arc for sharing across threads.
     // After threads join, the Arc in this function is the last reference.
@@ -2284,7 +2291,9 @@ fn stream_and_mask(mut child: std::process::Child, secret_values: Vec<Zeroizing<
     });
 
     // Wait for child to exit
-    let status = child.wait().expect("failed to wait on child");
+    let status = child
+        .wait()
+        .map_err(|e| CrosstacheError::config(format!("failed to wait on child process: {e}")))?;
 
     // Join threads (they'll finish once child closes pipe write-ends)
     let _ = stdout_thread.join();
@@ -2294,7 +2303,7 @@ fn stream_and_mask(mut child: std::process::Child, secret_values: Vec<Zeroizing<
     let _ = std::io::stdout().flush();
     let _ = std::io::stderr().flush();
 
-    status.code().unwrap_or(1)
+    Ok(status.code().unwrap_or(1))
 }
 
 async fn execute_secret_inject(

--- a/src/cli/upgrade_ops.rs
+++ b/src/cli/upgrade_ops.rs
@@ -47,9 +47,10 @@ pub(crate) async fn execute_upgrade_command(check: bool, force: bool) -> Result<
             "Run 'xv upgrade' to install, or download from {}",
             release.html_url
         ));
-        // Exit with code 1 for scriptability (e.g., `xv upgrade --check && echo "up to date"`)
+        // Exit 0 so `xv upgrade --check && xv upgrade` chains work correctly.
+        // The update-available status is already surfaced via the stdout messages above.
         // We call exit directly to avoid main.rs printing error-formatted output.
-        std::process::exit(1);
+        std::process::exit(0);
     }
 
     output::info(&format!("Update available: v{current} → v{latest}"));

--- a/src/secret/manager.rs
+++ b/src/secret/manager.rs
@@ -327,6 +327,18 @@ impl AzureSecretOperations {
     }
 }
 
+/// Read the body of an HTTP error response for diagnostic messages.
+///
+/// If reading the body fails (e.g. the connection was dropped), returns a
+/// descriptive placeholder rather than a bare empty string so callers always
+/// have actionable context in their error messages.
+async fn read_error_body(response: reqwest::Response) -> String {
+    response
+        .text()
+        .await
+        .unwrap_or_else(|e| format!("(failed to read error body: {e})"))
+}
+
 #[async_trait]
 impl SecretOperations for AzureSecretOperations {
     async fn set_secret(
@@ -406,7 +418,7 @@ impl SecretOperations for AzureSecretOperations {
 
         if !response.status().is_success() {
             let status = response.status();
-            let error_text = response.text().await.unwrap_or_default();
+            let error_text = read_error_body(response).await;
             return Err(CrosstacheError::azure_api(format!(
                 "Failed to set secret: HTTP {status} - {error_text}"
             )));
@@ -467,7 +479,7 @@ impl SecretOperations for AzureSecretOperations {
                     suggestion: None,
                 });
             }
-            let error_text = response.text().await.unwrap_or_default();
+            let error_text = read_error_body(response).await;
             return Err(CrosstacheError::azure_api(format!(
                 "Failed to get secret: HTTP {status} - {error_text}"
             )));
@@ -615,7 +627,7 @@ impl SecretOperations for AzureSecretOperations {
                     "Secret version '{version}' not found for secret '{secret_name}'"
                 )));
             }
-            let error_text = response.text().await.unwrap_or_default();
+            let error_text = read_error_body(response).await;
             return Err(CrosstacheError::azure_api(format!(
                 "Failed to get secret version: HTTP {} - {}",
                 status, error_text
@@ -756,7 +768,7 @@ impl SecretOperations for AzureSecretOperations {
 
             if !response.status().is_success() {
                 let status = response.status();
-                let error_text = response.text().await.unwrap_or_default();
+                let error_text = read_error_body(response).await;
                 return Err(CrosstacheError::azure_api(format!(
                     "Failed to list secrets: HTTP {status} - {error_text}"
                 )));
@@ -934,7 +946,7 @@ impl SecretOperations for AzureSecretOperations {
                     "Deleted secret '{secret_name}' not found or cannot be restored"
                 )));
             }
-            let error_text = response.text().await.unwrap_or_default();
+            let error_text = read_error_body(response).await;
             return Err(CrosstacheError::azure_api(format!(
                 "Failed to restore secret: HTTP {status} - {error_text}"
             )));
@@ -1058,7 +1070,7 @@ impl SecretOperations for AzureSecretOperations {
                     "Deleted secret '{secret_name}' not found or cannot be purged"
                 )));
             }
-            let error_text = response.text().await.unwrap_or_default();
+            let error_text = read_error_body(response).await;
             return Err(CrosstacheError::azure_api(format!(
                 "Failed to purge secret: HTTP {status} - {error_text}"
             )));
@@ -1125,7 +1137,7 @@ impl SecretOperations for AzureSecretOperations {
 
             if !response.status().is_success() {
                 let status = response.status();
-                let error_text = response.text().await.unwrap_or_default();
+                let error_text = read_error_body(response).await;
                 return Err(CrosstacheError::azure_api(format!(
                     "Failed to list secret versions: HTTP {} - {}",
                     status, error_text

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -23,3 +23,4 @@ pub mod resource_detector;
 pub mod retry;
 pub mod sanitizer;
 pub mod suggestions;
+pub mod url_helpers;

--- a/src/utils/url_helpers.rs
+++ b/src/utils/url_helpers.rs
@@ -1,0 +1,81 @@
+//! URL construction and OData query helpers.
+//!
+//! These helpers ensure that user-controlled values are properly escaped
+//! before being embedded in OData filter expressions or URL path segments,
+//! preventing OData injection and URL path injection attacks.
+
+/// Build an OData `eq` filter expression, escaping single quotes in `value`.
+///
+/// OData string literals delimit with single quotes; a literal `'` must be
+/// doubled (`''`).  Without this escaping an attacker-controlled value could
+/// break out of the literal and inject arbitrary filter logic.
+///
+/// # Example
+/// ```
+/// use crosstache::utils::url_helpers::odata_eq;
+/// assert_eq!(odata_eq("principalId", "abc-123"), "principalId eq 'abc-123'");
+/// assert_eq!(odata_eq("id", "it's"), "id eq 'it''s'");
+/// ```
+pub fn odata_eq(field: &str, value: &str) -> String {
+    let escaped = value.replace('\'', "''");
+    format!("{field} eq '{escaped}'")
+}
+
+/// Build a URL from a `base` string and additional `segments`, percent-encoding each segment.
+///
+/// Each segment is encoded with [`urlencoding::encode`] so that characters
+/// such as `@`, `/`, `?`, and `#` in user-supplied values cannot traverse
+/// outside their intended path component.
+///
+/// # Example
+/// ```
+/// use crosstache::utils::url_helpers::graph_url;
+/// let url = graph_url("https://graph.microsoft.com/v1.0/users", &["user@example.com"]);
+/// assert_eq!(url, "https://graph.microsoft.com/v1.0/users/user%40example.com");
+/// ```
+pub fn graph_url(base: &str, segments: &[&str]) -> String {
+    let mut url = base.to_string();
+    for seg in segments {
+        url.push('/');
+        url.push_str(&urlencoding::encode(seg));
+    }
+    url
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn odata_eq_no_special_chars() {
+        assert_eq!(
+            odata_eq("principalId", "00000000-0000-0000-0000-000000000000"),
+            "principalId eq '00000000-0000-0000-0000-000000000000'"
+        );
+    }
+
+    #[test]
+    fn odata_eq_escapes_single_quote() {
+        assert_eq!(odata_eq("name", "it's"), "name eq 'it''s'");
+    }
+
+    #[test]
+    fn odata_eq_escapes_multiple_quotes() {
+        assert_eq!(odata_eq("x", "a'b'c"), "x eq 'a''b''c'");
+    }
+
+    #[test]
+    fn graph_url_encodes_at_sign() {
+        let url = graph_url("https://graph.microsoft.com/v1.0/users", &["user@corp.com"]);
+        assert_eq!(
+            url,
+            "https://graph.microsoft.com/v1.0/users/user%40corp.com"
+        );
+    }
+
+    #[test]
+    fn graph_url_multiple_segments() {
+        let url = graph_url("https://example.com", &["seg/1", "seg 2"]);
+        assert_eq!(url, "https://example.com/seg%2F1/seg%202");
+    }
+}

--- a/src/vault/operations.rs
+++ b/src/vault/operations.rs
@@ -762,7 +762,8 @@ impl VaultOperations for AzureVaultOperations {
 
             // List role assignments for this scope
             let list_url = self.build_arm_url(&format!(
-                "{scope}/providers/Microsoft.Authorization/roleAssignments?api-version=2022-04-01&$filter=principalId eq '{user_object_id}'"
+                "{scope}/providers/Microsoft.Authorization/roleAssignments?api-version=2022-04-01&$filter={}",
+                crate::utils::url_helpers::odata_eq("principalId", user_object_id)
             ));
 
             let response = self


### PR DESCRIPTION
## Summary

Six fixes from the deep-dive code review (`dev/CODE_REVIEW.md`), covering remaining P1s and key P2 items.

### Fix 1: OData/URL escaping helpers (P1)
- **New file:** `src/utils/url_helpers.rs` with `odata_eq()` and `graph_url()` helpers
- **Added dep:** `urlencoding` crate
- **Applied at:** `vault/operations.rs` (principalId filter), `detect.rs` (tenant filter), `auth.rs` (Graph user URL)
- **Closes:** OData filter injection and Graph URL injection (3 sites)

### Fix 2: `read_error_body` helper (P2)
- **File:** `src/secret/manager.rs`
- **Problem:** 7× `.text().await.unwrap_or_default()` silently discarded Azure error details
- **Fix:** Added `read_error_body()` async helper; operators now see actual Azure error messages

### Fix 3: Replace `.expect()` panics in `xv run` (P1)
- **File:** `src/cli/secret_ops.rs`
- **Problem:** `.expect("stdout was piped")`, `.expect("stderr was piped")`, `.expect("failed to wait on child")` panic on edge cases
- **Fix:** Proper `?" error propagation via `CrosstacheError`

### Fix 4: Symlink validation before decrypt (P1)
- **File:** `src/backend/local/secrets.rs`
- **Problem:** No symlink check before opening secret files — attacker with vault-dir write access could symlink to arbitrary files
- **Fix:** `symlink_metadata` check rejects symlinks with clear error before any file open

### Fix 5: `xv upgrade --check` exit code (P1)
- **File:** `src/cli/upgrade_ops.rs`
- **Problem:** Exit code 1 when update available broke `xv upgrade --check && xv upgrade` chains
- **Fix:** Both cases exit 0; difference surfaced via stdout

### Fix 6: Path traversal check hardening (P1)
- **File:** `src/cli/file_ops.rs`
- **Problem:** `canonicalize().unwrap_or(path)` fallback defeated the traversal check when parent didn't exist
- **Fix:** Rewrote to reject `..` components before any filesystem call

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo check --all-features` — compiles
- [ ] Verify OData filters properly escape `'` characters
- [ ] Verify symlink rejection in local backend
- [ ] Verify `xv upgrade --check` exit codes

Addresses: P1 items 7-12 and P2 items from `dev/CODE_REVIEW.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple security-sensitive surfaces (Azure URL/query construction, local secret file reads, and download path handling), so regressions could break Azure interactions or local secret access despite being mostly defensive changes.
> 
> **Overview**
> **Hardens multiple injection and filesystem attack surfaces.** Adds `utils::url_helpers` plus `urlencoding` to ensure user-controlled values are escaped in OData filters and percent-encoded in Microsoft Graph URL path segments, and applies this to Graph/ARM calls in `azure/auth.rs`, `azure/detect.rs`, and `vault/operations.rs`.
> 
> **Tightens local/CLI safety and diagnostics.** Rejects symlinked secret metadata/encrypted files in the local backend before any read/decrypt, rewrites recursive blob download traversal detection to reject `..` components without `canonicalize()`, replaces `expect()` panics in `xv run` output masking with propagated `CrosstacheError`s, improves Azure REST error reporting by reliably capturing error bodies, and changes `xv upgrade --check` to exit `0` when an update is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04b95f9bde7015d8455fbee8d6fef5b0e377af9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->