### PR TITLE
fix: validate vault names in cache keys to prevent path traversal

### DIFF
--- a/src/cache/manager.rs
+++ b/src/cache/manager.rs
@@ -9,7 +9,9 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::path::{Path, PathBuf};
 use tracing::debug;
 
-use crate::cache::models::{CacheEntry, CacheEntryInfo, CacheKey, CacheStatus};
+use crate::cache::models::{
+    validate_cache_vault_name, CacheEntry, CacheEntryInfo, CacheKey, CacheStatus,
+};
 use crate::cache::refresh;
 
 // ---------------------------------------------------------------------------
@@ -192,7 +194,15 @@ impl CacheManager {
 
     /// Delete the entire vault-scoped cache directory.
     pub fn invalidate_vault(&self, vault_name: &str) {
+        if let Err(reason) = validate_cache_vault_name(vault_name) {
+            debug!("invalidate_vault({vault_name}): rejected — {reason}");
+            return;
+        }
         let vault_dir = self.cache_dir.join(vault_name);
+        if !vault_dir.starts_with(&self.cache_dir) {
+            debug!("invalidate_vault({vault_name}): path escapes cache dir — skipped");
+            return;
+        }
         if vault_dir.exists() {
             if let Err(e) = std::fs::remove_dir_all(&vault_dir) {
                 debug!("invalidate_vault({vault_name}): {e}");
@@ -211,7 +221,13 @@ impl CacheManager {
     /// * `vault = None`       — clears the entire cache directory.
     pub fn clear(&self, vault: Option<&str>) {
         match vault {
-            Some(name) => self.invalidate_vault(name),
+            Some(name) => {
+                if let Err(reason) = validate_cache_vault_name(name) {
+                    debug!("clear({name}): rejected — {reason}");
+                    return;
+                }
+                self.invalidate_vault(name);
+            }
             None => {
                 if self.cache_dir.exists() {
                     if let Err(e) = std::fs::remove_dir_all(&self.cache_dir) {
@@ -586,5 +602,48 @@ mod tests {
         assert_eq!(s.entries.len(), 2);
         assert!(s.enabled);
         assert_eq!(s.ttl_secs, 300);
+    }
+
+    #[test]
+    fn test_invalidate_vault_rejects_traversal_name() {
+        let dir = tempdir().unwrap();
+        let cache_dir = dir.path().join("cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        // Create a directory outside the cache root that an attacker would
+        // want to delete.
+        let outside = dir.path().join("outside_target");
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("important.txt"), b"do not delete").unwrap();
+
+        let mgr = make_manager(&cache_dir, true, 300);
+
+        // Attempt to invalidate with a traversal name.
+        mgr.invalidate_vault("../outside_target");
+
+        // The outside directory must still exist.
+        assert!(
+            outside.exists(),
+            "invalidate_vault traversal should NOT delete outside directory"
+        );
+        assert!(outside.join("important.txt").exists());
+    }
+
+    #[test]
+    fn test_clear_vault_rejects_traversal_name() {
+        let dir = tempdir().unwrap();
+        let cache_dir = dir.path().join("cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        let outside = dir.path().join("outside_target2");
+        std::fs::create_dir_all(&outside).unwrap();
+
+        let mgr = make_manager(&cache_dir, true, 300);
+        mgr.clear(Some("../outside_target2"));
+
+        assert!(
+            outside.exists(),
+            "clear(Some(traversal)) should NOT delete outside directory"
+        );
     }
 }

--- a/src/cache/models.rs
+++ b/src/cache/models.rs
@@ -5,7 +5,7 @@
 use chrono::{DateTime, Utc};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 /// A cached response stored on disk as JSON.
 #[derive(Debug, Serialize, Deserialize)]
@@ -36,12 +36,74 @@ pub enum CacheKey {
     FileList { vault_name: String, recursive: bool },
 }
 
+/// Validate that a vault name is a single safe filesystem component.
+///
+/// Mirrors `validate_vault_name` in `backend::local::paths` but returns
+/// `Result<(), String>` so the cache module stays independent of the backend
+/// error types.
+pub(crate) fn validate_cache_vault_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("vault name cannot be empty".to_string());
+    }
+    if name == "." || name == ".." {
+        return Err("vault name must not be '.' or '..'".to_string());
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err("vault name must not contain path separators".to_string());
+    }
+    if name.starts_with('-') {
+        return Err("vault name must not start with '-'".to_string());
+    }
+    if name.chars().any(|ch| ch.is_control()) {
+        return Err("vault name must not contain control characters".to_string());
+    }
+    let path = Path::new(name);
+    let mut components = path.components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(component)), None) if component == name => Ok(()),
+        _ => Err(
+            "vault name must be a single path component without separators or prefixes".to_string(),
+        ),
+    }
+}
+
+/// Defence-in-depth: verify that `candidate` is a child of `base`.
+fn ensure_cache_child_path(base: &Path, candidate: &Path) -> bool {
+    candidate.starts_with(base)
+}
+
+/// Compute a safe fallback directory name for an invalid vault name.
+///
+/// The result is always a single safe component that cannot escape the cache
+/// directory.
+fn safe_fallback_dir(vault_name: &str) -> String {
+    let hash = vault_name
+        .bytes()
+        .fold(0u64, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u64));
+    format!("_invalid_{hash:x}")
+}
+
 impl CacheKey {
     /// Resolve this key to its file path under the given cache directory.
+    ///
+    /// Vault names are validated before being used as path components.
+    /// Invalid names are replaced with a deterministic safe fallback so the
+    /// cache continues to function without escaping the cache root.
     pub fn to_path(&self, cache_dir: &Path) -> PathBuf {
         match self {
             CacheKey::SecretsList { vault_name } => {
-                cache_dir.join(vault_name).join("secrets-list.json")
+                let dir_name = match validate_cache_vault_name(vault_name) {
+                    Ok(()) => vault_name.clone(),
+                    Err(_) => safe_fallback_dir(vault_name),
+                };
+                let candidate = cache_dir.join(&dir_name).join("secrets-list.json");
+                if ensure_cache_child_path(cache_dir, &candidate) {
+                    candidate
+                } else {
+                    cache_dir
+                        .join(safe_fallback_dir(vault_name))
+                        .join("secrets-list.json")
+                }
             }
             CacheKey::VaultList => cache_dir.join("vaults-list.json"),
             CacheKey::FileList {
@@ -53,7 +115,16 @@ impl CacheKey {
                 } else {
                     "files-list.json"
                 };
-                cache_dir.join(vault_name).join(filename)
+                let dir_name = match validate_cache_vault_name(vault_name) {
+                    Ok(()) => vault_name.clone(),
+                    Err(_) => safe_fallback_dir(vault_name),
+                };
+                let candidate = cache_dir.join(&dir_name).join(filename);
+                if ensure_cache_child_path(cache_dir, &candidate) {
+                    candidate
+                } else {
+                    cache_dir.join(safe_fallback_dir(vault_name)).join(filename)
+                }
             }
         }
     }
@@ -108,6 +179,9 @@ impl std::str::FromStr for CacheKey {
             if vault_name.is_empty() {
                 return Err("Missing vault name after 'secrets:'".to_string());
             }
+            validate_cache_vault_name(vault_name).map_err(|reason| {
+                format!("Invalid vault name '{vault_name}' in cache key: {reason}")
+            })?;
             return Ok(CacheKey::SecretsList {
                 vault_name: vault_name.to_string(),
             });
@@ -116,6 +190,9 @@ impl std::str::FromStr for CacheKey {
             if vault_name.is_empty() {
                 return Err("Missing vault name after 'files-recursive:'".to_string());
             }
+            validate_cache_vault_name(vault_name).map_err(|reason| {
+                format!("Invalid vault name '{vault_name}' in cache key: {reason}")
+            })?;
             return Ok(CacheKey::FileList {
                 vault_name: vault_name.to_string(),
                 recursive: true,
@@ -125,6 +202,9 @@ impl std::str::FromStr for CacheKey {
             if vault_name.is_empty() {
                 return Err("Missing vault name after 'files:'".to_string());
             }
+            validate_cache_vault_name(vault_name).map_err(|reason| {
+                format!("Invalid vault name '{vault_name}' in cache key: {reason}")
+            })?;
             return Ok(CacheKey::FileList {
                 vault_name: vault_name.to_string(),
                 recursive: false,
@@ -217,6 +297,33 @@ mod tests {
     }
 
     #[test]
+    fn test_cache_key_from_str_rejects_traversal_vault_names() {
+        // Path traversal
+        assert!("secrets:../outside".parse::<CacheKey>().is_err());
+        assert!("secrets:../../etc".parse::<CacheKey>().is_err());
+        assert!("files:../outside".parse::<CacheKey>().is_err());
+        assert!("files-recursive:../../etc".parse::<CacheKey>().is_err());
+
+        // Separators
+        assert!("secrets:foo/bar".parse::<CacheKey>().is_err());
+        assert!("secrets:foo\\bar".parse::<CacheKey>().is_err());
+
+        // Special names
+        assert!("secrets:.".parse::<CacheKey>().is_err());
+        assert!("secrets:..".parse::<CacheKey>().is_err());
+
+        // Absolute
+        assert!("secrets:/absolute".parse::<CacheKey>().is_err());
+
+        // Control characters
+        assert!("secrets:bad\nname".parse::<CacheKey>().is_err());
+        assert!("secrets:bad\x00name".parse::<CacheKey>().is_err());
+
+        // Leading dash
+        assert!("secrets:-badname".parse::<CacheKey>().is_err());
+    }
+
+    #[test]
     fn test_cache_key_to_path() {
         let base = PathBuf::from("/cache");
 
@@ -248,5 +355,80 @@ mod tests {
             key.to_path(&base),
             PathBuf::from("/cache/myvault/files-list-recursive.json")
         );
+    }
+
+    #[test]
+    fn test_to_path_never_escapes_cache_dir_for_adversarial_names() {
+        let base = PathBuf::from("/cache");
+
+        // These vault names are invalid and should be replaced with a safe
+        // fallback. Critically, the result must always be under /cache/.
+        let adversarial = [
+            "../..",
+            "../../etc",
+            "foo/bar",
+            "/absolute",
+            "\\absolute",
+            "..",
+            ".",
+            "bad\nname",
+            "bad\x00name",
+            "-leading",
+        ];
+
+        for bad_name in adversarial {
+            let key = CacheKey::SecretsList {
+                vault_name: bad_name.to_string(),
+            };
+            let path = key.to_path(&base);
+            assert!(
+                path.starts_with(&base),
+                "to_path escaped cache_dir for vault name {bad_name:?}: {}",
+                path.display()
+            );
+
+            let key = CacheKey::FileList {
+                vault_name: bad_name.to_string(),
+                recursive: true,
+            };
+            let path = key.to_path(&base);
+            assert!(
+                path.starts_with(&base),
+                "to_path escaped cache_dir for vault name {bad_name:?}: {}",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_cache_vault_name_accepts_valid() {
+        for name in ["default", "work-secrets", "team_1", "Vault123"] {
+            assert!(
+                validate_cache_vault_name(name).is_ok(),
+                "should accept {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_cache_vault_name_rejects_invalid() {
+        for name in [
+            "",
+            ".",
+            "..",
+            "../outside",
+            "../../outside",
+            "outside/child",
+            "/absolute",
+            "\\absolute",
+            "parent\\child",
+            "bad\nname",
+            "-leading",
+        ] {
+            assert!(
+                validate_cache_vault_name(name).is_err(),
+                "should reject {name:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
CacheKey::to_path() joined vault_name directly into cache paths without validation. A malicious name like '../../target' could escape the cache directory, enabling reads/writes/deletes outside the cache root. The same unvalidated name flowed into invalidate_vault() which calls remove_dir_all.

Changes:
- Add validate_cache_vault_name() mirroring backend::local::paths
- Add ensure_cache_child_path() as defence-in-depth
- Invalid vault names in to_path() fall back to a safe hashed dir
- CacheKey::from_str() now rejects invalid vault names at parse time
- invalidate_vault() and clear(Some(name)) validate before joining
- Add comprehensive traversal/safety tests for both modules

Closes P1 finding: cache keys embed unvalidated vault names in paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cache path construction and directory deletion logic to harden against path traversal; incorrect validation could change cache directory layout or prevent expected cache invalidation for edge-case vault names.
> 
> **Overview**
> Prevents path traversal via cache `vault_name` by validating names before they become filesystem components.
> 
> `CacheKey::to_path()` now replaces invalid vault names with a deterministic safe fallback directory and includes a defence-in-depth check that the resulting path stays under the cache root. `CacheKey::from_str()` rejects invalid vault names, and `CacheManager::invalidate_vault()`/`clear(Some(_))` now validate inputs before calling `remove_dir_all`.
> 
> Adds tests covering traversal/invalid-name rejection and ensuring cache paths never escape the cache directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34b7ed01c03e5e90dca3e75d2b0fe234198fd58e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->