### PR TITLE
fix(hardening): P3/P4 batch — 19 medium and nit fixes from code review

### DIFF
--- a/src/backend/azure/detect.rs
+++ b/src/backend/azure/detect.rs
@@ -222,6 +222,14 @@ impl AzureDetector {
 
     /// Get detailed tenant information
     async fn get_tenant_details(tenant_id: &str) -> Option<AzureTenant> {
+        // Validate tenant_id is a UUID before embedding in OData filter
+        if !is_valid_uuid(tenant_id) {
+            eprintln!(
+                "warning: tenant_id {:?} is not a valid UUID; skipping tenant details lookup",
+                tenant_id
+            );
+            return None;
+        }
         let output = Command::new("az")
             .args([
                 "rest",
@@ -564,6 +572,22 @@ impl AzureEnvironment {
 
         instructions
     }
+}
+
+/// Validate that a string matches the UUID format
+/// (8-4-4-4-12 lowercase or uppercase hex digits with hyphens).
+fn is_valid_uuid(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 5 {
+        return false;
+    }
+    let expected_lens = [8usize, 4, 4, 4, 12];
+    for (part, &expected) in parts.iter().zip(expected_lens.iter()) {
+        if part.len() != expected || !part.chars().all(|c| c.is_ascii_hexdigit()) {
+            return false;
+        }
+    }
+    true
 }
 
 #[cfg(test)]

--- a/src/backend/local/crypto.rs
+++ b/src/backend/local/crypto.rs
@@ -77,7 +77,8 @@ pub fn decrypt_bytes_from_file(
         .map_err(|e| BackendError::Internal(format!("decrypt header: {e}")))?
     {
         age::Decryptor::Recipients(d) => d,
-        _ => {
+        _other => {
+            eprintln!("warning: unexpected age decryptor variant (expected Recipients)");
             return Err(BackendError::Internal(
                 "unexpected passphrase-encrypted file".into(),
             ));
@@ -110,7 +111,8 @@ pub fn decrypt_from_file(
         .map_err(|e| BackendError::Internal(format!("decrypt header: {e}")))?
     {
         age::Decryptor::Recipients(d) => d,
-        _ => {
+        _other => {
+            eprintln!("warning: unexpected age decryptor variant (expected Recipients)");
             return Err(BackendError::Internal(
                 "unexpected passphrase-encrypted file".into(),
             ));
@@ -134,6 +136,15 @@ pub fn decrypt_from_file(
 /// The file may contain comments (lines starting with `#`) and blank lines;
 /// the first line matching the `AGE-SECRET-KEY-*` pattern is used.
 pub fn load_identity(key_path: &Path) -> Result<age::x25519::Identity, BackendError> {
+    let file_size = fs::metadata(key_path)
+        .map_err(|e| BackendError::Internal(format!("stat key {}: {e}", key_path.display())))?
+        .len();
+    if file_size > 1024 {
+        return Err(BackendError::Internal(format!(
+            "key file {} is too large ({file_size} bytes, max 1024)",
+            key_path.display()
+        )));
+    }
     let contents = fs::read_to_string(key_path)
         .map_err(|e| BackendError::Internal(format!("read key {}: {e}", key_path.display())))?;
 

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -67,7 +67,7 @@ fn encode_name(name: &str) -> String {
 }
 
 /// Decode a URL-encoded filename back to the original secret name.
-#[allow(dead_code)] // Used in tests and will be needed for list operations in future PRs.
+#[cfg(test)]
 fn decode_name(encoded: &str) -> String {
     url::form_urlencoded::parse(encoded.as_bytes())
         .map(|(k, _)| k.into_owned())
@@ -665,11 +665,6 @@ impl SecretBackend for LocalSecretBackend {
 
         // Sort by version number
         versions.sort_by_key(|v| v.version_number.unwrap_or(0));
-
-        // Set sequential version numbers (1-based)
-        for (i, v) in versions.iter_mut().enumerate() {
-            v.version_number = Some(i as u32 + 1);
-        }
 
         Ok(versions)
     }

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -181,8 +181,18 @@ fn next_version(store_path: &Path, vault: &str, name: &str) -> u32 {
                 if let Some(num_str) = rest.split('.').next() {
                     if let Ok(n) = num_str.parse::<u32>() {
                         max = max.max(n);
+                    } else {
+                        eprintln!(
+                            "warning: ignoring non-numeric entry {:?} in versions directory",
+                            fname
+                        );
                     }
                 }
+            } else {
+                eprintln!(
+                    "warning: ignoring non-numeric entry {:?} in versions directory",
+                    fname
+                );
             }
         }
     }
@@ -457,7 +467,13 @@ impl SecretBackend for LocalSecretBackend {
 
             let meta = match read_meta(&entry.path()) {
                 Ok(m) => m,
-                Err(_) => continue,
+                Err(e) => {
+                    eprintln!(
+                        "warning: secret {:?} exists but has corrupted metadata: {}",
+                        fname, e
+                    );
+                    continue;
+                }
             };
 
             // Apply group filter

--- a/src/blob/manager.rs
+++ b/src/blob/manager.rs
@@ -51,6 +51,7 @@ impl BlobManager {
     /// Override the chunk size (MB) and maximum concurrent uploads used by
     /// `upload_large_file`.  Returns `self` for builder-style chaining.
     pub fn with_blob_config(mut self, chunk_size_mb: usize, max_concurrent_uploads: usize) -> Self {
+        // Clamp to minimum of 1 to prevent division by zero
         self.chunk_size_mb = chunk_size_mb.max(1);
         self.max_concurrent_uploads = max_concurrent_uploads.max(1);
         self

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -1226,6 +1226,13 @@ async fn execute_file_download_recursive(
             ))
         })?;
     }
+    eprintln!(
+        "Downloading to: {}",
+        output_path
+            .canonicalize()
+            .unwrap_or_else(|_| output_path.to_path_buf())
+            .display()
+    );
 
     let mut all_files_to_download = Vec::new();
 

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -409,12 +409,15 @@ fn execute_custom_generator(script_path: &str, length: usize) -> Result<String> 
 
 /// Mask secret values in text output
 pub(crate) fn mask_secrets(text: &str, secrets: &[Zeroizing<String>]) -> String {
-    let mut result = text.to_string();
+    // Sort secrets by length descending so longer values are masked first,
+    // preventing partial matches. Skip values < 4 chars to avoid masking
+    // common short strings.
+    let mut sorted: Vec<&Zeroizing<String>> = secrets.iter().collect();
+    sorted.sort_by(|a, b| b.len().cmp(&a.len()));
 
-    for secret in secrets {
+    let mut result = text.to_string();
+    for secret in sorted {
         if secret.len() >= 4 {
-            // Only mask secrets that are at least 4 characters
-            // Replace with [MASKED] to indicate redaction
             result = result.replace(secret.as_str(), "[MASKED]");
         }
     }

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -229,7 +229,10 @@ fn linux_clipboard_copy(text: &str) -> Option<std::result::Result<(), String>> {
                         }
                     }
                 }
-                Err(_) => continue, // tool exists but failed to spawn, try next
+                Err(e) => {
+                    eprintln!("warning: failed to spawn {cmd}: {e}");
+                    continue;
+                }
             }
         }
     }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -1634,9 +1634,9 @@ async fn execute_secret_find(
         combined
     } else {
         // Single-vault path (existing logic from Task 5).
-        let vault_name = single_vault
-            .as_ref()
-            .expect("single-vault find always resolves a vault name");
+        let vault_name = single_vault.as_ref().ok_or_else(|| {
+            CrosstacheError::config("vault name not resolved for single-vault search".to_string())
+        })?;
         let progress = crate::utils::interactive::ProgressIndicator::new("Loading secrets...");
         let all_secrets = secret_manager
             .secret_ops()
@@ -1706,9 +1706,11 @@ async fn execute_secret_find(
                 output::info("No secrets found across all vaults");
             }
         } else {
-            let vault_name = single_vault
-                .as_ref()
-                .expect("single-vault empty-result message needs vault name");
+            let vault_name = single_vault.as_ref().ok_or_else(|| {
+                CrosstacheError::config(
+                    "vault name not resolved for single-vault search".to_string(),
+                )
+            })?;
             if let Some(p) = pattern {
                 output::info(&format!("No secrets match '{p}' in vault '{vault_name}'"));
             } else {

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -37,6 +37,8 @@ pub struct VaultContext {
     /// Last used timestamp
     pub last_used: chrono::DateTime<chrono::Utc>,
     /// Usage count for prioritization
+    // Note: usage_count is best-effort and non-atomic. This is acceptable for a CLI tool
+    // (single process) but would need atomic operations in a server context.
     #[serde(default)]
     pub usage_count: u32,
 }

--- a/src/scan/installer.rs
+++ b/src/scan/installer.rs
@@ -52,6 +52,19 @@ pub fn install(force: bool) -> Result<HookInstallStatus> {
     }
     std::fs::write(&path, HOOK_BODY)?;
     set_executable(&path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = std::fs::metadata(&path) {
+            let perms = meta.permissions();
+            if perms.mode() & 0o111 == 0 {
+                eprintln!(
+                    "warning: hook file {:?} is not executable; run: chmod +x {:?}",
+                    path, path
+                );
+            }
+        }
+    }
     Ok(HookInstallStatus::Installed(path))
 }
 

--- a/src/secret/manager.rs
+++ b/src/secret/manager.rs
@@ -684,8 +684,11 @@ impl SecretOperations for AzureSecretOperations {
             .unwrap_or(version)
             .to_string();
 
-        let attributes = &json["attributes"];
-        let enabled = attributes["enabled"].as_bool().unwrap_or(true);
+        let attributes = json.get("attributes").unwrap_or(&serde_json::Value::Null);
+        let enabled = attributes
+            .get("enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
 
         let created_ts = attributes
             .get("created")
@@ -1193,7 +1196,9 @@ impl SecretOperations for AzureSecretOperations {
 
             if let Some(value_array) = json["value"].as_array() {
                 for version_json in value_array {
-                    let attributes = &version_json["attributes"];
+                    let attributes = version_json
+                        .get("attributes")
+                        .unwrap_or(&serde_json::Value::Null);
 
                     let version = version_json["id"]
                         .as_str()
@@ -1201,9 +1206,18 @@ impl SecretOperations for AzureSecretOperations {
                         .unwrap_or("unknown")
                         .to_string();
 
-                    let enabled = attributes["enabled"].as_bool().unwrap_or(true);
-                    let created_timestamp = attributes["created"].as_i64().unwrap_or(0);
-                    let updated_timestamp = attributes["updated"].as_i64().unwrap_or(0);
+                    let enabled = attributes
+                        .get("enabled")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(true);
+                    let created_timestamp = attributes
+                        .get("created")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
+                    let updated_timestamp = attributes
+                        .get("updated")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
 
                     let created_on = DateTime::from_timestamp(created_timestamp, 0)
                         .unwrap_or_else(Utc::now)

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -63,13 +63,19 @@ fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
 }
 
 fn reset_terminal_sync() {
-    disable_raw_mode().ok();
-    execute!(io::stdout(), LeaveAlternateScreen).ok();
+    if let Err(e) = disable_raw_mode() {
+        eprintln!("warning: failed to disable raw mode: {e}");
+    }
+    if let Err(e) = execute!(io::stdout(), LeaveAlternateScreen) {
+        eprintln!("warning: failed to leave alternate screen: {e}");
+    }
 }
 
 fn teardown_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
     reset_terminal_sync();
-    terminal.show_cursor().ok();
+    if let Err(e) = terminal.show_cursor() {
+        eprintln!("warning: failed to show cursor: {e}");
+    }
     Ok(())
 }
 

--- a/src/utils/sanitizer.rs
+++ b/src/utils/sanitizer.rs
@@ -76,6 +76,10 @@ pub fn sanitize_secret_name(name: &str) -> Result<String> {
 }
 
 /// Generate a hash-based name for secrets that can't be sanitized normally
+///
+/// SHA-256 truncated to 128 bits (16 bytes / 32 hex chars). This provides sufficient
+/// collision resistance for filename deduplication — birthday bound is ~2^64 which
+/// far exceeds our use case.
 pub fn hash_secret_name(name: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(name.as_bytes());

--- a/src/vault/operations.rs
+++ b/src/vault/operations.rs
@@ -1016,7 +1016,13 @@ impl VaultOperations for AzureVaultOperations {
             .await
         {
             Ok(token) => token.token.secret().to_string(),
-            Err(_) => return HashMap::new(),
+            Err(e) => {
+                eprintln!(
+                    "warning: Graph API call failed, role assignments may be incomplete: {}",
+                    e
+                );
+                return HashMap::new();
+            }
         };
 
         let mut headers = HeaderMap::new();
@@ -1039,16 +1045,32 @@ impl VaultOperations for AzureVaultOperations {
             .await
         {
             Ok(resp) => resp,
-            Err(_) => return HashMap::new(),
+            Err(e) => {
+                eprintln!(
+                    "warning: Graph API call failed, role assignments may be incomplete: {}",
+                    e
+                );
+                return HashMap::new();
+            }
         };
 
         if !response.status().is_success() {
+            eprintln!(
+                "warning: Graph API call failed, role assignments may be incomplete: HTTP {}",
+                response.status()
+            );
             return HashMap::new();
         }
 
         let data: Value = match response.json().await {
             Ok(d) => d,
-            Err(_) => return HashMap::new(),
+            Err(e) => {
+                eprintln!(
+                    "warning: Graph API call failed, role assignments may be incomplete: {}",
+                    e
+                );
+                return HashMap::new();
+            }
         };
 
         let mut result = HashMap::new();
@@ -1099,8 +1121,17 @@ impl AzureVaultOperations {
             .unwrap_or_default()
             .to_string();
 
-        // Extract resource group from ID
-        let resource_group = id.split('/').nth(4).unwrap_or_default().to_string();
+        // Extract resource group from ARM resource ID (/subscriptions/<sub>/resourceGroups/<rg>/...)
+        let resource_group = match id.split('/').nth(4) {
+            Some(rg) => rg.to_string(),
+            None => {
+                eprintln!(
+                    "warning: malformed ARM resource ID {:?}, resource group could not be extracted",
+                    id
+                );
+                String::new()
+            }
+        };
 
         let subscription_id = id
             .split('/')


### PR DESCRIPTION
## Summary

Batched P3 (medium) and P4 (nit/style) fixes from `dev/CODE_REVIEW.md`. All low-risk, no behavior changes to happy paths.

### P3 fixes (commit 1):
1. **mask_secrets**: Sort by length descending, skip <4 char values
2. **list_secrets**: Warn on corrupted metadata instead of silent skip
3. **next_version**: Warn on non-numeric version dir entries
4. **detect.rs**: Validate tenant_id as UUID before OData filter
5. **blob/manager.rs**: Document chunk_size clamping (already safe)
6. **resolve_principal_ids**: Log warnings on Graph API failures
7. **ARM ID parsing**: Proper error handling on malformed resource IDs
8. **usage_count**: Document as best-effort non-atomic (CLI context)
9. **sanitizer hash**: Document 128-bit truncation rationale
10. **scan/installer**: Warn if pre-commit hook not executable after write

### P4 fixes (commit 2):
1. **TUI teardown**: Log warnings instead of silent `.ok()`
2. **clipboard errors**: Distinguish tool-not-found from tool-failed
3. **crypto decrypt**: Log unexpected recipient variants
4. **crypto key read**: 1 KiB size cap on key files
5. **decode_name**: Mark `#[cfg(test)]` (only used in tests)
6. **enabled parsing**: Normalize pattern across all 4 sites
7. **secret_ops .expect()**: Replace with proper error propagation
8. **file_ops download**: Print resolved target dir before downloading
9. **list_versions**: Preserve original version numbers

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo check --all-features` — compiles
- [ ] Verify mask_secrets orders correctly with overlapping secrets
- [ ] Verify corrupted metadata produces visible warning

13 files changed, +166/-34 lines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk hardening and UX improvements; behavior changes are mostly additional validation/logging and more defensive parsing, with one new constraint that rejects overly large local age key files.
> 
> **Overview**
> Hardens several code paths by adding input validation, defensive JSON parsing, and more explicit warnings instead of silently ignoring errors (Azure tenant UUID/OData filter, Graph API lookups, corrupted local secret metadata, non-numeric version entries, and TUI/clipboard process failures).
> 
> Tightens local secret/crypto handling by capping age identity key file size, warning on unexpected decryptor variants, and preserving original secret version numbers when listing versions. Improves CLI output safety/clarity by masking longer secrets first, printing resolved download targets, and replacing a couple of `expect()`s with proper error propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db0520091093d3720dbef35e865fff58ba3578bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->