### PR TITLE
fix(local): reject traversal vault names

### DIFF
--- a/src/backend/local/files.rs
+++ b/src/backend/local/files.rs
@@ -18,7 +18,7 @@ use crate::blob::models::{FileInfo, FileListRequest, FileUploadRequest};
 use crate::utils::helpers::create_private_dir;
 use crate::utils::progress::ProgressReporter;
 
-use super::crypto;
+use super::{crypto, paths};
 
 // ---------------------------------------------------------------------------
 // Path helpers
@@ -29,18 +29,18 @@ fn encode_name(name: &str) -> String {
     url::form_urlencoded::byte_serialize(name.as_bytes()).collect()
 }
 
-fn files_dir(store_path: &Path, vault: &str) -> PathBuf {
-    store_path.join("vaults").join(vault).join("files")
+fn files_dir(store_path: &Path, vault: &str) -> Result<PathBuf, BackendError> {
+    paths::files_dir(store_path, vault)
 }
 
-fn file_age_path(store_path: &Path, vault: &str, name: &str) -> PathBuf {
+fn file_age_path(store_path: &Path, vault: &str, name: &str) -> Result<PathBuf, BackendError> {
     let enc = encode_name(name);
-    files_dir(store_path, vault).join(format!("{enc}.age"))
+    Ok(files_dir(store_path, vault)?.join(format!("{enc}.age")))
 }
 
-fn file_meta_path(store_path: &Path, vault: &str, name: &str) -> PathBuf {
+fn file_meta_path(store_path: &Path, vault: &str, name: &str) -> Result<PathBuf, BackendError> {
     let enc = encode_name(name);
-    files_dir(store_path, vault).join(format!("{enc}.meta.json"))
+    Ok(files_dir(store_path, vault)?.join(format!("{enc}.meta.json")))
 }
 
 // ---------------------------------------------------------------------------
@@ -97,13 +97,13 @@ impl FileBackend for LocalFileBackend {
         request: FileUploadRequest,
         _reporter: Option<&dyn ProgressReporter>,
     ) -> Result<FileInfo, BackendError> {
-        let fdir = files_dir(&self.store_path, &self.vault);
+        let fdir = files_dir(&self.store_path, &self.vault)?;
         create_private_dir(&fdir)
             .map_err(|e| BackendError::Internal(format!("mkdir files: {e}")))?;
 
         let original_size = request.content.len() as u64;
-        let ap = file_age_path(&self.store_path, &self.vault, &request.name);
-        let mp = file_meta_path(&self.store_path, &self.vault, &request.name);
+        let ap = file_age_path(&self.store_path, &self.vault, &request.name)?;
+        let mp = file_meta_path(&self.store_path, &self.vault, &request.name)?;
 
         // Encrypt and write file content
         crypto::encrypt_to_file(&ap, &request.content, &self.recipients)?;
@@ -132,7 +132,7 @@ impl FileBackend for LocalFileBackend {
         name: &str,
         _reporter: Option<&dyn ProgressReporter>,
     ) -> Result<Vec<u8>, BackendError> {
-        let ap = file_age_path(&self.store_path, &self.vault, name);
+        let ap = file_age_path(&self.store_path, &self.vault, name)?;
         if !ap.exists() {
             return Err(BackendError::NotFound {
                 name: name.to_string(),
@@ -144,7 +144,7 @@ impl FileBackend for LocalFileBackend {
     }
 
     async fn list_files(&self, request: FileListRequest) -> Result<Vec<FileInfo>, BackendError> {
-        let fdir = files_dir(&self.store_path, &self.vault);
+        let fdir = files_dir(&self.store_path, &self.vault)?;
         if !fdir.exists() {
             return Ok(Vec::new());
         }
@@ -193,8 +193,8 @@ impl FileBackend for LocalFileBackend {
     }
 
     async fn delete_file(&self, name: &str) -> Result<(), BackendError> {
-        let ap = file_age_path(&self.store_path, &self.vault, name);
-        let mp = file_meta_path(&self.store_path, &self.vault, name);
+        let ap = file_age_path(&self.store_path, &self.vault, name)?;
+        let mp = file_meta_path(&self.store_path, &self.vault, name)?;
 
         if !ap.exists() && !mp.exists() {
             return Err(BackendError::NotFound {
@@ -216,7 +216,7 @@ impl FileBackend for LocalFileBackend {
     }
 
     async fn get_file_info(&self, name: &str) -> Result<FileInfo, BackendError> {
-        let mp = file_meta_path(&self.store_path, &self.vault, name);
+        let mp = file_meta_path(&self.store_path, &self.vault, name)?;
         if !mp.exists() {
             return Err(BackendError::NotFound {
                 name: name.to_string(),
@@ -282,6 +282,33 @@ mod tests {
         // Download and verify
         let bytes = backend.download_file("cert.pem", None).await.unwrap();
         assert_eq!(bytes, b"-----BEGIN CERTIFICATE-----\nMIIBxTCCA...");
+    }
+
+    #[tokio::test]
+    async fn rejects_traversal_vault_name_for_file_writes() {
+        let tmp = TempDir::new().unwrap();
+        let store = tmp.path().to_path_buf();
+        let key_path = tmp.path().join("key.txt");
+        let recipients_path = tmp.path().join("recipients.txt");
+        let (identity, recipients) = generate_keypair(&key_path, &recipients_path).unwrap();
+        let backend = LocalFileBackend::new(store, "../../outside".into(), identity, recipients);
+
+        let result = backend
+            .upload_file(
+                FileUploadRequest {
+                    name: "escape.txt".into(),
+                    content: b"content".to_vec(),
+                    content_type: None,
+                    groups: Vec::new(),
+                    metadata: HashMap::new(),
+                    tags: HashMap::new(),
+                },
+                None,
+            )
+            .await;
+
+        assert!(matches!(result, Err(BackendError::InvalidArgument(_))));
+        assert!(!tmp.path().join("outside").exists());
     }
 
     #[tokio::test]

--- a/src/backend/local/mod.rs
+++ b/src/backend/local/mod.rs
@@ -25,6 +25,7 @@ pub mod config;
 pub mod crypto;
 #[cfg(feature = "file-ops")]
 pub mod files;
+pub mod paths;
 pub mod secrets;
 pub mod vaults;
 
@@ -80,7 +81,7 @@ impl LocalBackend {
         crypto::set_dir_permissions(&config.store_path)?;
 
         // Ensure vaults directory exists
-        let vaults_dir = config.store_path.join("vaults");
+        let vaults_dir = paths::vaults_dir(&config.store_path);
         create_private_dir(&vaults_dir).map_err(|e| {
             BackendError::Internal(format!(
                 "create vaults directory {}: {e}",
@@ -92,7 +93,7 @@ impl LocalBackend {
         let (identity, recipients) = Self::resolve_keys(&config)?;
 
         // Create default vault if it doesn't exist
-        let default_vault_dir = vaults_dir.join(&config.default_vault);
+        let default_vault_dir = paths::vault_dir(&config.store_path, &config.default_vault)?;
         if !default_vault_dir.join(".vault.json").exists() {
             create_private_dir(default_vault_dir.join("secrets"))
                 .map_err(|e| BackendError::Internal(format!("create default vault: {e}")))?;

--- a/src/backend/local/paths.rs
+++ b/src/backend/local/paths.rs
@@ -1,0 +1,134 @@
+//! Shared path safety helpers for the local backend.
+
+use std::path::{Component, Path, PathBuf};
+
+use crate::backend::error::BackendError;
+
+/// Validate that a local vault name is a single safe filesystem component.
+///
+/// Local vault names are used as directory names under `<store>/vaults/`.
+/// Reject separators, parent/current-directory components, Windows prefixes,
+/// control characters, and names that are awkward or unsafe on common filesystems.
+pub(crate) fn validate_vault_name(name: &str) -> Result<(), BackendError> {
+    if name.is_empty() {
+        return Err(invalid_vault_name(name, "vault name cannot be empty"));
+    }
+
+    if name == "." || name == ".." {
+        return Err(invalid_vault_name(
+            name,
+            "vault name must not be '.' or '..'",
+        ));
+    }
+
+    if name.contains('/') || name.contains('\\') {
+        return Err(invalid_vault_name(
+            name,
+            "vault name must not contain path separators",
+        ));
+    }
+
+    if name.starts_with('-') {
+        return Err(invalid_vault_name(
+            name,
+            "vault name must not start with '-'",
+        ));
+    }
+
+    if name.chars().any(|ch| ch.is_control()) {
+        return Err(invalid_vault_name(
+            name,
+            "vault name must not contain control characters",
+        ));
+    }
+
+    let path = Path::new(name);
+    let mut components = path.components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(component)), None) if component == name => Ok(()),
+        _ => Err(invalid_vault_name(
+            name,
+            "vault name must be a single path component without separators or prefixes",
+        )),
+    }
+}
+
+pub(crate) fn vaults_dir(store_path: &Path) -> PathBuf {
+    store_path.join("vaults")
+}
+
+pub(crate) fn vault_dir(store_path: &Path, name: &str) -> Result<PathBuf, BackendError> {
+    validate_vault_name(name)?;
+    let vaults_dir = vaults_dir(store_path);
+    let candidate = vaults_dir.join(name);
+    ensure_child_path(&vaults_dir, &candidate, name)?;
+    Ok(candidate)
+}
+
+pub(crate) fn secrets_dir(store_path: &Path, vault: &str) -> Result<PathBuf, BackendError> {
+    Ok(vault_dir(store_path, vault)?.join("secrets"))
+}
+
+pub(crate) fn trash_base_dir(store_path: &Path, vault: &str) -> Result<PathBuf, BackendError> {
+    Ok(vault_dir(store_path, vault)?.join(".trash"))
+}
+
+#[cfg(feature = "file-ops")]
+pub(crate) fn files_dir(store_path: &Path, vault: &str) -> Result<PathBuf, BackendError> {
+    Ok(vault_dir(store_path, vault)?.join("files"))
+}
+
+fn invalid_vault_name(name: &str, reason: &str) -> BackendError {
+    BackendError::InvalidArgument(format!(
+        "invalid local vault name '{name}': {reason}. Use a single directory name such as 'default' or 'work-secrets'."
+    ))
+}
+
+fn ensure_child_path(base: &Path, candidate: &Path, name: &str) -> Result<(), BackendError> {
+    if candidate.starts_with(base) {
+        Ok(())
+    } else {
+        Err(invalid_vault_name(
+            name,
+            "resolved vault path escapes the local vaults directory",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_single_component_vault_names() {
+        for name in ["default", "work-secrets", "team_1", "Vault123"] {
+            validate_vault_name(name).expect(name);
+        }
+    }
+
+    #[test]
+    fn rejects_path_traversal_and_separators() {
+        for name in [
+            "",
+            ".",
+            "..",
+            "../outside",
+            "../../outside",
+            "outside/child",
+            "/absolute",
+            "\\absolute",
+            "parent\\child",
+            "bad\nname",
+        ] {
+            assert!(validate_vault_name(name).is_err(), "{name:?}");
+        }
+    }
+
+    #[test]
+    fn vault_dir_never_escapes_vaults_root() {
+        let store = PathBuf::from("/tmp/store");
+        let path = vault_dir(&store, "default").unwrap();
+        assert_eq!(path, store.join("vaults").join("default"));
+        assert!(vault_dir(&store, "../../outside").is_err());
+    }
+}

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -25,7 +25,7 @@ use crate::backend::error::BackendError;
 use crate::backend::secret::SecretBackend;
 use crate::secret::manager::{SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest};
 
-use super::crypto;
+use super::{crypto, paths};
 
 // ---------------------------------------------------------------------------
 // Metadata persisted alongside each secret
@@ -74,36 +74,32 @@ fn decode_name(encoded: &str) -> String {
         .collect()
 }
 
-fn secrets_dir(store_path: &Path, vault: &str) -> PathBuf {
-    store_path.join("vaults").join(vault).join("secrets")
+fn secrets_dir(store_path: &Path, vault: &str) -> Result<PathBuf, BackendError> {
+    paths::secrets_dir(store_path, vault)
 }
 
-fn age_path(store_path: &Path, vault: &str, name: &str) -> PathBuf {
+fn age_path(store_path: &Path, vault: &str, name: &str) -> Result<PathBuf, BackendError> {
     let enc = encode_name(name);
-    secrets_dir(store_path, vault).join(format!("{enc}.age"))
+    Ok(secrets_dir(store_path, vault)?.join(format!("{enc}.age")))
 }
 
-fn meta_path(store_path: &Path, vault: &str, name: &str) -> PathBuf {
+fn meta_path(store_path: &Path, vault: &str, name: &str) -> Result<PathBuf, BackendError> {
     let enc = encode_name(name);
-    secrets_dir(store_path, vault).join(format!("{enc}.meta.json"))
+    Ok(secrets_dir(store_path, vault)?.join(format!("{enc}.meta.json")))
 }
 
-fn versions_dir(store_path: &Path, vault: &str, name: &str) -> PathBuf {
+fn versions_dir(store_path: &Path, vault: &str, name: &str) -> Result<PathBuf, BackendError> {
     let enc = encode_name(name);
-    secrets_dir(store_path, vault).join(".versions").join(enc)
+    Ok(secrets_dir(store_path, vault)?.join(".versions").join(enc))
 }
 
-fn trash_dir(store_path: &Path, vault: &str, name: &str) -> PathBuf {
+fn trash_dir(store_path: &Path, vault: &str, name: &str) -> Result<PathBuf, BackendError> {
     let enc = encode_name(name);
-    store_path
-        .join("vaults")
-        .join(vault)
-        .join(".trash")
-        .join(enc)
+    Ok(paths::trash_base_dir(store_path, vault)?.join(enc))
 }
 
-fn trash_base_dir(store_path: &Path, vault: &str) -> PathBuf {
-    store_path.join("vaults").join(vault).join(".trash")
+fn trash_base_dir(store_path: &Path, vault: &str) -> Result<PathBuf, BackendError> {
+    paths::trash_base_dir(store_path, vault)
 }
 
 // ---------------------------------------------------------------------------
@@ -168,10 +164,10 @@ fn write_meta(path: &Path, meta: &SecretMeta) -> Result<(), BackendError> {
 }
 
 /// Determine the next version number by scanning `.versions/<name>/`.
-fn next_version(store_path: &Path, vault: &str, name: &str) -> u32 {
-    let vdir = versions_dir(store_path, vault, name);
+fn next_version(store_path: &Path, vault: &str, name: &str) -> Result<u32, BackendError> {
+    let vdir = versions_dir(store_path, vault, name)?;
     if !vdir.exists() {
-        return 1;
+        return Ok(1);
     }
     let mut max: u32 = 0;
     if let Ok(entries) = fs::read_dir(&vdir) {
@@ -196,20 +192,20 @@ fn next_version(store_path: &Path, vault: &str, name: &str) -> u32 {
             }
         }
     }
-    max + 1
+    Ok(max + 1)
 }
 
 /// Archive the current secret to `.versions/<name>/v<N>.*`.
 fn archive_current(store_path: &Path, vault: &str, name: &str) -> Result<u32, BackendError> {
-    let ap = age_path(store_path, vault, name);
-    let mp = meta_path(store_path, vault, name);
+    let ap = age_path(store_path, vault, name)?;
+    let mp = meta_path(store_path, vault, name)?;
 
     if !ap.exists() && !mp.exists() {
         return Ok(1);
     }
 
-    let ver = next_version(store_path, vault, name);
-    let vdir = versions_dir(store_path, vault, name);
+    let ver = next_version(store_path, vault, name)?;
+    let vdir = versions_dir(store_path, vault, name)?;
     fs::create_dir_all(&vdir)
         .map_err(|e| BackendError::Internal(format!("mkdir versions: {e}")))?;
 
@@ -276,7 +272,7 @@ impl SecretBackend for LocalSecretBackend {
         let recipients = self.recipients.clone();
 
         // Validate vault exists before attempting to lock.
-        let vault_dir = self.store_path.join("vaults").join(vault);
+        let vault_dir = paths::vault_dir(&self.store_path, vault)?;
         let vault_json = vault_dir.join(".vault.json");
         if !vault_json.exists() {
             return Err(BackendError::VaultNotFound {
@@ -288,13 +284,13 @@ impl SecretBackend for LocalSecretBackend {
         // Acquire exclusive vault lock for the duration of the mutation.
         let _lock = lock_vault(&vault_dir)?;
 
-        let sdir = secrets_dir(&store, vault);
+        let sdir = secrets_dir(&store, vault)?;
         create_private_dir(&sdir)
             .map_err(|e| BackendError::Internal(format!("mkdir secrets: {e}")))?;
 
         let name = request.name.clone();
-        let ap = age_path(&store, vault, &name);
-        let mp = meta_path(&store, vault, &name);
+        let ap = age_path(&store, vault, &name)?;
+        let mp = meta_path(&store, vault, &name)?;
 
         // If secret already exists, archive old version.
         let version = if mp.exists() {
@@ -343,7 +339,7 @@ impl SecretBackend for LocalSecretBackend {
         name: &str,
         include_value: bool,
     ) -> Result<SecretProperties, BackendError> {
-        let mp = meta_path(&self.store_path, vault, name);
+        let mp = meta_path(&self.store_path, vault, name)?;
         if !mp.exists() {
             return Err(BackendError::NotFound {
                 name: name.to_string(),
@@ -366,7 +362,7 @@ impl SecretBackend for LocalSecretBackend {
         let meta = read_meta(&mp)?;
 
         let value = if include_value {
-            let ap = age_path(&self.store_path, vault, name);
+            let ap = age_path(&self.store_path, vault, name)?;
 
             if fs::symlink_metadata(&ap)
                 .map(|m| m.is_symlink())
@@ -394,7 +390,7 @@ impl SecretBackend for LocalSecretBackend {
         include_value: bool,
     ) -> Result<SecretProperties, BackendError> {
         // First check if this is the current version.
-        let mp = meta_path(&self.store_path, vault, name);
+        let mp = meta_path(&self.store_path, vault, name)?;
         if mp.exists() {
             let meta = read_meta(&mp)?;
             if meta.version == version {
@@ -403,7 +399,7 @@ impl SecretBackend for LocalSecretBackend {
         }
 
         // Look in .versions/
-        let vdir = versions_dir(&self.store_path, vault, name);
+        let vdir = versions_dir(&self.store_path, vault, name)?;
         let meta_file = vdir.join(format!("{version}.meta.json"));
         if !meta_file.exists() {
             return Err(BackendError::NotFound {
@@ -450,7 +446,7 @@ impl SecretBackend for LocalSecretBackend {
         vault: &str,
         group_filter: Option<&str>,
     ) -> Result<Vec<SecretSummary>, BackendError> {
-        let sdir = secrets_dir(&self.store_path, vault);
+        let sdir = secrets_dir(&self.store_path, vault)?;
         if !sdir.exists() {
             return Ok(Vec::new());
         }
@@ -492,7 +488,7 @@ impl SecretBackend for LocalSecretBackend {
     }
 
     async fn delete_secret(&self, vault: &str, name: &str) -> Result<(), BackendError> {
-        let vault_dir = self.store_path.join("vaults").join(vault);
+        let vault_dir = paths::vault_dir(&self.store_path, vault)?;
         if !vault_dir.join(".vault.json").exists() {
             return Err(BackendError::VaultNotFound {
                 name: vault.to_string(),
@@ -501,8 +497,8 @@ impl SecretBackend for LocalSecretBackend {
         }
         let _lock = lock_vault(&vault_dir)?;
 
-        let mp = meta_path(&self.store_path, vault, name);
-        let ap = age_path(&self.store_path, vault, name);
+        let mp = meta_path(&self.store_path, vault, name)?;
+        let ap = age_path(&self.store_path, vault, name)?;
 
         if !mp.exists() && !ap.exists() {
             return Err(BackendError::NotFound {
@@ -512,7 +508,7 @@ impl SecretBackend for LocalSecretBackend {
         }
 
         // Soft delete: move files to .trash/{encoded_name}/
-        let tdir = trash_dir(&self.store_path, vault, name);
+        let tdir = trash_dir(&self.store_path, vault, name)?;
         fs::create_dir_all(&tdir)
             .map_err(|e| BackendError::Internal(format!("mkdir trash: {e}")))?;
 
@@ -552,10 +548,10 @@ impl SecretBackend for LocalSecretBackend {
         request: SecretUpdateRequest,
     ) -> Result<SecretProperties, BackendError> {
         // Acquire exclusive vault lock — update_secret may call archive_current/next_version.
-        let vault_dir = self.store_path.join("vaults").join(vault);
+        let vault_dir = paths::vault_dir(&self.store_path, vault)?;
         let _lock = lock_vault(&vault_dir)?;
 
-        let mp = meta_path(&self.store_path, vault, name);
+        let mp = meta_path(&self.store_path, vault, name)?;
         if !mp.exists() {
             return Err(BackendError::NotFound {
                 name: name.to_string(),
@@ -577,7 +573,7 @@ impl SecretBackend for LocalSecretBackend {
                 .unwrap_or(0);
             meta.version = format!("v{}", old_num + 1);
 
-            let ap = age_path(&self.store_path, vault, name);
+            let ap = age_path(&self.store_path, vault, name)?;
             crypto::encrypt_to_file(&ap, new_value.as_bytes(), &self.recipients)?;
         }
 
@@ -642,7 +638,7 @@ impl SecretBackend for LocalSecretBackend {
         let mut versions = Vec::new();
 
         // Collect archived versions
-        let vdir = versions_dir(&self.store_path, vault, name);
+        let vdir = versions_dir(&self.store_path, vault, name)?;
         if vdir.exists() {
             if let Ok(entries) = fs::read_dir(&vdir) {
                 for entry in entries.flatten() {
@@ -657,7 +653,7 @@ impl SecretBackend for LocalSecretBackend {
         }
 
         // Add current version
-        let mp = meta_path(&self.store_path, vault, name);
+        let mp = meta_path(&self.store_path, vault, name)?;
         if mp.exists() {
             let meta = read_meta(&mp)?;
             versions.push(meta_to_properties(&meta, None));
@@ -670,7 +666,7 @@ impl SecretBackend for LocalSecretBackend {
     }
 
     async fn secret_exists(&self, vault: &str, name: &str) -> Result<bool, BackendError> {
-        let mp = meta_path(&self.store_path, vault, name);
+        let mp = meta_path(&self.store_path, vault, name)?;
         Ok(mp.exists())
     }
 
@@ -681,11 +677,11 @@ impl SecretBackend for LocalSecretBackend {
         version: &str,
     ) -> Result<SecretProperties, BackendError> {
         // Acquire exclusive vault lock — rollback calls archive_current/next_version.
-        let vault_dir = self.store_path.join("vaults").join(vault);
+        let vault_dir = paths::vault_dir(&self.store_path, vault)?;
         let _lock = lock_vault(&vault_dir)?;
 
         // Find the target version in .versions/
-        let vdir = versions_dir(&self.store_path, vault, name);
+        let vdir = versions_dir(&self.store_path, vault, name)?;
         let ver_age = vdir.join(format!("{version}.age"));
         let ver_meta = vdir.join(format!("{version}.meta.json"));
 
@@ -700,8 +696,8 @@ impl SecretBackend for LocalSecretBackend {
         archive_current(&self.store_path, vault, name)?;
 
         // Copy the target version files to current
-        let ap = age_path(&self.store_path, vault, name);
-        let mp = meta_path(&self.store_path, vault, name);
+        let ap = age_path(&self.store_path, vault, name)?;
+        let mp = meta_path(&self.store_path, vault, name)?;
 
         if ver_age.exists() {
             fs::copy(&ver_age, &ap)
@@ -712,7 +708,7 @@ impl SecretBackend for LocalSecretBackend {
 
         // Update the version label to the next version number
         let mut meta = read_meta(&mp)?;
-        let next_ver = next_version(&self.store_path, vault, name);
+        let next_ver = next_version(&self.store_path, vault, name)?;
         meta.version = format!("v{next_ver}");
         meta.updated_at = Utc::now();
         write_meta(&mp, &meta)?;
@@ -725,7 +721,7 @@ impl SecretBackend for LocalSecretBackend {
         vault: &str,
         name: &str,
     ) -> Result<SecretProperties, BackendError> {
-        let vault_dir = self.store_path.join("vaults").join(vault);
+        let vault_dir = paths::vault_dir(&self.store_path, vault)?;
         if !vault_dir.join(".vault.json").exists() {
             return Err(BackendError::VaultNotFound {
                 name: vault.to_string(),
@@ -734,7 +730,7 @@ impl SecretBackend for LocalSecretBackend {
         }
         let _lock = lock_vault(&vault_dir)?;
 
-        let tdir = trash_dir(&self.store_path, vault, name);
+        let tdir = trash_dir(&self.store_path, vault, name)?;
         if !tdir.exists() {
             return Err(BackendError::NotFound {
                 name: format!("{name} (deleted)"),
@@ -754,12 +750,12 @@ impl SecretBackend for LocalSecretBackend {
         }
 
         // Move files back to secrets/
-        let sdir = secrets_dir(&self.store_path, vault);
+        let sdir = secrets_dir(&self.store_path, vault)?;
         fs::create_dir_all(&sdir)
             .map_err(|e| BackendError::Internal(format!("mkdir secrets: {e}")))?;
 
-        let ap = age_path(&self.store_path, vault, name);
-        let mp = meta_path(&self.store_path, vault, name);
+        let ap = age_path(&self.store_path, vault, name)?;
+        let mp = meta_path(&self.store_path, vault, name)?;
 
         if trash_age.exists() {
             fs::rename(&trash_age, &ap)
@@ -777,7 +773,7 @@ impl SecretBackend for LocalSecretBackend {
     }
 
     async fn purge_secret(&self, vault: &str, name: &str) -> Result<(), BackendError> {
-        let vault_dir = self.store_path.join("vaults").join(vault);
+        let vault_dir = paths::vault_dir(&self.store_path, vault)?;
         if !vault_dir.join(".vault.json").exists() {
             return Err(BackendError::VaultNotFound {
                 name: vault.to_string(),
@@ -787,14 +783,14 @@ impl SecretBackend for LocalSecretBackend {
         let _lock = lock_vault(&vault_dir)?;
 
         // Permanently remove from .trash/
-        let tdir = trash_dir(&self.store_path, vault, name);
+        let tdir = trash_dir(&self.store_path, vault, name)?;
         if tdir.exists() {
             fs::remove_dir_all(&tdir)
                 .map_err(|e| BackendError::Internal(format!("purge trash: {e}")))?;
         }
 
         // Also remove any .versions/ for that secret
-        let vdir = versions_dir(&self.store_path, vault, name);
+        let vdir = versions_dir(&self.store_path, vault, name)?;
         if vdir.exists() {
             fs::remove_dir_all(&vdir)
                 .map_err(|e| BackendError::Internal(format!("purge versions: {e}")))?;
@@ -804,7 +800,7 @@ impl SecretBackend for LocalSecretBackend {
     }
 
     async fn list_deleted_secrets(&self, vault: &str) -> Result<Vec<SecretSummary>, BackendError> {
-        let tbase = trash_base_dir(&self.store_path, vault);
+        let tbase = trash_base_dir(&self.store_path, vault)?;
         if !tbase.exists() {
             return Ok(Vec::new());
         }
@@ -914,6 +910,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rejects_traversal_vault_name_for_secret_writes() {
+        let (backend, tmp) = test_backend();
+        let outside = tmp.path().join("outside");
+
+        let result = backend
+            .set_secret("../../outside", make_request("escape", "value"))
+            .await;
+        assert!(matches!(result, Err(BackendError::InvalidArgument(_))));
+        assert!(!outside.exists());
+    }
+
+    #[tokio::test]
     async fn set_secret_versions() {
         let (backend, _tmp) = test_backend();
 
@@ -999,10 +1007,12 @@ mod tests {
             .delete_secret("default", "restore-me")
             .await
             .unwrap();
-        assert!(!backend
-            .secret_exists("default", "restore-me")
-            .await
-            .unwrap());
+        assert!(
+            !backend
+                .secret_exists("default", "restore-me")
+                .await
+                .unwrap()
+        );
 
         // Restore
         let restored = backend
@@ -1012,10 +1022,12 @@ mod tests {
         assert_eq!(restored.name, "restore-me");
 
         // Should exist again
-        assert!(backend
-            .secret_exists("default", "restore-me")
-            .await
-            .unwrap());
+        assert!(
+            backend
+                .secret_exists("default", "restore-me")
+                .await
+                .unwrap()
+        );
 
         // Value should be recoverable
         let got = backend
@@ -1131,10 +1143,12 @@ mod tests {
             .set_secret("default", make_request("exists-test", "val"))
             .await
             .unwrap();
-        assert!(backend
-            .secret_exists("default", "exists-test")
-            .await
-            .unwrap());
+        assert!(
+            backend
+                .secret_exists("default", "exists-test")
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/src/backend/local/vaults.rs
+++ b/src/backend/local/vaults.rs
@@ -12,6 +12,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::backend::error::BackendError;
+use crate::backend::local::paths;
 use crate::backend::vault::VaultBackend;
 use crate::vault::models::{VaultCreateRequest, VaultProperties, VaultSummary};
 
@@ -43,19 +44,19 @@ impl LocalVaultBackend {
     }
 
     fn vaults_dir(&self) -> PathBuf {
-        self.store_path.join("vaults")
+        paths::vaults_dir(&self.store_path)
     }
 
-    fn vault_dir(&self, name: &str) -> PathBuf {
-        self.vaults_dir().join(name)
+    fn vault_dir(&self, name: &str) -> Result<PathBuf, BackendError> {
+        paths::vault_dir(&self.store_path, name)
     }
 
-    fn vault_json_path(&self, name: &str) -> PathBuf {
-        self.vault_dir(name).join(".vault.json")
+    fn vault_json_path(&self, name: &str) -> Result<PathBuf, BackendError> {
+        Ok(self.vault_dir(name)?.join(".vault.json"))
     }
 
     fn read_vault_meta(&self, name: &str) -> Result<VaultMeta, BackendError> {
-        let path = self.vault_json_path(name);
+        let path = self.vault_json_path(name)?;
         if !path.exists() {
             return Err(BackendError::VaultNotFound {
                 name: name.to_string(),
@@ -68,15 +69,15 @@ impl LocalVaultBackend {
             .map_err(|e| BackendError::Internal(format!("parse vault meta: {e}")))
     }
 
-    fn vault_meta_to_properties(&self, meta: &VaultMeta) -> VaultProperties {
-        VaultProperties {
+    fn vault_meta_to_properties(&self, meta: &VaultMeta) -> Result<VaultProperties, BackendError> {
+        Ok(VaultProperties {
             id: format!("local:{}", meta.name),
             name: meta.name.clone(),
             location: "local".to_string(),
             resource_group: String::new(),
             subscription_id: String::new(),
             tenant_id: String::new(),
-            uri: format!("file://{}", self.vault_dir(&meta.name).display()),
+            uri: format!("file://{}", self.vault_dir(&meta.name)?.display()),
             enabled_for_deployment: false,
             enabled_for_disk_encryption: false,
             enabled_for_template_deployment: false,
@@ -87,7 +88,7 @@ impl LocalVaultBackend {
             created_at: meta.created_at,
             tags: meta.tags.clone(),
             enable_rbac_authorization: Some(false),
-        }
+        })
     }
 }
 
@@ -102,10 +103,8 @@ impl VaultBackend for LocalVaultBackend {
             return Err(BackendError::Internal("vault name cannot be empty".into()));
         }
 
-        let vault_dir = self.vault_dir(name);
-        let vault_json = self.vault_json_path(name);
-
-        if vault_json.exists() {
+        let vault_dir = self.vault_dir(name)?;
+        if vault_dir.join(".vault.json").exists() {
             return Err(BackendError::Conflict(format!(
                 "vault '{name}' already exists"
             )));
@@ -123,15 +122,15 @@ impl VaultBackend for LocalVaultBackend {
 
         let json = serde_json::to_string_pretty(&meta)
             .map_err(|e| BackendError::Internal(format!("serialize vault meta: {e}")))?;
-        fs::write(&vault_json, json)
+        fs::write(vault_dir.join(".vault.json"), json)
             .map_err(|e| BackendError::Internal(format!("write vault meta: {e}")))?;
 
-        Ok(self.vault_meta_to_properties(&meta))
+        self.vault_meta_to_properties(&meta)
     }
 
     async fn get_vault(&self, name: &str) -> Result<VaultProperties, BackendError> {
         let meta = self.read_vault_meta(name)?;
-        Ok(self.vault_meta_to_properties(&meta))
+        self.vault_meta_to_properties(&meta)
     }
 
     async fn list_vaults(&self) -> Result<Vec<VaultSummary>, BackendError> {
@@ -149,7 +148,7 @@ impl VaultBackend for LocalVaultBackend {
                 continue;
             }
             let name = entry.file_name().to_string_lossy().to_string();
-            let vault_json = self.vault_json_path(&name);
+            let vault_json = self.vault_json_path(&name)?;
             if !vault_json.exists() {
                 continue;
             }
@@ -173,8 +172,8 @@ impl VaultBackend for LocalVaultBackend {
     }
 
     async fn delete_vault(&self, name: &str) -> Result<(), BackendError> {
-        let vault_dir = self.vault_dir(name);
-        let vault_json = self.vault_json_path(name);
+        let vault_dir = self.vault_dir(name)?;
+        let vault_json = self.vault_json_path(name)?;
 
         if !vault_json.exists() {
             return Err(BackendError::VaultNotFound {
@@ -254,6 +253,32 @@ mod tests {
 
         let got = backend.get_vault("myvault").await.unwrap();
         assert_eq!(got.name, "myvault");
+    }
+
+    #[tokio::test]
+    async fn rejects_traversal_vault_names() {
+        let (backend, tmp) = test_vault_backend();
+        let outside = tmp.path().join("outside");
+
+        let result = backend.create_vault(create_request("../../outside")).await;
+        assert!(matches!(result, Err(BackendError::InvalidArgument(_))));
+        assert!(!outside.exists());
+
+        let result = backend.delete_vault("../../outside").await;
+        assert!(matches!(result, Err(BackendError::InvalidArgument(_))));
+    }
+
+    #[tokio::test]
+    async fn rejects_separator_vault_names() {
+        let (backend, _tmp) = test_vault_backend();
+
+        for name in ["nested/vault", "nested\\vault", "/absolute"] {
+            let result = backend.create_vault(create_request(name)).await;
+            assert!(
+                matches!(result, Err(BackendError::InvalidArgument(_))),
+                "{name}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes the P1 local backend path traversal issue from `docs/code-review-gpt55.md`.

Local vault names were previously joined directly into filesystem paths under `<store>/vaults/`, so names like `../../outside` could escape the local store. This PR centralizes local vault path handling and validates vault names before any local vault/secret/file path is constructed.

## Changes

- Add `src/backend/local/paths.rs` with shared local path safety helpers
- Reject local vault names that are empty, `.`, `..`, contain `/` or `\`, contain control characters, start with `-`, or otherwise do not parse as a single normal path component
- Route local vault, secret, trash, and file path construction through the shared helpers
- Validate configured local default vault during `LocalBackend::new`
- Add regression tests for traversal/separator vault names in:
  - local vault operations
  - local secret writes
  - local file writes
  - shared path helper behavior

## Test Plan

- `cargo test --lib local:: --no-default-features`
- `cargo test --lib local::`
- `cargo build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive change that tightens vault-name validation and reroutes many local filesystem paths through it, which could break existing installs that relied on previously-accepted vault names or edge-case path behavior.
> 
> **Overview**
> **Prevents local-store path traversal via vault names.** Introduces a new `local::paths` module that validates vault names as a single safe path component and builds vault/scoped directories through guarded helpers.
> 
> Updates local vault, secret (including trash/version paths), and file backends to use these helpers (returning `InvalidArgument` for invalid vault names) and adds regression tests ensuring traversal/separator vault names are rejected and never write outside the store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5732d9ab7ebd5c4a03331e4a8829f22f1141fca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->