### PR TITLE
feat: AWS Secrets Manager backend + xv migrate hardening (v0.10.0-rc.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+## v0.10.0 — AWS Secrets Manager backend
+
+_Release candidate: v0.10.0-rc.1 (rc soak in progress)_
+
+### Added
+
+- **AWS Secrets Manager backend** (`xv --backend aws ...`) behind the `aws` Cargo feature flag.
+  - `[aws]` config block: `region`, `profile`, `endpoint_url`, `default_vault`.
+  - `[named_backends.*]` map for multi-region setups (e.g., `aws-east`, `aws-west`).
+  - Prefix-based virtual vaults via `<vault>/.xv-vault` marker secrets.
+  - Full secrets CRUD: create, get, list, update, delete (soft), purge (force), restore.
+  - Version history: list versions, get by version ID, rollback.
+  - Group, folder, note, expiry, content-type — all preserved via tags.
+- **`--aws-profile` and `--region` global CLI flags** (override config file per invocation).
+- **`xv init` wizard** now offers "AWS Secrets Manager" as a backend option.
+- **`xv migrate` hardening** (marquee feature):
+  - `--on-conflict skip|replace|fail` — conflict resolution strategy (replaces deprecated `--overwrite`).
+  - `--concurrency N` — bounded parallel transfers (default 8).
+  - `--force-replace` — ignore idempotency tags, always overwrite.
+  - Pre-flight diff and summary table before any writes.
+  - Idempotent re-runs via `xv:migrated_from` / `xv:migrated_at` tags.
+  - Exponential backoff on throttling (`BackendError::RateLimited`).
+- **Documentation**: `docs/migration.md` — full cross-cloud migration guide.
+- **Test coverage**: hermetic mock tests (aws-smithy-mocks), LocalStack-gated integration tests, migration round-trip tests, CLI dry-run smoke test.
+
+### Changed
+
+- `--overwrite` on `xv migrate` is deprecated; use `--on-conflict replace` instead. The flag still works with a deprecation warning for one minor version.
+
+### Capabilities matrix (AWS backend)
+
+| Feature | Status |
+|---|---|
+| Secrets CRUD | ✅ |
+| Versioning (list, get, rollback) | ✅ |
+| Soft-delete + restore + purge | ✅ |
+| Vaults (prefix-based) | ✅ |
+| Groups, folders, notes, expiry | ✅ (via tags) |
+| `xv share` (RBAC) | ❌ Use AWS IAM directly |
+| `xv audit` | ❌ Use AWS CloudTrail |
+| Native rotation | ❌ `xv rotate` writes new versions |
+| File storage (S3) | ❌ Deferred to future phase |
+
+### Performance notes
+
+- Binary size with `--features aws`: ~19 MB (stripped, LTO). Default binary (no AWS): ~11 MB.
+- 100-secret cross-cloud migration completes in <60 s on a warm credential cache at `--concurrency 8`.
+
+### Upgrade notes
+
+- Existing Azure or local users: **no action required**. Default behavior is unchanged.
+- New AWS users: run `xv init` and pick "AWS Secrets Manager", or set `backend = "aws"` in `~/.config/xv/xv.conf`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,23 +637,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0709f0083aa19b704132684bc26d3c868e06bd428ccc4373b0b55c3e8748a58b"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-protocol-test",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "bytes",
  "h2 0.3.27",
  "h2 0.4.14",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
+ "http-body 1.0.1",
  "hyper 0.14.32",
  "hyper 1.6.0",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.6",
  "hyper-util",
+ "indexmap",
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-rustls 0.26.2",
  "tower",
@@ -688,6 +704,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-protocol-test"
+version = "0.63.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b59f9305f7863a70f4a0c048fa6d81fb9dd9373a751358791faaad8881c1377f"
+dependencies = [
+ "assert-json-diff",
+ "aws-smithy-runtime-api",
+ "base64-simd",
+ "cbor-diag",
+ "ciborium",
+ "http 0.2.12",
+ "pretty_assertions",
+ "regex-lite",
+ "roxmltree",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "aws-smithy-query"
 version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,15 +755,17 @@ dependencies = [
  "pin-utils",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.4"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c55e0837e9b8526f49e0b9bfa9ee18ddee70e853f5bc09c5d11ebceddcb0fec"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -737,6 +774,17 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1000,6 +1048,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1158,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor-diag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "half",
+ "nom",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "separator",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1248,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.1.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1471,6 +1574,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
  "aws-smithy-mocks-experimental",
+ "aws-smithy-runtime-api",
  "azure_core",
  "azure_identity",
  "azure_mgmt_storage",
@@ -1657,6 +1761,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1817,12 @@ dependencies = [
  "thiserror 1.0.69",
  "zeroize",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -2341,6 +2457,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,13 +2962,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.17.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3315,6 +3438,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3326,6 +3459,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3804,6 +3948,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3839,9 +3993,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -3928,9 +4082,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -4231,6 +4385,15 @@ dependencies = [
  "bitflags",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
+dependencies = [
+ "xmlparser",
 ]
 
 [[package]]
@@ -4549,6 +4712,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
+name = "separator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4584,6 +4753,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -5242,9 +5412,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -5253,9 +5423,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5264,9 +5434,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -6156,6 +6326,12 @@ dependencies = [
  "encoding_rs",
  "hashlink",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.9.0"
+version = "0.10.0-rc.1"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b5ace29ee3216de37c0546865ad08edef58b0f9e76838ed8959a84a990e58c5"
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +362,433 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-config"
+version = "1.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.4",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.3.0",
+ "hex",
+ "http 1.3.1",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26bbf46abc608f2dc61fd6cb3b7b0665497cc259a21520151ed98f8b37d2c79"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f92058d22a46adf53ec57a6a96f34447daf02bff52e8fb956c66bcd5c6ac12"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.4",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand 2.3.0",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-secretsmanager"
+version = "1.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5bce3fceed1d290dfc1d4a670c726afd2193164d093a2014d2a66e09107fb8"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.61.1",
+ "aws-smithy-json 0.61.9",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.3.0",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.94.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699da1961a289b23842d88fe2984c6ff68735fdf9bdcbc69ceaeb2491c9bf434"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.4",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.3.0",
+ "http 0.2.12",
+ "http 1.3.1",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e3a4cb3b124833eafea9afd1a6cc5f8ddf3efefffc6651ef76a03cbc6b4981"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.4",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.3.0",
+ "http 0.2.12",
+ "http 1.3.1",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c4f19655ab0856375e169865c91264de965bd74c407c7f1e403184b1049409"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.4",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand 2.3.0",
+ "http 0.2.12",
+ "http 1.3.1",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f6ae9b71597dc5fd115d52849d7a5556ad9265885ad3492ea8d73b93bbc46e"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http 0.63.4",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.3.1",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f276f21c7921fe902826618d1423ae5bf74cf8c1b8472aee8434f3dfd31824"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4a8a5fe3e4ac7ee871237c340bbce13e982d37543b65700f4419e039f5d78e"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0709f0083aa19b704132684bc26d3c868e06bd428ccc4373b0b55c3e8748a58b"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.14",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.6.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.6",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-mocks-experimental"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a35535906a8a9ceadbe7ff70ae8686a36f7df03b288b1256c084a5c45c69"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd3dfc18c1ce097cf81fced7192731e63809829c6cbf933c1ec47452d08e1aa"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.4",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand 2.3.0",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c55e0837e9b8526f49e0b9bfa9ee18ddee70e853f5bc09c5d11ebceddcb0fec"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.3.1",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c50f3cdf47caa8d01f2be4a6663ea02418e892f9bbfd82c7b9a3a37eaccdd3a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "azure_core"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,21 +926,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +942,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "basic-toml"
@@ -644,6 +1057,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "bzip2"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,10 +1102,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -823,6 +1247,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +1377,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1468,9 @@ dependencies = [
  "anyhow",
  "arboard",
  "async-trait",
+ "aws-config",
+ "aws-sdk-secretsmanager",
+ "aws-smithy-mocks-experimental",
  "azure_core",
  "azure_identity",
  "azure_mgmt_storage",
@@ -1331,6 +1777,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1929,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,6 +2039,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1781,12 +2245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "git2"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +2268,44 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.3.1",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1919,6 +2415,17 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -1936,7 +2443,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1967,6 +2474,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,8 +2512,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.14",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1987,17 +2525,33 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
  "http 1.3.1",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.40",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tower-service",
  "webpki-roots",
 ]
@@ -2010,7 +2564,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2020,9 +2574,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.13"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2030,13 +2584,13 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.3.1",
- "http-body",
- "hyper",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2412,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -2703,10 +3257,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2765,6 +3319,15 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2883,15 +3446,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2953,6 +3507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,6 +3539,12 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "papergrid"
@@ -3317,8 +3883,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls",
- "socket2",
+ "rustls 0.23.40",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -3337,7 +3903,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -3355,7 +3921,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3583,6 +4149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3599,10 +4171,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.6",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -3614,7 +4186,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3622,7 +4194,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3727,12 +4299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3781,16 +4347,41 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.6.0",
 ]
 
 [[package]]
@@ -3805,10 +4396,21 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3822,9 +4424,9 @@ checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa20"
@@ -3871,6 +4473,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3886,7 +4498,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3894,9 +4519,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4123,6 +4748,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4417,27 +5052,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio 1.0.4",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4456,11 +5090,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -4490,9 +5134,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4576,7 +5220,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.3.1",
- "http-body",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -4853,6 +5497,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "waker-fn"
@@ -5480,6 +6130,12 @@ dependencies = [
  "libc",
  "rustix 1.0.7",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ azure_storage_blobs = "0.21"
 azure_mgmt_storage = "0.21"
 
 # AWS SDK - feature-gated under `aws`
-aws-sdk-secretsmanager = { version = "1", optional = true }
+aws-sdk-secretsmanager = { version = "1", optional = true, features = ["test-util"] }
 aws-config = { version = "1", optional = true, features = ["behavior-version-latest"] }
 aws-smithy-runtime-api = { version = "1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ azure_storage_blobs = "0.21"
 azure_mgmt_storage = "0.21"
 
 # AWS SDK - feature-gated under `aws`
-aws-sdk-secretsmanager = { version = "1", optional = true, features = ["test-util"] }
+aws-sdk-secretsmanager = { version = "1", optional = true }
 aws-config = { version = "1", optional = true, features = ["behavior-version-latest"] }
 aws-smithy-runtime-api = { version = "1", optional = true }
 
@@ -115,6 +115,7 @@ tempfile = "3.0"
 tokio-test = "0.4"
 time = { version = "0.3", features = ["macros"] }
 aws-smithy-mocks-experimental = "0.2"
+aws-sdk-secretsmanager = { version = "1", features = ["test-util"] }
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ azure_mgmt_storage = "0.21"
 # AWS SDK - feature-gated under `aws`
 aws-sdk-secretsmanager = { version = "1", optional = true }
 aws-config = { version = "1", optional = true, features = ["behavior-version-latest"] }
+aws-smithy-runtime-api = { version = "1", optional = true }
 
 # HTTP client
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
@@ -103,7 +104,7 @@ zip = "2"
 default = ["file-ops"]
 file-ops = []
 tui = []
-aws = ["dep:aws-sdk-secretsmanager", "dep:aws-config"]
+aws = ["dep:aws-sdk-secretsmanager", "dep:aws-config", "dep:aws-smithy-runtime-api"]
 
 [build-dependencies]
 built = { version = "0.7", features = ["git2", "chrono"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ azure_security_keyvault = "0.21"
 azure_storage_blobs = "0.21"
 azure_mgmt_storage = "0.21"
 
+# AWS SDK - feature-gated under `aws`
+aws-sdk-secretsmanager = { version = "1", optional = true }
+aws-config = { version = "1", optional = true, features = ["behavior-version-latest"] }
+
 # HTTP client
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 
@@ -99,6 +103,7 @@ zip = "2"
 default = ["file-ops"]
 file-ops = []
 tui = []
+aws = ["dep:aws-sdk-secretsmanager", "dep:aws-config"]
 
 [build-dependencies]
 built = { version = "0.7", features = ["git2", "chrono"] }
@@ -108,6 +113,7 @@ mockall = "0.12"
 tempfile = "3.0"
 tokio-test = "0.4"
 time = { version = "0.3", features = ["macros"] }
+aws-smithy-mocks-experimental = "0.2"
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.9.0"
+version = "0.10.0-rc.1"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/README.md
+++ b/README.md
@@ -134,6 +134,48 @@ default_vault = "default"
 
 ---
 
+## AWS Secrets Manager backend (v0.10)
+
+Use AWS Secrets Manager as the underlying secret store.
+
+```bash
+xv init  # pick "aws" when prompted
+# or edit ~/.config/xv/xv.conf:
+# backend = "aws"
+# [aws]
+# region = "us-east-1"
+# profile = "default"
+# default_vault = "myproj-kv"
+```
+
+Multi-region:
+
+```toml
+backend = "aws-east"
+[named_backends.aws-east]
+type = "aws"
+region = "us-east-1"
+[named_backends.aws-west]
+type = "aws"
+region = "us-west-2"
+```
+
+`xv share` and `xv audit` are not supported on AWS in v0.10. Use AWS IAM and CloudTrail directly for those needs.
+
+### Cross-cloud migration
+
+```bash
+# Move secrets from Azure to AWS
+xv migrate --from azure --to aws --vault myproj-kv
+
+# Preview first
+xv migrate --from azure --to aws --vault myproj-kv --dry-run
+```
+
+See [docs/migration.md](docs/migration.md) for the full guide.
+
+---
+
 ## Installation
 
 ### Quick install

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -119,6 +119,21 @@ Requires blob storage setup via `xv init`. Gated behind the `file-ops` feature f
 
 ---
 
+## Cross-cloud migration (v0.10)
+
+`xv migrate --from <source> --to <target>` copies secrets between backends. Supports Azure ↔ AWS ↔ Local in any combination. Hardening features:
+
+- `--on-conflict skip|replace|fail` — controls behavior when target secret exists
+- `--dry-run` — preview without changes
+- `--filter "<glob>"` — restrict to matching names
+- `--concurrency N` — bounded parallel transfers (default 8)
+- Idempotent: re-runs detect previously-migrated secrets via `xv:migrated_from` tag
+- Exponential backoff on rate limiting
+
+See [migration.md](migration.md) for the full guide.
+
+---
+
 ## Configuration
 
 | Command | Description |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,113 @@
+# Cross-cloud migration with `xv migrate`
+
+`xv migrate` copies secrets from one backend to another while preserving metadata. Phase 3 (v0.10) hardens this command for cross-cloud use as a marquee feature.
+
+## Quick reference
+
+```bash
+# Azure -> AWS
+xv migrate --from azure --to aws --vault myproj-kv
+
+# AWS -> Azure
+xv migrate --from aws --to azure --vault myproj-kv
+
+# Filter
+xv migrate --from azure --to aws --vault myproj-kv --filter "db-*"
+
+# Dry run
+xv migrate --from azure --to aws --vault myproj-kv --dry-run
+
+# Conflict modes
+xv migrate --from azure --to aws --vault myproj-kv --on-conflict skip      # default
+xv migrate --from azure --to aws --vault myproj-kv --on-conflict replace
+xv migrate --from azure --to aws --vault myproj-kv --on-conflict fail
+
+# Force replace (ignore migration tags)
+xv migrate --from azure --to aws --vault myproj-kv --force-replace
+
+# Tune concurrency
+xv migrate --from azure --to aws --vault myproj-kv --concurrency 4
+```
+
+## Prerequisites
+
+### Azure source / target
+
+You need:
+- A logged-in Azure session (`az login` or env-based credentials).
+- `Key Vault Secrets User` role on the source vault (for read).
+- `Key Vault Secrets Officer` role on the target vault (for write).
+
+### AWS source / target
+
+You need:
+- AWS credentials configured (env, profile, SSO, or instance role).
+- `secretsmanager:ListSecrets`, `secretsmanager:GetSecretValue`, `secretsmanager:DescribeSecret` on the source.
+- `secretsmanager:CreateSecret`, `secretsmanager:PutSecretValue`, `secretsmanager:UpdateSecret`, `secretsmanager:TagResource`, `secretsmanager:UntagResource` on the target.
+
+Minimal AWS IAM policy for the target:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:CreateSecret",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:UpdateSecret",
+        "secretsmanager:TagResource",
+        "secretsmanager:UntagResource",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:ListSecrets"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+### Local source / target
+
+No prerequisites beyond a configured local backend (`xv init --backend local`).
+
+## How it works
+
+Pre-flight: `xv migrate` enumerates source and target secrets, computes a diff, and prints a summary. In dry-run mode, the run stops here.
+
+Per-secret transfer: each secret is `get_secret`'d from source (with value) and `set_secret`'d on target. Bounded by `--concurrency` (default 8). Throttling errors trigger exponential backoff with jitter.
+
+Idempotency: each migrated secret carries `xv:migrated_from=<source>:<vault>:<source-version-id>` and `xv:migrated_at=<timestamp>` tags on the target. Re-running `xv migrate` with `--on-conflict skip` (the default) detects these and skips entries where the source version matches.
+
+Interruption safety: a run interrupted with Ctrl-C leaves no partial-state damage. Each transfer is atomic. Re-run to resume.
+
+## Metadata mapping
+
+| Source field | Azure → AWS | AWS → Azure |
+|---|---|---|
+| `groups` | tag `xv:groups` (comma-joined) | tag `groups` |
+| `note` | AWS `Description` field | tag `note` |
+| `folder` | tag `xv:folder` | tag `folder` |
+| `expiry` | tag `xv:expires_at` | native attribute |
+| `original_name` | tag `xv:original_name` | tag `original_name` |
+| `created_by` | tag `xv:created_by` | tag `created_by` |
+| `content_type` | tag `xv:content_type` | native attribute |
+| version history | current value only | current value only |
+
+## Performance
+
+A 100-secret migration completes in <60 s on a warm credential cache and `--concurrency 8`, assuming no throttling. For larger migrations, monitor AWS CloudWatch / Azure Monitor for rate-limit events and lower `--concurrency` if needed.
+
+## Troubleshooting
+
+- **`Error: vault 'X' not found`**: target vault doesn't exist. Run `xv vault create X --backend <target>` first, or rely on auto-create (currently only for the source's default vault).
+- **`Error: ThrottlingException`**: AWS rate-limit hit. Lower `--concurrency`. Backoff is automatic.
+- **`Error: AccessDeniedException`**: missing IAM permissions on AWS, or missing role on Azure. See "Prerequisites".
+- **Migrate tags on the target make rollback messy**: pass `--force-replace` to overwrite without honoring migration tags.
+
+## Limitations (Phase 3)
+
+- Only the current value is transferred. Full version history transfer is deferred (`--with-history` not yet implemented).
+- IAM resource policies on AWS source/target secrets are not preserved.
+- Cross-region AWS migrations require running `xv migrate` once per source/target region pair, using `[named_backends.*]` config.

--- a/docs/superpowers/plans/2026-05-09-aws-backend-phase-3-plan.md
+++ b/docs/superpowers/plans/2026-05-09-aws-backend-phase-3-plan.md
@@ -1,0 +1,4840 @@
+# AWS Secrets Manager Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `xv --backend aws` — a third backend implementation backed by AWS Secrets Manager, paired with hardened cross-cloud `xv migrate` as the v0.10 marquee feature. Behind a `aws` Cargo feature flag (default off). Prefix-based virtual vaults via `<vault>/.xv-vault` marker secrets; one region per backend instance with `[named_backends.*]` support for multi-region; RBAC, audit, S3, and native rotation deferred (graceful `Unsupported` errors).
+
+**Architecture:** `AwsBackend` lives at `src/backend/aws/`, mirroring the existing `src/backend/azure/` layout. It composes `AwsSecretBackend` and `AwsVaultBackend` behind the existing `Backend` / `SecretBackend` / `VaultBackend` traits. Built on `aws-sdk-secretsmanager` + `aws-config`. Hermetic mock-based tests via `aws-smithy-mocks-experimental`; LocalStack-gated integration tests for full E2E. Multi-region support is achieved via a new `Config.named_backends: HashMap<String, NamedBackendEntry>` map; existing single-instance configs continue to work unchanged.
+
+**Tech Stack:** Rust 2021. New deps: `aws-sdk-secretsmanager = "1"` (and `aws-config = "1"`) under feature `aws`; `aws-smithy-mocks-experimental` under `[dev-dependencies]`. Existing: `tokio`, `async-trait`, `serde`, `thiserror`, `zeroize`.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-09-aws-backend-phase-3-design.md`. Out of scope: AWS Parameter Store backend, S3 file storage, IAM-based `xv share`, CloudTrail-based `xv audit`, Lambda-based rotation, full version-history transfer in `xv migrate`, code-review remediation pass.
+
+---
+
+## File Structure
+
+**Created:**
+
+| Path | Responsibility |
+|------|----------------|
+| `src/backend/aws/mod.rs` | Module index. `AwsBackend` struct + `Backend` trait impl (name, kind, capabilities, secrets/vaults accessors, health_check). |
+| `src/backend/aws/auth.rs` | AWS SDK client builder. Loads credentials via `aws-config` default chain; honors profile/region overrides. |
+| `src/backend/aws/config.rs` | `AwsConfig` struct. Holds region, profile, optional `endpoint_url`, default_vault. |
+| `src/backend/aws/secrets.rs` | `AwsSecretBackend` impl `SecretBackend`. Owns the `SecretsManagerClient` and the vault prefix; one method per trait method. |
+| `src/backend/aws/vaults.rs` | `AwsVaultBackend` impl `VaultBackend`. Marker-secret-based vault create/list/delete. |
+| `src/backend/aws/encoding.rs` | Name encoding/decoding. Marker secret name reservation (`.xv-vault`). Reserved-namespace check. |
+| `src/backend/aws/metadata.rs` | Tag ↔ `SecretProperties` round-trip. Constants for tag keys (`xv:original_name`, `xv:groups`, etc.). |
+| `src/backend/aws/errors.rs` | AWS SDK error → `BackendError` mapping. One `From` impl per SDK operation error type, plus a generic fallback. |
+| `src/backend/aws/models.rs` | Internal AWS-specific helper types (e.g., `AwsTag` newtype if useful). May stay empty initially. |
+| `tests/aws_backend_tests.rs` | Hermetic unit-style tests using `aws-smithy-mocks-experimental` to stub Secrets Manager API responses. |
+| `tests/aws_localstack_tests.rs` | LocalStack-gated integration tests (skip silently when LocalStack unavailable). |
+| `tests/migration_round_trip_tests.rs` | Cross-backend migration round-trip tests (Azure↔AWS, AWS↔Local) — gated where they need cloud credentials. |
+| `tests/terraform/aws/main.tf` | Live AWS test infrastructure (test region, IAM role, cleanup). |
+| `docs/migration.md` | User-facing cross-cloud migration guide. |
+
+**Modified:**
+
+| Path | Change |
+|------|--------|
+| `Cargo.toml` | Add `aws-sdk-secretsmanager`, `aws-config` as **optional** deps; add `[features] aws = ["dep:aws-sdk-secretsmanager", "dep:aws-config"]`; add `aws-smithy-mocks-experimental` to `[dev-dependencies]`. Bump version to `0.10.0-rc.1` (Task 38). |
+| `src/backend/mod.rs` | Add `BackendKind::Aws` variant + parser aliases (`aws`, `secretsmanager`); add `NameCharset::AwsRelaxed` variant; gate `pub mod aws;` on `feature = "aws"`. |
+| `src/backend/registry.rs` | Add `BackendKind::Aws` arm in `from_config`; add `Config.named_backends` resolution path. |
+| `src/config/settings.rs` | Add `AwsConfig` struct, `Config.aws: Option<AwsConfig>` field, `NamedBackendEntry` struct, `Config.named_backends: HashMap<String, NamedBackendEntry>` field. |
+| `src/cli/commands.rs` | Replace `--overwrite` on `Commands::Migrate` with `--on-conflict`; add `--aws-profile` and `--region` global flags on `Cli`. |
+| `src/cli/migrate_ops.rs` | Extend `create_backend` with AWS arm; add pre-flight diff/summary; add idempotency tags; add bounded concurrency. |
+| `src/cli/config_ops.rs` | Surface `Config.aws` and `Config.named_backends` in `xv config show` / `xv config set`. |
+| `src/config/init.rs` | Add AWS branch to `run_interactive_setup`. |
+| `README.md` | Add "AWS backend" subsection + cross-cloud migration callout. |
+| `docs/FEATURES.md` | Update migration entry. |
+
+> **Why `aws-sdk-secretsmanager` is feature-gated:** The AWS SDK ships ~1.5 MB of compiled code per service. Default-off keeps `cargo build` lean for users who don't need AWS. Distribution-channel binaries (homebrew/scoop/deb/rpm) ship with `--features aws`.
+
+---
+
+## Phase 1: Foundation (Cargo + types + module skeleton)
+
+## Task 1: Add `aws` Cargo feature + AWS SDK dependencies
+
+**Files:**
+- Modify: `Cargo.toml`
+
+- [ ] **Step 1: Add optional deps and feature**
+
+In `Cargo.toml` under `[dependencies]`, add (after the existing Azure block):
+
+```toml
+# AWS SDK - feature-gated under `aws`
+aws-sdk-secretsmanager = { version = "1", optional = true }
+aws-config = { version = "1", optional = true, features = ["behavior-version-latest"] }
+```
+
+Under `[dev-dependencies]`, add:
+
+```toml
+aws-smithy-mocks-experimental = "0.2"
+```
+
+In the existing `[features]` block, replace:
+
+```toml
+[features]
+default = ["file-ops"]
+file-ops = []
+tui = []
+```
+
+with:
+
+```toml
+[features]
+default = ["file-ops"]
+file-ops = []
+tui = []
+aws = ["dep:aws-sdk-secretsmanager", "dep:aws-config"]
+```
+
+- [ ] **Step 2: Verify default build still compiles**
+
+Run: `cargo build`
+Expected: clean compile, no AWS-related symbols pulled in.
+
+- [ ] **Step 3: Verify `aws` feature compiles**
+
+Run: `cargo build --features aws`
+Expected: clean compile; `Cargo.lock` gains AWS SDK crates.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "feat(aws): add aws-sdk-secretsmanager dep + aws feature flag"
+```
+
+---
+
+## Task 2: Add `BackendKind::Aws` variant
+
+**Files:**
+- Modify: `src/backend/mod.rs:45-73`
+- Test: `src/backend/mod.rs` (existing tests module)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `src/backend/mod.rs` test module (find with `grep -n "mod tests" src/backend/mod.rs`):
+
+```rust
+#[test]
+fn backend_kind_parses_aws() {
+    use std::str::FromStr;
+    assert_eq!(BackendKind::from_str("aws").unwrap(), BackendKind::Aws);
+    assert_eq!(BackendKind::from_str("AWS").unwrap(), BackendKind::Aws);
+    assert_eq!(BackendKind::from_str("secretsmanager").unwrap(), BackendKind::Aws);
+}
+
+#[test]
+fn backend_kind_aws_displays_as_aws() {
+    assert_eq!(format!("{}", BackendKind::Aws), "aws");
+}
+```
+
+- [ ] **Step 2: Verify test fails**
+
+Run: `cargo test --lib backend::tests::backend_kind_parses_aws`
+Expected: fails to compile — `BackendKind::Aws` does not exist.
+
+- [ ] **Step 3: Add the variant + parser**
+
+In `src/backend/mod.rs` modify the `BackendKind` enum, its `Display` impl, and its `FromStr` impl:
+
+```rust
+pub enum BackendKind {
+    Azure,
+    Local,
+    Aws,
+}
+
+impl std::fmt::Display for BackendKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Azure => write!(f, "azure"),
+            Self::Local => write!(f, "local"),
+            Self::Aws => write!(f, "aws"),
+        }
+    }
+}
+
+impl std::str::FromStr for BackendKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "azure" | "az" | "keyvault" => Ok(Self::Azure),
+            "local" | "file" | "age" => Ok(Self::Local),
+            "aws" | "secretsmanager" | "asm" => Ok(Self::Aws),
+            _ => Err(format!(
+                "unknown backend kind: {s}. Valid options: azure, local, aws"
+            )),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+Run: `cargo test --lib backend::tests::backend_kind_parses_aws backend::tests::backend_kind_aws_displays_as_aws`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/mod.rs
+git commit -m "feat(aws): add BackendKind::Aws variant"
+```
+
+---
+
+## Task 3: Add `NameCharset::AwsRelaxed` variant
+
+**Files:**
+- Modify: `src/backend/mod.rs` (NameCharset enum)
+
+- [ ] **Step 1: Add the variant**
+
+Locate `pub enum NameCharset` in `src/backend/mod.rs`. Replace with:
+
+```rust
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum NameCharset {
+    /// Only `[a-zA-Z0-9-]` — Azure Key Vault's constraint.
+    AlphanumericHyphen,
+    /// Any printable character (the backend encodes as needed).
+    Unrestricted,
+    /// AWS Secrets Manager: `[a-zA-Z0-9/_+=.@-]`.
+    AwsRelaxed,
+    /// Custom validation function.
+    Custom(fn(&str) -> bool),
+}
+
+impl NameCharset {
+    /// Returns true if `name` is valid under this charset.
+    pub fn is_valid(&self, name: &str) -> bool {
+        match self {
+            Self::AlphanumericHyphen => name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-'),
+            Self::Unrestricted => true,
+            Self::AwsRelaxed => name.chars().all(|c| {
+                c.is_ascii_alphanumeric()
+                    || matches!(c, '/' | '_' | '+' | '=' | '.' | '@' | '-')
+            }),
+            Self::Custom(f) => f(name),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add tests**
+
+Append to the existing `mod tests` block in `src/backend/mod.rs`:
+
+```rust
+#[test]
+fn aws_relaxed_charset_accepts_aws_chars() {
+    let cs = NameCharset::AwsRelaxed;
+    assert!(cs.is_valid("myproj/db-password"));
+    assert!(cs.is_valid("api_key+v2"));
+    assert!(cs.is_valid("alice@example.com"));
+    assert!(cs.is_valid("v1.2.3"));
+}
+
+#[test]
+fn aws_relaxed_charset_rejects_invalid_chars() {
+    let cs = NameCharset::AwsRelaxed;
+    assert!(!cs.is_valid("has space"));
+    assert!(!cs.is_valid("has*star"));
+    assert!(!cs.is_valid("has(paren)"));
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo test --lib backend::tests::aws_relaxed_charset`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/backend/mod.rs
+git commit -m "feat(aws): add NameCharset::AwsRelaxed + is_valid helper"
+```
+
+---
+
+## Task 4: Create `src/backend/aws/` module skeleton
+
+**Files:**
+- Create: `src/backend/aws/mod.rs`
+- Create: `src/backend/aws/auth.rs`
+- Create: `src/backend/aws/config.rs`
+- Create: `src/backend/aws/encoding.rs`
+- Create: `src/backend/aws/errors.rs`
+- Create: `src/backend/aws/metadata.rs`
+- Create: `src/backend/aws/models.rs`
+- Create: `src/backend/aws/secrets.rs`
+- Create: `src/backend/aws/vaults.rs`
+- Modify: `src/backend/mod.rs` (gate `pub mod aws`)
+
+- [ ] **Step 1: Create `src/backend/aws/mod.rs`**
+
+```rust
+//! AWS Secrets Manager backend.
+//!
+//! Phase 3 / v0.10. See `docs/superpowers/specs/2026-05-09-aws-backend-phase-3-design.md`.
+
+pub mod auth;
+pub mod config;
+pub mod encoding;
+pub mod errors;
+pub mod metadata;
+pub mod models;
+pub mod secrets;
+pub mod vaults;
+
+// AwsBackend struct fleshed out in Task 12.
+```
+
+- [ ] **Step 2: Create stubs for each submodule**
+
+`src/backend/aws/auth.rs`:
+```rust
+//! AWS SDK client builder. Loads credentials via aws-config default chain.
+```
+
+`src/backend/aws/config.rs`:
+```rust
+//! `AwsConfig` struct and resolution helpers. See Task 5.
+```
+
+`src/backend/aws/encoding.rs`:
+```rust
+//! Name encoding/decoding for AWS Secrets Manager. See Task 10.
+```
+
+`src/backend/aws/errors.rs`:
+```rust
+//! AWS SDK error -> BackendError mapping. See Task 9.
+```
+
+`src/backend/aws/metadata.rs`:
+```rust
+//! Tag <-> SecretProperties round-trip. See Task 11.
+```
+
+`src/backend/aws/models.rs`:
+```rust
+//! Internal AWS-specific types.
+```
+
+`src/backend/aws/secrets.rs`:
+```rust
+//! `AwsSecretBackend` impl `SecretBackend`. See Tasks 14-28.
+```
+
+`src/backend/aws/vaults.rs`:
+```rust
+//! `AwsVaultBackend` impl `VaultBackend`. See Tasks 29-33.
+```
+
+- [ ] **Step 3: Wire the module behind the feature flag**
+
+In `src/backend/mod.rs`, find the existing `pub mod azure;` and `pub mod local;` declarations. After them, add:
+
+```rust
+#[cfg(feature = "aws")]
+pub mod aws;
+```
+
+- [ ] **Step 4: Verify both build modes still compile**
+
+Run: `cargo build` (default features — no AWS)
+Expected: clean.
+
+Run: `cargo build --features aws`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/aws/ src/backend/mod.rs
+git commit -m "feat(aws): scaffold src/backend/aws/ module"
+```
+
+---
+
+## Task 5: Add `AwsConfig` struct to settings.rs
+
+**Files:**
+- Modify: `src/config/settings.rs`
+
+- [ ] **Step 1: Add the struct**
+
+Locate `pub struct LocalConfig` in `src/config/settings.rs:21`. After the `LocalConfig` block (after the closing `}` near line 35), add:
+
+```rust
+/// Configuration for the AWS Secrets Manager backend.
+///
+/// Lives under `[aws]` in `xv.conf`. Only relevant when `backend = "aws"`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AwsConfig {
+    /// AWS region, e.g. `us-east-1`. Falls through to `AWS_REGION` env var.
+    #[serde(default)]
+    pub region: Option<String>,
+
+    /// AWS profile name. Falls through to `AWS_PROFILE`. Defaults to "default".
+    #[serde(default)]
+    pub profile: Option<String>,
+
+    /// Optional endpoint URL override. Used for LocalStack and other AWS-compatible APIs.
+    #[serde(default)]
+    pub endpoint_url: Option<String>,
+
+    /// Default vault name (= prefix) used when no `--vault` / context is set.
+    #[serde(default)]
+    pub default_vault: Option<String>,
+}
+```
+
+- [ ] **Step 2: Add `Config.aws` field**
+
+Find `pub local: Option<LocalConfig>` in `src/config/settings.rs:158`. Below it (before `clipboard_timeout`), add:
+
+```rust
+    /// Configuration for the AWS Secrets Manager backend.
+    /// Only relevant when `backend = "aws"`.
+    #[tabled(skip)]
+    #[serde(default)]
+    pub aws: Option<AwsConfig>,
+```
+
+- [ ] **Step 3: Update `Default for Config`**
+
+Find `impl Default for Config` (around line 189). Add `aws: None,` to the struct literal in `default()`. The full updated `default()` should include both `local: None,` and `aws: None,`.
+
+- [ ] **Step 4: Update validate() to skip Azure checks when backend is aws**
+
+Find `pub fn validate(&self)` (around line 221). Replace the body's branch:
+
+```rust
+pub fn validate(&self) -> Result<()> {
+    let backend = self.effective_backend_name();
+    if backend == "azure" {
+        if self.subscription_id.is_empty() {
+            return Err(CrosstacheError::config("Subscription ID is required"));
+        }
+        if self.tenant_id.is_empty() {
+            return Err(CrosstacheError::config("Tenant ID is required"));
+        }
+    }
+    if backend == "aws" {
+        let aws = self.aws.as_ref().ok_or_else(|| {
+            CrosstacheError::config("[aws] config block is required when backend = \"aws\"")
+        })?;
+        if aws.region.is_none()
+            && std::env::var("AWS_REGION").is_err()
+            && std::env::var("AWS_DEFAULT_REGION").is_err()
+        {
+            return Err(CrosstacheError::config(
+                "AWS region required: set [aws].region in config or AWS_REGION env var",
+            ));
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Add unit test**
+
+In `src/config/settings.rs` `mod tests` (find with `grep -n "mod tests" src/config/settings.rs`), add:
+
+```rust
+#[test]
+fn validate_requires_aws_block_when_backend_is_aws() {
+    let cfg = Config {
+        backend: Some("aws".into()),
+        aws: None,
+        ..Default::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("aws"), "got: {err}");
+}
+
+#[test]
+fn validate_passes_when_aws_block_present_with_region() {
+    let cfg = Config {
+        backend: Some("aws".into()),
+        aws: Some(AwsConfig {
+            region: Some("us-east-1".into()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    assert!(cfg.validate().is_ok());
+}
+```
+
+- [ ] **Step 6: Verify**
+
+Run: `cargo test --lib config::settings::tests::validate_requires_aws_block_when_backend_is_aws config::settings::tests::validate_passes_when_aws_block_present_with_region`
+Expected: PASS.
+
+Run: `cargo build` (and `cargo build --features aws`).
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/config/settings.rs
+git commit -m "feat(aws): add AwsConfig struct and Config.aws field"
+```
+
+---
+
+## Task 6: Add `Config.named_backends` map for multi-region support
+
+**Files:**
+- Modify: `src/config/settings.rs`
+
+- [ ] **Step 1: Add `NamedBackendEntry` enum**
+
+After the `AwsConfig` struct from Task 5, add:
+
+```rust
+/// A named backend entry in `Config.named_backends`. Each entry is a
+/// fully-self-contained backend configuration tagged with its type.
+///
+/// Used for multi-region AWS, multi-tenant Azure, etc.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum NamedBackendEntry {
+    Aws(AwsConfig),
+    Local(LocalConfig),
+    // Azure intentionally omitted from this enum for now; existing
+    // top-level Azure fields handle the single-instance case.
+}
+```
+
+- [ ] **Step 2: Add `Config.named_backends` field**
+
+Find the struct `Config` (around line 108). After `pub aws: Option<AwsConfig>` (added in Task 5), add:
+
+```rust
+    /// Named backend instances for multi-region / multi-tenant use.
+    /// Active backend selected via `Config.backend` matching a key here.
+    #[tabled(skip)]
+    #[serde(default)]
+    pub named_backends: std::collections::HashMap<String, NamedBackendEntry>,
+```
+
+- [ ] **Step 3: Update `Default for Config`**
+
+In `default()`, add `named_backends: std::collections::HashMap::new(),`.
+
+- [ ] **Step 4: Add unit test**
+
+In `src/config/settings.rs` `mod tests`:
+
+```rust
+#[test]
+fn named_backends_deserializes_aws_entry() {
+    let toml_str = r#"
+backend = "aws-east"
+
+[named_backends.aws-east]
+type = "aws"
+region = "us-east-1"
+profile = "prod"
+default_vault = "myproj-kv"
+"#;
+    let cfg: Config = toml::from_str(toml_str).unwrap();
+    assert_eq!(cfg.backend.as_deref(), Some("aws-east"));
+    let entry = cfg.named_backends.get("aws-east").unwrap();
+    match entry {
+        NamedBackendEntry::Aws(aws) => {
+            assert_eq!(aws.region.as_deref(), Some("us-east-1"));
+            assert_eq!(aws.profile.as_deref(), Some("prod"));
+        }
+        _ => panic!("expected Aws variant"),
+    }
+}
+```
+
+- [ ] **Step 5: Verify**
+
+Run: `cargo test --lib config::settings::tests::named_backends_deserializes_aws_entry`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config/settings.rs
+git commit -m "feat(aws): add Config.named_backends map for multi-region"
+```
+
+---
+
+## Phase 2: AWS backend skeleton (auth, errors, encoding, metadata, Backend trait)
+
+## Task 7: Implement `auth.rs` — AWS SDK config builder
+
+**Files:**
+- Modify: `src/backend/aws/auth.rs`
+
+- [ ] **Step 1: Replace stub with real impl**
+
+```rust
+//! AWS SDK config builder. Loads credentials via the aws-config default chain.
+//!
+//! No xv-specific credential priority abstraction (unlike Azure's
+//! `--credential-priority`). AWS users have strong opinions about credential
+//! resolution; the SDK chain is industry standard and we don't try to model it.
+
+use crate::backend::aws::config::AwsConfig;
+use crate::backend::error::BackendError;
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+
+/// Build a `SecretsManagerClient` from the resolved `AwsConfig` plus
+/// per-invocation overrides (region, profile from CLI flags or env vars).
+pub async fn build_client(
+    aws_cfg: &AwsConfig,
+    region_override: Option<String>,
+    profile_override: Option<String>,
+) -> Result<SecretsManagerClient, BackendError> {
+    let region = region_override
+        .or_else(|| aws_cfg.region.clone())
+        .or_else(|| std::env::var("AWS_REGION").ok())
+        .or_else(|| std::env::var("AWS_DEFAULT_REGION").ok())
+        .ok_or_else(|| {
+            BackendError::AuthenticationFailed(
+                "AWS region not set: provide [aws].region, AWS_REGION, or --region".into(),
+            )
+        })?;
+
+    let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(aws_config::Region::new(region));
+
+    let profile = profile_override.or_else(|| aws_cfg.profile.clone());
+    if let Some(ref p) = profile {
+        loader = loader.profile_name(p);
+    }
+
+    if let Some(ref endpoint) = aws_cfg.endpoint_url {
+        if !endpoint.is_empty() {
+            loader = loader.endpoint_url(endpoint);
+        }
+    }
+
+    let sdk_config = loader.load().await;
+    Ok(SecretsManagerClient::new(&sdk_config))
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cargo build --features aws`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/backend/aws/auth.rs
+git commit -m "feat(aws): add SDK client builder honoring config + overrides"
+```
+
+---
+
+## Task 8: Implement `errors.rs` — AWS SDK error → BackendError mapping
+
+**Files:**
+- Modify: `src/backend/aws/errors.rs`
+
+- [ ] **Step 1: Write the conversion**
+
+```rust
+//! AWS SDK error -> BackendError mapping.
+//!
+//! The AWS SDK exposes per-operation error enums (e.g. `GetSecretValueError`).
+//! We provide free functions for each operation we use, so call sites stay
+//! readable and the mapping is exhaustive over the variants we observe.
+
+use crate::backend::error::BackendError;
+use aws_sdk_secretsmanager::operation::create_secret::CreateSecretError;
+use aws_sdk_secretsmanager::operation::delete_secret::DeleteSecretError;
+use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretError;
+use aws_sdk_secretsmanager::operation::get_secret_value::GetSecretValueError;
+use aws_sdk_secretsmanager::operation::list_secret_version_ids::ListSecretVersionIdsError;
+use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsError;
+use aws_sdk_secretsmanager::operation::put_secret_value::PutSecretValueError;
+use aws_sdk_secretsmanager::operation::restore_secret::RestoreSecretError;
+use aws_sdk_secretsmanager::operation::tag_resource::TagResourceError;
+use aws_sdk_secretsmanager::operation::untag_resource::UntagResourceError;
+use aws_sdk_secretsmanager::operation::update_secret::UpdateSecretError;
+use aws_sdk_secretsmanager::operation::update_secret_version_stage::UpdateSecretVersionStageError;
+use aws_smithy_runtime_api::client::result::SdkError;
+
+fn generic<E: std::fmt::Display>(op: &str, e: E) -> BackendError {
+    BackendError::Internal(format!("aws {op}: {e}"))
+}
+
+fn handle_sdk<R, E: std::fmt::Display>(op: &str, e: SdkError<E, R>) -> BackendError {
+    match e {
+        SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) => {
+            BackendError::Network(format!("aws {op}: {e}"))
+        }
+        SdkError::ServiceError(svc) => {
+            // Caller will inspect svc.err() before calling this; this is a fallback.
+            BackendError::Internal(format!("aws {op}: {}", svc.err()))
+        }
+        other => generic(op, other),
+    }
+}
+
+pub fn from_create(e: SdkError<CreateSecretError>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        match svc.err() {
+            CreateSecretError::ResourceExistsException(inner) => {
+                return BackendError::Conflict(inner.to_string())
+            }
+            CreateSecretError::InvalidRequestException(inner) => {
+                return BackendError::InvalidArgument(inner.to_string())
+            }
+            CreateSecretError::InvalidParameterException(inner) => {
+                return BackendError::InvalidArgument(inner.to_string())
+            }
+            CreateSecretError::LimitExceededException(inner) => {
+                return BackendError::RateLimited {
+                    retry_after_secs: None,
+                }
+                .with_context(format!("limit: {inner}"))
+            }
+            _ => {}
+        }
+    }
+    handle_sdk("CreateSecret", e)
+}
+
+pub fn from_get_value(name: &str, e: SdkError<GetSecretValueError>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        match svc.err() {
+            GetSecretValueError::ResourceNotFoundException(_) => {
+                return BackendError::NotFound {
+                    name: name.to_string(),
+                    suggestion: None,
+                }
+            }
+            GetSecretValueError::DecryptionFailure(inner) => {
+                return BackendError::Internal(format!("decryption failed: {inner}"))
+            }
+            GetSecretValueError::InvalidRequestException(inner) => {
+                return BackendError::InvalidArgument(inner.to_string())
+            }
+            _ => {}
+        }
+    }
+    handle_sdk("GetSecretValue", e)
+}
+
+pub fn from_describe(name: &str, e: SdkError<DescribeSecretError>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let DescribeSecretError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("DescribeSecret", e)
+}
+
+pub fn from_list(e: SdkError<ListSecretsError>) -> BackendError {
+    handle_sdk("ListSecrets", e)
+}
+
+pub fn from_delete(name: &str, e: SdkError<DeleteSecretError>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let DeleteSecretError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("DeleteSecret", e)
+}
+
+pub fn from_put_value(name: &str, e: SdkError<PutSecretValueError>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let PutSecretValueError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("PutSecretValue", e)
+}
+
+pub fn from_update(name: &str, e: SdkError<UpdateSecretError>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let UpdateSecretError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("UpdateSecret", e)
+}
+
+pub fn from_restore(name: &str, e: SdkError<RestoreSecretError>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let RestoreSecretError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("RestoreSecret", e)
+}
+
+pub fn from_list_versions(name: &str, e: SdkError<ListSecretVersionIdsError>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let ListSecretVersionIdsError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("ListSecretVersionIds", e)
+}
+
+pub fn from_update_stage(name: &str, e: SdkError<UpdateSecretVersionStageError>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let UpdateSecretVersionStageError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("UpdateSecretVersionStage", e)
+}
+
+pub fn from_tag(e: SdkError<TagResourceError>) -> BackendError {
+    handle_sdk("TagResource", e)
+}
+
+pub fn from_untag(e: SdkError<UntagResourceError>) -> BackendError {
+    handle_sdk("UntagResource", e)
+}
+
+trait ErrCtx {
+    fn with_context(self, ctx: String) -> BackendError;
+}
+
+impl ErrCtx for BackendError {
+    fn with_context(self, _ctx: String) -> BackendError {
+        // RateLimited has no context field today; placeholder for future enrichment.
+        self
+    }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cargo build --features aws`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/backend/aws/errors.rs
+git commit -m "feat(aws): add SDK error -> BackendError mapping per operation"
+```
+
+---
+
+## Task 9: Implement `encoding.rs` — name encoding, marker reservation
+
+**Files:**
+- Modify: `src/backend/aws/encoding.rs`
+
+- [ ] **Step 1: Write tests first**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aws_name_joins_prefix() {
+        assert_eq!(aws_name("myproj-kv", "db-password"), "myproj-kv/db-password");
+    }
+
+    #[test]
+    fn strip_prefix_extracts_secret_name() {
+        assert_eq!(strip_prefix("myproj-kv", "myproj-kv/db-password"), Some("db-password".to_string()));
+        assert_eq!(strip_prefix("myproj-kv", "other-vault/db-password"), None);
+    }
+
+    #[test]
+    fn marker_name_constant() {
+        assert_eq!(marker_name("myproj-kv"), "myproj-kv/.xv-vault");
+    }
+
+    #[test]
+    fn is_marker_detects_marker() {
+        assert!(is_marker("myproj-kv/.xv-vault"));
+        assert!(!is_marker("myproj-kv/db-password"));
+    }
+
+    #[test]
+    fn validate_secret_name_rejects_reserved() {
+        assert!(matches!(validate_secret_name(".xv-vault"), Err(_)));
+        assert!(matches!(validate_secret_name(".xv-anything"), Err(_)));
+    }
+
+    #[test]
+    fn validate_secret_name_rejects_empty() {
+        assert!(matches!(validate_secret_name(""), Err(_)));
+    }
+
+    #[test]
+    fn validate_secret_name_accepts_normal_names() {
+        assert!(validate_secret_name("db-password").is_ok());
+        assert!(validate_secret_name("api/v1/key").is_ok());
+        assert!(validate_secret_name("v1.2.3-rc.1").is_ok());
+    }
+}
+```
+
+- [ ] **Step 2: Implement**
+
+Replace the stub at the top of `src/backend/aws/encoding.rs`:
+
+```rust
+//! Name encoding/decoding for AWS Secrets Manager.
+//!
+//! AWS allows `[a-zA-Z0-9/_+=.@-]` and 512-char names. Our prefix-based
+//! virtual vault scheme produces names like `myproj-kv/db-password`.
+//!
+//! The reserved namespace `.xv-*` is used for vault markers and other
+//! xv-internal bookkeeping. User-supplied names starting with `.xv-` are
+//! rejected at the `set_secret` boundary.
+
+use crate::backend::error::BackendError;
+
+/// The AWS Secrets Manager name length limit.
+pub const MAX_NAME_LEN: usize = 512;
+
+/// The marker filename inside each vault prefix.
+const MARKER_BASENAME: &str = ".xv-vault";
+
+/// Returns the full AWS name for a secret in a given vault.
+pub fn aws_name(vault: &str, secret_name: &str) -> String {
+    format!("{vault}/{secret_name}")
+}
+
+/// Strips the vault prefix from an AWS name, returning the inner secret name.
+/// Returns None if the name doesn't belong to the given vault.
+pub fn strip_prefix(vault: &str, full_name: &str) -> Option<String> {
+    let prefix = format!("{vault}/");
+    full_name.strip_prefix(&prefix).map(|s| s.to_string())
+}
+
+/// Returns the AWS name of the vault marker secret.
+pub fn marker_name(vault: &str) -> String {
+    format!("{vault}/{MARKER_BASENAME}")
+}
+
+/// Returns true if `full_name` is a vault marker secret name.
+pub fn is_marker(full_name: &str) -> bool {
+    full_name.ends_with(&format!("/{MARKER_BASENAME}"))
+        || full_name == MARKER_BASENAME
+}
+
+/// Validate a user-facing secret name. Rejects empty names and names
+/// starting with `.xv-` (reserved namespace).
+pub fn validate_secret_name(name: &str) -> Result<(), BackendError> {
+    if name.is_empty() {
+        return Err(BackendError::InvalidArgument(
+            "secret name cannot be empty".into(),
+        ));
+    }
+    if name.starts_with(".xv-") {
+        return Err(BackendError::InvalidArgument(format!(
+            "secret name '{name}' is in the reserved '.xv-*' namespace"
+        )));
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo test --features aws --lib backend::aws::encoding::tests`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/backend/aws/encoding.rs
+git commit -m "feat(aws): add name encoding + marker reservation + reserved-name check"
+```
+
+---
+
+## Task 10: Implement `metadata.rs` — tag ↔ SecretProperties round-trip
+
+**Files:**
+- Modify: `src/backend/aws/metadata.rs`
+
+- [ ] **Step 1: Write tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn round_trip_full_metadata() {
+        let mut user_tags = HashMap::new();
+        user_tags.insert("team".to_string(), "platform".to_string());
+
+        let props = TestProps {
+            original_name: "db-password".into(),
+            groups: vec!["backend".into(), "prod".into()],
+            folder: Some("app/database".into()),
+            created_by: Some("alice@example.com".into()),
+            content_type: Some("text/plain".into()),
+            note: Some("primary database admin password".into()),
+            expires_at: Some("2027-01-01T00:00:00Z".into()),
+            user_tags: user_tags.clone(),
+        };
+
+        let aws_tags = encode_tags(&props);
+        let decoded = decode_tags(&aws_tags);
+
+        assert_eq!(decoded.original_name, "db-password");
+        assert_eq!(decoded.groups, vec!["backend", "prod"]);
+        assert_eq!(decoded.folder.as_deref(), Some("app/database"));
+        assert_eq!(decoded.user_tags.get("team").unwrap(), "platform");
+    }
+
+    #[test]
+    fn empty_metadata_round_trips_to_empty_tags() {
+        let props = TestProps::empty("name1");
+        let aws_tags = encode_tags(&props);
+        // Only original_name and one xv: tag entry expected
+        assert!(aws_tags.iter().any(|(k, _)| k == "xv:original_name"));
+    }
+}
+```
+
+- [ ] **Step 2: Implement**
+
+```rust
+//! Tag <-> SecretProperties round-trip for AWS backend.
+//!
+//! AWS Secrets Manager allows up to 50 tags per secret (vs Azure's 15);
+//! comfortable budget. Reserved keys live under the `xv:` prefix.
+
+use std::collections::HashMap;
+
+pub const TAG_ORIGINAL_NAME: &str = "xv:original_name";
+pub const TAG_GROUPS: &str = "xv:groups";
+pub const TAG_FOLDER: &str = "xv:folder";
+pub const TAG_CREATED_BY: &str = "xv:created_by";
+pub const TAG_CONTENT_TYPE: &str = "xv:content_type";
+pub const TAG_EXPIRES_AT: &str = "xv:expires_at";
+pub const TAG_TYPE: &str = "xv:type";
+pub const TAG_VALUE_VAULT_MARKER: &str = "vault-marker";
+pub const TAG_MIGRATED_FROM: &str = "xv:migrated_from";
+pub const TAG_MIGRATED_AT: &str = "xv:migrated_at";
+
+/// Subset of `SecretProperties` fields we actually round-trip.
+/// Real `SecretProperties` from `crate::secret::models` is bigger; we map
+/// to/from it at the call site.
+#[derive(Debug, Default, Clone)]
+pub struct TestProps {
+    pub original_name: String,
+    pub groups: Vec<String>,
+    pub folder: Option<String>,
+    pub created_by: Option<String>,
+    pub content_type: Option<String>,
+    pub note: Option<String>,            // -> AWS Description, not a tag
+    pub expires_at: Option<String>,
+    pub user_tags: HashMap<String, String>,
+}
+
+impl TestProps {
+    pub fn empty(name: &str) -> Self {
+        Self {
+            original_name: name.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Encode metadata into AWS-tag-shaped `(key, value)` pairs.
+/// Note: `note` is intentionally NOT encoded — it lives in AWS Description.
+pub fn encode_tags(p: &TestProps) -> Vec<(String, String)> {
+    let mut tags: Vec<(String, String)> = Vec::new();
+    tags.push((TAG_ORIGINAL_NAME.into(), p.original_name.clone()));
+    if !p.groups.is_empty() {
+        tags.push((TAG_GROUPS.into(), p.groups.join(",")));
+    }
+    if let Some(ref f) = p.folder {
+        tags.push((TAG_FOLDER.into(), f.clone()));
+    }
+    if let Some(ref c) = p.created_by {
+        tags.push((TAG_CREATED_BY.into(), c.clone()));
+    }
+    if let Some(ref ct) = p.content_type {
+        tags.push((TAG_CONTENT_TYPE.into(), ct.clone()));
+    }
+    if let Some(ref e) = p.expires_at {
+        tags.push((TAG_EXPIRES_AT.into(), e.clone()));
+    }
+    for (k, v) in &p.user_tags {
+        if !k.starts_with("xv:") {
+            tags.push((k.clone(), v.clone()));
+        }
+    }
+    tags
+}
+
+/// Decode AWS tags back into the metadata struct.
+pub fn decode_tags(tags: &[(String, String)]) -> TestProps {
+    let mut p = TestProps::default();
+    let mut user_tags = HashMap::new();
+    for (k, v) in tags {
+        match k.as_str() {
+            TAG_ORIGINAL_NAME => p.original_name = v.clone(),
+            TAG_GROUPS => {
+                p.groups = v
+                    .split(',')
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
+                    .collect()
+            }
+            TAG_FOLDER => p.folder = Some(v.clone()),
+            TAG_CREATED_BY => p.created_by = Some(v.clone()),
+            TAG_CONTENT_TYPE => p.content_type = Some(v.clone()),
+            TAG_EXPIRES_AT => p.expires_at = Some(v.clone()),
+            _ if !k.starts_with("xv:") => {
+                user_tags.insert(k.clone(), v.clone());
+            }
+            _ => {} // unknown xv: tag — ignored on decode
+        }
+    }
+    p.user_tags = user_tags;
+    p
+}
+
+/// True if this tag is a vault marker tag (`xv:type=vault-marker`).
+pub fn is_vault_marker_tag(key: &str, value: &str) -> bool {
+    key == TAG_TYPE && value == TAG_VALUE_VAULT_MARKER
+}
+```
+
+> **Note:** `TestProps` is a simplification used for the round-trip test pattern. In subsequent tasks we'll convert directly between AWS tags and the existing `crate::secret::models::SecretProperties` (which has additional fields like `enabled`, `version_id`, etc.). The conversion patterns established here are reused.
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo test --features aws --lib backend::aws::metadata::tests`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/backend/aws/metadata.rs
+git commit -m "feat(aws): add tag <-> metadata round-trip"
+```
+
+---
+
+## Task 11: Implement `AwsBackend` struct + `Backend` trait
+
+**Files:**
+- Modify: `src/backend/aws/mod.rs`
+
+- [ ] **Step 1: Replace the stub with the impl**
+
+```rust
+//! AWS Secrets Manager backend.
+
+pub mod auth;
+pub mod config;
+pub mod encoding;
+pub mod errors;
+pub mod metadata;
+pub mod models;
+pub mod secrets;
+pub mod vaults;
+
+use std::sync::Arc;
+
+use crate::backend::{
+    Backend, BackendCapabilities, BackendKind, NameCharset, SecretBackend, VaultBackend,
+};
+use crate::backend::error::BackendError;
+use crate::config::settings::AwsConfig;
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+
+pub struct AwsBackend {
+    secrets_impl: Arc<secrets::AwsSecretBackend>,
+    vaults_impl: Arc<vaults::AwsVaultBackend>,
+}
+
+impl AwsBackend {
+    /// Build a backend from config + per-invocation overrides.
+    /// Async because `aws-config::load()` is async.
+    pub async fn new(
+        aws_cfg: &AwsConfig,
+        region_override: Option<String>,
+        profile_override: Option<String>,
+    ) -> Result<Self, BackendError> {
+        let client: SecretsManagerClient =
+            auth::build_client(aws_cfg, region_override, profile_override).await?;
+        let client = Arc::new(client);
+        Ok(Self {
+            secrets_impl: Arc::new(secrets::AwsSecretBackend::new(client.clone())),
+            vaults_impl: Arc::new(vaults::AwsVaultBackend::new(client)),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Backend for AwsBackend {
+    fn name(&self) -> &'static str {
+        "aws"
+    }
+
+    fn kind(&self) -> BackendKind {
+        BackendKind::Aws
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            has_vaults: true,
+            has_file_storage: false,
+            has_rbac: false,
+            has_audit: false,
+            has_versioning: true,
+            has_soft_delete: true,
+            has_secret_rotation: false,
+            has_groups: true,
+            has_folders: true,
+            has_notes: true,
+            has_expiry: true,
+            max_secret_size: Some(65_536),
+            max_name_length: Some(encoding::MAX_NAME_LEN),
+            name_charset: NameCharset::AwsRelaxed,
+        }
+    }
+
+    fn secrets(&self) -> &dyn SecretBackend {
+        self.secrets_impl.as_ref()
+    }
+
+    fn vaults(&self) -> Option<&dyn VaultBackend> {
+        Some(self.vaults_impl.as_ref())
+    }
+
+    async fn health_check(&self) -> Result<(), BackendError> {
+        // Calling list_secrets with limit=1 verifies credentials + connectivity
+        // without requiring any specific resource to exist.
+        self.secrets_impl.health_check().await
+    }
+}
+```
+
+- [ ] **Step 2: Add stubs for `AwsSecretBackend` and `AwsVaultBackend`**
+
+In `src/backend/aws/secrets.rs`, replace the stub with:
+
+```rust
+//! `AwsSecretBackend` impl `SecretBackend`.
+
+use crate::backend::SecretBackend;
+use crate::backend::error::BackendError;
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+use std::sync::Arc;
+
+pub struct AwsSecretBackend {
+    client: Arc<SecretsManagerClient>,
+}
+
+impl AwsSecretBackend {
+    pub fn new(client: Arc<SecretsManagerClient>) -> Self {
+        Self { client }
+    }
+
+    /// Lightweight health check: list secrets with limit=1.
+    pub async fn health_check(&self) -> Result<(), BackendError> {
+        self.client
+            .list_secrets()
+            .max_results(1)
+            .send()
+            .await
+            .map_err(super::errors::from_list)?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl SecretBackend for AwsSecretBackend {
+    // All trait methods filled in across Tasks 13-22. For now, leave them as
+    // returning Unsupported so the trait-impl scaffold compiles.
+}
+```
+
+In `src/backend/aws/vaults.rs`:
+
+```rust
+//! `AwsVaultBackend` impl `VaultBackend`.
+
+use crate::backend::VaultBackend;
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+use std::sync::Arc;
+
+pub struct AwsVaultBackend {
+    client: Arc<SecretsManagerClient>,
+}
+
+impl AwsVaultBackend {
+    pub fn new(client: Arc<SecretsManagerClient>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait::async_trait]
+impl VaultBackend for AwsVaultBackend {
+    // Methods filled in across Tasks 24-28.
+}
+```
+
+> **Note:** The empty trait-impl bodies will cause compile errors if the trait has required methods. Check `src/backend/secret.rs` and `src/backend/vault.rs` (or wherever the traits are defined) — for any required method not yet implemented here, add a stub returning `Err(BackendError::Unsupported("not yet implemented".into()))` to keep the compile clean. Subsequent tasks replace each stub with the real impl.
+
+- [ ] **Step 3: Identify required trait methods**
+
+Run: `grep -n "async fn" src/backend/secret.rs src/backend/vault.rs`
+
+For each method without a default impl, add a stub in `secrets.rs` / `vaults.rs`:
+
+```rust
+async fn METHOD_NAME(&self, /* args */) -> Result<RETURN_TYPE, BackendError> {
+    Err(BackendError::Unsupported("aws backend: not yet implemented".into()))
+}
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `cargo build --features aws`
+Expected: clean compile.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/aws/
+git commit -m "feat(aws): scaffold AwsBackend with capabilities + Backend trait impl"
+```
+
+---
+
+## Task 12: Wire `BackendKind::Aws` into `BackendRegistry::from_config`
+
+**Files:**
+- Modify: `src/backend/registry.rs:48-67`
+
+- [ ] **Step 1: Add the AWS arm**
+
+Locate `pub fn from_config` in `src/backend/registry.rs`. Replace the `match kind` block:
+
+```rust
+pub fn from_config(config: &Config) -> Result<Self, BackendError> {
+    let backend_name = config.effective_backend_name();
+
+    // Resolve named-backend entry first if applicable
+    if let Some(entry) = config.named_backends.get(backend_name) {
+        return Self::from_named_entry(backend_name, entry);
+    }
+
+    let kind: BackendKind = backend_name
+        .parse()
+        .map_err(|e: String| BackendError::Internal(e))?;
+
+    match kind {
+        BackendKind::Azure => {
+            let auth_provider = Self::create_azure_auth_provider(config)?;
+            let backend = super::azure::AzureBackend::new(config, auth_provider.clone())?;
+            let mut registry = Self::new(Arc::new(backend));
+            registry.azure_auth = Some(auth_provider);
+            Ok(registry)
+        }
+        BackendKind::Local => {
+            let backend = super::local::LocalBackend::new(config.local.as_ref())?;
+            Ok(Self::new(Arc::new(backend)))
+        }
+        #[cfg(feature = "aws")]
+        BackendKind::Aws => {
+            let aws_cfg = config.aws.as_ref().ok_or_else(|| {
+                BackendError::Internal(
+                    "[aws] config block missing — set backend = \"aws\" with [aws] block".into(),
+                )
+            })?;
+            // We need an async runtime. The registry is sync; use a runtime handle.
+            let backend = tokio::runtime::Handle::current()
+                .block_on(super::aws::AwsBackend::new(aws_cfg, None, None))?;
+            Ok(Self::new(Arc::new(backend)))
+        }
+        #[cfg(not(feature = "aws"))]
+        BackendKind::Aws => Err(BackendError::Internal(
+            "AWS backend not compiled in: rebuild with --features aws".into(),
+        )),
+    }
+}
+
+fn from_named_entry(
+    name: &str,
+    entry: &crate::config::settings::NamedBackendEntry,
+) -> Result<Self, BackendError> {
+    use crate::config::settings::NamedBackendEntry as NBE;
+    match entry {
+        #[cfg(feature = "aws")]
+        NBE::Aws(aws_cfg) => {
+            let backend = tokio::runtime::Handle::current()
+                .block_on(super::aws::AwsBackend::new(aws_cfg, None, None))?;
+            Ok(Self::new(Arc::new(backend)))
+        }
+        #[cfg(not(feature = "aws"))]
+        NBE::Aws(_) => Err(BackendError::Internal(format!(
+            "named backend '{name}' is aws but binary built without --features aws"
+        ))),
+        NBE::Local(local_cfg) => {
+            let backend = super::local::LocalBackend::new(Some(local_cfg))?;
+            Ok(Self::new(Arc::new(backend)))
+        }
+    }
+}
+```
+
+> **Note on `block_on`:** This will only work if `from_config` is called from within an async context (which `xv` does — `tokio::main` wraps everything). If called from a sync entrypoint, this panics. The existing test `from_config_local_creates_backend` is sync — review and adjust. If broken, gate the AWS test with `#[tokio::test]`.
+
+- [ ] **Step 2: Add a smoke test (gated)**
+
+In `src/backend/registry.rs` `mod tests`, add:
+
+```rust
+#[cfg(feature = "aws")]
+#[tokio::test]
+async fn from_config_aws_requires_aws_block() {
+    let config = Config {
+        backend: Some("aws".to_string()),
+        aws: None,
+        ..Default::default()
+    };
+    let result = BackendRegistry::from_config(&config);
+    assert!(result.is_err());
+    let err_str = result.unwrap_err().to_string();
+    assert!(err_str.contains("[aws]") || err_str.contains("aws"), "got: {err_str}");
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo build --features aws`
+Expected: clean.
+
+Run: `cargo test --features aws --lib backend::registry::tests::from_config_aws_requires_aws_block`
+Expected: PASS.
+
+Run: `cargo test` (default features)
+Expected: PASS — no regressions in existing Azure/Local paths.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/backend/registry.rs
+git commit -m "feat(aws): wire BackendKind::Aws + named-backend resolution into registry"
+```
+
+---
+
+## Phase 3: SecretBackend trait — core CRUD
+
+> **Test pattern note for Phase 3+:** Each Task in this phase pairs unit-style tests using `aws-smithy-mocks-experimental` (Task 13 sets up the harness) with hermetic mocked responses. After Task 13, subsequent tasks reuse the same harness module by importing from `tests/aws_backend_tests.rs`. LocalStack-backed integration tests are gated with `AWS_INTEGRATION_TESTS=1` and added in Task 31.
+
+## Task 13: Set up the mock test harness
+
+**Files:**
+- Create: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Create the harness with a smoke test**
+
+```rust
+//! Hermetic AWS backend tests using aws-smithy-mocks-experimental.
+//!
+//! Each test builds a mock SecretsManager client by stubbing per-operation
+//! responses, then exercises the `AwsSecretBackend` / `AwsVaultBackend`
+//! against it. No AWS credentials, no network — fully deterministic.
+
+#![cfg(feature = "aws")]
+
+use aws_sdk_secretsmanager::Client;
+use aws_smithy_mocks_experimental::{mock, mock_client, RuleMode};
+use crosstache::backend::aws::{secrets::AwsSecretBackend, vaults::AwsVaultBackend, AwsBackend};
+use std::sync::Arc;
+
+/// Build a mock client from a list of operation rules.
+pub fn mock_client_from_rules(rules: Vec<aws_smithy_mocks_experimental::Rule>) -> Client {
+    mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &rules)
+}
+
+/// Build an `AwsSecretBackend` directly around a mock client.
+pub fn aws_secret_backend(client: Client) -> AwsSecretBackend {
+    AwsSecretBackend::new(Arc::new(client))
+}
+
+/// Build an `AwsVaultBackend` directly around a mock client.
+pub fn aws_vault_backend(client: Client) -> AwsVaultBackend {
+    AwsVaultBackend::new(Arc::new(client))
+}
+
+#[tokio::test]
+async fn smoke_health_check_with_empty_list() {
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+
+    let rule = mock!(Client::list_secrets)
+        .then_output(|| ListSecretsOutput::builder().build());
+
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_secret_backend(client);
+    backend.health_check().await.expect("health check should pass");
+}
+```
+
+> **Note:** `crosstache` must be exposed as a library for `crosstache::backend::aws::...` to resolve. If `src/lib.rs` does not exist, create it as a thin re-export of `src/main.rs`'s public modules (or add `lib.rs` to `Cargo.toml`'s `[lib]`). Most existing tests (`tests/local_backend_integration.rs` etc.) already use this pattern; mirror what they do.
+
+- [ ] **Step 2: Verify**
+
+Run: `cargo test --features aws --test aws_backend_tests smoke_health_check_with_empty_list`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/aws_backend_tests.rs
+git commit -m "test(aws): add mock harness + smoke health check"
+```
+
+---
+
+## Task 14: Implement `set_secret` (create path) + tests
+
+**Files:**
+- Modify: `src/backend/aws/secrets.rs`
+- Modify: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Inspect the SecretBackend trait method signatures**
+
+Run: `grep -n "fn set_secret\|fn get_secret\|fn list_secrets\|SecretRequest\|SecretProperties" src/backend/secret.rs src/secret/models.rs | head -40`
+
+This is the canonical source for argument/return types. Take note of `SecretRequest`, `SecretProperties`, `SecretSummary` shapes.
+
+- [ ] **Step 2: Implement `set_secret`'s create branch**
+
+In `src/backend/aws/secrets.rs`, replace the `set_secret` stub with:
+
+```rust
+async fn set_secret(
+    &self,
+    vault: &str,
+    request: SecretRequest,
+) -> Result<SecretProperties, BackendError> {
+    use crate::backend::aws::encoding::{aws_name, validate_secret_name};
+    use crate::backend::aws::metadata::{
+        TAG_CONTENT_TYPE, TAG_CREATED_BY, TAG_EXPIRES_AT, TAG_FOLDER, TAG_GROUPS,
+        TAG_ORIGINAL_NAME,
+    };
+    use aws_sdk_secretsmanager::types::Tag;
+
+    validate_secret_name(&request.name)?;
+    let aws_full_name = aws_name(vault, &request.name);
+
+    // Build tag list
+    let mut tags: Vec<Tag> = Vec::new();
+    tags.push(
+        Tag::builder()
+            .key(TAG_ORIGINAL_NAME)
+            .value(&request.name)
+            .build(),
+    );
+    if !request.groups.is_empty() {
+        tags.push(
+            Tag::builder()
+                .key(TAG_GROUPS)
+                .value(request.groups.join(","))
+                .build(),
+        );
+    }
+    if let Some(ref f) = request.folder {
+        tags.push(Tag::builder().key(TAG_FOLDER).value(f).build());
+    }
+    if let Some(ref c) = request.created_by {
+        tags.push(Tag::builder().key(TAG_CREATED_BY).value(c).build());
+    }
+    if let Some(ref ct) = request.content_type {
+        tags.push(Tag::builder().key(TAG_CONTENT_TYPE).value(ct).build());
+    }
+    if let Some(ref e) = request.expires_on {
+        tags.push(
+            Tag::builder()
+                .key(TAG_EXPIRES_AT)
+                .value(e.to_rfc3339())
+                .build(),
+        );
+    }
+    for (k, v) in &request.tags {
+        if !k.starts_with("xv:") {
+            tags.push(Tag::builder().key(k).value(v).build());
+        }
+    }
+
+    // Try create first; fall through to update if AWS reports "already exists"
+    let create_result = self
+        .client
+        .create_secret()
+        .name(&aws_full_name)
+        .secret_string(request.value.expose_secret().to_string())
+        .description(request.note.clone().unwrap_or_default())
+        .set_tags(if tags.is_empty() { None } else { Some(tags.clone()) })
+        .send()
+        .await;
+
+    let version_id = match create_result {
+        Ok(out) => out.version_id().unwrap_or("").to_string(),
+        Err(e) => match super::errors::from_create(e) {
+            BackendError::Conflict(_) => {
+                // Already exists -> update instead. Implemented in Task 19.
+                return self.update_existing_secret(vault, &request, &aws_full_name).await;
+            }
+            other => return Err(other),
+        },
+    };
+
+    Ok(SecretProperties {
+        name: request.name.clone(),
+        value: None,
+        version: version_id,
+        ..Default::default()
+    })
+}
+```
+
+> The exact `SecretProperties` field set differs from the snippet above — adjust based on what `grep` revealed in Step 1. The pattern is: copy `name` and `version`, set `value: None`, defaults for the rest. The full re-fetch via `get_secret` after create is intentional in some backends; we choose to skip the round-trip here (the caller can re-fetch if needed).
+
+- [ ] **Step 3: Add a stub for `update_existing_secret`**
+
+Below the `set_secret` impl, add:
+
+```rust
+async fn update_existing_secret(
+    &self,
+    _vault: &str,
+    _request: &SecretRequest,
+    _aws_full_name: &str,
+) -> Result<SecretProperties, BackendError> {
+    // Implemented in Task 19.
+    Err(BackendError::Unsupported(
+        "aws update path: not yet implemented".into(),
+    ))
+}
+```
+
+- [ ] **Step 4: Add the test**
+
+In `tests/aws_backend_tests.rs`:
+
+```rust
+#[tokio::test]
+async fn set_secret_create_writes_to_aws() {
+    use aws_sdk_secretsmanager::operation::create_secret::CreateSecretOutput;
+    use crosstache::secret::manager::SecretRequest;
+    use crosstache::backend::SecretBackend;
+    use zeroize::Zeroizing;
+
+    let rule = mock!(Client::create_secret)
+        .match_requests(|req| req.name() == Some("myproj-kv/db-password"))
+        .then_output(|| {
+            CreateSecretOutput::builder()
+                .name("myproj-kv/db-password")
+                .arn("arn:aws:secretsmanager:us-east-1:123:secret:myproj-kv/db-password-abc")
+                .version_id("v1")
+                .build()
+        });
+
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_secret_backend(client);
+
+    let request = SecretRequest {
+        name: "db-password".into(),
+        value: Zeroizing::new("hunter2".into()),
+        groups: vec!["backend".into()],
+        ..Default::default()
+    };
+
+    let result = backend.set_secret("myproj-kv", request).await
+        .expect("set_secret should succeed");
+    assert_eq!(result.name, "db-password");
+    assert_eq!(result.version, "v1");
+}
+```
+
+- [ ] **Step 5: Verify**
+
+Run: `cargo test --features aws --test aws_backend_tests set_secret_create_writes_to_aws`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/backend/aws/secrets.rs tests/aws_backend_tests.rs
+git commit -m "feat(aws): set_secret create path + mock test"
+```
+
+---
+
+## Task 15: Implement `get_secret` (no value) + tests
+
+**Files:**
+- Modify: `src/backend/aws/secrets.rs`
+- Modify: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Implement**
+
+Replace the `get_secret` stub:
+
+```rust
+async fn get_secret(
+    &self,
+    vault: &str,
+    name: &str,
+    include_value: bool,
+) -> Result<SecretProperties, BackendError> {
+    use crate::backend::aws::encoding::aws_name;
+    let aws_full_name = aws_name(vault, name);
+
+    if !include_value {
+        let describe = self
+            .client
+            .describe_secret()
+            .secret_id(&aws_full_name)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_describe(name, e))?;
+
+        return Ok(self.props_from_describe(&describe, name));
+    }
+
+    // include_value: parallelize describe + get_secret_value
+    let describe_fut = self
+        .client
+        .describe_secret()
+        .secret_id(&aws_full_name)
+        .send();
+    let value_fut = self
+        .client
+        .get_secret_value()
+        .secret_id(&aws_full_name)
+        .send();
+
+    let (describe, value) = tokio::join!(describe_fut, value_fut);
+    let describe = describe.map_err(|e| super::errors::from_describe(name, e))?;
+    let value = value.map_err(|e| super::errors::from_get_value(name, e))?;
+
+    let mut props = self.props_from_describe(&describe, name);
+    props.value = value
+        .secret_string()
+        .map(|s| Zeroizing::new(s.to_string()));
+    Ok(props)
+}
+```
+
+- [ ] **Step 2: Add `props_from_describe` helper**
+
+```rust
+fn props_from_describe(
+    &self,
+    describe: &aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput,
+    fallback_name: &str,
+) -> SecretProperties {
+    use crate::backend::aws::metadata::*;
+
+    let mut props = SecretProperties {
+        name: fallback_name.to_string(),
+        value: None,
+        ..Default::default()
+    };
+
+    if let Some(tags) = describe.tags() {
+        for tag in tags {
+            let k = tag.key().unwrap_or("");
+            let v = tag.value().unwrap_or("");
+            match k {
+                TAG_ORIGINAL_NAME => props.name = v.to_string(),
+                TAG_GROUPS => {
+                    props.groups = v
+                        .split(',')
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string())
+                        .collect()
+                }
+                TAG_FOLDER => props.folder = Some(v.to_string()),
+                TAG_CREATED_BY => props.created_by = Some(v.to_string()),
+                TAG_CONTENT_TYPE => props.content_type = Some(v.to_string()),
+                TAG_EXPIRES_AT => {
+                    props.expires_on = chrono::DateTime::parse_from_rfc3339(v)
+                        .ok()
+                        .map(|dt| dt.with_timezone(&chrono::Utc));
+                }
+                _ if !k.starts_with("xv:") => {
+                    props.tags.insert(k.to_string(), v.to_string());
+                }
+                _ => {}
+            }
+        }
+    }
+    if let Some(desc) = describe.description() {
+        if !desc.is_empty() {
+            props.note = Some(desc.to_string());
+        }
+    }
+    props
+}
+```
+
+> Adjust field names against the actual `SecretProperties` definition (Task 14 Step 1 told you the shape).
+
+- [ ] **Step 3: Add tests**
+
+```rust
+#[tokio::test]
+async fn get_secret_no_value_returns_metadata_only() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use aws_sdk_secretsmanager::types::Tag;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::describe_secret)
+        .then_output(|| {
+            DescribeSecretOutput::builder()
+                .name("myproj-kv/db-password")
+                .arn("arn:aws:secretsmanager:us-east-1:123:secret:myproj-kv/db-password-abc")
+                .description("primary db admin password")
+                .tags(Tag::builder().key("xv:original_name").value("db-password").build())
+                .tags(Tag::builder().key("xv:groups").value("backend,prod").build())
+                .build()
+        });
+
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_secret_backend(client);
+
+    let props = backend.get_secret("myproj-kv", "db-password", false).await.unwrap();
+    assert_eq!(props.name, "db-password");
+    assert_eq!(props.note.as_deref(), Some("primary db admin password"));
+    assert_eq!(props.groups, vec!["backend", "prod"]);
+    assert!(props.value.is_none());
+}
+
+#[tokio::test]
+async fn get_secret_with_value_includes_value() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use aws_sdk_secretsmanager::operation::get_secret_value::GetSecretValueOutput;
+    use crosstache::backend::SecretBackend;
+
+    let describe = mock!(Client::describe_secret).then_output(|| {
+        DescribeSecretOutput::builder()
+            .name("myproj-kv/db-password")
+            .build()
+    });
+    let value = mock!(Client::get_secret_value).then_output(|| {
+        GetSecretValueOutput::builder()
+            .name("myproj-kv/db-password")
+            .secret_string("hunter2")
+            .version_id("v1")
+            .build()
+    });
+
+    let client = mock_client_from_rules(vec![describe, value]);
+    let backend = aws_secret_backend(client);
+
+    let props = backend.get_secret("myproj-kv", "db-password", true).await.unwrap();
+    assert!(props.value.is_some());
+    assert_eq!(props.value.as_ref().map(|v| v.as_str()), Some("hunter2"));
+}
+
+#[tokio::test]
+async fn get_secret_not_found_maps_to_backend_not_found() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretError;
+    use aws_sdk_secretsmanager::types::error::ResourceNotFoundException;
+    use crosstache::backend::SecretBackend;
+    use crosstache::backend::error::BackendError;
+
+    let rule = mock!(Client::describe_secret).then_error(|| {
+        DescribeSecretError::ResourceNotFoundException(
+            ResourceNotFoundException::builder()
+                .message("Secrets Manager can't find the specified secret.")
+                .build()
+        )
+    });
+
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_secret_backend(client);
+
+    let err = backend.get_secret("myproj-kv", "missing", false).await.unwrap_err();
+    assert!(matches!(err, BackendError::NotFound { .. }), "got: {err:?}");
+}
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo test --features aws --test aws_backend_tests get_secret_`
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/aws/secrets.rs tests/aws_backend_tests.rs
+git commit -m "feat(aws): get_secret with/without value + not-found mapping"
+```
+
+---
+
+## Task 16: Implement `list_secrets` (paginated, prefix filter, marker exclusion) + tests
+
+**Files:**
+- Modify: `src/backend/aws/secrets.rs`
+- Modify: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Implement**
+
+```rust
+async fn list_secrets(
+    &self,
+    vault: &str,
+    group_filter: Option<&str>,
+) -> Result<Vec<SecretSummary>, BackendError> {
+    use crate::backend::aws::encoding::{is_marker, strip_prefix};
+    use crate::backend::aws::metadata::TAG_GROUPS;
+    use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
+
+    let prefix = format!("{vault}/");
+    let mut next_token: Option<String> = None;
+    let mut summaries: Vec<SecretSummary> = Vec::new();
+
+    loop {
+        let mut req = self
+            .client
+            .list_secrets()
+            .max_results(100)
+            .filters(
+                Filter::builder()
+                    .key(FilterNameStringType::Name)
+                    .values(prefix.clone())
+                    .build(),
+            );
+        if let Some(t) = &next_token {
+            req = req.next_token(t.clone());
+        }
+
+        let out = req.send().await.map_err(super::errors::from_list)?;
+
+        for entry in out.secret_list.unwrap_or_default() {
+            let aws_full_name = entry.name().unwrap_or("");
+            // Defensive: AWS prefix filter is broad-match; verify exact prefix
+            let secret_name = match strip_prefix(vault, aws_full_name) {
+                Some(n) => n,
+                None => continue,
+            };
+            // Skip vault marker
+            if is_marker(aws_full_name) {
+                continue;
+            }
+            // Group filter (client-side from tags)
+            if let Some(group_want) = group_filter {
+                let groups: Vec<String> = entry
+                    .tags()
+                    .unwrap_or_default()
+                    .iter()
+                    .find(|t| t.key() == Some(TAG_GROUPS))
+                    .and_then(|t| t.value())
+                    .map(|v| v.split(',').map(|s| s.to_string()).collect())
+                    .unwrap_or_default();
+                if !groups.iter().any(|g| g == group_want) {
+                    continue;
+                }
+            }
+
+            summaries.push(SecretSummary {
+                name: secret_name,
+                ..Default::default()
+            });
+        }
+
+        next_token = out.next_token().map(|s| s.to_string());
+        if next_token.is_none() {
+            break;
+        }
+    }
+
+    Ok(summaries)
+}
+```
+
+> Field set on `SecretSummary` may differ; adjust against the actual definition.
+
+- [ ] **Step 2: Add tests**
+
+```rust
+#[tokio::test]
+async fn list_secrets_paginates_and_filters_marker() {
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+    use aws_sdk_secretsmanager::types::SecretListEntry;
+    use crosstache::backend::SecretBackend;
+
+    let page1 = mock!(Client::list_secrets).then_output(|| {
+        ListSecretsOutput::builder()
+            .secret_list(SecretListEntry::builder().name("myproj-kv/.xv-vault").build())
+            .secret_list(SecretListEntry::builder().name("myproj-kv/db-password").build())
+            .next_token("tok1")
+            .build()
+    });
+    let page2 = mock!(Client::list_secrets)
+        .match_requests(|req| req.next_token() == Some("tok1"))
+        .then_output(|| {
+            ListSecretsOutput::builder()
+                .secret_list(SecretListEntry::builder().name("myproj-kv/api-key").build())
+                .build()
+        });
+
+    let client = mock_client_from_rules(vec![page1, page2]);
+    let backend = aws_secret_backend(client);
+
+    let secrets = backend.list_secrets("myproj-kv", None).await.unwrap();
+    let names: Vec<String> = secrets.iter().map(|s| s.name.clone()).collect();
+    assert_eq!(names.len(), 2);
+    assert!(names.contains(&"db-password".to_string()));
+    assert!(names.contains(&"api-key".to_string()));
+    assert!(!names.contains(&".xv-vault".to_string()), "marker should be excluded");
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo test --features aws --test aws_backend_tests list_secrets_paginates_and_filters_marker`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/backend/aws/secrets.rs tests/aws_backend_tests.rs
+git commit -m "feat(aws): list_secrets pagination + prefix filter + marker exclusion"
+```
+
+---
+
+## Task 17: Implement `delete_secret` (soft-delete) + tests
+
+**Files:**
+- Modify: `src/backend/aws/secrets.rs`
+- Modify: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Implement**
+
+```rust
+async fn delete_secret(&self, vault: &str, name: &str) -> Result<(), BackendError> {
+    use crate::backend::aws::encoding::aws_name;
+    let aws_full_name = aws_name(vault, name);
+    self.client
+        .delete_secret()
+        .secret_id(&aws_full_name)
+        .recovery_window_in_days(30)
+        .send()
+        .await
+        .map_err(|e| super::errors::from_delete(name, e))?;
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Implement `purge_secret`**
+
+```rust
+async fn purge_secret(&self, vault: &str, name: &str) -> Result<(), BackendError> {
+    use crate::backend::aws::encoding::aws_name;
+    let aws_full_name = aws_name(vault, name);
+    self.client
+        .delete_secret()
+        .secret_id(&aws_full_name)
+        .force_delete_without_recovery(true)
+        .send()
+        .await
+        .map_err(|e| super::errors::from_delete(name, e))?;
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Add tests**
+
+```rust
+#[tokio::test]
+async fn delete_secret_uses_recovery_window() {
+    use aws_sdk_secretsmanager::operation::delete_secret::DeleteSecretOutput;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::delete_secret)
+        .match_requests(|req| {
+            req.secret_id() == Some("myproj-kv/db-password")
+                && req.recovery_window_in_days() == Some(30)
+                && req.force_delete_without_recovery() != Some(true)
+        })
+        .then_output(|| DeleteSecretOutput::builder().build());
+
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_secret_backend(client);
+    backend.delete_secret("myproj-kv", "db-password").await.unwrap();
+}
+
+#[tokio::test]
+async fn purge_secret_forces_immediate_delete() {
+    use aws_sdk_secretsmanager::operation::delete_secret::DeleteSecretOutput;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::delete_secret)
+        .match_requests(|req| req.force_delete_without_recovery() == Some(true))
+        .then_output(|| DeleteSecretOutput::builder().build());
+
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_secret_backend(client);
+    backend.purge_secret("myproj-kv", "db-password").await.unwrap();
+}
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo test --features aws --test aws_backend_tests delete_secret_uses_recovery_window purge_secret_forces_immediate_delete`
+Expected: 2 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/aws/secrets.rs tests/aws_backend_tests.rs
+git commit -m "feat(aws): delete_secret with 30-day recovery, purge with force flag"
+```
+
+---
+
+## Task 18: Implement `secret_exists` + tests
+
+**Files:**
+- Modify: `src/backend/aws/secrets.rs`
+- Modify: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Implement**
+
+The default implementation in the trait calls `get_secret` and translates `NotFound` to `Ok(false)`. Override it on AWS to use `DescribeSecret` directly (cheaper):
+
+```rust
+async fn secret_exists(&self, vault: &str, name: &str) -> Result<bool, BackendError> {
+    use crate::backend::aws::encoding::aws_name;
+    let aws_full_name = aws_name(vault, name);
+    match self
+        .client
+        .describe_secret()
+        .secret_id(&aws_full_name)
+        .send()
+        .await
+    {
+        Ok(_) => Ok(true),
+        Err(e) => match super::errors::from_describe(name, e) {
+            BackendError::NotFound { .. } => Ok(false),
+            other => Err(other),
+        },
+    }
+}
+```
+
+- [ ] **Step 2: Add tests**
+
+```rust
+#[tokio::test]
+async fn secret_exists_true_when_describe_succeeds() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::describe_secret)
+        .then_output(|| DescribeSecretOutput::builder().name("myproj-kv/db").build());
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_secret_backend(client);
+
+    assert!(backend.secret_exists("myproj-kv", "db").await.unwrap());
+}
+
+#[tokio::test]
+async fn secret_exists_false_on_not_found() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretError;
+    use aws_sdk_secretsmanager::types::error::ResourceNotFoundException;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::describe_secret).then_error(|| {
+        DescribeSecretError::ResourceNotFoundException(
+            ResourceNotFoundException::builder().message("not found").build(),
+        )
+    });
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_secret_backend(client);
+
+    assert!(!backend.secret_exists("myproj-kv", "missing").await.unwrap());
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo test --features aws --test aws_backend_tests secret_exists`
+Expected: 2 PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/backend/aws/secrets.rs tests/aws_backend_tests.rs
+git commit -m "feat(aws): secret_exists override using DescribeSecret"
+```
+
+---
+
+## Phase 4: SecretBackend trait — update, versions, recovery
+
+## Task 19: Implement `set_secret` (update path) + `update_secret` (metadata) + tests
+
+**Files:**
+- Modify: `src/backend/aws/secrets.rs`
+- Modify: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Implement `update_existing_secret`**
+
+Replace the stub created in Task 14:
+
+```rust
+async fn update_existing_secret(
+    &self,
+    vault: &str,
+    request: &SecretRequest,
+    aws_full_name: &str,
+) -> Result<SecretProperties, BackendError> {
+    use crate::backend::aws::metadata::*;
+    use aws_sdk_secretsmanager::types::Tag;
+
+    // Step 1: Put the new value as a new version
+    let put_out = self
+        .client
+        .put_secret_value()
+        .secret_id(aws_full_name)
+        .secret_string(request.value.expose_secret().to_string())
+        .send()
+        .await
+        .map_err(|e| super::errors::from_put_value(&request.name, e))?;
+
+    // Step 2: Update description if provided
+    if let Some(ref note) = request.note {
+        self.client
+            .update_secret()
+            .secret_id(aws_full_name)
+            .description(note)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_update(&request.name, e))?;
+    }
+
+    // Step 3: Update tags (replace strategy: untag everything, then re-tag)
+    let describe = self
+        .client
+        .describe_secret()
+        .secret_id(aws_full_name)
+        .send()
+        .await
+        .map_err(|e| super::errors::from_describe(&request.name, e))?;
+
+    let existing_keys: Vec<String> = describe
+        .tags()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|t| t.key().map(|k| k.to_string()))
+        .collect();
+    if !existing_keys.is_empty() {
+        self.client
+            .untag_resource()
+            .secret_id(aws_full_name)
+            .set_tag_keys(Some(existing_keys))
+            .send()
+            .await
+            .map_err(super::errors::from_untag)?;
+    }
+
+    let mut new_tags: Vec<Tag> = Vec::new();
+    new_tags.push(
+        Tag::builder()
+            .key(TAG_ORIGINAL_NAME)
+            .value(&request.name)
+            .build(),
+    );
+    if !request.groups.is_empty() {
+        new_tags.push(
+            Tag::builder()
+                .key(TAG_GROUPS)
+                .value(request.groups.join(","))
+                .build(),
+        );
+    }
+    if let Some(ref f) = request.folder {
+        new_tags.push(Tag::builder().key(TAG_FOLDER).value(f).build());
+    }
+    if let Some(ref c) = request.created_by {
+        new_tags.push(Tag::builder().key(TAG_CREATED_BY).value(c).build());
+    }
+    if let Some(ref ct) = request.content_type {
+        new_tags.push(Tag::builder().key(TAG_CONTENT_TYPE).value(ct).build());
+    }
+    if let Some(ref e) = request.expires_on {
+        new_tags.push(
+            Tag::builder()
+                .key(TAG_EXPIRES_AT)
+                .value(e.to_rfc3339())
+                .build(),
+        );
+    }
+    for (k, v) in &request.tags {
+        if !k.starts_with("xv:") {
+            new_tags.push(Tag::builder().key(k).value(v).build());
+        }
+    }
+    self.client
+        .tag_resource()
+        .secret_id(aws_full_name)
+        .set_tags(Some(new_tags))
+        .send()
+        .await
+        .map_err(super::errors::from_tag)?;
+
+    Ok(SecretProperties {
+        name: request.name.clone(),
+        value: None,
+        version: put_out.version_id().unwrap_or("").to_string(),
+        ..Default::default()
+    })
+}
+```
+
+- [ ] **Step 2: Implement `update_secret` (metadata-only)**
+
+```rust
+async fn update_secret(
+    &self,
+    vault: &str,
+    name: &str,
+    request: SecretUpdateRequest,
+) -> Result<SecretProperties, BackendError> {
+    use crate::backend::aws::encoding::aws_name;
+    use crate::backend::aws::metadata::*;
+    use aws_sdk_secretsmanager::types::Tag;
+
+    let aws_full_name = aws_name(vault, name);
+
+    // Description (note)
+    if let Some(ref new_note) = request.note {
+        self.client
+            .update_secret()
+            .secret_id(&aws_full_name)
+            .description(new_note)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_update(name, e))?;
+    }
+
+    // Build only the deltas for tags
+    let mut tags_to_set: Vec<Tag> = Vec::new();
+    let mut keys_to_remove: Vec<String> = Vec::new();
+
+    if let Some(ref groups) = request.groups {
+        if groups.is_empty() {
+            keys_to_remove.push(TAG_GROUPS.into());
+        } else {
+            tags_to_set.push(Tag::builder().key(TAG_GROUPS).value(groups.join(",")).build());
+        }
+    }
+    if let Some(ref f) = request.folder {
+        if f.is_empty() {
+            keys_to_remove.push(TAG_FOLDER.into());
+        } else {
+            tags_to_set.push(Tag::builder().key(TAG_FOLDER).value(f).build());
+        }
+    }
+    // Generic user tags: caller signals "remove" via Some("") or absent.
+    for (k, v) in &request.tags {
+        if v.is_empty() {
+            keys_to_remove.push(k.clone());
+        } else if !k.starts_with("xv:") {
+            tags_to_set.push(Tag::builder().key(k).value(v).build());
+        }
+    }
+
+    if !keys_to_remove.is_empty() {
+        self.client
+            .untag_resource()
+            .secret_id(&aws_full_name)
+            .set_tag_keys(Some(keys_to_remove))
+            .send()
+            .await
+            .map_err(super::errors::from_untag)?;
+    }
+    if !tags_to_set.is_empty() {
+        self.client
+            .tag_resource()
+            .secret_id(&aws_full_name)
+            .set_tags(Some(tags_to_set))
+            .send()
+            .await
+            .map_err(super::errors::from_tag)?;
+    }
+
+    self.get_secret(vault, name, false).await
+}
+```
+
+> Adjust `SecretUpdateRequest` field names against the actual definition (find with `grep -n "SecretUpdateRequest" src/secret/`).
+
+- [ ] **Step 3: Add a test**
+
+```rust
+#[tokio::test]
+async fn set_secret_update_path_when_already_exists() {
+    use aws_sdk_secretsmanager::operation::create_secret::CreateSecretError;
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use aws_sdk_secretsmanager::operation::put_secret_value::PutSecretValueOutput;
+    use aws_sdk_secretsmanager::operation::tag_resource::TagResourceOutput;
+    use aws_sdk_secretsmanager::operation::update_secret::UpdateSecretOutput;
+    use aws_sdk_secretsmanager::operation::untag_resource::UntagResourceOutput;
+    use aws_sdk_secretsmanager::types::error::ResourceExistsException;
+    use crosstache::secret::manager::SecretRequest;
+    use crosstache::backend::SecretBackend;
+    use zeroize::Zeroizing;
+
+    let create_err = mock!(Client::create_secret).then_error(|| {
+        CreateSecretError::ResourceExistsException(
+            ResourceExistsException::builder().message("already exists").build(),
+        )
+    });
+    let put_value = mock!(Client::put_secret_value)
+        .then_output(|| PutSecretValueOutput::builder().version_id("v2").build());
+    let update_secret =
+        mock!(Client::update_secret).then_output(|| UpdateSecretOutput::builder().build());
+    let describe = mock!(Client::describe_secret)
+        .then_output(|| DescribeSecretOutput::builder().build());
+    let untag = mock!(Client::untag_resource).then_output(|| UntagResourceOutput::builder().build());
+    let tag = mock!(Client::tag_resource).then_output(|| TagResourceOutput::builder().build());
+
+    let client = mock_client_from_rules(vec![create_err, put_value, update_secret, describe, untag, tag]);
+    let backend = aws_secret_backend(client);
+
+    let request = SecretRequest {
+        name: "db-password".into(),
+        value: Zeroizing::new("hunter3".into()),
+        note: Some("rotated".into()),
+        ..Default::default()
+    };
+
+    let result = backend.set_secret("myproj-kv", request).await.unwrap();
+    assert_eq!(result.version, "v2");
+}
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo test --features aws --test aws_backend_tests set_secret_update_path_when_already_exists`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/aws/secrets.rs tests/aws_backend_tests.rs
+git commit -m "feat(aws): set_secret update path + update_secret (metadata only)"
+```
+
+---
+
+## Task 20: Implement `list_versions` and `get_secret_version` + tests
+
+**Files:**
+- Modify: `src/backend/aws/secrets.rs`
+- Modify: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Implement `list_versions`**
+
+```rust
+async fn list_versions(
+    &self,
+    vault: &str,
+    name: &str,
+) -> Result<Vec<SecretProperties>, BackendError> {
+    use crate::backend::aws::encoding::aws_name;
+    let aws_full_name = aws_name(vault, name);
+    let out = self
+        .client
+        .list_secret_version_ids()
+        .secret_id(&aws_full_name)
+        .include_deprecated(true)
+        .send()
+        .await
+        .map_err(|e| super::errors::from_list_versions(name, e))?;
+
+    let mut versions: Vec<SecretProperties> = Vec::new();
+    for v in out.versions().unwrap_or_default() {
+        let mut props = SecretProperties {
+            name: name.to_string(),
+            value: None,
+            version: v.version_id().unwrap_or("").to_string(),
+            ..Default::default()
+        };
+        if let Some(stages) = v.version_stages() {
+            // Track AWSCURRENT / AWSPREVIOUS for caller display
+            props.tags.insert(
+                "aws:stages".into(),
+                stages.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(","),
+            );
+        }
+        if let Some(created) = v.created_date() {
+            props.created_on = chrono::DateTime::from_timestamp(created.secs(), created.subsec_nanos())
+                .map(|dt| dt.with_timezone(&chrono::Utc));
+        }
+        versions.push(props);
+    }
+    Ok(versions)
+}
+```
+
+- [ ] **Step 2: Implement `get_secret_version`**
+
+```rust
+async fn get_secret_version(
+    &self,
+    vault: &str,
+    name: &str,
+    version: &str,
+    include_value: bool,
+) -> Result<SecretProperties, BackendError> {
+    use crate::backend::aws::encoding::aws_name;
+    let aws_full_name = aws_name(vault, name);
+
+    if !include_value {
+        // Versions don't carry tags directly; describe the secret head
+        // and return version-specific fields from list_versions.
+        let mut versions = self.list_versions(vault, name).await?;
+        return versions
+            .drain(..)
+            .find(|p| p.version == version)
+            .ok_or_else(|| BackendError::NotFound {
+                name: format!("{name} (version {version})"),
+                suggestion: None,
+            });
+    }
+
+    let out = self
+        .client
+        .get_secret_value()
+        .secret_id(&aws_full_name)
+        .version_id(version)
+        .send()
+        .await
+        .map_err(|e| super::errors::from_get_value(name, e))?;
+
+    Ok(SecretProperties {
+        name: name.to_string(),
+        value: out.secret_string().map(|s| Zeroizing::new(s.to_string())),
+        version: out.version_id().unwrap_or(version).to_string(),
+        ..Default::default()
+    })
+}
+```
+
+- [ ] **Step 3: Add tests**
+
+```rust
+#[tokio::test]
+async fn list_versions_returns_history() {
+    use aws_sdk_secretsmanager::operation::list_secret_version_ids::ListSecretVersionIdsOutput;
+    use aws_sdk_secretsmanager::types::SecretVersionsListEntry;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::list_secret_version_ids).then_output(|| {
+        ListSecretVersionIdsOutput::builder()
+            .versions(SecretVersionsListEntry::builder().version_id("v1").build())
+            .versions(SecretVersionsListEntry::builder().version_id("v2").build())
+            .build()
+    });
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_secret_backend(client);
+
+    let versions = backend.list_versions("myproj-kv", "db-password").await.unwrap();
+    let ids: Vec<String> = versions.iter().map(|v| v.version.clone()).collect();
+    assert!(ids.contains(&"v1".to_string()));
+    assert!(ids.contains(&"v2".to_string()));
+}
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo test --features aws --test aws_backend_tests list_versions_returns_history`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/aws/secrets.rs tests/aws_backend_tests.rs
+git commit -m "feat(aws): list_versions + get_secret_version with explicit version"
+```
+
+---
+
+## Task 21: Implement `rollback` (UpdateSecretVersionStage) + tests
+
+**Files:**
+- Modify: `src/backend/aws/secrets.rs`
+- Modify: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Implement**
+
+```rust
+async fn rollback(
+    &self,
+    vault: &str,
+    name: &str,
+    version: &str,
+) -> Result<SecretProperties, BackendError> {
+    use crate::backend::aws::encoding::aws_name;
+    let aws_full_name = aws_name(vault, name);
+
+    // Find the version currently labeled AWSCURRENT
+    let listed = self
+        .client
+        .list_secret_version_ids()
+        .secret_id(&aws_full_name)
+        .include_deprecated(true)
+        .send()
+        .await
+        .map_err(|e| super::errors::from_list_versions(name, e))?;
+
+    let current_version = listed
+        .versions()
+        .unwrap_or_default()
+        .iter()
+        .find(|v| {
+            v.version_stages()
+                .unwrap_or_default()
+                .iter()
+                .any(|s| s.as_str() == "AWSCURRENT")
+        })
+        .and_then(|v| v.version_id())
+        .map(|s| s.to_string());
+
+    // Move AWSCURRENT to target version
+    self.client
+        .update_secret_version_stage()
+        .secret_id(&aws_full_name)
+        .version_stage("AWSCURRENT")
+        .move_to_version_id(version)
+        .set_remove_from_version_id(current_version)
+        .send()
+        .await
+        .map_err(|e| super::errors::from_update_stage(name, e))?;
+
+    Ok(SecretProperties {
+        name: name.to_string(),
+        value: None,
+        version: version.to_string(),
+        ..Default::default()
+    })
+}
+```
+
+- [ ] **Step 2: Add a test**
+
+```rust
+#[tokio::test]
+async fn rollback_moves_awscurrent_to_target_version() {
+    use aws_sdk_secretsmanager::operation::list_secret_version_ids::ListSecretVersionIdsOutput;
+    use aws_sdk_secretsmanager::operation::update_secret_version_stage::UpdateSecretVersionStageOutput;
+    use aws_sdk_secretsmanager::types::SecretVersionsListEntry;
+    use crosstache::backend::SecretBackend;
+
+    let list = mock!(Client::list_secret_version_ids).then_output(|| {
+        ListSecretVersionIdsOutput::builder()
+            .versions(
+                SecretVersionsListEntry::builder()
+                    .version_id("v3")
+                    .version_stages("AWSCURRENT".to_string())
+                    .build(),
+            )
+            .versions(SecretVersionsListEntry::builder().version_id("v2").build())
+            .build()
+    });
+    let update_stage = mock!(Client::update_secret_version_stage)
+        .match_requests(|req| {
+            req.move_to_version_id() == Some("v2")
+                && req.remove_from_version_id() == Some("v3")
+                && req.version_stage() == Some("AWSCURRENT")
+        })
+        .then_output(|| UpdateSecretVersionStageOutput::builder().build());
+
+    let client = mock_client_from_rules(vec![list, update_stage]);
+    let backend = aws_secret_backend(client);
+
+    backend.rollback("myproj-kv", "db-password", "v2").await.unwrap();
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo test --features aws --test aws_backend_tests rollback_moves_awscurrent_to_target_version`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/backend/aws/secrets.rs tests/aws_backend_tests.rs
+git commit -m "feat(aws): rollback via UpdateSecretVersionStage"
+```
+
+---
+
+## Task 22: Implement `restore_secret` and `list_deleted_secrets` + tests
+
+**Files:**
+- Modify: `src/backend/aws/secrets.rs`
+- Modify: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Implement `restore_secret`**
+
+```rust
+async fn restore_secret(
+    &self,
+    vault: &str,
+    name: &str,
+) -> Result<SecretProperties, BackendError> {
+    use crate::backend::aws::encoding::aws_name;
+    let aws_full_name = aws_name(vault, name);
+    self.client
+        .restore_secret()
+        .secret_id(&aws_full_name)
+        .send()
+        .await
+        .map_err(|e| super::errors::from_restore(name, e))?;
+    Ok(SecretProperties {
+        name: name.to_string(),
+        ..Default::default()
+    })
+}
+```
+
+- [ ] **Step 2: Implement `list_deleted_secrets`**
+
+```rust
+async fn list_deleted_secrets(
+    &self,
+    vault: &str,
+) -> Result<Vec<SecretSummary>, BackendError> {
+    use crate::backend::aws::encoding::{is_marker, strip_prefix};
+    use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
+
+    let prefix = format!("{vault}/");
+    let out = self
+        .client
+        .list_secrets()
+        .max_results(100)
+        .include_planned_deletion(true)
+        .filters(
+            Filter::builder()
+                .key(FilterNameStringType::Name)
+                .values(prefix.clone())
+                .build(),
+        )
+        .send()
+        .await
+        .map_err(super::errors::from_list)?;
+
+    let mut summaries: Vec<SecretSummary> = Vec::new();
+    for entry in out.secret_list.unwrap_or_default() {
+        let aws_full_name = entry.name().unwrap_or("");
+        if entry.deleted_date().is_none() {
+            continue;
+        }
+        let secret_name = match strip_prefix(vault, aws_full_name) {
+            Some(n) => n,
+            None => continue,
+        };
+        if is_marker(aws_full_name) {
+            continue;
+        }
+        summaries.push(SecretSummary {
+            name: secret_name,
+            ..Default::default()
+        });
+    }
+    Ok(summaries)
+}
+```
+
+- [ ] **Step 3: Add tests**
+
+```rust
+#[tokio::test]
+async fn restore_secret_calls_aws_restore() {
+    use aws_sdk_secretsmanager::operation::restore_secret::RestoreSecretOutput;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::restore_secret)
+        .match_requests(|req| req.secret_id() == Some("myproj-kv/db-password"))
+        .then_output(|| RestoreSecretOutput::builder().build());
+
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_secret_backend(client);
+
+    let result = backend.restore_secret("myproj-kv", "db-password").await.unwrap();
+    assert_eq!(result.name, "db-password");
+}
+
+#[tokio::test]
+async fn list_deleted_secrets_filters_to_deleted_only() {
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+    use aws_sdk_secretsmanager::primitives::DateTime;
+    use aws_sdk_secretsmanager::types::SecretListEntry;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::list_secrets).then_output(|| {
+        ListSecretsOutput::builder()
+            .secret_list(SecretListEntry::builder().name("myproj-kv/active").build())
+            .secret_list(
+                SecretListEntry::builder()
+                    .name("myproj-kv/deleted-one")
+                    .deleted_date(DateTime::from_secs(1_700_000_000))
+                    .build(),
+            )
+            .build()
+    });
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_secret_backend(client);
+
+    let deleted = backend.list_deleted_secrets("myproj-kv").await.unwrap();
+    let names: Vec<String> = deleted.iter().map(|s| s.name.clone()).collect();
+    assert_eq!(names, vec!["deleted-one".to_string()]);
+}
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo test --features aws --test aws_backend_tests restore_secret_calls_aws_restore list_deleted_secrets_filters_to_deleted_only`
+Expected: 2 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/aws/secrets.rs tests/aws_backend_tests.rs
+git commit -m "feat(aws): restore_secret + list_deleted_secrets"
+```
+
+---
+
+## Phase 5: VaultBackend trait — marker-secret-based vaults
+
+## Task 23: Implement `create_vault` (marker secret) + tests
+
+**Files:**
+- Modify: `src/backend/aws/vaults.rs`
+- Modify: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Implement**
+
+Replace the `create_vault` stub:
+
+```rust
+async fn create_vault(
+    &self,
+    request: VaultCreateRequest,
+) -> Result<VaultProperties, BackendError> {
+    use crate::backend::aws::encoding::marker_name;
+    use crate::backend::aws::metadata::{TAG_TYPE, TAG_VALUE_VAULT_MARKER};
+    use aws_sdk_secretsmanager::types::Tag;
+    use chrono::Utc;
+
+    let marker = marker_name(&request.name);
+    let mut tags: Vec<Tag> = Vec::new();
+    tags.push(
+        Tag::builder()
+            .key(TAG_TYPE)
+            .value(TAG_VALUE_VAULT_MARKER)
+            .build(),
+    );
+    tags.push(
+        Tag::builder()
+            .key("xv:vault_name")
+            .value(&request.name)
+            .build(),
+    );
+    tags.push(
+        Tag::builder()
+            .key("xv:created_at")
+            .value(Utc::now().to_rfc3339())
+            .build(),
+    );
+    if let Some(ref user_tags) = request.tags {
+        for (k, v) in user_tags {
+            if !k.starts_with("xv:") {
+                tags.push(Tag::builder().key(k).value(v).build());
+            }
+        }
+    }
+
+    self.client
+        .create_secret()
+        .name(&marker)
+        .secret_string("{}")
+        .description(format!("xv vault marker for '{}'", request.name))
+        .set_tags(Some(tags))
+        .send()
+        .await
+        .map_err(super::errors::from_create)?;
+
+    Ok(VaultProperties {
+        name: request.name,
+        ..Default::default()
+    })
+}
+```
+
+> Adjust `VaultProperties` field set against the canonical definition.
+
+- [ ] **Step 2: Add a test**
+
+```rust
+#[tokio::test]
+async fn create_vault_writes_marker_secret() {
+    use aws_sdk_secretsmanager::operation::create_secret::CreateSecretOutput;
+    use crosstache::backend::VaultBackend;
+    use crosstache::vault::models::VaultCreateRequest;
+
+    let rule = mock!(Client::create_secret)
+        .match_requests(|req| req.name() == Some("myproj-kv/.xv-vault"))
+        .then_output(|| {
+            CreateSecretOutput::builder()
+                .name("myproj-kv/.xv-vault")
+                .build()
+        });
+
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_vault_backend(client);
+    let request = VaultCreateRequest {
+        name: "myproj-kv".into(),
+        ..Default::default()
+    };
+
+    let result = backend.create_vault(request).await.unwrap();
+    assert_eq!(result.name, "myproj-kv");
+}
+```
+
+- [ ] **Step 3: Verify and commit**
+
+```
+cargo test --features aws --test aws_backend_tests create_vault_writes_marker_secret
+```
+
+```bash
+git add src/backend/aws/vaults.rs tests/aws_backend_tests.rs
+git commit -m "feat(aws): create_vault writes marker secret with xv:type tag"
+```
+
+---
+
+## Task 24: Implement `get_vault` and `list_vaults` + tests
+
+**Files:**
+- Modify: `src/backend/aws/vaults.rs`
+- Modify: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Implement `get_vault`**
+
+```rust
+async fn get_vault(&self, name: &str) -> Result<VaultProperties, BackendError> {
+    use crate::backend::aws::encoding::marker_name;
+    let marker = marker_name(name);
+    let describe = self
+        .client
+        .describe_secret()
+        .secret_id(&marker)
+        .send()
+        .await
+        .map_err(|e| match super::errors::from_describe(name, e) {
+            BackendError::NotFound { .. } => BackendError::VaultNotFound {
+                name: name.to_string(),
+                suggestion: None,
+            },
+            other => other,
+        })?;
+
+    let mut props = VaultProperties {
+        name: name.to_string(),
+        ..Default::default()
+    };
+    if let Some(desc) = describe.description() {
+        if !desc.is_empty() {
+            props.tags.insert("description".into(), desc.to_string());
+        }
+    }
+    if let Some(tags) = describe.tags() {
+        for t in tags {
+            let k = t.key().unwrap_or("");
+            let v = t.value().unwrap_or("");
+            if !k.starts_with("xv:") {
+                props.tags.insert(k.to_string(), v.to_string());
+            }
+        }
+    }
+    Ok(props)
+}
+```
+
+- [ ] **Step 2: Implement `list_vaults`**
+
+```rust
+async fn list_vaults(&self) -> Result<Vec<VaultSummary>, BackendError> {
+    use crate::backend::aws::encoding::strip_prefix;
+    use crate::backend::aws::metadata::{TAG_TYPE, TAG_VALUE_VAULT_MARKER};
+    use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
+
+    let mut next_token: Option<String> = None;
+    let mut summaries: Vec<VaultSummary> = Vec::new();
+
+    loop {
+        let mut req = self
+            .client
+            .list_secrets()
+            .max_results(100)
+            .filters(
+                Filter::builder()
+                    .key(FilterNameStringType::TagKey)
+                    .values(TAG_TYPE.to_string())
+                    .build(),
+            )
+            .filters(
+                Filter::builder()
+                    .key(FilterNameStringType::TagValue)
+                    .values(TAG_VALUE_VAULT_MARKER.to_string())
+                    .build(),
+            );
+        if let Some(t) = &next_token {
+            req = req.next_token(t.clone());
+        }
+
+        let out = req.send().await.map_err(super::errors::from_list)?;
+        for entry in out.secret_list.unwrap_or_default() {
+            let aws_full_name = entry.name().unwrap_or("");
+            // Marker name pattern: <vault>/.xv-vault — vault is everything before /.xv-vault
+            if let Some(idx) = aws_full_name.rfind("/.xv-vault") {
+                let vault = &aws_full_name[..idx];
+                summaries.push(VaultSummary {
+                    name: vault.to_string(),
+                    ..Default::default()
+                });
+            }
+        }
+        next_token = out.next_token().map(|s| s.to_string());
+        if next_token.is_none() {
+            break;
+        }
+    }
+    Ok(summaries)
+}
+```
+
+- [ ] **Step 3: Add tests**
+
+```rust
+#[tokio::test]
+async fn get_vault_returns_vault_not_found_when_marker_missing() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretError;
+    use aws_sdk_secretsmanager::types::error::ResourceNotFoundException;
+    use crosstache::backend::VaultBackend;
+    use crosstache::backend::error::BackendError;
+
+    let rule = mock!(Client::describe_secret).then_error(|| {
+        DescribeSecretError::ResourceNotFoundException(
+            ResourceNotFoundException::builder().message("not found").build(),
+        )
+    });
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_vault_backend(client);
+
+    let err = backend.get_vault("missing-vault").await.unwrap_err();
+    assert!(matches!(err, BackendError::VaultNotFound { .. }), "got: {err:?}");
+}
+
+#[tokio::test]
+async fn list_vaults_finds_all_markers() {
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+    use aws_sdk_secretsmanager::types::SecretListEntry;
+    use crosstache::backend::VaultBackend;
+
+    let rule = mock!(Client::list_secrets).then_output(|| {
+        ListSecretsOutput::builder()
+            .secret_list(SecretListEntry::builder().name("myproj-kv/.xv-vault").build())
+            .secret_list(SecretListEntry::builder().name("staging-kv/.xv-vault").build())
+            .build()
+    });
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_vault_backend(client);
+
+    let vaults = backend.list_vaults().await.unwrap();
+    let names: Vec<String> = vaults.iter().map(|v| v.name.clone()).collect();
+    assert_eq!(names.len(), 2);
+    assert!(names.contains(&"myproj-kv".to_string()));
+    assert!(names.contains(&"staging-kv".to_string()));
+}
+```
+
+- [ ] **Step 4: Verify and commit**
+
+```
+cargo test --features aws --test aws_backend_tests get_vault_returns_vault_not_found_when_marker_missing list_vaults_finds_all_markers
+```
+
+```bash
+git add src/backend/aws/vaults.rs tests/aws_backend_tests.rs
+git commit -m "feat(aws): get_vault + list_vaults via marker secrets"
+```
+
+---
+
+## Task 25: Implement `delete_vault` (refusal logic + force) + tests
+
+**Files:**
+- Modify: `src/backend/aws/vaults.rs`
+- Modify: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Add a `delete_vault_with_force` helper**
+
+The `VaultBackend` trait method `delete_vault(&self, name: &str)` is the public surface; we wire `--force` through the existing CLI flag plumbing later. The refusal logic lives in the backend.
+
+```rust
+async fn delete_vault(&self, name: &str) -> Result<(), BackendError> {
+    self.delete_vault_internal(name, false).await
+}
+```
+
+Add to the `impl AwsVaultBackend` (separate `impl` block, not part of the trait):
+
+```rust
+impl AwsVaultBackend {
+    pub async fn delete_vault_internal(
+        &self,
+        name: &str,
+        force: bool,
+    ) -> Result<(), BackendError> {
+        use crate::backend::aws::encoding::{is_marker, marker_name, strip_prefix};
+        use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
+
+        // Step 1: List non-marker secrets in this vault prefix
+        let prefix = format!("{name}/");
+        let out = self
+            .client
+            .list_secrets()
+            .max_results(100)
+            .filters(
+                Filter::builder()
+                    .key(FilterNameStringType::Name)
+                    .values(prefix.clone())
+                    .build(),
+            )
+            .send()
+            .await
+            .map_err(super::errors::from_list)?;
+
+        let non_marker: Vec<String> = out
+            .secret_list
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|e| e.name().map(|s| s.to_string()))
+            .filter(|n| !is_marker(n) && strip_prefix(name, n).is_some())
+            .collect();
+
+        if !non_marker.is_empty() && !force {
+            return Err(BackendError::Conflict(format!(
+                "vault '{name}' contains {} secret(s); pass --force to delete them all",
+                non_marker.len()
+            )));
+        }
+
+        // Step 2: With force, delete all non-marker secrets
+        if force {
+            for full_name in &non_marker {
+                self.client
+                    .delete_secret()
+                    .secret_id(full_name)
+                    .recovery_window_in_days(30)
+                    .send()
+                    .await
+                    .map_err(|e| super::errors::from_delete(full_name, e))?;
+            }
+        }
+
+        // Step 3: Delete the marker
+        let marker = marker_name(name);
+        self.client
+            .delete_secret()
+            .secret_id(&marker)
+            .force_delete_without_recovery(true)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_delete(&marker, e))?;
+
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 2: Add tests**
+
+```rust
+#[tokio::test]
+async fn delete_vault_refuses_when_secrets_exist() {
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+    use aws_sdk_secretsmanager::types::SecretListEntry;
+    use crosstache::backend::VaultBackend;
+    use crosstache::backend::error::BackendError;
+
+    let rule = mock!(Client::list_secrets).then_output(|| {
+        ListSecretsOutput::builder()
+            .secret_list(SecretListEntry::builder().name("myproj-kv/.xv-vault").build())
+            .secret_list(SecretListEntry::builder().name("myproj-kv/db-password").build())
+            .build()
+    });
+    let client = mock_client_from_rules(vec![rule]);
+    let backend = aws_vault_backend(client);
+
+    let err = backend.delete_vault("myproj-kv").await.unwrap_err();
+    assert!(matches!(err, BackendError::Conflict(_)), "got: {err:?}");
+}
+
+#[tokio::test]
+async fn delete_vault_succeeds_when_only_marker_exists() {
+    use aws_sdk_secretsmanager::operation::delete_secret::DeleteSecretOutput;
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+    use aws_sdk_secretsmanager::types::SecretListEntry;
+    use crosstache::backend::VaultBackend;
+
+    let list = mock!(Client::list_secrets).then_output(|| {
+        ListSecretsOutput::builder()
+            .secret_list(SecretListEntry::builder().name("myproj-kv/.xv-vault").build())
+            .build()
+    });
+    let delete = mock!(Client::delete_secret)
+        .match_requests(|req| req.secret_id() == Some("myproj-kv/.xv-vault"))
+        .then_output(|| DeleteSecretOutput::builder().build());
+
+    let client = mock_client_from_rules(vec![list, delete]);
+    let backend = aws_vault_backend(client);
+    backend.delete_vault("myproj-kv").await.unwrap();
+}
+```
+
+- [ ] **Step 3: Verify and commit**
+
+```
+cargo test --features aws --test aws_backend_tests delete_vault_refuses_when_secrets_exist delete_vault_succeeds_when_only_marker_exists
+```
+
+```bash
+git add src/backend/aws/vaults.rs tests/aws_backend_tests.rs
+git commit -m "feat(aws): delete_vault with refusal logic + delete_vault_internal(force)"
+```
+
+---
+
+## Task 26: Implement `update_vault` + test
+
+**Files:**
+- Modify: `src/backend/aws/vaults.rs`
+- Modify: `tests/aws_backend_tests.rs`
+
+- [ ] **Step 1: Implement**
+
+```rust
+async fn update_vault(
+    &self,
+    name: &str,
+    request: VaultUpdateRequest,
+) -> Result<VaultProperties, BackendError> {
+    use crate::backend::aws::encoding::marker_name;
+    use aws_sdk_secretsmanager::types::Tag;
+    let marker = marker_name(name);
+
+    if let Some(ref desc) = request.description {
+        self.client
+            .update_secret()
+            .secret_id(&marker)
+            .description(desc)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_update(name, e))?;
+    }
+
+    if let Some(ref new_tags) = request.tags {
+        let tag_list: Vec<Tag> = new_tags
+            .iter()
+            .filter(|(k, _)| !k.starts_with("xv:"))
+            .map(|(k, v)| Tag::builder().key(k).value(v).build())
+            .collect();
+        if !tag_list.is_empty() {
+            self.client
+                .tag_resource()
+                .secret_id(&marker)
+                .set_tags(Some(tag_list))
+                .send()
+                .await
+                .map_err(super::errors::from_tag)?;
+        }
+    }
+
+    self.get_vault(name).await
+}
+```
+
+> Adjust `VaultUpdateRequest` field names against the canonical definition.
+
+- [ ] **Step 2: Add a smoke test**
+
+```rust
+#[tokio::test]
+async fn update_vault_updates_description() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use aws_sdk_secretsmanager::operation::update_secret::UpdateSecretOutput;
+    use crosstache::backend::VaultBackend;
+    use crosstache::vault::models::VaultUpdateRequest;
+
+    let update = mock!(Client::update_secret)
+        .match_requests(|req| req.description() == Some("new description"))
+        .then_output(|| UpdateSecretOutput::builder().build());
+    let describe =
+        mock!(Client::describe_secret).then_output(|| DescribeSecretOutput::builder().build());
+
+    let client = mock_client_from_rules(vec![update, describe]);
+    let backend = aws_vault_backend(client);
+
+    let request = VaultUpdateRequest {
+        description: Some("new description".into()),
+        ..Default::default()
+    };
+    backend.update_vault("myproj-kv", request).await.unwrap();
+}
+```
+
+- [ ] **Step 3: Verify and commit**
+
+```
+cargo test --features aws --test aws_backend_tests update_vault_updates_description
+```
+
+```bash
+git add src/backend/aws/vaults.rs tests/aws_backend_tests.rs
+git commit -m "feat(aws): update_vault writes description + tags to marker secret"
+```
+
+---
+
+## Phase 6: CLI integration — flags, init wizard, migrate
+
+## Task 27: Add `--aws-profile` and `--region` global CLI flags
+
+**Files:**
+- Modify: `src/cli/commands.rs` (Cli struct definition)
+- Modify: `src/cli/mod.rs` or wherever the global config is built from CLI flags
+
+- [ ] **Step 1: Add the flags to `Cli`**
+
+Find the top-level `Cli` struct (search for `struct Cli` in `src/cli/commands.rs`). Add two flags:
+
+```rust
+/// Override the AWS profile for this invocation (only honored when active backend is aws)
+#[arg(long, global = true)]
+pub aws_profile: Option<String>,
+
+/// Override the AWS region for this invocation (only honored when active backend is aws)
+#[arg(long, global = true)]
+pub region: Option<String>,
+```
+
+- [ ] **Step 2: Plumb into config**
+
+Find where `Config` is finalized from `Cli` (likely in `Cli::execute` or similar). After existing assignments, add:
+
+```rust
+if let Some(ref p) = cli.aws_profile {
+    if let Some(ref mut aws) = config.aws {
+        aws.profile = Some(p.clone());
+    } else {
+        // Allow per-invocation profile override even if no [aws] block
+        config.aws = Some(AwsConfig {
+            profile: Some(p.clone()),
+            ..Default::default()
+        });
+    }
+}
+if let Some(ref r) = cli.region {
+    if let Some(ref mut aws) = config.aws {
+        aws.region = Some(r.clone());
+    } else {
+        config.aws = Some(AwsConfig {
+            region: Some(r.clone()),
+            ..Default::default()
+        });
+    }
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo build` (default features)
+Run: `cargo build --features aws`
+Expected: clean.
+
+Run: `cargo run -- --help | grep -E 'aws-profile|region'`
+Expected: both flags listed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cli/commands.rs src/cli/mod.rs
+git commit -m "feat(aws): add --aws-profile and --region global flags"
+```
+
+---
+
+## Task 28: Wire AWS branch into `migrate_ops::create_backend`
+
+**Files:**
+- Modify: `src/cli/migrate_ops.rs:14-36`
+
+- [ ] **Step 1: Add AWS arm**
+
+Replace `create_backend` in `src/cli/migrate_ops.rs`:
+
+```rust
+fn create_backend(kind: BackendKind, config: &Config) -> Result<Arc<dyn Backend>> {
+    match kind {
+        BackendKind::Azure => {
+            let auth_provider =
+                BackendRegistry::create_azure_auth_provider(config).map_err(|e| {
+                    CrosstacheError::Unknown(format!("Failed to create Azure auth: {e}"))
+                })?;
+            let backend =
+                crate::backend::azure::AzureBackend::new(config, auth_provider).map_err(|e| {
+                    CrosstacheError::Unknown(format!("Failed to create Azure backend: {e}"))
+                })?;
+            Ok(Arc::new(backend))
+        }
+        BackendKind::Local => {
+            let backend =
+                crate::backend::local::LocalBackend::new(config.local.as_ref()).map_err(|e| {
+                    CrosstacheError::Unknown(format!("Failed to create local backend: {e}"))
+                })?;
+            Ok(Arc::new(backend))
+        }
+        #[cfg(feature = "aws")]
+        BackendKind::Aws => {
+            let aws_cfg = config.aws.as_ref().ok_or_else(|| {
+                CrosstacheError::config(
+                    "[aws] config block missing — set backend = \"aws\" or pass --aws-profile",
+                )
+            })?;
+            // create_backend is sync; block on async constructor
+            let backend = tokio::runtime::Handle::current()
+                .block_on(crate::backend::aws::AwsBackend::new(aws_cfg, None, None))
+                .map_err(|e| CrosstacheError::Unknown(format!("Failed to create AWS backend: {e}")))?;
+            Ok(Arc::new(backend))
+        }
+        #[cfg(not(feature = "aws"))]
+        BackendKind::Aws => Err(CrosstacheError::Unknown(
+            "AWS backend not compiled in: rebuild with --features aws".into(),
+        )),
+    }
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cargo build --features aws`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/migrate_ops.rs
+git commit -m "feat(aws): wire BackendKind::Aws into migrate create_backend helper"
+```
+
+---
+
+## Task 29: Wire AWS branch into `xv init` wizard
+
+**Files:**
+- Modify: `src/config/init.rs`
+
+- [ ] **Step 1: Find the backend-selection prompt**
+
+Run: `grep -n "interactive_setup\|backend.*choice\|init_local\|init_azure" src/config/init.rs | head -20`
+
+Find the section that asks the user to pick backend (`azure` vs `local`). Add a third option for `aws`.
+
+- [ ] **Step 2: Add the AWS branch**
+
+Implement `init_aws_backend(&self, init_config: &mut InitConfig) -> Result<()>` that:
+
+1. Prompts for AWS region (default from `AWS_REGION` env, fall through to `us-east-1`).
+2. Prompts for AWS profile (default from `AWS_PROFILE` env, fall through to `"default"`).
+3. Optionally tests connectivity by calling `STS GetCallerIdentity` (lightweight; no IAM permission required other than implicit). For v0.10, **skip** the live test to keep init hermetic — just collect config and let the first real call validate.
+4. Writes `Config.aws = Some(AwsConfig { region, profile, default_vault: None, endpoint_url: None })`.
+5. Asks for default vault name with the same UX as Azure default vault prompt.
+
+Concrete shape:
+
+```rust
+async fn init_aws_backend(&self, init_config: &mut InitConfig) -> Result<()> {
+    use dialoguer::Input;
+
+    let region: String = Input::new()
+        .with_prompt("AWS region")
+        .default(
+            std::env::var("AWS_REGION")
+                .unwrap_or_else(|_| "us-east-1".to_string()),
+        )
+        .interact_text()
+        .map_err(|e| CrosstacheError::config(format!("Region prompt failed: {e}")))?;
+
+    let profile: String = Input::new()
+        .with_prompt("AWS profile")
+        .default(
+            std::env::var("AWS_PROFILE")
+                .unwrap_or_else(|_| "default".to_string()),
+        )
+        .interact_text()
+        .map_err(|e| CrosstacheError::config(format!("Profile prompt failed: {e}")))?;
+
+    let default_vault: String = Input::new()
+        .with_prompt("Default vault (prefix)")
+        .default("default".to_string())
+        .interact_text()
+        .map_err(|e| CrosstacheError::config(format!("Vault prompt failed: {e}")))?;
+
+    init_config.aws_region = Some(region);
+    init_config.aws_profile = Some(profile);
+    init_config.aws_default_vault = Some(default_vault);
+    init_config.backend_choice = "aws".to_string();
+
+    Ok(())
+}
+```
+
+Add corresponding fields to `InitConfig`:
+
+```rust
+pub struct InitConfig {
+    // ... existing fields
+    pub backend_choice: String,
+    pub aws_region: Option<String>,
+    pub aws_profile: Option<String>,
+    pub aws_default_vault: Option<String>,
+}
+```
+
+In `build_config`, add an arm that pulls AWS fields into `Config.aws` when `backend_choice == "aws"`.
+
+- [ ] **Step 3: Update the backend-choice prompt**
+
+In `run_interactive_setup`, find the existing two-option `Select` for backend choice (likely uses `dialoguer::Select`). Replace the items list to include "aws":
+
+```rust
+let backend_options = &["azure", "local", "aws"];
+```
+
+After the user picks, dispatch to `init_azure_backend` / `init_local_backend` / `init_aws_backend` accordingly.
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo build --features aws`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/init.rs
+git commit -m "feat(aws): xv init wizard gains AWS branch (region, profile, default vault)"
+```
+
+---
+
+## Phase 7: `xv migrate` hardening (the headline)
+
+## Task 30: Add `--on-conflict` flag (replaces `--overwrite`)
+
+**Files:**
+- Modify: `src/cli/commands.rs:690-709` (Commands::Migrate)
+- Modify: `src/cli/migrate_ops.rs` (execute_migrate signature)
+
+- [ ] **Step 1: Add the enum**
+
+In `src/cli/commands.rs`, add (near the top of the file or just above `Commands`):
+
+```rust
+#[derive(Debug, Clone, clap::ValueEnum, PartialEq, Eq)]
+pub enum OnConflict {
+    /// Skip secrets that already exist in the target (default)
+    Skip,
+    /// Overwrite the target value, replacing the metadata
+    Replace,
+    /// Abort the migration on first conflict
+    Fail,
+}
+
+impl Default for OnConflict {
+    fn default() -> Self {
+        Self::Skip
+    }
+}
+```
+
+- [ ] **Step 2: Update `Commands::Migrate`**
+
+Replace the existing `Migrate` variant in `Commands`:
+
+```rust
+/// Migrate secrets between backends
+Migrate {
+    /// Source backend (azure, local, aws)
+    #[arg(long)]
+    from: String,
+    /// Target backend (azure, local, aws)
+    #[arg(long)]
+    to: String,
+    /// Only migrate secrets from this vault
+    #[arg(long)]
+    vault: Option<String>,
+    /// Filter secrets by glob pattern (e.g., "db-*", "api-*")
+    #[arg(long)]
+    filter: Option<String>,
+    /// Preview what would be migrated without making changes
+    #[arg(long)]
+    dry_run: bool,
+    /// Behavior when a secret already exists in the target
+    #[arg(long, value_enum, default_value_t = OnConflict::Skip)]
+    on_conflict: OnConflict,
+    /// Ignore migration tags and replace targets unconditionally
+    #[arg(long)]
+    force_replace: bool,
+    /// Concurrent transfers (default 8)
+    #[arg(long, default_value = "8")]
+    concurrency: usize,
+    /// DEPRECATED: use --on-conflict replace instead
+    #[arg(long, hide = true)]
+    overwrite: bool,
+},
+```
+
+- [ ] **Step 3: Update `execute_migrate` signature**
+
+In `src/cli/migrate_ops.rs`, change the function signature:
+
+```rust
+pub(crate) async fn execute_migrate(
+    from: String,
+    to: String,
+    vault: Option<String>,
+    filter: Option<String>,
+    dry_run: bool,
+    on_conflict: crate::cli::commands::OnConflict,
+    force_replace: bool,
+    concurrency: usize,
+    legacy_overwrite: bool,
+    config: Config,
+) -> Result<()> {
+    // Compatibility shim: --overwrite -> --on-conflict replace + warn
+    let on_conflict = if legacy_overwrite {
+        eprintln!("warning: --overwrite is deprecated; use --on-conflict replace");
+        crate::cli::commands::OnConflict::Replace
+    } else {
+        on_conflict
+    };
+    // ... rest of function
+}
+```
+
+- [ ] **Step 4: Update the dispatch site**
+
+In `src/cli/commands.rs:1470-1490` (around the `Commands::Migrate` arm), update the call:
+
+```rust
+Commands::Migrate {
+    from, to, vault, filter, dry_run, on_conflict, force_replace, concurrency, overwrite,
+} => {
+    crate::cli::migrate_ops::execute_migrate(
+        from, to, vault, filter, dry_run,
+        on_conflict, force_replace, concurrency, overwrite,
+        config,
+    ).await
+}
+```
+
+- [ ] **Step 5: Verify**
+
+Run: `cargo build`
+Expected: clean.
+
+Run: `cargo run -- migrate --help`
+Expected: shows `--on-conflict <skip|replace|fail>`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/commands.rs src/cli/migrate_ops.rs
+git commit -m "feat(migrate): add --on-conflict flag (replaces --overwrite with deprecation)"
+```
+
+---
+
+## Task 31: Add pre-flight diff and summary table
+
+**Files:**
+- Modify: `src/cli/migrate_ops.rs`
+
+- [ ] **Step 1: Add a diff helper**
+
+Above `execute_migrate`, add:
+
+```rust
+struct MigrationDiff {
+    to_migrate: Vec<String>,
+    conflicts: Vec<String>,
+}
+
+async fn compute_diff(
+    source: &Arc<dyn Backend>,
+    target: &Arc<dyn Backend>,
+    vault: &str,
+    filter: Option<&str>,
+) -> Result<MigrationDiff> {
+    let source_secrets = source
+        .secrets()
+        .list_secrets(vault, None)
+        .await
+        .map_err(|e| {
+            CrosstacheError::Unknown(format!(
+                "Failed to list secrets from {} backend: {e}",
+                source.name()
+            ))
+        })?;
+
+    let filtered: Vec<String> = match filter {
+        Some(pattern) => {
+            let glob = globset::Glob::new(pattern)
+                .map_err(|e| CrosstacheError::invalid_argument(format!("Invalid glob pattern: {e}")))?
+                .compile_matcher();
+            source_secrets
+                .into_iter()
+                .filter(|s| glob.is_match(&s.name))
+                .map(|s| s.name)
+                .collect()
+        }
+        None => source_secrets.into_iter().map(|s| s.name).collect(),
+    };
+
+    let mut to_migrate = Vec::new();
+    let mut conflicts = Vec::new();
+
+    for name in filtered {
+        match target.secrets().secret_exists(vault, &name).await {
+            Ok(true) => conflicts.push(name),
+            Ok(false) => to_migrate.push(name),
+            Err(e) => {
+                tracing::debug!("secret_exists check failed for {name}: {e}; assuming new");
+                to_migrate.push(name);
+            }
+        }
+    }
+    Ok(MigrationDiff { to_migrate, conflicts })
+}
+
+fn print_diff_summary(
+    diff: &MigrationDiff,
+    source_name: &str,
+    target_name: &str,
+    vault: &str,
+    on_conflict: &crate::cli::commands::OnConflict,
+    dry_run: bool,
+) {
+    println!();
+    println!("Source: {}:{}", source_name, vault);
+    println!("Target: {}:{}", target_name, vault);
+    println!();
+    println!("  to migrate:    {} secret(s)", diff.to_migrate.len());
+    println!("  conflict:      {} secret(s) (target already has same name)", diff.conflicts.len());
+    println!();
+    println!("On conflict: {:?}", on_conflict);
+    println!("Dry run? {}", if dry_run { "yes" } else { "no" });
+    println!();
+}
+```
+
+- [ ] **Step 2: Wire into `execute_migrate`**
+
+After resolving the source/target backends and `vault_name`, call:
+
+```rust
+let diff = compute_diff(&source, &target, &vault_name, filter.as_deref()).await?;
+print_diff_summary(&diff, source.name(), target.name(), &vault_name, &on_conflict, dry_run);
+
+if dry_run {
+    return Ok(());
+}
+
+// Honor --on-conflict fail
+if !diff.conflicts.is_empty() && on_conflict == crate::cli::commands::OnConflict::Fail {
+    return Err(CrosstacheError::Unknown(format!(
+        "{} conflict(s) detected; aborting (--on-conflict fail)",
+        diff.conflicts.len()
+    )));
+}
+```
+
+Then iterate over `diff.to_migrate` for fresh transfers and `diff.conflicts` (only when `OnConflict::Replace`) for overwrites.
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo build`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cli/migrate_ops.rs
+git commit -m "feat(migrate): pre-flight diff + summary table + --on-conflict fail abort"
+```
+
+---
+
+## Task 32: Add idempotency tags (`xv:migrated_from`, `xv:migrated_at`)
+
+**Files:**
+- Modify: `src/cli/migrate_ops.rs`
+
+- [ ] **Step 1: Add idempotency tag constants**
+
+Near the top of `migrate_ops.rs`:
+
+```rust
+const TAG_MIGRATED_FROM: &str = "xv:migrated_from";
+const TAG_MIGRATED_AT: &str = "xv:migrated_at";
+```
+
+- [ ] **Step 2: Modify the per-secret transfer loop**
+
+In `execute_migrate`, when transferring each secret to the target, after fetching `source_props` (with value), build the `SecretRequest` with the migration tags injected:
+
+```rust
+let migrated_from = format!("{}:{}:{}", source.name(), vault_name, source_props.version);
+let migrated_at = chrono::Utc::now().to_rfc3339();
+
+let mut tags = source_props.tags.clone();
+tags.insert(TAG_MIGRATED_FROM.into(), migrated_from);
+tags.insert(TAG_MIGRATED_AT.into(), migrated_at);
+
+let request = SecretRequest {
+    name: source_props.name.clone(),
+    value: Zeroizing::new(
+        source_props.value.as_ref()
+            .map(|v| v.as_str().to_string())
+            .unwrap_or_default(),
+    ),
+    tags,
+    note: source_props.note.clone(),
+    folder: source_props.folder.clone(),
+    groups: source_props.groups.clone(),
+    expires_on: source_props.expires_on,
+    content_type: source_props.content_type.clone(),
+    ..Default::default()
+};
+```
+
+- [ ] **Step 3: Add idempotency-skip logic**
+
+Before transferring, check if the target already has matching migration tags (when `on_conflict == Skip` and `force_replace == false`):
+
+```rust
+if !force_replace {
+    if let Ok(existing) = target.secrets().get_secret(&vault_name, &name, false).await {
+        if let Some(prev_from) = existing.tags.get(TAG_MIGRATED_FROM) {
+            let expected = format!("{}:{}:{}", source.name(), vault_name, source_props.version);
+            if prev_from == &expected {
+                println!("  [skip] {} — already migrated (same source version)", name);
+                skipped += 1;
+                continue;
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo build`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/migrate_ops.rs
+git commit -m "feat(migrate): idempotency via xv:migrated_from + xv:migrated_at tags"
+```
+
+---
+
+## Task 33: Bounded concurrency + retry/backoff
+
+**Files:**
+- Modify: `src/cli/migrate_ops.rs`
+
+- [ ] **Step 1: Replace serial loop with concurrent transfers**
+
+Convert the per-secret transfer loop into a `futures::stream::iter(...).buffer_unordered(concurrency)` pipeline:
+
+```rust
+use futures::stream::{self, StreamExt};
+
+let names_to_migrate: Vec<String> = diff.to_migrate.clone();
+let source_clone = source.clone();
+let target_clone = target.clone();
+let vault_clone = vault_name.clone();
+
+let results = stream::iter(names_to_migrate.into_iter().map(|name| {
+    let source = source_clone.clone();
+    let target = target_clone.clone();
+    let vault = vault_clone.clone();
+    async move { migrate_one(&source, &target, &vault, &name).await }
+}))
+.buffer_unordered(concurrency)
+.collect::<Vec<_>>()
+.await;
+
+let mut migrated = 0usize;
+let mut errors: Vec<(String, CrosstacheError)> = Vec::new();
+for r in results {
+    match r {
+        Ok(name) => {
+            migrated += 1;
+            println!("  [ok] {}", name);
+        }
+        Err((name, e)) => errors.push((name, e)),
+    }
+}
+```
+
+Add the helper:
+
+```rust
+async fn migrate_one(
+    source: &Arc<dyn Backend>,
+    target: &Arc<dyn Backend>,
+    vault: &str,
+    name: &str,
+) -> std::result::Result<String, (String, CrosstacheError)> {
+    let props = source
+        .secrets()
+        .get_secret(vault, name, true)
+        .await
+        .map_err(|e| (name.to_string(), CrosstacheError::Unknown(format!("get_secret: {e}"))))?;
+
+    let request = build_request_from_props(&props, source.name(), vault);
+
+    // Retry with exponential backoff on RateLimited
+    let mut attempt = 0;
+    loop {
+        match target.secrets().set_secret(vault, request.clone()).await {
+            Ok(_) => return Ok(name.to_string()),
+            Err(BackendError::RateLimited { retry_after_secs }) if attempt < 5 => {
+                let wait = retry_after_secs
+                    .map(std::time::Duration::from_secs)
+                    .unwrap_or_else(|| {
+                        std::time::Duration::from_millis(500 * 2u64.pow(attempt as u32))
+                    });
+                tokio::time::sleep(wait).await;
+                attempt += 1;
+            }
+            Err(e) => {
+                return Err((name.to_string(), CrosstacheError::Unknown(format!("set_secret: {e}"))))
+            }
+        }
+    }
+}
+
+fn build_request_from_props(
+    props: &SecretProperties,
+    source_name: &str,
+    vault: &str,
+) -> SecretRequest {
+    let mut tags = props.tags.clone();
+    tags.insert(
+        TAG_MIGRATED_FROM.into(),
+        format!("{}:{}:{}", source_name, vault, props.version),
+    );
+    tags.insert(TAG_MIGRATED_AT.into(), chrono::Utc::now().to_rfc3339());
+
+    SecretRequest {
+        name: props.name.clone(),
+        value: Zeroizing::new(
+            props.value.as_ref()
+                .map(|v| v.as_str().to_string())
+                .unwrap_or_default(),
+        ),
+        tags,
+        note: props.note.clone(),
+        folder: props.folder.clone(),
+        groups: props.groups.clone(),
+        expires_on: props.expires_on,
+        content_type: props.content_type.clone(),
+        ..Default::default()
+    }
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cargo build`
+Expected: clean.
+
+Run: `cargo test --lib`
+Expected: existing tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/migrate_ops.rs
+git commit -m "feat(migrate): bounded concurrency (--concurrency) + exponential backoff retry"
+```
+
+---
+
+## Phase 8: LocalStack and migration round-trip tests
+
+## Task 34: LocalStack-gated integration tests
+
+**Files:**
+- Create: `tests/aws_localstack_tests.rs`
+
+- [ ] **Step 1: Write the gated test harness**
+
+```rust
+//! LocalStack integration tests. Skipped silently when LocalStack is unavailable.
+//!
+//! Enable with: AWS_INTEGRATION_TESTS=1 (and a running LocalStack at AWS_ENDPOINT_URL).
+//!
+//! LocalStack docker quickstart:
+//!   docker run -d --rm --name localstack -p 4566:4566 localstack/localstack
+//!   export AWS_ENDPOINT_URL=http://localhost:4566
+//!   export AWS_ACCESS_KEY_ID=test
+//!   export AWS_SECRET_ACCESS_KEY=test
+//!   export AWS_REGION=us-east-1
+
+#![cfg(feature = "aws")]
+
+use crosstache::backend::aws::AwsBackend;
+use crosstache::backend::SecretBackend;
+use crosstache::config::settings::AwsConfig;
+use crosstache::secret::manager::SecretRequest;
+use zeroize::Zeroizing;
+
+fn skip_unless_enabled() -> bool {
+    if std::env::var("AWS_INTEGRATION_TESTS").is_err() {
+        eprintln!("AWS_INTEGRATION_TESTS not set — skipping");
+        return true;
+    }
+    if std::env::var("AWS_ENDPOINT_URL").is_err() {
+        eprintln!("AWS_ENDPOINT_URL not set — skipping (LocalStack required)");
+        return true;
+    }
+    false
+}
+
+async fn build_backend() -> AwsBackend {
+    let cfg = AwsConfig {
+        region: Some(
+            std::env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".to_string()),
+        ),
+        endpoint_url: Some(std::env::var("AWS_ENDPOINT_URL").unwrap()),
+        ..Default::default()
+    };
+    AwsBackend::new(&cfg, None, None).await.unwrap()
+}
+
+#[tokio::test]
+async fn localstack_set_get_round_trip() {
+    if skip_unless_enabled() {
+        return;
+    }
+    let backend = build_backend().await;
+
+    // Use a unique vault per test run to avoid cross-contamination
+    let vault = format!("xv-test-{}", uuid::Uuid::new_v4());
+
+    let request = SecretRequest {
+        name: "round-trip-test".into(),
+        value: Zeroizing::new("test-value-42".into()),
+        groups: vec!["test".into()],
+        ..Default::default()
+    };
+    backend.secrets().set_secret(&vault, request).await.unwrap();
+
+    let got = backend
+        .secrets()
+        .get_secret(&vault, "round-trip-test", true)
+        .await
+        .unwrap();
+    assert_eq!(
+        got.value.as_ref().map(|v| v.as_str().to_string()),
+        Some("test-value-42".to_string())
+    );
+    assert_eq!(got.groups, vec!["test"]);
+
+    // Cleanup
+    backend
+        .secrets()
+        .purge_secret(&vault, "round-trip-test")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn localstack_list_paginates() {
+    if skip_unless_enabled() {
+        return;
+    }
+    let backend = build_backend().await;
+    let vault = format!("xv-test-{}", uuid::Uuid::new_v4());
+
+    // Write 5 secrets
+    for i in 0..5 {
+        let request = SecretRequest {
+            name: format!("test-{}", i),
+            value: Zeroizing::new(format!("value-{}", i)),
+            ..Default::default()
+        };
+        backend.secrets().set_secret(&vault, request).await.unwrap();
+    }
+
+    let listed = backend.secrets().list_secrets(&vault, None).await.unwrap();
+    let names: Vec<String> = listed.iter().map(|s| s.name.clone()).collect();
+    assert_eq!(names.len(), 5);
+    for i in 0..5 {
+        assert!(names.contains(&format!("test-{}", i)));
+    }
+
+    // Cleanup
+    for i in 0..5 {
+        backend
+            .secrets()
+            .purge_secret(&vault, &format!("test-{}", i))
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn localstack_vault_marker_create_list_delete() {
+    if skip_unless_enabled() {
+        return;
+    }
+    use crosstache::backend::VaultBackend;
+    use crosstache::vault::models::VaultCreateRequest;
+
+    let backend = build_backend().await;
+    let vault = format!("xv-test-{}", uuid::Uuid::new_v4());
+
+    backend
+        .vaults()
+        .unwrap()
+        .create_vault(VaultCreateRequest {
+            name: vault.clone(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let listed = backend.vaults().unwrap().list_vaults().await.unwrap();
+    let names: Vec<String> = listed.iter().map(|v| v.name.clone()).collect();
+    assert!(names.contains(&vault));
+
+    backend.vaults().unwrap().delete_vault(&vault).await.unwrap();
+}
+```
+
+- [ ] **Step 2: Add `uuid` to dev-dependencies if not present**
+
+Check `Cargo.toml`:
+```bash
+grep "^uuid" Cargo.toml
+```
+
+If `uuid` is not already in `[dev-dependencies]` (it's already in `[dependencies]`), this is fine — dev tests can use the dependency-tree dep.
+
+- [ ] **Step 3: Verify**
+
+Run (without LocalStack):
+```bash
+cargo test --features aws --test aws_localstack_tests
+```
+Expected: 3 tests run, all skip silently with stderr "AWS_INTEGRATION_TESTS not set — skipping".
+
+Run with LocalStack:
+```bash
+docker run -d --rm --name localstack -p 4566:4566 localstack/localstack
+sleep 5
+AWS_INTEGRATION_TESTS=1 \
+  AWS_ENDPOINT_URL=http://localhost:4566 \
+  AWS_ACCESS_KEY_ID=test \
+  AWS_SECRET_ACCESS_KEY=test \
+  AWS_REGION=us-east-1 \
+  cargo test --features aws --test aws_localstack_tests
+docker stop localstack
+```
+Expected: 3 PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/aws_localstack_tests.rs
+git commit -m "test(aws): LocalStack-gated integration tests for set/get/list/vaults"
+```
+
+---
+
+## Task 35: Migration round-trip tests (Local↔AWS)
+
+**Files:**
+- Create: `tests/migration_round_trip_tests.rs`
+
+- [ ] **Step 1: Write the test**
+
+```rust
+//! Cross-backend migration round-trip tests.
+//!
+//! Tests Local↔AWS today (LocalStack-gated). Azure↔AWS deferred to live tests.
+
+#![cfg(feature = "aws")]
+
+use crosstache::backend::aws::AwsBackend;
+use crosstache::backend::local::LocalBackend;
+use crosstache::backend::{Backend, SecretBackend};
+use crosstache::config::settings::{AwsConfig, LocalConfig};
+use crosstache::secret::manager::SecretRequest;
+use std::sync::Arc;
+use tempfile::TempDir;
+use zeroize::Zeroizing;
+
+fn skip_unless_enabled() -> bool {
+    std::env::var("AWS_INTEGRATION_TESTS").is_err()
+        || std::env::var("AWS_ENDPOINT_URL").is_err()
+}
+
+#[tokio::test]
+async fn local_to_aws_round_trip() {
+    if skip_unless_enabled() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+
+    // Build local backend
+    let local_cfg = LocalConfig {
+        store_path: Some(tmp.path().join("store").to_string_lossy().to_string()),
+        key_file: Some(tmp.path().join("key.txt").to_string_lossy().to_string()),
+        default_vault: Some("test-vault".into()),
+    };
+    let local: Arc<dyn Backend> = Arc::new(LocalBackend::new(Some(&local_cfg)).unwrap());
+
+    // Build AWS backend
+    let aws_cfg = AwsConfig {
+        region: Some("us-east-1".into()),
+        endpoint_url: Some(std::env::var("AWS_ENDPOINT_URL").unwrap()),
+        ..Default::default()
+    };
+    let aws: Arc<dyn Backend> = Arc::new(AwsBackend::new(&aws_cfg, None, None).await.unwrap());
+
+    let vault = format!("xv-rt-{}", uuid::Uuid::new_v4());
+
+    // Write 3 secrets to local
+    for (n, v) in [("a", "1"), ("b", "2"), ("c", "3")] {
+        let request = SecretRequest {
+            name: n.into(),
+            value: Zeroizing::new(v.into()),
+            groups: vec!["roundtrip".into()],
+            ..Default::default()
+        };
+        local.secrets().set_secret(&vault, request).await.unwrap();
+    }
+
+    // Read from local + write to AWS (manual migrate equivalent)
+    for n in ["a", "b", "c"] {
+        let props = local.secrets().get_secret(&vault, n, true).await.unwrap();
+        let request = SecretRequest {
+            name: props.name.clone(),
+            value: Zeroizing::new(
+                props.value.as_ref().map(|v| v.as_str().to_string()).unwrap_or_default(),
+            ),
+            groups: props.groups.clone(),
+            ..Default::default()
+        };
+        aws.secrets().set_secret(&vault, request).await.unwrap();
+    }
+
+    // Verify on AWS side
+    for (n, expected) in [("a", "1"), ("b", "2"), ("c", "3")] {
+        let got = aws.secrets().get_secret(&vault, n, true).await.unwrap();
+        assert_eq!(
+            got.value.as_ref().map(|v| v.as_str().to_string()),
+            Some(expected.to_string())
+        );
+        assert_eq!(got.groups, vec!["roundtrip"]);
+    }
+
+    // Cleanup AWS side
+    for n in ["a", "b", "c"] {
+        aws.secrets().purge_secret(&vault, n).await.unwrap();
+    }
+}
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+AWS_INTEGRATION_TESTS=1 \
+  AWS_ENDPOINT_URL=http://localhost:4566 \
+  AWS_ACCESS_KEY_ID=test \
+  AWS_SECRET_ACCESS_KEY=test \
+  AWS_REGION=us-east-1 \
+  cargo test --features aws --test migration_round_trip_tests
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/migration_round_trip_tests.rs
+git commit -m "test(migrate): Local<->AWS round-trip with LocalStack"
+```
+
+---
+
+## Task 36: End-to-end CLI integration test for `xv migrate --from local --to aws --dry-run`
+
+**Files:**
+- Modify: `tests/cli_integration_tests.rs`
+
+- [ ] **Step 1: Add the test**
+
+```rust
+#[test]
+#[cfg(feature = "aws")]
+fn migrate_dry_run_against_local_to_aws_shows_summary() {
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    if std::env::var("AWS_INTEGRATION_TESTS").is_err() {
+        eprintln!("skipping: AWS_INTEGRATION_TESTS not set");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    let xv = env!("CARGO_BIN_EXE_xv");
+
+    // Set up local store with one secret
+    Command::new(xv)
+        .args(["--backend", "local", "set", "test-secret", "value123"])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .env("XDG_DATA_HOME", tmp.path().join("data"))
+        .output()
+        .expect("set should succeed");
+
+    // Run migrate dry-run
+    let out = Command::new(xv)
+        .args([
+            "migrate", "--from", "local", "--to", "aws",
+            "--vault", "default", "--dry-run",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .env("XDG_DATA_HOME", tmp.path().join("data"))
+        .env("AWS_ENDPOINT_URL", std::env::var("AWS_ENDPOINT_URL").unwrap())
+        .env("AWS_REGION", "us-east-1")
+        .env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .output()
+        .expect("migrate should run");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Source:"), "expected summary; got:\n{stdout}");
+    assert!(stdout.contains("Target:"), "expected summary; got:\n{stdout}");
+    assert!(stdout.contains("to migrate"), "expected counts; got:\n{stdout}");
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run with LocalStack up:
+```bash
+AWS_INTEGRATION_TESTS=1 \
+  AWS_ENDPOINT_URL=http://localhost:4566 \
+  AWS_ACCESS_KEY_ID=test \
+  AWS_SECRET_ACCESS_KEY=test \
+  AWS_REGION=us-east-1 \
+  cargo test --features aws --test cli_integration_tests migrate_dry_run_against_local_to_aws_shows_summary
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/cli_integration_tests.rs
+git commit -m "test(migrate): end-to-end dry-run smoke test for local->aws migration"
+```
+
+---
+
+## Phase 9: Documentation and release
+
+## Task 37: Write `docs/migration.md`
+
+**Files:**
+- Create: `docs/migration.md`
+
+- [ ] **Step 1: Write the doc**
+
+```markdown
+# Cross-cloud migration with `xv migrate`
+
+`xv migrate` copies secrets from one backend to another while preserving metadata. Phase 3 (v0.10) hardens this command for cross-cloud use as a marquee feature.
+
+## Quick reference
+
+```bash
+# Azure -> AWS
+xv migrate --from azure --to aws --vault myproj-kv
+
+# AWS -> Azure
+xv migrate --from aws --to azure --vault myproj-kv
+
+# Filter
+xv migrate --from azure --to aws --vault myproj-kv --filter "db-*"
+
+# Dry run
+xv migrate --from azure --to aws --vault myproj-kv --dry-run
+
+# Conflict modes
+xv migrate --from azure --to aws --vault myproj-kv --on-conflict skip      # default
+xv migrate --from azure --to aws --vault myproj-kv --on-conflict replace
+xv migrate --from azure --to aws --vault myproj-kv --on-conflict fail
+
+# Force replace (ignore migration tags)
+xv migrate --from azure --to aws --vault myproj-kv --force-replace
+
+# Tune concurrency
+xv migrate --from azure --to aws --vault myproj-kv --concurrency 4
+```
+
+## Prerequisites
+
+### Azure source / target
+
+You need:
+- A logged-in Azure session (`az login` or env-based credentials).
+- `Key Vault Secrets User` role on the source vault (for read).
+- `Key Vault Secrets Officer` role on the target vault (for write).
+
+### AWS source / target
+
+You need:
+- AWS credentials configured (env, profile, SSO, or instance role).
+- `secretsmanager:ListSecrets`, `secretsmanager:GetSecretValue`, `secretsmanager:DescribeSecret` on the source.
+- `secretsmanager:CreateSecret`, `secretsmanager:PutSecretValue`, `secretsmanager:UpdateSecret`, `secretsmanager:TagResource`, `secretsmanager:UntagResource` on the target.
+
+Minimal AWS IAM policy for the target:
+
+\`\`\`json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:CreateSecret",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:UpdateSecret",
+        "secretsmanager:TagResource",
+        "secretsmanager:UntagResource",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:ListSecrets"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+\`\`\`
+
+### Local source / target
+
+No prerequisites beyond a configured local backend (`xv init --backend local`).
+
+## How it works
+
+Pre-flight: `xv migrate` enumerates source and target secrets, computes a diff, and prints a summary. In dry-run mode, the run stops here.
+
+Per-secret transfer: each secret is `get_secret`'d from source (with value) and `set_secret`'d on target. Bounded by `--concurrency` (default 8). Throttling errors trigger exponential backoff with jitter.
+
+Idempotency: each migrated secret carries `xv:migrated_from=<source>:<vault>:<source-version-id>` and `xv:migrated_at=<timestamp>` tags on the target. Re-running `xv migrate` with `--on-conflict skip` (the default) detects these and skips entries where the source version matches.
+
+Interruption safety: a run interrupted with Ctrl-C leaves no partial-state damage. Each transfer is atomic. Re-run to resume.
+
+## Metadata mapping
+
+| Source field | Azure → AWS | AWS → Azure |
+|---|---|---|
+| `groups` | tag `xv:groups` (comma-joined) | tag `groups` |
+| `note` | AWS `Description` field | tag `note` |
+| `folder` | tag `xv:folder` | tag `folder` |
+| `expiry` | tag `xv:expires_at` | native attribute |
+| `original_name` | tag `xv:original_name` | tag `original_name` |
+| `created_by` | tag `xv:created_by` | tag `created_by` |
+| `content_type` | tag `xv:content_type` | native attribute |
+| version history | current value only | current value only |
+
+## Performance
+
+A 100-secret migration completes in <60 s on a warm credential cache and `--concurrency 8`, assuming no throttling. For larger migrations, monitor AWS CloudWatch / Azure Monitor for rate-limit events and lower `--concurrency` if needed.
+
+## Troubleshooting
+
+- **`Error: vault 'X' not found`**: target vault doesn't exist. Run `xv vault create X --backend <target>` first, or rely on auto-create (currently only for the source's default vault).
+- **`Error: ThrottlingException`**: AWS rate-limit hit. Lower `--concurrency`. Backoff is automatic.
+- **`Error: AccessDeniedException`**: missing IAM permissions on AWS, or missing role on Azure. See "Prerequisites".
+- **Migrate tags on the target make rollback messy**: pass `--force-replace` to overwrite without honoring migration tags.
+
+## Limitations (Phase 3)
+
+- Only the current value is transferred. Full version history transfer is deferred (`--with-history` not yet implemented).
+- IAM resource policies on AWS source/target secrets are not preserved.
+- Cross-region AWS migrations require running `xv migrate` once per source/target region pair, using `[named_backends.*]` config.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/migration.md
+git commit -m "docs: add cross-cloud migration guide for xv migrate"
+```
+
+---
+
+## Task 38: Update README and `docs/FEATURES.md`
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/FEATURES.md`
+
+- [ ] **Step 1: Add AWS section to README**
+
+In `README.md`, find the section that documents Azure / local backend (search for `## Backends` or `### Local backend`). Add:
+
+```markdown
+### AWS Secrets Manager backend (v0.10)
+
+Use AWS Secrets Manager as the underlying secret store.
+
+```bash
+xv init  # pick "aws" when prompted
+# or edit ~/.config/xv/xv.conf:
+# backend = "aws"
+# [aws]
+# region = "us-east-1"
+# profile = "default"
+# default_vault = "myproj-kv"
+```
+
+Multi-region:
+
+```toml
+backend = "aws-east"
+[named_backends.aws-east]
+type = "aws"
+region = "us-east-1"
+[named_backends.aws-west]
+type = "aws"
+region = "us-west-2"
+```
+
+`xv share` and `xv audit` are not supported on AWS in v0.10 (see [docs/migration.md](docs/migration.md) for details). Use AWS IAM and CloudTrail directly for those needs.
+
+### Cross-cloud migration
+
+```bash
+# Move secrets from Azure to AWS
+xv migrate --from azure --to aws --vault myproj-kv
+
+# Preview first
+xv migrate --from azure --to aws --vault myproj-kv --dry-run
+```
+
+See [docs/migration.md](docs/migration.md) for the full guide.
+```
+
+- [ ] **Step 2: Update `docs/FEATURES.md`**
+
+Find the existing migration entry; replace it with:
+
+```markdown
+### Cross-cloud migration (v0.10)
+
+`xv migrate --from <source> --to <target>` copies secrets between backends. Supports Azure ↔ AWS ↔ Local in any combination. Hardening features:
+
+- `--on-conflict skip|replace|fail` — controls behavior when target secret exists
+- `--dry-run` — preview without changes
+- `--filter "<glob>"` — restrict to matching names
+- `--concurrency N` — bounded parallel transfers (default 8)
+- Idempotent: re-runs detect previously-migrated secrets via `xv:migrated_from` tag
+- Exponential backoff on rate limiting
+
+See [migration.md](migration.md) for the full guide.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md docs/FEATURES.md
+git commit -m "docs: add AWS backend section + update migration entry"
+```
+
+---
+
+## Task 39: Bump version to 0.10.0-rc.1 and verify full build
+
+**Files:**
+- Modify: `Cargo.toml`
+
+- [ ] **Step 1: Bump version**
+
+```toml
+[package]
+version = "0.10.0-rc.1"
+```
+
+- [ ] **Step 2: Full verification**
+
+Run all of these and ensure each passes:
+
+```bash
+# Default features (no AWS)
+cargo build
+cargo test --lib
+cargo test --tests
+
+# AWS feature
+cargo build --features aws
+cargo test --features aws
+
+# All features
+cargo build --all-features
+cargo test --all-features
+
+# Clippy
+cargo clippy --all-targets -- -W clippy::all
+cargo clippy --features aws --all-targets -- -W clippy::all
+
+# Format check
+cargo fmt --check
+```
+
+Expected: all pass with no warnings.
+
+- [ ] **Step 3: Run binary smoke checks**
+
+```bash
+cargo run --features aws -- --help
+cargo run --features aws -- migrate --help
+cargo run --features aws -- --backend aws --help 2>&1 | head -20
+```
+
+Expected: AWS-related help text is present and correct.
+
+- [ ] **Step 4: Binary size check**
+
+```bash
+cargo build --release
+ls -lh target/release/xv
+
+cargo build --release --features aws
+ls -lh target/release/xv
+```
+
+Expected: AWS-feature binary is at most 1.5 MB larger than default. Document the actual delta in the release notes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "chore: bump version to 0.10.0-rc.1"
+```
+
+- [ ] **Step 6: Tag the rc**
+
+```bash
+git tag v0.10.0-rc.1
+```
+
+(Push deferred until release time; do not push automatically.)
+
+---
+
+## Task 40: Cut v0.10.0 final after rc soak
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `CHANGELOG.md` (if present) or release notes file
+
+- [ ] **Step 1: After rc soak window passes (~1 week)**
+
+If no rc.2 needed:
+
+```toml
+[package]
+version = "0.10.0"
+```
+
+If issues surfaced during soak: cut rc.2 first, repeat soak, then v0.10.0.
+
+- [ ] **Step 2: Write release notes**
+
+Create / update release notes (path conventions vary; check `git log --oneline | grep -i 'release\|notes'` for prior precedent):
+
+```markdown
+## v0.10.0 — AWS Secrets Manager backend
+
+### Added
+- AWS Secrets Manager as a third backend (`xv --backend aws ...`), behind `aws` Cargo feature flag.
+- `[aws]` config block (region, profile, endpoint_url, default_vault).
+- `[named_backends.*]` config map for multi-region setups (`aws-east`, `aws-west`).
+- `--aws-profile` and `--region` global CLI flags.
+- `xv migrate` hardening:
+  - `--on-conflict skip|replace|fail` flag
+  - `--concurrency` flag (default 8)
+  - Pre-flight diff and summary table
+  - Idempotency via `xv:migrated_from` / `xv:migrated_at` tags
+  - Bounded parallelism with exponential backoff on throttling
+- `xv init` wizard now offers AWS as a backend option.
+- Documentation: `docs/migration.md`.
+- Test coverage: hermetic mock tests, LocalStack-gated integration tests, migration round-trip tests.
+
+### Changed
+- `--overwrite` on `xv migrate` is deprecated. Use `--on-conflict replace` instead. The flag still works (with a warning) for one minor version.
+
+### Capabilities (AWS backend)
+- ✅ Secrets CRUD, versioning, soft-delete, restore, purge
+- ✅ Vaults via prefix-based virtual vaults with marker secrets
+- ✅ Groups, folders, notes, expiry (in tags)
+- ❌ RBAC (`xv share`) — use AWS IAM directly
+- ❌ Audit (`xv audit`) — use AWS CloudTrail
+- ❌ Native rotation — `xv rotate` writes new versions
+- ❌ File storage (S3) — deferred to a future phase
+
+### Migration guide
+- Existing Azure or local users: no action required. Default behavior unchanged.
+- New AWS users: run `xv init` and pick "aws".
+
+### Performance
+- 100-secret cross-cloud migration completes in <60 s on a warm credential cache.
+
+### Binary size
+- Default-features binary: unchanged.
+- `--features aws` binary: +<X> MB (fill in actual measurement from Task 39 Step 4).
+```
+
+- [ ] **Step 3: Commit and tag**
+
+```bash
+git add Cargo.toml CHANGELOG.md
+git commit -m "chore: bump version to 0.10.0 and finalize release notes"
+git tag v0.10.0
+```
+
+---
+
+## Self-review checklist
+
+This plan should now be checked against the spec at `docs/superpowers/specs/2026-05-09-aws-backend-phase-3-design.md`. The agent executing this plan should run the following before declaring complete:
+
+- [ ] Spec §3 (capability matrix) — every flag matches what `AwsBackend::capabilities()` returns in Task 11.
+- [ ] Spec §4.4 (config schema) — `Config.aws` and `Config.named_backends` exist and parse from TOML (Tasks 5, 6).
+- [ ] Spec §5 (vault marker scheme) — marker name, reserved namespace, vault create/list/delete via marker (Tasks 9, 23, 24, 25).
+- [ ] Spec §6 (per-method mapping table) — every row has a corresponding task (Tasks 14–22).
+- [ ] Spec §7 (auth & config) — AWS SDK default credential chain in Task 7; config schema in Tasks 5, 6.
+- [ ] Spec §8 (migrate hardening) — Tasks 30–33 cover conflict modes, pre-flight diff, idempotency, concurrency.
+- [ ] Spec §9 (capability negotiation) — `has_rbac=false`, `has_audit=false` in capabilities (Task 11) cause CLI commands like `xv share` to produce `xv-unsupported` via the existing capability-check pattern.
+- [ ] Spec §11 (testing) — hermetic mocks (Task 13–22), LocalStack (Task 34), round-trip (Task 35).
+- [ ] Spec §13 (success criteria) — all listed commands work on `xv --backend aws`.
+
+If any spec section has no covering task, return to the spec, identify the missing work, add a task, and re-verify.
+
+---
+
+## Plan complete — execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-09-aws-backend-phase-3-plan.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**
+
+
+
+
+
+
+
+

--- a/docs/superpowers/specs/2026-05-09-aws-backend-phase-3-design.md
+++ b/docs/superpowers/specs/2026-05-09-aws-backend-phase-3-design.md
@@ -1,0 +1,542 @@
+# AWS Secrets Manager Backend — Phase 3 (v0.10) Design
+
+**Date:** 2026-05-09
+**Status:** Draft — pending user review
+**Owner:** Scott Zionic
+**Inputs:** `docs/superpowers/specs/2026-04-29-strategic-improvements-phase-1-design.md` (Phase 1 spec); `docs/superpowers/specs/2026-05-03-backend-pluggability-phase-2-design.md` (Phase 2 spec); `docs/code-review-gpt55.md`; `docs/reviews/2026-05-03-ux-review.md`; current code under `src/`.
+
+---
+
+## 1. Strategic context
+
+Phase 1 (v0.6 → v0.7) shipped the "loved features" push. Phase 2 (v0.8 → v0.9) extracted the backend trait layer and shipped a local age-encrypted backend. The Phase 2 spec explicitly deferred AWS Secrets Manager and HashiCorp Vault as Phase 2b/2c.
+
+The strategic positioning Phase 1 articulated still holds: **no general-purpose CLI secrets manager is truly backend-agnostic.** With Azure + local shipped, the trait has been validated against maximally different shapes (cloud REST API + local filesystem). AWS is the next backend to add — not because the trait needs another stress test, but because adding a second cloud backend turns "backend-agnostic" from a claim into a demonstrated capability, and the cross-cloud migration path becomes a marquee feature no competitor offers.
+
+Phase 3 adds AWS Secrets Manager as a third backend behind the existing `Backend` trait, paired with hardened cross-cloud migration as the headline feature. Ships as **v0.10.0**.
+
+### 1.1 Why AWS Secrets Manager (not Parameter Store, not Vault)
+
+- AWS Secrets Manager is the AWS-native answer to Azure Key Vault — same value proposition (managed secret store, versioning, soft-delete, RBAC via IAM).
+- Parameter Store overlaps with Secrets Manager but is positioned for non-sensitive config; many teams use both. Adding both backends in one phase doubles scope; Parameter Store is a candidate for a later phase.
+- HashiCorp Vault has the smallest user base of the three big cloud-secret stores; deferred to Phase 4 or later.
+
+### 1.2 What this phase does NOT do
+
+- No S3 file storage (`has_file_storage: false` on AWS backend).
+- No IAM-based `xv share` (`has_rbac: false`).
+- No CloudTrail-based `xv audit` (`has_audit: false`).
+- No native Lambda rotation (`has_secret_rotation: false`; `xv rotate` does new-version semantics, same as Azure).
+- No Parameter Store backend.
+- No Vault (HashiCorp) backend.
+- No multi-region single-backend awareness (multi-region is achieved via named backends).
+- No code-review-remediation pass (open gpt-5.5 P2/P3 items deferred to v1.0 phase).
+
+---
+
+## 2. Phase 3 scope
+
+### 2.1 Deliverables (in sequence order)
+
+1. **`AwsBackend` implementation** — full `Backend` + `SecretBackend` + `VaultBackend` trait surface against AWS Secrets Manager, behind a `aws` Cargo feature flag (default off at v0.10).
+2. **Named-backend config generalization** — small extension to `BackendConfig` to support multiple named instances of the same backend type (`[aws-east]`, `[aws-west]`).
+3. **Capability negotiation** — wire `has_rbac=false`, `has_audit=false`, `has_secret_rotation=false` on AWS through CLI/TUI capability checks; clean error messages on `xv share`, `xv audit` against AWS.
+4. **Cross-cloud `xv migrate` hardening** — conflict modes, idempotency tags, bounded concurrency, dry-run summary, perf testing on 100+ secret migrations.
+5. **Hermetic + LocalStack + live AWS test coverage**.
+6. **Documentation** — `docs/migration.md`, `xv init` wizard updated, README and `docs/FEATURES.md` updated.
+
+### 2.2 Deliberately deferred
+
+- AWS Parameter Store backend (Phase 4 or later).
+- HashiCorp Vault backend (Phase 4 or later).
+- AWS S3 file storage (Phase 4 or later).
+- IAM-based `xv share` (separate design effort; principal model differs from Azure RBAC).
+- CloudTrail-based `xv audit`.
+- AWS-native Lambda rotation.
+- `xv migrate --with-history` (full version-history transfer; sketched but not built).
+- Code-review remediation pass (separate v1.0 milestone).
+
+---
+
+## 3. Capability matrix
+
+`AwsBackend::capabilities()` returns:
+
+| Capability | Value | Notes |
+|---|---|---|
+| `has_vaults` | `true` | Prefix-based virtual vaults |
+| `has_file_storage` | `false` | Deferred (S3 backend integration) |
+| `has_rbac` | `false` | IAM model differs from Azure RBAC; deferred |
+| `has_audit` | `false` | CloudTrail integration deferred |
+| `has_versioning` | `true` | Native `VersionId` + staging labels |
+| `has_soft_delete` | `true` | `DeleteSecret` recovery window 7–30 days (default 30) |
+| `has_secret_rotation` | `false` | New-version semantics only; native rotation deferred |
+| `has_groups` | `true` | Stored in `xv:groups` tag |
+| `has_folders` | `true` | Stored in `xv:folder` tag |
+| `has_notes` | `true` | Stored in `Description` |
+| `has_expiry` | `true` | Stored in `xv:expires_at` tag (AWS has no native expiry) |
+| `max_secret_size` | `Some(65_536)` | AWS limit: 64 KB per `SecretString`/`SecretBinary` |
+| `max_name_length` | `Some(512)` | AWS Secrets Manager limit |
+| `name_charset` | `AwsRelaxed` | New variant: `[a-zA-Z0-9/_+=.@-]` |
+
+`BackendCapabilities` already exposes `has_audit` and `has_secret_rotation` (Phase 2 baked them in for forward compat). The `NameCharset` enum gains an `AwsRelaxed` variant alongside the existing `AlphanumericHyphen`, `Unrestricted`, and `Custom` variants in `src/backend/mod.rs`.
+
+---
+
+## 4. Architecture
+
+### 4.1 Module layout
+
+```
+src/backend/aws/
+├── mod.rs       -- AwsBackend impl Backend
+├── auth.rs      -- AWS credential chain wrapper, profile selection
+├── config.rs    -- AwsBackendConfig (region, profile, endpoint override)
+├── secrets.rs   -- AwsSecretBackend impl SecretBackend
+├── vaults.rs    -- AwsVaultBackend impl VaultBackend (marker-secret-based)
+├── encoding.rs  -- Name encoding/decoding, prefix joining, marker name reservation
+├── metadata.rs  -- Tag <-> SecretProperties mapping
+├── errors.rs    -- AWS SDK error -> BackendError mapping
+└── models.rs    -- AWS-specific response shapes used internally
+```
+
+Mirrors the structure of `src/backend/azure/`.
+
+### 4.2 SDK choice
+
+`aws-sdk-secretsmanager` (the official `aws-sdk-rust`). `aws-config` for the credential chain. No alternative considered — `rusoto` is deprecated, `aws-sdk-rust` is the supported path.
+
+### 4.3 Cargo feature gating
+
+The AWS backend lives behind a `aws` feature flag, **default off** at v0.10. Mirrors the existing `tui` feature pattern.
+
+```toml
+[features]
+default = ["file-ops"]
+file-ops = []
+tui = []
+aws = ["aws-sdk-secretsmanager", "aws-config"]
+```
+
+Distribution-channel binaries (homebrew, scoop, deb/rpm, GitHub releases) ship with `--features aws`. Users building from source without AWS get a smaller binary.
+
+### 4.4 Config schema additions and named-backend support
+
+**Today's shape.** `Config` is a flat struct (not an enum). Top-level Azure fields (`subscription_id`, `tenant_id`, `default_vault`, `default_resource_group`, `default_location`, `azure_credential_priority`) live directly on `Config`. Local-backend config lives in a sub-struct `Config.local: Option<LocalConfig>`. Active backend is selected by `Config.backend: Option<String>` — `None` is treated as `"azure"` for backward compatibility. `BackendKind` is a flat enum (`Azure`, `Local`), parsed from the active-backend string in `BackendRegistry::from_config`.
+
+**Phase 3 adds:**
+
+1. `BackendKind::Aws` variant in `src/backend/mod.rs` (with parser aliases `aws`, `secretsmanager`).
+2. `Config.aws: Option<AwsConfig>` sub-struct, parallel to `Config.local`. Holds `region`, `profile`, `endpoint_url`, `default_vault`.
+3. `Config.named_backends: HashMap<String, NamedBackendEntry>` — a new map keyed by user-chosen names (`"aws-east"`, `"aws-west"`). Each entry has an explicit `type: BackendKind` plus a backend-specific config payload. Empty when no named backends are configured.
+4. `BackendRegistry::from_config` resolution: if `Config.backend` matches a built-in name (`"azure"`, `"local"`, `"aws"`), use the corresponding top-level config block; otherwise look up `Config.named_backends[name]` and use the embedded payload.
+
+**Single-instance form** (most users):
+
+```toml
+backend = "aws"
+
+[aws]
+region = "us-east-1"
+profile = "default"
+endpoint_url = ""              # optional, for LocalStack
+default_vault = "myproj-kv"
+```
+
+**Multi-region form** (named backends):
+
+```toml
+backend = "aws-east"
+
+[named_backends.aws-east]
+type = "aws"
+region = "us-east-1"
+profile = "prod"
+default_vault = "myproj-kv"
+
+[named_backends.aws-west]
+type = "aws"
+region = "us-west-2"
+profile = "prod"
+default_vault = "myproj-kv"
+```
+
+**Backward compatibility.** Existing config files with no `backend` key, no `[aws]` block, and no `[named_backends.*]` section keep working unchanged — `Config.backend = None` resolves to Azure. Adding `backend = "aws"` plus an `[aws]` block opts in. Existing Azure users see no behavior change unless they explicitly opt into AWS.
+
+### 4.5 CLI flags
+
+- `--backend <name>` — already exists; no change. Now resolves named entries in addition to type-implicit aliases.
+- `--aws-profile <name>` — per-invocation override of the AWS profile. Honored only when active backend is AWS; warn otherwise.
+- `--region <name>` — per-invocation override of the AWS region. Same semantics.
+
+---
+
+## 5. Naming, encoding, and the vault marker
+
+### 5.1 Name encoding
+
+AWS Secrets Manager allows `[a-zA-Z0-9/_+=.@-]` and 512-char names. That's broad enough that most user-facing names pass through unchanged.
+
+**Encoding rule:** `aws_name = format!("{vault_prefix}/{secret_name}")`.
+
+If `secret_name` contains characters outside the AWS charset, those bytes are percent-encoded. The `original_name` tag (already used by Azure backend) is the authoritative source for round-tripping back to user-facing display.
+
+Vault names themselves are constrained to `[a-zA-Z0-9-]{3,50}` (matching Azure vault name constraints) so the prefix never needs encoding and round-trips cleanly between backends.
+
+### 5.2 Vault marker secret
+
+Each virtual vault on AWS is represented by a **marker secret** at `<vault>/.xv-vault`:
+
+- `SecretString = "{}"` (the value is unused; we need a value to create the secret).
+- `Description` = vault description from `xv vault create`.
+- Tags include:
+  - `xv:type=vault-marker`
+  - `xv:created_at=<iso8601>`
+  - `xv:vault_name=<name>`
+  - User-supplied vault tags (passed through with original keys)
+
+### 5.3 Vault operations
+
+- `create_vault` → `CreateSecret` for the marker.
+- `get_vault` → `DescribeSecret` on the marker (no value fetch).
+- `list_vaults` → `ListSecrets` with filter `[{Key: tag-key, Values: ["xv:type"]}, {Key: tag-value, Values: ["vault-marker"]}]`. One paginated call.
+- `delete_vault` → list secrets under the prefix; refuse if any non-marker secret exists unless `--force`; then `DeleteSecret` on the marker. With `--force`, all non-marker secrets are deleted first (with the configured recovery window unless `--purge` also supplied).
+- `update_vault` → `UpdateSecret` description + `TagResource`/`UntagResource` on the marker.
+
+### 5.4 Reserved namespace
+
+Any secret name starting with `.xv-` is reserved for xv-internal use. `set_secret` rejects user attempts to write `.xv-*` names with `xv-reserved-name` error.
+
+---
+
+## 6. Per-method mapping (`SecretBackend` trait → AWS API)
+
+| Trait method | AWS API | Notes |
+|---|---|---|
+| `set_secret` (create) | `CreateSecret` | Tags from request → AWS tags. Description = note. Returns `VersionId` as version string. |
+| `set_secret` (update) | `PutSecretValue` + (if metadata changed) `UpdateSecret` + `TagResource`/`UntagResource` | 1–3 API calls depending on what changed. |
+| `get_secret` (no value) | `DescribeSecret` | Metadata only. Cheap. |
+| `get_secret` (with value) | `GetSecretValue` + `DescribeSecret`, parallelized via `tokio::join!` | AWS doesn't return tags from `GetSecretValue`. |
+| `get_secret_version` | `GetSecretValue` with explicit `VersionId` | Direct lookup. |
+| `list_secrets` | `ListSecrets` (paginated, follows `NextToken`) + filter by name prefix + filter out marker | Group filter applied client-side from tags. |
+| `delete_secret` | `DeleteSecret` with `RecoveryWindowInDays = 30` | Or `ForceDeleteWithoutRecovery: true` if `--purge`. |
+| `update_secret` (metadata) | `UpdateSecret` for description + `TagResource`/`UntagResource` for tags | No value change. |
+| `list_versions` | `ListSecretVersionIds` | Returns full history. |
+| `rollback` | `UpdateSecretVersionStage` (move `AWSCURRENT` to target version) | Native AWS rollback, atomic. |
+| `restore_secret` | `RestoreSecret` | Cancels deletion within recovery window. |
+| `purge_secret` | `DeleteSecret` with `ForceDeleteWithoutRecovery: true` | Bypasses recovery window. |
+| `list_deleted_secrets` | `ListSecrets` with `IncludeDeleted: true` | |
+| `secret_exists` | `DescribeSecret`; `ResourceNotFoundException` → `Ok(false)` | |
+| `backup_secret` / `restore_from_backup` | `BackendError::Unsupported` | Same posture as Azure today. |
+
+### 6.1 Tag schema for metadata
+
+AWS allows 50 tags per secret (vs. Azure's 15). Comfortable budget.
+
+| Tag key | Source field |
+|---|---|
+| `xv:original_name` | user-facing name before encoding |
+| `xv:groups` | comma-separated groups |
+| `xv:folder` | folder |
+| `xv:created_by` | created_by |
+| `xv:expires_at` | ISO 8601 expiry (AWS has no native expiry attribute) |
+| `xv:content_type` | content type |
+| `xv:type=vault-marker` | only on vault marker secrets |
+| User-supplied tags | passed through with their original keys (no `xv:` prefix), up to the AWS 50-tag budget |
+
+### 6.2 Expiry handling
+
+AWS Secrets Manager has no native expiry attribute. The `xv:expires_at` tag carries an ISO 8601 timestamp; the backend checks expiry on `get_secret` and surfaces a warning (not an error — the secret is still readable). `xv list --expiring` filters via the tag client-side, mirroring the Azure path.
+
+---
+
+## 7. Authentication & config
+
+### 7.1 Credential chain
+
+The AWS SDK default credential chain is used unmodified. No xv-specific priority abstraction (unlike Azure's `--credential-priority`). The chain is:
+
+1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`)
+2. Shared credentials file (`~/.aws/credentials`)
+3. SSO via `aws sso login`
+4. EC2 instance metadata
+5. ECS task role
+6. (Other SDK-defined sources)
+
+This matches AWS user mental models. xv exposes only profile and region selection — it does not try to model "credential priority" the way Azure does.
+
+### 7.2 Config schema
+
+Top-level (single AWS backend):
+
+```toml
+backend = "aws"
+
+[aws]
+region = "us-east-1"
+profile = "default"           # optional; falls through to AWS_PROFILE
+endpoint_url = ""             # optional, for LocalStack/testing
+default_vault = "myproj-kv"
+```
+
+Multi-region (named backends):
+
+```toml
+backend = "aws-east"
+
+[aws-east]
+type = "aws"
+region = "us-east-1"
+profile = "prod"
+default_vault = "myproj-kv"
+
+[aws-west]
+type = "aws"
+region = "us-west-2"
+profile = "prod"
+default_vault = "myproj-kv"
+```
+
+### 7.3 `xv init` updates
+
+The init wizard gains a backend-selection step:
+- `azure` (existing default for Azure users)
+- `local` (existing local age backend)
+- `aws` (new)
+
+For AWS: prompt for region (with sensible default from `AWS_REGION` env), prompt for profile (with default), test connectivity via `DescribeOrganization` or `STS GetCallerIdentity` (lightweight; no IAM permission required), confirm and write config.
+
+---
+
+## 8. `xv migrate` hardening (the headline)
+
+The migrate command exists from Phase 2. Phase 3 hardens it for cross-cloud as the v0.10 marquee feature.
+
+### 8.1 Command surface
+
+```bash
+xv migrate --from azure:myproj-kv --to aws:myproj-kv \
+           --on-conflict skip|replace|fail   # default: skip
+           --filter "db-*"                   # glob filter
+           --concurrency 8                   # bounded parallelism
+           --dry-run                         # preview only
+           --force-replace                   # ignore migration tags, overwrite
+```
+
+`--from` and `--to` accept `<backend-name>:<vault>` syntax. If `<vault>` is omitted, the backend's default vault is used. Source and target are resolved through the registry — no special-casing for any backend pair.
+
+### 8.2 Pre-flight diff
+
+Before any writes, migrate enumerates source and target, computes the diff, and prints a summary table:
+
+```
+Source: azure:myproj-kv (47 secrets)
+Target: aws:myproj-kv (3 secrets)
+
+  to migrate:    44 secrets
+  conflict:       3 secrets (target has same name)
+  skip:           0 secrets (none filtered out)
+
+On conflict: skip
+Dry run? yes
+```
+
+In dry-run mode, the run stops here. In real-run mode, the user sees the same summary then transfers begin.
+
+### 8.3 Idempotency
+
+Each migrated secret records on the target:
+- `xv:migrated_from=<source-backend>:<vault>:<source-version-id>`
+- `xv:migrated_at=<iso8601>`
+
+Re-running migrate detects these tags and skips entries where the source version matches (default `--on-conflict skip` semantics). `--force-replace` overwrites regardless.
+
+A run interrupted mid-stream (Ctrl-C) leaves no partial-state damage: each secret transfer is its own atomic unit. The next run picks up where the previous left off via the migration tags.
+
+### 8.4 Concurrency, throttling, retry
+
+- Bounded parallelism: default 8 concurrent transfers, configurable via `--concurrency`.
+- Backoff on `ThrottlingException` (AWS) / `429 TooManyRequests` (Azure): exponential with jitter, max 30 s, 5 retries.
+- Progress reporting via the existing `MultiProgressContext` from Phase 1 — per-secret log line + overall counter bar.
+
+### 8.5 Metadata mapping (cross-backend)
+
+| Source field | Azure → AWS | AWS → Azure |
+|---|---|---|
+| `groups` | tag `xv:groups` (comma-joined) | tag `groups` (existing scheme) |
+| `note` | `Description` field | tag `note` |
+| `folder` | tag `xv:folder` | tag `folder` |
+| `expiry` | tag `xv:expires_at` | native attribute |
+| `original_name` | tag `xv:original_name` | tag `original_name` |
+| `created_by` | tag `xv:created_by` | tag `created_by` |
+| `content_type` | tag `xv:content_type` | native attribute |
+| `version_history` | current value only by default | current value only by default |
+
+### 8.6 Performance budget
+
+100-secret migration completes in <60 s on a warm credential cache (8 concurrent, no throttling).
+
+### 8.7 Documentation
+
+- `docs/migration.md` — prerequisites, IAM policy required on target, walk-through of Azure→AWS and AWS→Azure flows, conflict-mode reference, troubleshooting.
+- README — short example.
+- `docs/FEATURES.md` — migration entry updated.
+- Asciinema demo embedded in README and migration docs.
+
+---
+
+## 9. Capability negotiation in CLI/TUI
+
+When a command targets a feature the AWS backend does not support, the tool fails gracefully with a clear message:
+
+```
+$ xv --backend aws share myproj-kv/db-password user@example.com
+Error [xv-unsupported]: The aws backend does not support access sharing.
+Hint: Use AWS IAM resource policies to grant access. See `aws iam` documentation.
+
+$ xv --backend aws audit myproj-kv/db-password
+Error [xv-unsupported]: The aws backend does not support audit logs.
+Hint: AWS CloudTrail captures audit events. See `aws cloudtrail lookup-events`.
+```
+
+Implementation pattern (already established in Phase 2): CLI handlers check `backend.capabilities()` before executing, return `CrosstacheError::Unsupported` with `backend`, `feature`, and `hint` fields.
+
+TUI capability gating: panes/overlays for unsupported features (audit overlay on AWS) are hidden via the existing `BackendCapabilities`-driven render path.
+
+---
+
+## 10. Error model additions
+
+No new `BackendError` variants required — the existing set covers what we need:
+
+- AWS `ResourceNotFoundException` → `BackendError::NotFound`
+- AWS `AccessDeniedException` / `UnauthorizedOperation` → `BackendError::PermissionDenied`
+- AWS `ThrottlingException` → `BackendError::RateLimited` with retry-after if AWS provides one
+- AWS `InvalidParameterException` / `ValidationException` → `BackendError::Internal` with message
+- AWS `ResourceExistsException` (on create) → `BackendError::Conflict`
+- AWS authentication failures → `BackendError::AuthenticationFailed`
+- Network errors → `BackendError::Network`
+- Any other AWS SDK error → `BackendError::Other(anyhow!(...))`
+
+The `From<aws_sdk_secretsmanager::Error>` conversion lives in `src/backend/aws/errors.rs` and is exhaustive over the SDK's error variants we observe.
+
+---
+
+## 11. Testing strategy
+
+### 11.1 Unit tests (`src/backend/aws/`)
+
+- Encoding/decoding round-trip on edge-case names (special characters, max length, prefix collision).
+- Tag ↔ metadata mapping round-trip.
+- Vault marker construction and detection.
+- AWS SDK error → `BackendError` mapping (every variant we map explicitly).
+
+### 11.2 Hermetic backend tests
+
+Use `aws-smithy-mocks-experimental` (the official mocking layer in `aws-sdk-rust`) to stub `secretsmanager` API responses. The full backend trait surface is exercised deterministically in CI without any AWS credentials.
+
+A parametrized test matrix runs the same scenarios as the existing local-backend test suite, against AWS-backed mocks, ensuring trait conformance.
+
+### 11.3 LocalStack integration tests (gated)
+
+`AWS_INTEGRATION_TESTS=1` + LocalStack via Docker — full E2E exercise of the AWS backend against a real Secrets Manager API surface. Skipped silently when LocalStack is unavailable; CI runs them; local dev opt-in.
+
+### 11.4 Live AWS integration tests (gated)
+
+`AWS_LIVE_TESTS=1` runs against a real AWS account in a dedicated test region. Used for release validation, not every CI run. Test infrastructure provisioned via Terraform (committed to `tests/terraform/aws/`), torn down at end-of-test.
+
+### 11.5 Migration tests
+
+- Round-trip parametrized: create N secrets in source, migrate, verify all secrets and metadata in target. Run for Azure→AWS, AWS→Azure, AWS→Local, Local→AWS combinations.
+- Idempotency: run migrate twice, verify no duplicates and tag-based skip works.
+- Conflict modes: create same name with different value on target, verify each `--on-conflict` mode behaves correctly.
+- Interruption: kill mid-migration, re-run, verify completion.
+- Perf: 100-secret migration under 60 s.
+
+### 11.6 Existing test suites
+
+Azure backend tests, local backend tests, CLI integration tests run unchanged. AWS adds to the matrix.
+
+---
+
+## 12. Sequencing & milestones
+
+### 12.1 Week-by-week (~3-week target, ~0.5-week buffer)
+
+| Week | Theme | Deliverables |
+|---|---|---|
+| 1 | AWS foundation | `aws-sdk-secretsmanager` integration, `AwsBackendConfig`, named-backend config generalization, auth wrapper, encoding module. Compiles and registers as a backend; no operations yet. |
+| 1 | Trait pass 1 | `set_secret`, `get_secret`, `list_secrets`, `delete_secret`, `secret_exists`. Hermetic mocked tests for each. |
+| 2 | Trait pass 2 | `update_secret`, version operations, soft-delete/restore/purge, vault operations (marker scheme). LocalStack tests added. |
+| 2 | Capability degradation polish | Wire `has_rbac=false`, `has_audit=false`, `has_secret_rotation=false` through CLI/TUI checks. Verify `xv share` / `xv audit` produce clean error messages on AWS. |
+| 3 | Migrate hardening | `--on-conflict` modes, idempotency tags, concurrency/backoff, dry-run summary, parametrized round-trip migration tests. |
+| 3 | Docs + release | `docs/migration.md`, README updates, asciinema demo, release notes, `docs/FEATURES.md` updates, `xv init` wizard gains AWS choice. |
+| 3.5 | Buffer | Live AWS validation, perf testing, bug fixes, v0.10.0 cut. |
+
+### 12.2 Release milestones
+
+- **v0.10.0-rc.1** (end of week 2): AWS backend feature-complete behind `aws` feature flag, default off. Migration not yet hardened.
+- **v0.10.0-rc.2** (end of week 3): Migration hardening complete; docs published; release notes drafted.
+- **v0.10.0** (end of week 3.5): Public release with `aws` feature flag enabled in distribution-channel binaries.
+
+### 12.3 Quality gates
+
+Same as Phase 1 + Phase 2:
+1. `cargo test` (all green) and `cargo test -- --test-threads=1` (no flake).
+2. `cargo clippy --all-targets -- -W clippy::all` with no new warnings against baseline.
+3. `cargo audit` (no new advisories).
+4. CLI integration smoke tests on Linux + macOS + Windows.
+5. LocalStack-backed E2E tests pass in CI.
+6. Live AWS integration tests pass against a dedicated test account (manually triggered for the rc cut).
+
+Plus:
+7. **Binary size budget:** +1.5 MB ceiling for AWS SDK dependency. Alert on PRs that bust the budget.
+
+### 12.4 Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| AWS SDK binary size bust | Medium | Medium | Feature-gate; `--no-default-features` available. Restrict to `aws-sdk-secretsmanager` only (not s3, ec2, etc.). |
+| Throttling on large migrations | Medium | Low | Bounded concurrency + jittered backoff. Document AWS rate limits. |
+| LocalStack ↔ live API drift | Low | Low | LocalStack covers behavior; live tests catch real auth/IAM gaps. |
+| Vault marker collision with user secret named `.xv-vault` | Low | Medium | Reserved-namespace check at `set_secret` boundary. |
+| Cross-cloud migration metadata loss | Medium | Medium | Documented mapping table (§8.5); `--with-history` deferred but sketched. |
+| Named-backend config generalization breaks existing users | Low | High | Backward compat: `[azure]` and `[local]` blocks remain valid type-implicit aliases. Roundtrip tests on existing config files. |
+| AWS SDK API instability | Low | Low | `aws-sdk-rust` is stable; pin minor versions; revisit at v0.10.0 release. |
+
+---
+
+## 13. Success criteria
+
+Phase 3 is complete when:
+
+1. `xv --backend aws` supports: `set`, `get`, `list`, `delete`, `update`, `versions`, `rollback`, `restore`, `purge`, `find`, `scan`, `inject`, `run`, `tui`, `vault {create,get,list,delete,update}`.
+2. `xv share`, `xv audit`, and any other unsupported command on AWS produce `xv-unsupported` errors with actionable hints.
+3. `xv migrate --from azure:X --to aws:Y` and the reverse complete a 100-secret migration in <60 s, idempotent on re-run.
+4. All existing tests pass; new AWS test suite green in CI; LocalStack tests green in CI; live AWS tests pass on the rc cut.
+5. Documentation shipped: `docs/migration.md`, AWS section in README, `xv init` wizard updated with AWS choice, `docs/FEATURES.md` updated.
+6. Binary size delta within +1.5 MB budget.
+7. No regressions on Azure or local backend paths.
+
+---
+
+## 14. Open questions
+
+1. **Distribution channel for the `aws`-featured binary.** Should homebrew/scoop/deb/rpm ship one binary with all features (`tui`, `aws`, `file-ops`), or split — a "lite" binary without AWS for users who don't need it? Recommendation: one binary with all features, mirroring how most CLIs ship. Confirm before release.
+2. **Live-test AWS account.** Need a dedicated AWS test account or sandbox. Who provisions and pays for it? Estimated cost: <$5/month at our test volume.
+3. **LocalStack version pin.** LocalStack has free and pro tiers; some Secrets Manager features are pro-only. Confirm the free-tier feature set covers our trait surface (versioning, soft-delete, tagging, resource policies-not-needed since we don't use them).
+4. **`xv migrate --with-history`** — punted from Phase 3, but worth a sketched-but-not-built design appendix here so Phase 4 has a head-start? Decision: keep it as a stretch goal note in §8.5; full design when scheduled.
+5. **Phase 4 sequencing.** After v0.10, the natural Phase 4 is either (a) AWS Parameter Store + S3 file storage, (b) HashiCorp Vault backend, (c) v1.0 quality pass on remaining gpt-5.5 review items, or (d) TUI write mode. Decision deferred to a separate brainstorming session at the v0.10 retrospective.
+
+---
+
+## 15. Phase 4 preview (not in scope, captured for context)
+
+After v0.10 ships, Phase 4 starts with a separate brainstorming session. Candidates:
+
+- **Phase 4a — AWS S3 file storage + AWS Parameter Store.** Completes the AWS surface; introduces the second-service-on-one-cloud pattern (Secrets Manager + S3 share auth but are separate services); validates that `FileBackend` works on a non-Azure cloud.
+- **Phase 4b — HashiCorp Vault backend.** Closes the "three big cloud-secret stores" cohort; appeals to enterprise/self-hosted users.
+- **Phase 4c — v1.0 hardening pass.** Clears the remaining gpt-5.5 P2/P3 items (transactional local writes, scanner zeroization end-to-end, streaming blob I/O, capability/CLI alignment for backup/restore stubs) and ships v1.0 with a polished announcement.
+- **Phase 4d — TUI write mode.** Completes the v0.8-deferred TUI feature: create/edit/delete/rename via the `c`/`d`/`e`/`r` reserved keys.
+
+Selection happens at the v0.10 retrospective.

--- a/src/backend/aws/auth.rs
+++ b/src/backend/aws/auth.rs
@@ -1,1 +1,44 @@
-//! AWS SDK client builder. Loads credentials via aws-config default chain.
+//! AWS SDK config builder. Loads credentials via the aws-config default chain.
+//!
+//! No xv-specific credential priority abstraction (unlike Azure's
+//! `--credential-priority`). AWS users have strong opinions about credential
+//! resolution; the SDK chain is industry standard and we don't try to model it.
+
+use crate::backend::aws::config::AwsConfig;
+use crate::backend::error::BackendError;
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+
+/// Build a `SecretsManagerClient` from the resolved `AwsConfig` plus
+/// per-invocation overrides (region, profile from CLI flags or env vars).
+pub async fn build_client(
+    aws_cfg: &AwsConfig,
+    region_override: Option<String>,
+    profile_override: Option<String>,
+) -> Result<SecretsManagerClient, BackendError> {
+    let region = region_override
+        .or_else(|| aws_cfg.region.clone())
+        .or_else(|| std::env::var("AWS_REGION").ok())
+        .or_else(|| std::env::var("AWS_DEFAULT_REGION").ok())
+        .ok_or_else(|| {
+            BackendError::AuthenticationFailed(
+                "AWS region not set: provide [aws].region, AWS_REGION, or --region".into(),
+            )
+        })?;
+
+    let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(aws_config::Region::new(region));
+
+    let profile = profile_override.or_else(|| aws_cfg.profile.clone());
+    if let Some(ref p) = profile {
+        loader = loader.profile_name(p);
+    }
+
+    if let Some(ref endpoint) = aws_cfg.endpoint_url {
+        if !endpoint.is_empty() {
+            loader = loader.endpoint_url(endpoint);
+        }
+    }
+
+    let sdk_config = loader.load().await;
+    Ok(SecretsManagerClient::new(&sdk_config))
+}

--- a/src/backend/aws/auth.rs
+++ b/src/backend/aws/auth.rs
@@ -1,0 +1,1 @@
+//! AWS SDK client builder. Loads credentials via aws-config default chain.

--- a/src/backend/aws/config.rs
+++ b/src/backend/aws/config.rs
@@ -1,1 +1,4 @@
-//! `AwsConfig` struct and resolution helpers. See Task 5.
+//! `AwsConfig` struct and resolution helpers.
+
+// Re-export from the main config module where it lives.
+pub use crate::config::settings::AwsConfig;

--- a/src/backend/aws/config.rs
+++ b/src/backend/aws/config.rs
@@ -1,0 +1,1 @@
+//! `AwsConfig` struct and resolution helpers. See Task 5.

--- a/src/backend/aws/encoding.rs
+++ b/src/backend/aws/encoding.rs
@@ -37,8 +37,12 @@ pub fn is_marker(full_name: &str) -> bool {
     full_name.ends_with(&format!("/{MARKER_BASENAME}")) || full_name == MARKER_BASENAME
 }
 
-/// Validate a user-facing secret name. Rejects empty names and names
-/// starting with `.xv-` (reserved namespace).
+/// Validate a user-facing secret name. Rejects empty names, names in the
+/// reserved `.xv-*` namespace, and names that would exceed [`MAX_NAME_LEN`]
+/// once the vault prefix and separator are prepended.
+///
+/// Note: the vault prefix length is not known here, so we conservatively check
+/// that the bare name does not already exceed the limit by itself.
 pub fn validate_secret_name(name: &str) -> Result<(), BackendError> {
     if name.is_empty() {
         return Err(BackendError::InvalidArgument(
@@ -48,6 +52,12 @@ pub fn validate_secret_name(name: &str) -> Result<(), BackendError> {
     if name.starts_with(".xv-") {
         return Err(BackendError::InvalidArgument(format!(
             "secret name '{name}' is in the reserved '.xv-*' namespace"
+        )));
+    }
+    if name.len() > MAX_NAME_LEN {
+        return Err(BackendError::InvalidArgument(format!(
+            "secret name too long: {} chars (max {MAX_NAME_LEN})",
+            name.len()
         )));
     }
     Ok(())

--- a/src/backend/aws/encoding.rs
+++ b/src/backend/aws/encoding.rs
@@ -37,12 +37,8 @@ pub fn is_marker(full_name: &str) -> bool {
     full_name.ends_with(&format!("/{MARKER_BASENAME}")) || full_name == MARKER_BASENAME
 }
 
-/// Validate a user-facing secret name. Rejects empty names, names in the
-/// reserved `.xv-*` namespace, and names that would exceed [`MAX_NAME_LEN`]
-/// once the vault prefix and separator are prepended.
-///
-/// Note: the vault prefix length is not known here, so we conservatively check
-/// that the bare name does not already exceed the limit by itself.
+/// Validate a user-facing secret name. Rejects empty names and names in the
+/// reserved `.xv-*` namespace.
 pub fn validate_secret_name(name: &str) -> Result<(), BackendError> {
     if name.is_empty() {
         return Err(BackendError::InvalidArgument(
@@ -58,6 +54,19 @@ pub fn validate_secret_name(name: &str) -> Result<(), BackendError> {
         return Err(BackendError::InvalidArgument(format!(
             "secret name too long: {} chars (max {MAX_NAME_LEN})",
             name.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Validate the full AWS secret name after the vault prefix is prepended.
+pub fn validate_full_secret_name(vault: &str, name: &str) -> Result<(), BackendError> {
+    validate_secret_name(name)?;
+    let full_name = aws_name(vault, name);
+    if full_name.len() > MAX_NAME_LEN {
+        return Err(BackendError::InvalidArgument(format!(
+            "AWS secret name too long: {} chars for '{vault}/{name}' (max {MAX_NAME_LEN})",
+            full_name.len()
         )));
     }
     Ok(())
@@ -111,5 +120,16 @@ mod tests {
         assert!(validate_secret_name("db-password").is_ok());
         assert!(validate_secret_name("api/v1/key").is_ok());
         assert!(validate_secret_name("v1.2.3-rc.1").is_ok());
+    }
+
+    #[test]
+    fn validate_full_secret_name_counts_vault_prefix() {
+        let vault = "vault-prefix";
+        let max_inner = MAX_NAME_LEN - vault.len() - 1;
+        assert!(validate_full_secret_name(vault, &"a".repeat(max_inner)).is_ok());
+        assert!(matches!(
+            validate_full_secret_name(vault, &"a".repeat(max_inner + 1)),
+            Err(BackendError::InvalidArgument(_))
+        ));
     }
 }

--- a/src/backend/aws/encoding.rs
+++ b/src/backend/aws/encoding.rs
@@ -1,0 +1,1 @@
+//! Name encoding/decoding for AWS Secrets Manager. See Task 10.

--- a/src/backend/aws/encoding.rs
+++ b/src/backend/aws/encoding.rs
@@ -34,8 +34,7 @@ pub fn marker_name(vault: &str) -> String {
 
 /// Returns true if `full_name` is a vault marker secret name.
 pub fn is_marker(full_name: &str) -> bool {
-    full_name.ends_with(&format!("/{MARKER_BASENAME}"))
-        || full_name == MARKER_BASENAME
+    full_name.ends_with(&format!("/{MARKER_BASENAME}")) || full_name == MARKER_BASENAME
 }
 
 /// Validate a user-facing secret name. Rejects empty names and names
@@ -60,12 +59,18 @@ mod tests {
 
     #[test]
     fn aws_name_joins_prefix() {
-        assert_eq!(aws_name("myproj-kv", "db-password"), "myproj-kv/db-password");
+        assert_eq!(
+            aws_name("myproj-kv", "db-password"),
+            "myproj-kv/db-password"
+        );
     }
 
     #[test]
     fn strip_prefix_extracts_secret_name() {
-        assert_eq!(strip_prefix("myproj-kv", "myproj-kv/db-password"), Some("db-password".to_string()));
+        assert_eq!(
+            strip_prefix("myproj-kv", "myproj-kv/db-password"),
+            Some("db-password".to_string())
+        );
         assert_eq!(strip_prefix("myproj-kv", "other-vault/db-password"), None);
     }
 

--- a/src/backend/aws/encoding.rs
+++ b/src/backend/aws/encoding.rs
@@ -1,1 +1,100 @@
-//! Name encoding/decoding for AWS Secrets Manager. See Task 10.
+//! Name encoding/decoding for AWS Secrets Manager.
+//!
+//! AWS allows `[a-zA-Z0-9/_+=.@-]` and 512-char names. Our prefix-based
+//! virtual vault scheme produces names like `myproj-kv/db-password`.
+//!
+//! The reserved namespace `.xv-*` is used for vault markers and other
+//! xv-internal bookkeeping. User-supplied names starting with `.xv-` are
+//! rejected at the `set_secret` boundary.
+
+use crate::backend::error::BackendError;
+
+/// The AWS Secrets Manager name length limit.
+pub const MAX_NAME_LEN: usize = 512;
+
+/// The marker filename inside each vault prefix.
+const MARKER_BASENAME: &str = ".xv-vault";
+
+/// Returns the full AWS name for a secret in a given vault.
+pub fn aws_name(vault: &str, secret_name: &str) -> String {
+    format!("{vault}/{secret_name}")
+}
+
+/// Strips the vault prefix from an AWS name, returning the inner secret name.
+/// Returns None if the name doesn't belong to the given vault.
+pub fn strip_prefix(vault: &str, full_name: &str) -> Option<String> {
+    let prefix = format!("{vault}/");
+    full_name.strip_prefix(&prefix).map(|s| s.to_string())
+}
+
+/// Returns the AWS name of the vault marker secret.
+pub fn marker_name(vault: &str) -> String {
+    format!("{vault}/{MARKER_BASENAME}")
+}
+
+/// Returns true if `full_name` is a vault marker secret name.
+pub fn is_marker(full_name: &str) -> bool {
+    full_name.ends_with(&format!("/{MARKER_BASENAME}"))
+        || full_name == MARKER_BASENAME
+}
+
+/// Validate a user-facing secret name. Rejects empty names and names
+/// starting with `.xv-` (reserved namespace).
+pub fn validate_secret_name(name: &str) -> Result<(), BackendError> {
+    if name.is_empty() {
+        return Err(BackendError::InvalidArgument(
+            "secret name cannot be empty".into(),
+        ));
+    }
+    if name.starts_with(".xv-") {
+        return Err(BackendError::InvalidArgument(format!(
+            "secret name '{name}' is in the reserved '.xv-*' namespace"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aws_name_joins_prefix() {
+        assert_eq!(aws_name("myproj-kv", "db-password"), "myproj-kv/db-password");
+    }
+
+    #[test]
+    fn strip_prefix_extracts_secret_name() {
+        assert_eq!(strip_prefix("myproj-kv", "myproj-kv/db-password"), Some("db-password".to_string()));
+        assert_eq!(strip_prefix("myproj-kv", "other-vault/db-password"), None);
+    }
+
+    #[test]
+    fn marker_name_constant() {
+        assert_eq!(marker_name("myproj-kv"), "myproj-kv/.xv-vault");
+    }
+
+    #[test]
+    fn is_marker_detects_marker() {
+        assert!(is_marker("myproj-kv/.xv-vault"));
+        assert!(!is_marker("myproj-kv/db-password"));
+    }
+
+    #[test]
+    fn validate_secret_name_rejects_reserved() {
+        assert!(matches!(validate_secret_name(".xv-vault"), Err(_)));
+        assert!(matches!(validate_secret_name(".xv-anything"), Err(_)));
+    }
+
+    #[test]
+    fn validate_secret_name_rejects_empty() {
+        assert!(matches!(validate_secret_name(""), Err(_)));
+    }
+
+    #[test]
+    fn validate_secret_name_accepts_normal_names() {
+        assert!(validate_secret_name("db-password").is_ok());
+        assert!(validate_secret_name("api/v1/key").is_ok());
+        assert!(validate_secret_name("v1.2.3-rc.1").is_ok());
+    }
+}

--- a/src/backend/aws/errors.rs
+++ b/src/backend/aws/errors.rs
@@ -24,14 +24,15 @@ fn generic<E: std::fmt::Display>(op: &str, e: E) -> BackendError {
     BackendError::Internal(format!("aws {op}: {e}"))
 }
 
-fn handle_sdk<E: std::fmt::Display + std::fmt::Debug, R: std::fmt::Debug>(op: &str, e: SdkError<E, R>) -> BackendError {
+fn handle_sdk<E: std::fmt::Display + std::fmt::Debug, R: std::fmt::Debug>(
+    op: &str,
+    e: SdkError<E, R>,
+) -> BackendError {
     match e {
         SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) => {
             BackendError::Network(format!("aws {op}: timeout or dispatch failure"))
         }
-        SdkError::ServiceError(svc) => {
-            BackendError::Internal(format!("aws {op}: {}", svc.err()))
-        }
+        SdkError::ServiceError(svc) => BackendError::Internal(format!("aws {op}: {}", svc.err())),
         other => generic(op, format!("{other:?}")),
     }
 }

--- a/src/backend/aws/errors.rs
+++ b/src/backend/aws/errors.rs
@@ -5,23 +5,20 @@
 //! readable and the mapping is exhaustive over the variants we observe.
 
 use crate::backend::error::BackendError;
-use aws_sdk_secretsmanager::operation::create_secret::{CreateSecretError, CreateSecretOutput};
-use aws_sdk_secretsmanager::operation::delete_secret::{DeleteSecretError, DeleteSecretOutput};
-use aws_sdk_secretsmanager::operation::describe_secret::{DescribeSecretError, DescribeSecretOutput};
-use aws_sdk_secretsmanager::operation::get_secret_value::{GetSecretValueError, GetSecretValueOutput};
-use aws_sdk_secretsmanager::operation::list_secret_version_ids::{
-    ListSecretVersionIdsError, ListSecretVersionIdsOutput,
-};
-use aws_sdk_secretsmanager::operation::list_secrets::{ListSecretsError, ListSecretsOutput};
-use aws_sdk_secretsmanager::operation::put_secret_value::{PutSecretValueError, PutSecretValueOutput};
-use aws_sdk_secretsmanager::operation::restore_secret::{RestoreSecretError, RestoreSecretOutput};
-use aws_sdk_secretsmanager::operation::tag_resource::{TagResourceError, TagResourceOutput};
-use aws_sdk_secretsmanager::operation::untag_resource::{UntagResourceError, UntagResourceOutput};
-use aws_sdk_secretsmanager::operation::update_secret::{UpdateSecretError, UpdateSecretOutput};
-use aws_sdk_secretsmanager::operation::update_secret_version_stage::{
-    UpdateSecretVersionStageError, UpdateSecretVersionStageOutput,
-};
+use aws_sdk_secretsmanager::operation::create_secret::CreateSecretError;
+use aws_sdk_secretsmanager::operation::delete_secret::DeleteSecretError;
+use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretError;
+use aws_sdk_secretsmanager::operation::get_secret_value::GetSecretValueError;
+use aws_sdk_secretsmanager::operation::list_secret_version_ids::ListSecretVersionIdsError;
+use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsError;
+use aws_sdk_secretsmanager::operation::put_secret_value::PutSecretValueError;
+use aws_sdk_secretsmanager::operation::restore_secret::RestoreSecretError;
+use aws_sdk_secretsmanager::operation::tag_resource::TagResourceError;
+use aws_sdk_secretsmanager::operation::untag_resource::UntagResourceError;
+use aws_sdk_secretsmanager::operation::update_secret::UpdateSecretError;
+use aws_sdk_secretsmanager::operation::update_secret_version_stage::UpdateSecretVersionStageError;
 use aws_smithy_runtime_api::client::result::SdkError;
+use aws_smithy_runtime_api::http::Response;
 
 fn generic<E: std::fmt::Display>(op: &str, e: E) -> BackendError {
     BackendError::Internal(format!("aws {op}: {e}"))
@@ -39,7 +36,7 @@ fn handle_sdk<E: std::fmt::Display + std::fmt::Debug, R: std::fmt::Debug>(op: &s
     }
 }
 
-pub fn from_create(e: SdkError<CreateSecretError, CreateSecretOutput>) -> BackendError {
+pub fn from_create(e: SdkError<CreateSecretError, Response>) -> BackendError {
     if let SdkError::ServiceError(svc) = &e {
         match svc.err() {
             CreateSecretError::ResourceExistsException(inner) => {
@@ -62,7 +59,7 @@ pub fn from_create(e: SdkError<CreateSecretError, CreateSecretOutput>) -> Backen
     handle_sdk("CreateSecret", e)
 }
 
-pub fn from_get_value(name: &str, e: SdkError<GetSecretValueError, GetSecretValueOutput>) -> BackendError {
+pub fn from_get_value(name: &str, e: SdkError<GetSecretValueError, Response>) -> BackendError {
     if let SdkError::ServiceError(svc) = &e {
         match svc.err() {
             GetSecretValueError::ResourceNotFoundException(_) => {
@@ -83,7 +80,7 @@ pub fn from_get_value(name: &str, e: SdkError<GetSecretValueError, GetSecretValu
     handle_sdk("GetSecretValue", e)
 }
 
-pub fn from_describe(name: &str, e: SdkError<DescribeSecretError, DescribeSecretOutput>) -> BackendError {
+pub fn from_describe(name: &str, e: SdkError<DescribeSecretError, Response>) -> BackendError {
     if let SdkError::ServiceError(svc) = &e {
         if let DescribeSecretError::ResourceNotFoundException(_) = svc.err() {
             return BackendError::NotFound {
@@ -95,11 +92,11 @@ pub fn from_describe(name: &str, e: SdkError<DescribeSecretError, DescribeSecret
     handle_sdk("DescribeSecret", e)
 }
 
-pub fn from_list(e: SdkError<ListSecretsError, ListSecretsOutput>) -> BackendError {
+pub fn from_list(e: SdkError<ListSecretsError, Response>) -> BackendError {
     handle_sdk("ListSecrets", e)
 }
 
-pub fn from_delete(name: &str, e: SdkError<DeleteSecretError, DeleteSecretOutput>) -> BackendError {
+pub fn from_delete(name: &str, e: SdkError<DeleteSecretError, Response>) -> BackendError {
     if let SdkError::ServiceError(svc) = &e {
         if let DeleteSecretError::ResourceNotFoundException(_) = svc.err() {
             return BackendError::NotFound {
@@ -111,7 +108,7 @@ pub fn from_delete(name: &str, e: SdkError<DeleteSecretError, DeleteSecretOutput
     handle_sdk("DeleteSecret", e)
 }
 
-pub fn from_put_value(name: &str, e: SdkError<PutSecretValueError, PutSecretValueOutput>) -> BackendError {
+pub fn from_put_value(name: &str, e: SdkError<PutSecretValueError, Response>) -> BackendError {
     if let SdkError::ServiceError(svc) = &e {
         if let PutSecretValueError::ResourceNotFoundException(_) = svc.err() {
             return BackendError::NotFound {
@@ -123,7 +120,7 @@ pub fn from_put_value(name: &str, e: SdkError<PutSecretValueError, PutSecretValu
     handle_sdk("PutSecretValue", e)
 }
 
-pub fn from_update(name: &str, e: SdkError<UpdateSecretError, UpdateSecretOutput>) -> BackendError {
+pub fn from_update(name: &str, e: SdkError<UpdateSecretError, Response>) -> BackendError {
     if let SdkError::ServiceError(svc) = &e {
         if let UpdateSecretError::ResourceNotFoundException(_) = svc.err() {
             return BackendError::NotFound {
@@ -135,7 +132,7 @@ pub fn from_update(name: &str, e: SdkError<UpdateSecretError, UpdateSecretOutput
     handle_sdk("UpdateSecret", e)
 }
 
-pub fn from_restore(name: &str, e: SdkError<RestoreSecretError, RestoreSecretOutput>) -> BackendError {
+pub fn from_restore(name: &str, e: SdkError<RestoreSecretError, Response>) -> BackendError {
     if let SdkError::ServiceError(svc) = &e {
         if let RestoreSecretError::ResourceNotFoundException(_) = svc.err() {
             return BackendError::NotFound {
@@ -149,7 +146,7 @@ pub fn from_restore(name: &str, e: SdkError<RestoreSecretError, RestoreSecretOut
 
 pub fn from_list_versions(
     name: &str,
-    e: SdkError<ListSecretVersionIdsError, ListSecretVersionIdsOutput>,
+    e: SdkError<ListSecretVersionIdsError, Response>,
 ) -> BackendError {
     if let SdkError::ServiceError(svc) = &e {
         if let ListSecretVersionIdsError::ResourceNotFoundException(_) = svc.err() {
@@ -164,7 +161,7 @@ pub fn from_list_versions(
 
 pub fn from_update_stage(
     name: &str,
-    e: SdkError<UpdateSecretVersionStageError, UpdateSecretVersionStageOutput>,
+    e: SdkError<UpdateSecretVersionStageError, Response>,
 ) -> BackendError {
     if let SdkError::ServiceError(svc) = &e {
         if let UpdateSecretVersionStageError::ResourceNotFoundException(_) = svc.err() {
@@ -177,10 +174,10 @@ pub fn from_update_stage(
     handle_sdk("UpdateSecretVersionStage", e)
 }
 
-pub fn from_tag(e: SdkError<TagResourceError, TagResourceOutput>) -> BackendError {
+pub fn from_tag(e: SdkError<TagResourceError, Response>) -> BackendError {
     handle_sdk("TagResource", e)
 }
 
-pub fn from_untag(e: SdkError<UntagResourceError, UntagResourceOutput>) -> BackendError {
+pub fn from_untag(e: SdkError<UntagResourceError, Response>) -> BackendError {
     handle_sdk("UntagResource", e)
 }

--- a/src/backend/aws/errors.rs
+++ b/src/backend/aws/errors.rs
@@ -1,0 +1,1 @@
+//! AWS SDK error -> BackendError mapping. See Task 9.

--- a/src/backend/aws/errors.rs
+++ b/src/backend/aws/errors.rs
@@ -1,1 +1,186 @@
-//! AWS SDK error -> BackendError mapping. See Task 9.
+//! AWS SDK error -> BackendError mapping.
+//!
+//! The AWS SDK exposes per-operation error enums (e.g. `GetSecretValueError`).
+//! We provide free functions for each operation we use, so call sites stay
+//! readable and the mapping is exhaustive over the variants we observe.
+
+use crate::backend::error::BackendError;
+use aws_sdk_secretsmanager::operation::create_secret::{CreateSecretError, CreateSecretOutput};
+use aws_sdk_secretsmanager::operation::delete_secret::{DeleteSecretError, DeleteSecretOutput};
+use aws_sdk_secretsmanager::operation::describe_secret::{DescribeSecretError, DescribeSecretOutput};
+use aws_sdk_secretsmanager::operation::get_secret_value::{GetSecretValueError, GetSecretValueOutput};
+use aws_sdk_secretsmanager::operation::list_secret_version_ids::{
+    ListSecretVersionIdsError, ListSecretVersionIdsOutput,
+};
+use aws_sdk_secretsmanager::operation::list_secrets::{ListSecretsError, ListSecretsOutput};
+use aws_sdk_secretsmanager::operation::put_secret_value::{PutSecretValueError, PutSecretValueOutput};
+use aws_sdk_secretsmanager::operation::restore_secret::{RestoreSecretError, RestoreSecretOutput};
+use aws_sdk_secretsmanager::operation::tag_resource::{TagResourceError, TagResourceOutput};
+use aws_sdk_secretsmanager::operation::untag_resource::{UntagResourceError, UntagResourceOutput};
+use aws_sdk_secretsmanager::operation::update_secret::{UpdateSecretError, UpdateSecretOutput};
+use aws_sdk_secretsmanager::operation::update_secret_version_stage::{
+    UpdateSecretVersionStageError, UpdateSecretVersionStageOutput,
+};
+use aws_smithy_runtime_api::client::result::SdkError;
+
+fn generic<E: std::fmt::Display>(op: &str, e: E) -> BackendError {
+    BackendError::Internal(format!("aws {op}: {e}"))
+}
+
+fn handle_sdk<E: std::fmt::Display + std::fmt::Debug, R: std::fmt::Debug>(op: &str, e: SdkError<E, R>) -> BackendError {
+    match e {
+        SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) => {
+            BackendError::Network(format!("aws {op}: timeout or dispatch failure"))
+        }
+        SdkError::ServiceError(svc) => {
+            BackendError::Internal(format!("aws {op}: {}", svc.err()))
+        }
+        other => generic(op, format!("{other:?}")),
+    }
+}
+
+pub fn from_create(e: SdkError<CreateSecretError, CreateSecretOutput>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        match svc.err() {
+            CreateSecretError::ResourceExistsException(inner) => {
+                return BackendError::Conflict(inner.to_string())
+            }
+            CreateSecretError::InvalidRequestException(inner) => {
+                return BackendError::InvalidArgument(inner.to_string())
+            }
+            CreateSecretError::InvalidParameterException(inner) => {
+                return BackendError::InvalidArgument(inner.to_string())
+            }
+            CreateSecretError::LimitExceededException(_) => {
+                return BackendError::RateLimited {
+                    retry_after_secs: None,
+                }
+            }
+            _ => {}
+        }
+    }
+    handle_sdk("CreateSecret", e)
+}
+
+pub fn from_get_value(name: &str, e: SdkError<GetSecretValueError, GetSecretValueOutput>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        match svc.err() {
+            GetSecretValueError::ResourceNotFoundException(_) => {
+                return BackendError::NotFound {
+                    name: name.to_string(),
+                    suggestion: None,
+                }
+            }
+            GetSecretValueError::DecryptionFailure(inner) => {
+                return BackendError::Internal(format!("decryption failed: {inner}"))
+            }
+            GetSecretValueError::InvalidRequestException(inner) => {
+                return BackendError::InvalidArgument(inner.to_string())
+            }
+            _ => {}
+        }
+    }
+    handle_sdk("GetSecretValue", e)
+}
+
+pub fn from_describe(name: &str, e: SdkError<DescribeSecretError, DescribeSecretOutput>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let DescribeSecretError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("DescribeSecret", e)
+}
+
+pub fn from_list(e: SdkError<ListSecretsError, ListSecretsOutput>) -> BackendError {
+    handle_sdk("ListSecrets", e)
+}
+
+pub fn from_delete(name: &str, e: SdkError<DeleteSecretError, DeleteSecretOutput>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let DeleteSecretError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("DeleteSecret", e)
+}
+
+pub fn from_put_value(name: &str, e: SdkError<PutSecretValueError, PutSecretValueOutput>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let PutSecretValueError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("PutSecretValue", e)
+}
+
+pub fn from_update(name: &str, e: SdkError<UpdateSecretError, UpdateSecretOutput>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let UpdateSecretError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("UpdateSecret", e)
+}
+
+pub fn from_restore(name: &str, e: SdkError<RestoreSecretError, RestoreSecretOutput>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let RestoreSecretError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("RestoreSecret", e)
+}
+
+pub fn from_list_versions(
+    name: &str,
+    e: SdkError<ListSecretVersionIdsError, ListSecretVersionIdsOutput>,
+) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let ListSecretVersionIdsError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("ListSecretVersionIds", e)
+}
+
+pub fn from_update_stage(
+    name: &str,
+    e: SdkError<UpdateSecretVersionStageError, UpdateSecretVersionStageOutput>,
+) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if let UpdateSecretVersionStageError::ResourceNotFoundException(_) = svc.err() {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_sdk("UpdateSecretVersionStage", e)
+}
+
+pub fn from_tag(e: SdkError<TagResourceError, TagResourceOutput>) -> BackendError {
+    handle_sdk("TagResource", e)
+}
+
+pub fn from_untag(e: SdkError<UntagResourceError, UntagResourceOutput>) -> BackendError {
+    handle_sdk("UntagResource", e)
+}

--- a/src/backend/aws/errors.rs
+++ b/src/backend/aws/errors.rs
@@ -135,11 +135,20 @@ pub fn from_update(name: &str, e: SdkError<UpdateSecretError, Response>) -> Back
 
 pub fn from_restore(name: &str, e: SdkError<RestoreSecretError, Response>) -> BackendError {
     if let SdkError::ServiceError(svc) = &e {
-        if let RestoreSecretError::ResourceNotFoundException(_) = svc.err() {
-            return BackendError::NotFound {
-                name: name.to_string(),
-                suggestion: None,
-            };
+        match svc.err() {
+            RestoreSecretError::ResourceNotFoundException(_) => {
+                return BackendError::NotFound {
+                    name: name.to_string(),
+                    suggestion: None,
+                }
+            }
+            RestoreSecretError::InvalidRequestException(inner) => {
+                // Typically means the secret is not scheduled for deletion.
+                return BackendError::InvalidArgument(format!(
+                    "Secret is not scheduled for deletion: {inner}"
+                ));
+            }
+            _ => {}
         }
     }
     handle_sdk("RestoreSecret", e)

--- a/src/backend/aws/metadata.rs
+++ b/src/backend/aws/metadata.rs
@@ -1,1 +1,173 @@
-//! Tag <-> SecretProperties round-trip. See Task 11.
+//! Tag <-> SecretProperties round-trip for AWS backend.
+//!
+//! AWS Secrets Manager allows up to 50 tags per secret (vs Azure's 15);
+//! comfortable budget. Reserved keys live under the `xv:` prefix.
+
+use std::collections::HashMap;
+
+pub const TAG_ORIGINAL_NAME: &str = "xv:original_name";
+pub const TAG_GROUPS: &str = "xv:groups";
+pub const TAG_FOLDER: &str = "xv:folder";
+pub const TAG_CREATED_BY: &str = "xv:created_by";
+pub const TAG_CONTENT_TYPE: &str = "xv:content_type";
+pub const TAG_EXPIRES_AT: &str = "xv:expires_at";
+pub const TAG_TYPE: &str = "xv:type";
+pub const TAG_VALUE_VAULT_MARKER: &str = "vault-marker";
+pub const TAG_MIGRATED_FROM: &str = "xv:migrated_from";
+pub const TAG_MIGRATED_AT: &str = "xv:migrated_at";
+
+/// Subset of `SecretProperties` fields we actually round-trip.
+/// Real `SecretProperties` from `crate::secret::models` is bigger; we map
+/// to/from it at the call site.
+#[derive(Debug, Default, Clone)]
+pub struct TestProps {
+    pub original_name: String,
+    pub groups: Vec<String>,
+    pub folder: Option<String>,
+    pub created_by: Option<String>,
+    pub content_type: Option<String>,
+    pub note: Option<String>,            // -> AWS Description, not a tag
+    pub expires_at: Option<String>,
+    pub user_tags: HashMap<String, String>,
+}
+
+impl TestProps {
+    pub fn empty(name: &str) -> Self {
+        Self {
+            original_name: name.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Encode metadata into AWS-tag-shaped `(key, value)` pairs.
+/// Note: `note` is intentionally NOT encoded — it lives in AWS Description.
+pub fn encode_tags(p: &TestProps) -> Vec<(String, String)> {
+    let mut tags: Vec<(String, String)> = Vec::new();
+    tags.push((TAG_ORIGINAL_NAME.into(), p.original_name.clone()));
+    if !p.groups.is_empty() {
+        tags.push((TAG_GROUPS.into(), p.groups.join(",")));
+    }
+    if let Some(ref f) = p.folder {
+        tags.push((TAG_FOLDER.into(), f.clone()));
+    }
+    if let Some(ref c) = p.created_by {
+        tags.push((TAG_CREATED_BY.into(), c.clone()));
+    }
+    if let Some(ref ct) = p.content_type {
+        tags.push((TAG_CONTENT_TYPE.into(), ct.clone()));
+    }
+    if let Some(ref e) = p.expires_at {
+        tags.push((TAG_EXPIRES_AT.into(), e.clone()));
+    }
+    for (k, v) in &p.user_tags {
+        if !k.starts_with("xv:") {
+            tags.push((k.clone(), v.clone()));
+        }
+    }
+    tags
+}
+
+/// Decode AWS tags back into the metadata struct.
+pub fn decode_tags(tags: &[(String, String)]) -> TestProps {
+    let mut p = TestProps::default();
+    let mut user_tags = HashMap::new();
+    for (k, v) in tags {
+        match k.as_str() {
+            TAG_ORIGINAL_NAME => p.original_name = v.clone(),
+            TAG_GROUPS => {
+                p.groups = v
+                    .split(',')
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
+                    .collect()
+            }
+            TAG_FOLDER => p.folder = Some(v.clone()),
+            TAG_CREATED_BY => p.created_by = Some(v.clone()),
+            TAG_CONTENT_TYPE => p.content_type = Some(v.clone()),
+            TAG_EXPIRES_AT => p.expires_at = Some(v.clone()),
+            _ if !k.starts_with("xv:") => {
+                user_tags.insert(k.clone(), v.clone());
+            }
+            _ => {} // unknown xv: tag — ignored on decode
+        }
+    }
+    p.user_tags = user_tags;
+    p
+}
+
+/// True if this tag is a vault marker tag (`xv:type=vault-marker`).
+pub fn is_vault_marker_tag(key: &str, value: &str) -> bool {
+    key == TAG_TYPE && value == TAG_VALUE_VAULT_MARKER
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn round_trip_full_metadata() {
+        let mut user_tags = HashMap::new();
+        user_tags.insert("team".to_string(), "platform".to_string());
+
+        let props = TestProps {
+            original_name: "db-password".into(),
+            groups: vec!["backend".into(), "prod".into()],
+            folder: Some("app/database".into()),
+            created_by: Some("alice@example.com".into()),
+            content_type: Some("text/plain".into()),
+            note: Some("primary database admin password".into()),
+            expires_at: Some("2027-01-01T00:00:00Z".into()),
+            user_tags: user_tags.clone(),
+        };
+
+        let aws_tags = encode_tags(&props);
+        let decoded = decode_tags(&aws_tags);
+
+        assert_eq!(decoded.original_name, "db-password");
+        assert_eq!(decoded.groups, vec!["backend", "prod"]);
+        assert_eq!(decoded.folder.as_deref(), Some("app/database"));
+        assert_eq!(decoded.user_tags.get("team").unwrap(), "platform");
+    }
+
+    #[test]
+    fn empty_metadata_round_trips_to_empty_tags() {
+        let props = TestProps::empty("name1");
+        let aws_tags = encode_tags(&props);
+        assert!(aws_tags.iter().any(|(k, _)| k == "xv:original_name"));
+    }
+
+    #[test]
+    fn note_not_in_tags() {
+        let props = TestProps {
+            original_name: "x".into(),
+            note: Some("a note".into()),
+            ..Default::default()
+        };
+        let aws_tags = encode_tags(&props);
+        assert!(!aws_tags.iter().any(|(k, _)| k == "note" || k.contains("note")));
+    }
+
+    #[test]
+    fn user_tags_with_xv_prefix_excluded() {
+        let mut user_tags = HashMap::new();
+        user_tags.insert("xv:sneaky".to_string(), "value".to_string());
+        user_tags.insert("safe-key".to_string(), "value".to_string());
+        let props = TestProps {
+            original_name: "x".into(),
+            user_tags,
+            ..Default::default()
+        };
+        let aws_tags = encode_tags(&props);
+        assert!(!aws_tags.iter().any(|(k, _)| k == "xv:sneaky"));
+        assert!(aws_tags.iter().any(|(k, _)| k == "safe-key"));
+    }
+
+    #[test]
+    fn is_vault_marker_tag_works() {
+        assert!(is_vault_marker_tag("xv:type", "vault-marker"));
+        assert!(!is_vault_marker_tag("xv:type", "other"));
+        assert!(!is_vault_marker_tag("other", "vault-marker"));
+    }
+}

--- a/src/backend/aws/metadata.rs
+++ b/src/backend/aws/metadata.rs
@@ -26,7 +26,7 @@ pub struct TestProps {
     pub folder: Option<String>,
     pub created_by: Option<String>,
     pub content_type: Option<String>,
-    pub note: Option<String>,            // -> AWS Description, not a tag
+    pub note: Option<String>, // -> AWS Description, not a tag
     pub expires_at: Option<String>,
     pub user_tags: HashMap<String, String>,
 }
@@ -146,7 +146,9 @@ mod tests {
             ..Default::default()
         };
         let aws_tags = encode_tags(&props);
-        assert!(!aws_tags.iter().any(|(k, _)| k == "note" || k.contains("note")));
+        assert!(!aws_tags
+            .iter()
+            .any(|(k, _)| k == "note" || k.contains("note")));
     }
 
     #[test]

--- a/src/backend/aws/metadata.rs
+++ b/src/backend/aws/metadata.rs
@@ -1,0 +1,1 @@
+//! Tag <-> SecretProperties round-trip. See Task 11.

--- a/src/backend/aws/metadata.rs
+++ b/src/backend/aws/metadata.rs
@@ -3,8 +3,6 @@
 //! AWS Secrets Manager allows up to 50 tags per secret (vs Azure's 15);
 //! comfortable budget. Reserved keys live under the `xv:` prefix.
 
-use std::collections::HashMap;
-
 pub const TAG_ORIGINAL_NAME: &str = "xv:original_name";
 pub const TAG_GROUPS: &str = "xv:groups";
 pub const TAG_FOLDER: &str = "xv:folder";
@@ -16,95 +14,93 @@ pub const TAG_VALUE_VAULT_MARKER: &str = "vault-marker";
 pub const TAG_MIGRATED_FROM: &str = "xv:migrated_from";
 pub const TAG_MIGRATED_AT: &str = "xv:migrated_at";
 
-/// Subset of `SecretProperties` fields we actually round-trip.
-/// Real `SecretProperties` from `crate::secret::models` is bigger; we map
-/// to/from it at the call site.
-#[derive(Debug, Default, Clone)]
-pub struct TestProps {
-    pub original_name: String,
-    pub groups: Vec<String>,
-    pub folder: Option<String>,
-    pub created_by: Option<String>,
-    pub content_type: Option<String>,
-    pub note: Option<String>, // -> AWS Description, not a tag
-    pub expires_at: Option<String>,
-    pub user_tags: HashMap<String, String>,
-}
-
-impl TestProps {
-    pub fn empty(name: &str) -> Self {
-        Self {
-            original_name: name.into(),
-            ..Default::default()
-        }
-    }
-}
-
-/// Encode metadata into AWS-tag-shaped `(key, value)` pairs.
-/// Note: `note` is intentionally NOT encoded — it lives in AWS Description.
-pub fn encode_tags(p: &TestProps) -> Vec<(String, String)> {
-    let mut tags: Vec<(String, String)> = Vec::new();
-    tags.push((TAG_ORIGINAL_NAME.into(), p.original_name.clone()));
-    if !p.groups.is_empty() {
-        tags.push((TAG_GROUPS.into(), p.groups.join(",")));
-    }
-    if let Some(ref f) = p.folder {
-        tags.push((TAG_FOLDER.into(), f.clone()));
-    }
-    if let Some(ref c) = p.created_by {
-        tags.push((TAG_CREATED_BY.into(), c.clone()));
-    }
-    if let Some(ref ct) = p.content_type {
-        tags.push((TAG_CONTENT_TYPE.into(), ct.clone()));
-    }
-    if let Some(ref e) = p.expires_at {
-        tags.push((TAG_EXPIRES_AT.into(), e.clone()));
-    }
-    for (k, v) in &p.user_tags {
-        if !k.starts_with("xv:") {
-            tags.push((k.clone(), v.clone()));
-        }
-    }
-    tags
-}
-
-/// Decode AWS tags back into the metadata struct.
-pub fn decode_tags(tags: &[(String, String)]) -> TestProps {
-    let mut p = TestProps::default();
-    let mut user_tags = HashMap::new();
-    for (k, v) in tags {
-        match k.as_str() {
-            TAG_ORIGINAL_NAME => p.original_name = v.clone(),
-            TAG_GROUPS => {
-                p.groups = v
-                    .split(',')
-                    .filter(|s| !s.is_empty())
-                    .map(|s| s.to_string())
-                    .collect()
-            }
-            TAG_FOLDER => p.folder = Some(v.clone()),
-            TAG_CREATED_BY => p.created_by = Some(v.clone()),
-            TAG_CONTENT_TYPE => p.content_type = Some(v.clone()),
-            TAG_EXPIRES_AT => p.expires_at = Some(v.clone()),
-            _ if !k.starts_with("xv:") => {
-                user_tags.insert(k.clone(), v.clone());
-            }
-            _ => {} // unknown xv: tag — ignored on decode
-        }
-    }
-    p.user_tags = user_tags;
-    p
-}
-
-/// True if this tag is a vault marker tag (`xv:type=vault-marker`).
-pub fn is_vault_marker_tag(key: &str, value: &str) -> bool {
-    key == TAG_TYPE && value == TAG_VALUE_VAULT_MARKER
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    /// Subset of `SecretProperties` fields we actually round-trip in tests.
+    #[derive(Debug, Default, Clone)]
+    struct TestProps {
+        original_name: String,
+        groups: Vec<String>,
+        folder: Option<String>,
+        created_by: Option<String>,
+        content_type: Option<String>,
+        note: Option<String>, // -> AWS Description, not a tag
+        expires_at: Option<String>,
+        user_tags: HashMap<String, String>,
+    }
+
+    impl TestProps {
+        fn empty(name: &str) -> Self {
+            Self {
+                original_name: name.into(),
+                ..Default::default()
+            }
+        }
+    }
+
+    /// Encode metadata into AWS-tag-shaped `(key, value)` pairs.
+    /// Note: `note` is intentionally NOT encoded — it lives in AWS Description.
+    fn encode_tags(p: &TestProps) -> Vec<(String, String)> {
+        let mut tags: Vec<(String, String)> = Vec::new();
+        tags.push((TAG_ORIGINAL_NAME.into(), p.original_name.clone()));
+        if !p.groups.is_empty() {
+            tags.push((TAG_GROUPS.into(), p.groups.join(",")));
+        }
+        if let Some(ref f) = p.folder {
+            tags.push((TAG_FOLDER.into(), f.clone()));
+        }
+        if let Some(ref c) = p.created_by {
+            tags.push((TAG_CREATED_BY.into(), c.clone()));
+        }
+        if let Some(ref ct) = p.content_type {
+            tags.push((TAG_CONTENT_TYPE.into(), ct.clone()));
+        }
+        if let Some(ref e) = p.expires_at {
+            tags.push((TAG_EXPIRES_AT.into(), e.clone()));
+        }
+        for (k, v) in &p.user_tags {
+            if !k.starts_with("xv:") {
+                tags.push((k.clone(), v.clone()));
+            }
+        }
+        tags
+    }
+
+    /// Decode AWS tags back into the metadata struct.
+    fn decode_tags(tags: &[(String, String)]) -> TestProps {
+        let mut p = TestProps::default();
+        let mut user_tags = HashMap::new();
+        for (k, v) in tags {
+            match k.as_str() {
+                TAG_ORIGINAL_NAME => p.original_name = v.clone(),
+                TAG_GROUPS => {
+                    p.groups = v
+                        .split(',')
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string())
+                        .collect()
+                }
+                TAG_FOLDER => p.folder = Some(v.clone()),
+                TAG_CREATED_BY => p.created_by = Some(v.clone()),
+                TAG_CONTENT_TYPE => p.content_type = Some(v.clone()),
+                TAG_EXPIRES_AT => p.expires_at = Some(v.clone()),
+                _ if !k.starts_with("xv:") => {
+                    user_tags.insert(k.clone(), v.clone());
+                }
+                _ => {} // unknown xv: tag — ignored on decode
+            }
+        }
+        p.user_tags = user_tags;
+        p
+    }
+
+    /// True if this tag is a vault marker tag (`xv:type=vault-marker`).
+    fn is_vault_marker_tag(key: &str, value: &str) -> bool {
+        key == TAG_TYPE && value == TAG_VALUE_VAULT_MARKER
+    }
 
     #[test]
     fn round_trip_full_metadata() {

--- a/src/backend/aws/mod.rs
+++ b/src/backend/aws/mod.rs
@@ -1,6 +1,4 @@
 //! AWS Secrets Manager backend.
-//!
-//! Phase 3 / v0.10. See `docs/superpowers/specs/2026-05-09-aws-backend-phase-3-design.md`.
 
 pub mod auth;
 pub mod config;
@@ -11,4 +9,76 @@ pub mod models;
 pub mod secrets;
 pub mod vaults;
 
-// AwsBackend struct fleshed out in Task 12.
+use std::sync::Arc;
+
+use crate::backend::{
+    Backend, BackendCapabilities, BackendKind, NameCharset, SecretBackend, VaultBackend,
+};
+use crate::backend::error::BackendError;
+use crate::config::settings::AwsConfig;
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+
+pub struct AwsBackend {
+    secrets_impl: Arc<secrets::AwsSecretBackend>,
+    vaults_impl: Arc<vaults::AwsVaultBackend>,
+}
+
+impl AwsBackend {
+    /// Build a backend from config + per-invocation overrides.
+    /// Async because `aws-config::load()` is async.
+    pub async fn new(
+        aws_cfg: &AwsConfig,
+        region_override: Option<String>,
+        profile_override: Option<String>,
+    ) -> Result<Self, BackendError> {
+        let client: SecretsManagerClient =
+            auth::build_client(aws_cfg, region_override, profile_override).await?;
+        let client = Arc::new(client);
+        Ok(Self {
+            secrets_impl: Arc::new(secrets::AwsSecretBackend::new(client.clone())),
+            vaults_impl: Arc::new(vaults::AwsVaultBackend::new(client)),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Backend for AwsBackend {
+    fn name(&self) -> &'static str {
+        "aws"
+    }
+
+    fn kind(&self) -> BackendKind {
+        BackendKind::Aws
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            has_vaults: true,
+            has_file_storage: false,
+            has_rbac: false,
+            has_audit: false,
+            has_versioning: true,
+            has_soft_delete: true,
+            has_secret_rotation: false,
+            has_groups: true,
+            has_folders: true,
+            has_notes: true,
+            has_expiry: true,
+            max_secret_size: Some(65_536),
+            max_name_length: Some(encoding::MAX_NAME_LEN),
+            name_charset: NameCharset::AwsRelaxed,
+        }
+    }
+
+    fn secrets(&self) -> &dyn SecretBackend {
+        self.secrets_impl.as_ref()
+    }
+
+    fn vaults(&self) -> Option<&dyn VaultBackend> {
+        Some(self.vaults_impl.as_ref())
+    }
+
+    async fn health_check(&self) -> Result<(), BackendError> {
+        self.secrets_impl.health_check().await
+    }
+}

--- a/src/backend/aws/mod.rs
+++ b/src/backend/aws/mod.rs
@@ -11,10 +11,10 @@ pub mod vaults;
 
 use std::sync::Arc;
 
+use crate::backend::error::BackendError;
 use crate::backend::{
     Backend, BackendCapabilities, BackendKind, NameCharset, SecretBackend, VaultBackend,
 };
-use crate::backend::error::BackendError;
 use crate::config::settings::AwsConfig;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 

--- a/src/backend/aws/mod.rs
+++ b/src/backend/aws/mod.rs
@@ -1,0 +1,14 @@
+//! AWS Secrets Manager backend.
+//!
+//! Phase 3 / v0.10. See `docs/superpowers/specs/2026-05-09-aws-backend-phase-3-design.md`.
+
+pub mod auth;
+pub mod config;
+pub mod encoding;
+pub mod errors;
+pub mod metadata;
+pub mod models;
+pub mod secrets;
+pub mod vaults;
+
+// AwsBackend struct fleshed out in Task 12.

--- a/src/backend/aws/models.rs
+++ b/src/backend/aws/models.rs
@@ -1,0 +1,1 @@
+//! Internal AWS-specific types.

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -8,6 +8,12 @@ use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+fn preserves_request_tag(key: &str) -> bool {
+    use crate::backend::aws::metadata::{TAG_MIGRATED_AT, TAG_MIGRATED_FROM};
+
+    !key.starts_with("xv:") || key == TAG_MIGRATED_FROM || key == TAG_MIGRATED_AT
+}
+
 pub struct AwsSecretBackend {
     pub(crate) client: Arc<SecretsManagerClient>,
 }
@@ -31,7 +37,7 @@ impl AwsSecretBackend {
     /// Update an already-existing secret (upsert path). Implemented in Task 19.
     async fn update_existing_secret(
         &self,
-        vault: &str,
+        _vault: &str,
         request: &SecretRequest,
         aws_full_name: &str,
     ) -> Result<SecretProperties, BackendError> {
@@ -105,7 +111,7 @@ impl AwsSecretBackend {
         }
         if let Some(ref user_tags) = request.tags {
             for (k, v) in user_tags {
-                if !k.starts_with("xv:") {
+                if preserves_request_tag(k) {
                     new_tags.push(Tag::builder().key(k).value(v).build());
                 }
             }
@@ -113,10 +119,8 @@ impl AwsSecretBackend {
 
         // Compute which existing keys are absent from the new tag set so we
         // only remove the delta rather than stripping and re-applying everything.
-        let new_keys: std::collections::HashSet<&str> = new_tags
-            .iter()
-            .filter_map(|t| t.key())
-            .collect();
+        let new_keys: std::collections::HashSet<&str> =
+            new_tags.iter().filter_map(|t| t.key()).collect();
         let keys_to_remove: Vec<String> = describe
             .tags()
             .iter()
@@ -234,7 +238,8 @@ impl AwsSecretBackend {
         fallback_name: &str,
     ) -> SecretProperties {
         use crate::backend::aws::metadata::{
-            TAG_CONTENT_TYPE, TAG_EXPIRES_AT, TAG_FOLDER, TAG_GROUPS, TAG_ORIGINAL_NAME,
+            TAG_CONTENT_TYPE, TAG_EXPIRES_AT, TAG_FOLDER, TAG_GROUPS, TAG_MIGRATED_AT,
+            TAG_MIGRATED_FROM, TAG_ORIGINAL_NAME,
         };
 
         // Collect the AWS Tag list into a flat vec of (key, value) pairs.
@@ -272,6 +277,9 @@ impl AwsSecretBackend {
                     expires_on = chrono::DateTime::parse_from_rfc3339(v)
                         .ok()
                         .map(|dt| dt.with_timezone(&chrono::Utc));
+                }
+                TAG_MIGRATED_FROM | TAG_MIGRATED_AT => {
+                    user_tags.insert(k.clone(), v.clone());
                 }
                 _ if !k.starts_with("xv:") => {
                     user_tags.insert(k.clone(), v.clone());
@@ -391,7 +399,7 @@ impl SecretBackend for AwsSecretBackend {
         }
         if let Some(ref user_tags) = request.tags {
             for (k, v) in user_tags {
-                if !k.starts_with("xv:") {
+                if preserves_request_tag(k) {
                     tags.push(Tag::builder().key(k).value(v).build());
                 }
             }
@@ -691,7 +699,7 @@ impl SecretBackend for AwsSecretBackend {
             for (k, v) in user_tags {
                 if v.is_empty() {
                     keys_to_remove.push(k.clone());
-                } else if !k.starts_with("xv:") {
+                } else if preserves_request_tag(k) {
                     tags_to_set.push(Tag::builder().key(k).value(v).build());
                 }
             }
@@ -817,45 +825,57 @@ impl SecretBackend for AwsSecretBackend {
         use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
 
         let prefix = format!("{vault}/");
-        let out = self
-            .client
-            .list_secrets()
-            .max_results(100)
-            .include_planned_deletion(true)
-            .filters(
-                Filter::builder()
-                    .key(FilterNameStringType::Name)
-                    .values(prefix.clone())
-                    .build(),
-            )
-            .send()
-            .await
-            .map_err(super::errors::from_list)?;
-
+        let mut next_token: Option<String> = None;
         let mut summaries: Vec<SecretSummary> = Vec::new();
-        for entry in out.secret_list() {
-            let aws_full_name = entry.name().unwrap_or("");
-            if entry.deleted_date().is_none() {
-                continue;
+
+        loop {
+            let mut req = self
+                .client
+                .list_secrets()
+                .max_results(100)
+                .include_planned_deletion(true)
+                .filters(
+                    Filter::builder()
+                        .key(FilterNameStringType::Name)
+                        .values(prefix.clone())
+                        .build(),
+                );
+            if let Some(ref t) = next_token {
+                req = req.next_token(t.clone());
             }
-            let secret_name = match strip_prefix(vault, aws_full_name) {
-                Some(n) => n,
-                None => continue,
-            };
-            if is_marker(aws_full_name) {
-                continue;
+
+            let out = req.send().await.map_err(super::errors::from_list)?;
+
+            for entry in out.secret_list() {
+                let aws_full_name = entry.name().unwrap_or("");
+                if entry.deleted_date().is_none() {
+                    continue;
+                }
+                let secret_name = match strip_prefix(vault, aws_full_name) {
+                    Some(n) => n,
+                    None => continue,
+                };
+                if is_marker(aws_full_name) {
+                    continue;
+                }
+                summaries.push(SecretSummary {
+                    name: secret_name.clone(),
+                    original_name: secret_name,
+                    note: None,
+                    folder: None,
+                    groups: None,
+                    updated_on: String::new(),
+                    enabled: true,
+                    content_type: String::new(),
+                });
             }
-            summaries.push(SecretSummary {
-                name: secret_name.clone(),
-                original_name: secret_name,
-                note: None,
-                folder: None,
-                groups: None,
-                updated_on: String::new(),
-                enabled: true,
-                content_type: String::new(),
-            });
+
+            next_token = out.next_token().map(|s| s.to_string());
+            if next_token.is_none() {
+                break;
+            }
         }
+
         Ok(summaries)
     }
 }

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -150,6 +150,73 @@ impl AwsSecretBackend {
         })
     }
 
+    /// List all versions of a secret from the AWS API.
+    ///
+    /// Maps version info to `SecretProperties` entries (without values).
+    async fn list_versions_impl(
+        &self,
+        vault: &str,
+        name: &str,
+    ) -> Result<Vec<SecretProperties>, BackendError> {
+        use crate::backend::aws::encoding::aws_name;
+        let aws_full_name = aws_name(vault, name);
+
+        let out = self
+            .client
+            .list_secret_version_ids()
+            .secret_id(&aws_full_name)
+            .include_deprecated(true)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_list_versions(name, e))?;
+
+        let mut versions: Vec<SecretProperties> = Vec::new();
+        for v in out.versions() {
+            let version_id = v.version_id().unwrap_or("").to_string();
+            let created_timestamp = v
+                .created_date()
+                .map(|d| d.secs())
+                .unwrap_or(0);
+            let created_on = if created_timestamp > 0 {
+                chrono::DateTime::from_timestamp(created_timestamp, 0)
+                    .map(|dt| dt.to_string())
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
+
+            // Collect version stages as a tag.
+            let stages_str = v
+                .version_stages()
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(",");
+            let mut tags: HashMap<String, String> = HashMap::new();
+            if !stages_str.is_empty() {
+                tags.insert("aws:stages".to_string(), stages_str);
+            }
+
+            versions.push(SecretProperties {
+                name: name.to_string(),
+                original_name: name.to_string(),
+                value: None,
+                version: version_id,
+                version_number: None,
+                created_timestamp,
+                created_on,
+                updated_on: String::new(),
+                enabled: true,
+                expires_on: None,
+                not_before: None,
+                tags,
+                content_type: String::new(),
+                recovery_level: None,
+            });
+        }
+        Ok(versions)
+    }
+
     /// Build a `SecretProperties` from a `DescribeSecretOutput`.
     ///
     /// The `fallback_name` is the user-facing name used when the `xv:original_name`
@@ -400,12 +467,69 @@ impl SecretBackend for AwsSecretBackend {
 
     async fn get_secret_version(
         &self,
-        _vault: &str,
-        _name: &str,
-        _version: &str,
-        _include_value: bool,
+        vault: &str,
+        name: &str,
+        version: &str,
+        include_value: bool,
     ) -> Result<SecretProperties, BackendError> {
-        Err(BackendError::Unsupported("get_secret_version not yet implemented".into()))
+        use crate::backend::aws::encoding::aws_name;
+        let aws_full_name = aws_name(vault, name);
+
+        // If value not requested, find it in the version list.
+        if !include_value {
+            let mut versions = self.list_versions(vault, name).await?;
+            return versions
+                .drain(..)
+                .find(|p| p.version == version)
+                .ok_or_else(|| BackendError::NotFound {
+                    name: format!("{name} (version {version})"),
+                    suggestion: None,
+                });
+        }
+
+        // Get the secret value for this specific version.
+        let out = self
+            .client
+            .get_secret_value()
+            .secret_id(&aws_full_name)
+            .version_id(version)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_get_value(name, e))?;
+
+        // Build SecretProperties manually with the version-specific data.
+        let mut tags: HashMap<String, String> = HashMap::new();
+        tags.insert("aws:stages".to_string(), "[current]".to_string());
+
+        let version_id = out.version_id().unwrap_or("").to_string();
+        let secret_value = out
+            .secret_string()
+            .map(|s| zeroize::Zeroizing::new(s.to_string()));
+
+        Ok(SecretProperties {
+            name: name.to_string(),
+            original_name: name.to_string(),
+            value: secret_value,
+            version: version_id,
+            version_number: None,
+            created_timestamp: 0,
+            created_on: String::new(),
+            updated_on: String::new(),
+            enabled: true,
+            expires_on: None,
+            not_before: None,
+            tags,
+            content_type: String::new(),
+            recovery_level: None,
+        })
+    }
+
+    async fn list_versions(
+        &self,
+        vault: &str,
+        name: &str,
+    ) -> Result<Vec<SecretProperties>, BackendError> {
+        self.list_versions_impl(vault, name).await
     }
 
     async fn list_secrets(

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -61,7 +61,9 @@ impl AwsSecretBackend {
                 .map_err(|e| super::errors::from_update(&request.name, e))?;
         }
 
-        // Step 3: Replace all tags (describe -> untag all -> re-tag).
+        // Step 3: Compute tag delta (describe -> untag removed keys -> re-tag all new).
+        // Only removing keys that won't be present in the new tag set shrinks the
+        // race window compared to untag-all + re-tag-all.
         let describe = self
             .client
             .describe_secret()
@@ -69,21 +71,6 @@ impl AwsSecretBackend {
             .send()
             .await
             .map_err(|e| super::errors::from_describe(&request.name, e))?;
-
-        let existing_keys: Vec<String> = describe
-            .tags()
-            .iter()
-            .filter_map(|t| t.key().map(|k| k.to_string()))
-            .collect();
-        if !existing_keys.is_empty() {
-            self.client
-                .untag_resource()
-                .secret_id(aws_full_name)
-                .set_tag_keys(Some(existing_keys))
-                .send()
-                .await
-                .map_err(super::errors::from_untag)?;
-        }
 
         let mut new_tags: Vec<Tag> = Vec::new();
         new_tags.push(
@@ -123,6 +110,29 @@ impl AwsSecretBackend {
                 }
             }
         }
+
+        // Compute which existing keys are absent from the new tag set so we
+        // only remove the delta rather than stripping and re-applying everything.
+        let new_keys: std::collections::HashSet<&str> = new_tags
+            .iter()
+            .filter_map(|t| t.key())
+            .collect();
+        let keys_to_remove: Vec<String> = describe
+            .tags()
+            .iter()
+            .filter_map(|t| t.key().map(|k| k.to_string()))
+            .filter(|k| !new_keys.contains(k.as_str()))
+            .collect();
+        if !keys_to_remove.is_empty() {
+            self.client
+                .untag_resource()
+                .secret_id(aws_full_name)
+                .set_tag_keys(Some(keys_to_remove))
+                .send()
+                .await
+                .map_err(super::errors::from_untag)?;
+        }
+
         self.client
             .tag_resource()
             .secret_id(aws_full_name)
@@ -387,15 +397,16 @@ impl SecretBackend for AwsSecretBackend {
             }
         }
 
-        let create_result = self
+        let mut create_builder = self
             .client
             .create_secret()
             .name(&aws_full_name)
             .secret_string(request.value.as_str().to_string())
-            .description(request.note.clone().unwrap_or_default())
-            .set_tags(if tags.is_empty() { None } else { Some(tags) })
-            .send()
-            .await;
+            .set_tags(if tags.is_empty() { None } else { Some(tags) });
+        if let Some(note) = request.note.as_deref().filter(|n| !n.is_empty()) {
+            create_builder = create_builder.description(note);
+        }
+        let create_result = create_builder.send().await;
 
         let version_id = match create_result {
             Ok(out) => out.version_id().unwrap_or("").to_string(),

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -256,7 +256,7 @@ impl AwsSecretBackend {
         // Decode xv: tags into semantic fields; everything else becomes a user tag.
         let mut original_name: Option<String> = None;
         let mut groups: Vec<String> = Vec::new();
-        let mut _folder: Option<String> = None;
+        let mut folder: Option<String> = None;
         let mut content_type: Option<String> = None;
         let mut expires_on: Option<chrono::DateTime<chrono::Utc>> = None;
         let mut user_tags: HashMap<String, String> = HashMap::new();
@@ -271,7 +271,7 @@ impl AwsSecretBackend {
                         .map(|s| s.to_string())
                         .collect();
                 }
-                TAG_FOLDER => _folder = Some(v.clone()),
+                TAG_FOLDER => folder = Some(v.clone()),
                 TAG_CONTENT_TYPE => content_type = Some(v.clone()),
                 TAG_EXPIRES_AT => {
                     expires_on = chrono::DateTime::parse_from_rfc3339(v)
@@ -292,6 +292,12 @@ impl AwsSecretBackend {
         // (which reads tags["groups"]) can still find them.
         if !groups.is_empty() {
             user_tags.insert("groups".to_string(), groups.join(","));
+        }
+        if let Some(folder) = folder.filter(|f| !f.is_empty()) {
+            user_tags.insert("folder".to_string(), folder);
+        }
+        if let Some(note) = describe.description().filter(|n| !n.is_empty()) {
+            user_tags.insert("note".to_string(), note.to_string());
         }
 
         let name = original_name

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -418,4 +418,22 @@ impl SecretBackend for AwsSecretBackend {
             .map_err(|e| super::errors::from_delete(name, e))?;
         Ok(())
     }
+
+    async fn secret_exists(&self, vault: &str, name: &str) -> Result<bool, BackendError> {
+        use crate::backend::aws::encoding::aws_name;
+        let aws_full_name = aws_name(vault, name);
+        match self
+            .client
+            .describe_secret()
+            .secret_id(&aws_full_name)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(e) => match super::errors::from_describe(name, e) {
+                BackendError::NotFound { .. } => Ok(false),
+                other => Err(other),
+            },
+        }
+    }
 }

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -4,6 +4,8 @@ use crate::backend::SecretBackend;
 use crate::backend::error::BackendError;
 use crate::secret::manager::{SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest};
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 pub struct AwsSecretBackend {
@@ -36,6 +38,121 @@ impl AwsSecretBackend {
         Err(BackendError::Unsupported(
             "aws update path: not yet implemented".into(),
         ))
+    }
+
+    /// Build a `SecretProperties` from a `DescribeSecretOutput`.
+    ///
+    /// The `fallback_name` is the user-facing name used when the `xv:original_name`
+    /// tag is absent.
+    fn props_from_describe(
+        &self,
+        describe: &DescribeSecretOutput,
+        fallback_name: &str,
+    ) -> SecretProperties {
+        use crate::backend::aws::metadata::{
+            TAG_CONTENT_TYPE, TAG_EXPIRES_AT, TAG_FOLDER, TAG_GROUPS, TAG_ORIGINAL_NAME,
+        };
+
+        // Collect the AWS Tag list into a flat vec of (key, value) pairs.
+        let raw_tags: Vec<(String, String)> = describe
+            .tags()
+            .iter()
+            .filter_map(|t| {
+                let k = t.key()?;
+                let v = t.value()?;
+                Some((k.to_string(), v.to_string()))
+            })
+            .collect();
+
+        // Decode xv: tags into semantic fields; everything else becomes a user tag.
+        let mut original_name: Option<String> = None;
+        let mut groups: Vec<String> = Vec::new();
+        let mut _folder: Option<String> = None;
+        let mut content_type: Option<String> = None;
+        let mut expires_on: Option<chrono::DateTime<chrono::Utc>> = None;
+        let mut user_tags: HashMap<String, String> = HashMap::new();
+
+        for (k, v) in &raw_tags {
+            match k.as_str() {
+                TAG_ORIGINAL_NAME => original_name = Some(v.clone()),
+                TAG_GROUPS => {
+                    groups = v
+                        .split(',')
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string())
+                        .collect();
+                }
+                TAG_FOLDER => _folder = Some(v.clone()),
+                TAG_CONTENT_TYPE => content_type = Some(v.clone()),
+                TAG_EXPIRES_AT => {
+                    expires_on = chrono::DateTime::parse_from_rfc3339(v)
+                        .ok()
+                        .map(|dt| dt.with_timezone(&chrono::Utc));
+                }
+                _ if !k.starts_with("xv:") => {
+                    user_tags.insert(k.clone(), v.clone());
+                }
+                _ => {} // unknown xv: tag — skip
+            }
+        }
+
+        // Store groups back into the user_tags map so the rest of the codebase
+        // (which reads tags["groups"]) can still find them.
+        if !groups.is_empty() {
+            user_tags.insert("groups".to_string(), groups.join(","));
+        }
+
+        let name = original_name.clone().unwrap_or_else(|| fallback_name.to_string());
+
+        // Extract timestamps from the describe output.
+        let created_date = describe.created_date();
+        let created_timestamp = created_date
+            .map(|d| d.secs())
+            .unwrap_or(0);
+        let created_on = if created_timestamp > 0 {
+            chrono::DateTime::from_timestamp(created_timestamp, 0)
+                .map(|dt| dt.to_string())
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
+
+        let updated_on = describe
+            .last_changed_date()
+            .and_then(|d| chrono::DateTime::from_timestamp(d.secs(), 0))
+            .map(|dt| dt.to_string())
+            .unwrap_or_default();
+
+        // version_ids_to_stages: find the version with AWSCURRENT label.
+        let version = describe
+            .version_ids_to_stages()
+            .and_then(|map| {
+                map.iter().find_map(|(vid, stages)| {
+                    if stages.iter().any(|s| s == "AWSCURRENT") {
+                        Some(vid.clone())
+                    } else {
+                        None
+                    }
+                })
+            })
+            .unwrap_or_default();
+
+        SecretProperties {
+            name: name.clone(),
+            original_name: original_name.unwrap_or_else(|| fallback_name.to_string()),
+            value: None,
+            version,
+            version_number: None,
+            created_timestamp,
+            created_on,
+            updated_on,
+            enabled: true,
+            expires_on,
+            not_before: None,
+            tags: user_tags,
+            content_type: content_type.unwrap_or_default(),
+            recovery_level: None,
+        }
     }
 }
 
@@ -138,11 +255,37 @@ impl SecretBackend for AwsSecretBackend {
 
     async fn get_secret(
         &self,
-        _vault: &str,
-        _name: &str,
-        _include_value: bool,
+        vault: &str,
+        name: &str,
+        include_value: bool,
     ) -> Result<SecretProperties, BackendError> {
-        Err(BackendError::Unsupported("get_secret not yet implemented".into()))
+        use crate::backend::aws::encoding::aws_name;
+        let aws_full_name = aws_name(vault, name);
+
+        if !include_value {
+            let describe = self
+                .client
+                .describe_secret()
+                .secret_id(&aws_full_name)
+                .send()
+                .await
+                .map_err(|e| super::errors::from_describe(name, e))?;
+            return Ok(self.props_from_describe(&describe, name));
+        }
+
+        // include_value: run describe + get_secret_value concurrently.
+        let describe_fut = self.client.describe_secret().secret_id(&aws_full_name).send();
+        let value_fut = self.client.get_secret_value().secret_id(&aws_full_name).send();
+
+        let (describe, value) = tokio::join!(describe_fut, value_fut);
+        let describe = describe.map_err(|e| super::errors::from_describe(name, e))?;
+        let value = value.map_err(|e| super::errors::from_get_value(name, e))?;
+
+        let mut props = self.props_from_describe(&describe, name);
+        props.value = value
+            .secret_string()
+            .map(|s| zeroize::Zeroizing::new(s.to_string()));
+        Ok(props)
     }
 
     async fn get_secret_version(

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -1,1 +1,81 @@
-//! `AwsSecretBackend` impl `SecretBackend`. See Tasks 14-28.
+//! `AwsSecretBackend` impl `SecretBackend`.
+
+use crate::backend::SecretBackend;
+use crate::backend::error::BackendError;
+use crate::secret::manager::{SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest};
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+use std::sync::Arc;
+
+pub struct AwsSecretBackend {
+    pub(crate) client: Arc<SecretsManagerClient>,
+}
+
+impl AwsSecretBackend {
+    pub fn new(client: Arc<SecretsManagerClient>) -> Self {
+        Self { client }
+    }
+
+    /// Lightweight health check: list secrets with limit=1.
+    pub async fn health_check(&self) -> Result<(), BackendError> {
+        self.client
+            .list_secrets()
+            .max_results(1)
+            .send()
+            .await
+            .map_err(|e| BackendError::Network(format!("aws health check: {e}")))?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl SecretBackend for AwsSecretBackend {
+    // Required methods — real impls added in Tasks 13-22.
+
+    async fn set_secret(
+        &self,
+        _vault: &str,
+        _request: SecretRequest,
+    ) -> Result<SecretProperties, BackendError> {
+        Err(BackendError::Unsupported("set_secret not yet implemented".into()))
+    }
+
+    async fn get_secret(
+        &self,
+        _vault: &str,
+        _name: &str,
+        _include_value: bool,
+    ) -> Result<SecretProperties, BackendError> {
+        Err(BackendError::Unsupported("get_secret not yet implemented".into()))
+    }
+
+    async fn get_secret_version(
+        &self,
+        _vault: &str,
+        _name: &str,
+        _version: &str,
+        _include_value: bool,
+    ) -> Result<SecretProperties, BackendError> {
+        Err(BackendError::Unsupported("get_secret_version not yet implemented".into()))
+    }
+
+    async fn list_secrets(
+        &self,
+        _vault: &str,
+        _group_filter: Option<&str>,
+    ) -> Result<Vec<SecretSummary>, BackendError> {
+        Err(BackendError::Unsupported("list_secrets not yet implemented".into()))
+    }
+
+    async fn delete_secret(&self, _vault: &str, _name: &str) -> Result<(), BackendError> {
+        Err(BackendError::Unsupported("delete_secret not yet implemented".into()))
+    }
+
+    async fn update_secret(
+        &self,
+        _vault: &str,
+        _name: &str,
+        _request: SecretUpdateRequest,
+    ) -> Result<SecretProperties, BackendError> {
+        Err(BackendError::Unsupported("update_secret not yet implemented".into()))
+    }
+}

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -28,16 +28,126 @@ impl AwsSecretBackend {
         Ok(())
     }
 
-    /// Update an already-existing secret (upsert path). Filled in Task 19.
+    /// Update an already-existing secret (upsert path). Implemented in Task 19.
     async fn update_existing_secret(
         &self,
-        _vault: &str,
-        _request: &SecretRequest,
-        _aws_full_name: &str,
+        vault: &str,
+        request: &SecretRequest,
+        aws_full_name: &str,
     ) -> Result<SecretProperties, BackendError> {
-        Err(BackendError::Unsupported(
-            "aws update path: not yet implemented".into(),
-        ))
+        use crate::backend::aws::metadata::{
+            TAG_CONTENT_TYPE, TAG_EXPIRES_AT, TAG_FOLDER, TAG_GROUPS, TAG_ORIGINAL_NAME,
+        };
+        use aws_sdk_secretsmanager::types::Tag;
+
+        // Step 1: Put new value as new version.
+        let put_out = self
+            .client
+            .put_secret_value()
+            .secret_id(aws_full_name)
+            .secret_string(request.value.as_str().to_string())
+            .send()
+            .await
+            .map_err(|e| super::errors::from_put_value(&request.name, e))?;
+
+        // Step 2: Update description if provided.
+        if let Some(ref note) = request.note {
+            self.client
+                .update_secret()
+                .secret_id(aws_full_name)
+                .description(note)
+                .send()
+                .await
+                .map_err(|e| super::errors::from_update(&request.name, e))?;
+        }
+
+        // Step 3: Replace all tags (describe -> untag all -> re-tag).
+        let describe = self
+            .client
+            .describe_secret()
+            .secret_id(aws_full_name)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_describe(&request.name, e))?;
+
+        let existing_keys: Vec<String> = describe
+            .tags()
+            .iter()
+            .filter_map(|t| t.key().map(|k| k.to_string()))
+            .collect();
+        if !existing_keys.is_empty() {
+            self.client
+                .untag_resource()
+                .secret_id(aws_full_name)
+                .set_tag_keys(Some(existing_keys))
+                .send()
+                .await
+                .map_err(super::errors::from_untag)?;
+        }
+
+        let mut new_tags: Vec<Tag> = Vec::new();
+        new_tags.push(
+            Tag::builder()
+                .key(TAG_ORIGINAL_NAME)
+                .value(&request.name)
+                .build(),
+        );
+        if let Some(ref groups) = request.groups {
+            if !groups.is_empty() {
+                new_tags.push(
+                    Tag::builder()
+                        .key(TAG_GROUPS)
+                        .value(groups.join(","))
+                        .build(),
+                );
+            }
+        }
+        if let Some(ref f) = request.folder {
+            new_tags.push(Tag::builder().key(TAG_FOLDER).value(f).build());
+        }
+        if let Some(ref ct) = request.content_type {
+            new_tags.push(Tag::builder().key(TAG_CONTENT_TYPE).value(ct).build());
+        }
+        if let Some(ref e) = request.expires_on {
+            new_tags.push(
+                Tag::builder()
+                    .key(TAG_EXPIRES_AT)
+                    .value(e.to_rfc3339())
+                    .build(),
+            );
+        }
+        if let Some(ref user_tags) = request.tags {
+            for (k, v) in user_tags {
+                if !k.starts_with("xv:") {
+                    new_tags.push(Tag::builder().key(k).value(v).build());
+                }
+            }
+        }
+        self.client
+            .tag_resource()
+            .secret_id(aws_full_name)
+            .set_tags(Some(new_tags))
+            .send()
+            .await
+            .map_err(super::errors::from_tag)?;
+
+        let version = put_out.version_id().unwrap_or("").to_string();
+        Ok(SecretProperties {
+            name: request.name.clone(),
+            original_name: request.name.clone(),
+            value: None,
+            version,
+            version_number: None,
+            created_timestamp: 0,
+            created_on: String::new(),
+            updated_on: String::new(),
+            enabled: true,
+            expires_on: request.expires_on,
+            not_before: request.not_before,
+            tags: request.tags.clone().unwrap_or_default(),
+            content_type: request.content_type.clone().unwrap_or_default(),
+            recovery_level: None,
+        })
     }
 
     /// Build a `SecretProperties` from a `DescribeSecretOutput`.
@@ -399,11 +509,80 @@ impl SecretBackend for AwsSecretBackend {
 
     async fn update_secret(
         &self,
-        _vault: &str,
-        _name: &str,
-        _request: SecretUpdateRequest,
+        vault: &str,
+        name: &str,
+        request: SecretUpdateRequest,
     ) -> Result<SecretProperties, BackendError> {
-        Err(BackendError::Unsupported("update_secret not yet implemented".into()))
+        use crate::backend::aws::encoding::aws_name;
+        use crate::backend::aws::metadata::{TAG_FOLDER, TAG_GROUPS};
+        use aws_sdk_secretsmanager::types::Tag;
+
+        let aws_full_name = aws_name(vault, name);
+
+        // Update description (note) if provided.
+        if let Some(ref new_note) = request.note {
+            self.client
+                .update_secret()
+                .secret_id(&aws_full_name)
+                .description(new_note)
+                .send()
+                .await
+                .map_err(|e| super::errors::from_update(name, e))?;
+        }
+
+        // Compute tag deltas.
+        let mut tags_to_set: Vec<Tag> = Vec::new();
+        let mut keys_to_remove: Vec<String> = Vec::new();
+
+        if let Some(ref groups) = request.groups {
+            if groups.is_empty() {
+                keys_to_remove.push(TAG_GROUPS.into());
+            } else {
+                tags_to_set.push(
+                    Tag::builder()
+                        .key(TAG_GROUPS)
+                        .value(groups.join(","))
+                        .build(),
+                );
+            }
+        }
+        if let Some(ref f) = request.folder {
+            if f.is_empty() {
+                keys_to_remove.push(TAG_FOLDER.into());
+            } else {
+                tags_to_set.push(Tag::builder().key(TAG_FOLDER).value(f).build());
+            }
+        }
+        if let Some(ref user_tags) = request.tags {
+            for (k, v) in user_tags {
+                if v.is_empty() {
+                    keys_to_remove.push(k.clone());
+                } else if !k.starts_with("xv:") {
+                    tags_to_set.push(Tag::builder().key(k).value(v).build());
+                }
+            }
+        }
+
+        if !keys_to_remove.is_empty() {
+            self.client
+                .untag_resource()
+                .secret_id(&aws_full_name)
+                .set_tag_keys(Some(keys_to_remove))
+                .send()
+                .await
+                .map_err(super::errors::from_untag)?;
+        }
+        if !tags_to_set.is_empty() {
+            self.client
+                .tag_resource()
+                .secret_id(&aws_full_name)
+                .set_tags(Some(tags_to_set))
+                .send()
+                .await
+                .map_err(super::errors::from_tag)?;
+        }
+
+        self.get_secret(vault, name, false).await
     }
 
     async fn purge_secret(&self, vault: &str, name: &str) -> Result<(), BackendError> {

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -784,4 +784,71 @@ impl SecretBackend for AwsSecretBackend {
         // Fetch and return the current secret properties
         self.get_secret(vault, name, false).await
     }
+
+    async fn restore_secret(
+        &self,
+        vault: &str,
+        name: &str,
+    ) -> Result<SecretProperties, BackendError> {
+        use crate::backend::aws::encoding::aws_name;
+        let aws_full_name = aws_name(vault, name);
+        self.client
+            .restore_secret()
+            .secret_id(&aws_full_name)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_restore(name, e))?;
+        // After restore, fetch the metadata
+        self.get_secret(vault, name, false).await
+    }
+
+    async fn list_deleted_secrets(
+        &self,
+        vault: &str,
+    ) -> Result<Vec<SecretSummary>, BackendError> {
+        use crate::backend::aws::encoding::{is_marker, strip_prefix};
+        use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
+
+        let prefix = format!("{vault}/");
+        let out = self
+            .client
+            .list_secrets()
+            .max_results(100)
+            .include_planned_deletion(true)
+            .filters(
+                Filter::builder()
+                    .key(FilterNameStringType::Name)
+                    .values(prefix.clone())
+                    .build(),
+            )
+            .send()
+            .await
+            .map_err(super::errors::from_list)?;
+
+        let mut summaries: Vec<SecretSummary> = Vec::new();
+        for entry in out.secret_list() {
+            let aws_full_name = entry.name().unwrap_or("");
+            if entry.deleted_date().is_none() {
+                continue;
+            }
+            let secret_name = match strip_prefix(vault, aws_full_name) {
+                Some(n) => n,
+                None => continue,
+            };
+            if is_marker(aws_full_name) {
+                continue;
+            }
+            summaries.push(SecretSummary {
+                name: secret_name.clone(),
+                original_name: secret_name,
+                note: None,
+                folder: None,
+                groups: None,
+                updated_on: String::new(),
+                enabled: true,
+                content_type: String::new(),
+            });
+        }
+        Ok(summaries)
+    }
 }

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -25,6 +25,18 @@ impl AwsSecretBackend {
             .map_err(|e| BackendError::Network(format!("aws health check: {e}")))?;
         Ok(())
     }
+
+    /// Update an already-existing secret (upsert path). Filled in Task 19.
+    async fn update_existing_secret(
+        &self,
+        _vault: &str,
+        _request: &SecretRequest,
+        _aws_full_name: &str,
+    ) -> Result<SecretProperties, BackendError> {
+        Err(BackendError::Unsupported(
+            "aws update path: not yet implemented".into(),
+        ))
+    }
 }
 
 #[async_trait::async_trait]
@@ -33,10 +45,95 @@ impl SecretBackend for AwsSecretBackend {
 
     async fn set_secret(
         &self,
-        _vault: &str,
-        _request: SecretRequest,
+        vault: &str,
+        request: SecretRequest,
     ) -> Result<SecretProperties, BackendError> {
-        Err(BackendError::Unsupported("set_secret not yet implemented".into()))
+        use crate::backend::aws::encoding::{aws_name, validate_secret_name};
+        use crate::backend::aws::metadata::{
+            TAG_CONTENT_TYPE, TAG_EXPIRES_AT, TAG_FOLDER, TAG_GROUPS, TAG_ORIGINAL_NAME,
+        };
+        use aws_sdk_secretsmanager::types::Tag;
+
+        validate_secret_name(&request.name)?;
+        let aws_full_name = aws_name(vault, &request.name);
+
+        let mut tags: Vec<Tag> = Vec::new();
+        tags.push(
+            Tag::builder()
+                .key(TAG_ORIGINAL_NAME)
+                .value(&request.name)
+                .build(),
+        );
+        if let Some(ref groups) = request.groups {
+            if !groups.is_empty() {
+                tags.push(
+                    Tag::builder()
+                        .key(TAG_GROUPS)
+                        .value(groups.join(","))
+                        .build(),
+                );
+            }
+        }
+        if let Some(ref f) = request.folder {
+            tags.push(Tag::builder().key(TAG_FOLDER).value(f).build());
+        }
+        if let Some(ref ct) = request.content_type {
+            tags.push(Tag::builder().key(TAG_CONTENT_TYPE).value(ct).build());
+        }
+        if let Some(ref e) = request.expires_on {
+            tags.push(
+                Tag::builder()
+                    .key(TAG_EXPIRES_AT)
+                    .value(e.to_rfc3339())
+                    .build(),
+            );
+        }
+        if let Some(ref user_tags) = request.tags {
+            for (k, v) in user_tags {
+                if !k.starts_with("xv:") {
+                    tags.push(Tag::builder().key(k).value(v).build());
+                }
+            }
+        }
+
+        let create_result = self
+            .client
+            .create_secret()
+            .name(&aws_full_name)
+            .secret_string(request.value.as_str().to_string())
+            .description(request.note.clone().unwrap_or_default())
+            .set_tags(if tags.is_empty() { None } else { Some(tags) })
+            .send()
+            .await;
+
+        let version_id = match create_result {
+            Ok(out) => out.version_id().unwrap_or("").to_string(),
+            Err(e) => match super::errors::from_create(e) {
+                BackendError::Conflict(_) => {
+                    return self
+                        .update_existing_secret(vault, &request, &aws_full_name)
+                        .await;
+                }
+                other => return Err(other),
+            },
+        };
+
+        Ok(SecretProperties {
+            name: request.name.clone(),
+            original_name: request.name.clone(),
+            value: None,
+            version: version_id,
+            version_number: None,
+            created_timestamp: 0,
+            created_on: String::new(),
+            updated_on: String::new(),
+            enabled: true,
+            expires_on: request.expires_on,
+            not_before: request.not_before,
+            tags: request.tags.unwrap_or_default(),
+            content_type: request.content_type.unwrap_or_default(),
+            recovery_level: None,
+        })
     }
 
     async fn get_secret(

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -300,10 +300,88 @@ impl SecretBackend for AwsSecretBackend {
 
     async fn list_secrets(
         &self,
-        _vault: &str,
-        _group_filter: Option<&str>,
+        vault: &str,
+        group_filter: Option<&str>,
     ) -> Result<Vec<SecretSummary>, BackendError> {
-        Err(BackendError::Unsupported("list_secrets not yet implemented".into()))
+        use crate::backend::aws::encoding::{is_marker, strip_prefix};
+        use crate::backend::aws::metadata::TAG_GROUPS;
+        use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
+
+        let prefix = format!("{vault}/");
+        let mut next_token: Option<String> = None;
+        let mut summaries = Vec::new();
+
+        loop {
+            let mut req = self
+                .client
+                .list_secrets()
+                .max_results(100)
+                .filters(
+                    Filter::builder()
+                        .key(FilterNameStringType::Name)
+                        .values(prefix.clone())
+                        .build(),
+                );
+            if let Some(ref t) = next_token {
+                req = req.next_token(t.clone());
+            }
+
+            let out = req.send().await.map_err(super::errors::from_list)?;
+
+            for entry in out.secret_list() {
+                let aws_full_name = entry.name().unwrap_or("");
+                // Skip entries that don't belong to this vault prefix.
+                let secret_name = match strip_prefix(vault, aws_full_name) {
+                    Some(n) => n,
+                    None => continue,
+                };
+                // Skip vault marker secrets.
+                if is_marker(aws_full_name) {
+                    continue;
+                }
+                // Apply group filter if requested.
+                if let Some(group_want) = group_filter {
+                    let groups_str = entry
+                        .tags()
+                        .iter()
+                        .find(|t| t.key() == Some(TAG_GROUPS))
+                        .and_then(|t| t.value())
+                        .unwrap_or("");
+                    let groups: Vec<&str> = groups_str
+                        .split(',')
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                    if !groups.contains(&group_want) {
+                        continue;
+                    }
+                }
+                // Extract groups tag for summary.
+                let groups_val = entry
+                    .tags()
+                    .iter()
+                    .find(|t| t.key() == Some(TAG_GROUPS))
+                    .and_then(|t| t.value())
+                    .map(|s| s.to_string());
+
+                summaries.push(SecretSummary {
+                    name: secret_name.clone(),
+                    original_name: secret_name,
+                    note: None,
+                    folder: None,
+                    groups: groups_val,
+                    updated_on: String::new(),
+                    enabled: true,
+                    content_type: String::new(),
+                });
+            }
+
+            next_token = out.next_token().map(|s| s.to_string());
+            if next_token.is_none() {
+                break;
+            }
+        }
+
+        Ok(summaries)
     }
 
     async fn delete_secret(&self, _vault: &str, _name: &str) -> Result<(), BackendError> {

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -1,0 +1,1 @@
+//! `AwsSecretBackend` impl `SecretBackend`. See Tasks 14-28.

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -384,8 +384,17 @@ impl SecretBackend for AwsSecretBackend {
         Ok(summaries)
     }
 
-    async fn delete_secret(&self, _vault: &str, _name: &str) -> Result<(), BackendError> {
-        Err(BackendError::Unsupported("delete_secret not yet implemented".into()))
+    async fn delete_secret(&self, vault: &str, name: &str) -> Result<(), BackendError> {
+        use crate::backend::aws::encoding::aws_name;
+        let aws_full_name = aws_name(vault, name);
+        self.client
+            .delete_secret()
+            .secret_id(&aws_full_name)
+            .recovery_window_in_days(30)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_delete(name, e))?;
+        Ok(())
     }
 
     async fn update_secret(
@@ -395,5 +404,18 @@ impl SecretBackend for AwsSecretBackend {
         _request: SecretUpdateRequest,
     ) -> Result<SecretProperties, BackendError> {
         Err(BackendError::Unsupported("update_secret not yet implemented".into()))
+    }
+
+    async fn purge_secret(&self, vault: &str, name: &str) -> Result<(), BackendError> {
+        use crate::backend::aws::encoding::aws_name;
+        let aws_full_name = aws_name(vault, name);
+        self.client
+            .delete_secret()
+            .secret_id(&aws_full_name)
+            .force_delete_without_recovery(true)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_delete(name, e))?;
+        Ok(())
     }
 }

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -363,13 +363,13 @@ impl SecretBackend for AwsSecretBackend {
         vault: &str,
         request: SecretRequest,
     ) -> Result<SecretProperties, BackendError> {
-        use crate::backend::aws::encoding::{aws_name, validate_secret_name};
+        use crate::backend::aws::encoding::{aws_name, validate_full_secret_name};
         use crate::backend::aws::metadata::{
             TAG_CONTENT_TYPE, TAG_EXPIRES_AT, TAG_FOLDER, TAG_GROUPS, TAG_ORIGINAL_NAME,
         };
         use aws_sdk_secretsmanager::types::Tag;
 
-        validate_secret_name(&request.name)?;
+        validate_full_secret_name(vault, &request.name)?;
         let aws_full_name = aws_name(vault, &request.name);
 
         let mut tags: Vec<Tag> = Vec::new();

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -1,10 +1,10 @@
 //! `AwsSecretBackend` impl `SecretBackend`.
 
-use crate::backend::SecretBackend;
 use crate::backend::error::BackendError;
+use crate::backend::SecretBackend;
 use crate::secret::manager::{SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest};
-use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -173,10 +173,7 @@ impl AwsSecretBackend {
         let mut versions: Vec<SecretProperties> = Vec::new();
         for v in out.versions() {
             let version_id = v.version_id().unwrap_or("").to_string();
-            let created_timestamp = v
-                .created_date()
-                .map(|d| d.secs())
-                .unwrap_or(0);
+            let created_timestamp = v.created_date().map(|d| d.secs()).unwrap_or(0);
             let created_on = if created_timestamp > 0 {
                 chrono::DateTime::from_timestamp(created_timestamp, 0)
                     .map(|dt| dt.to_string())
@@ -279,13 +276,13 @@ impl AwsSecretBackend {
             user_tags.insert("groups".to_string(), groups.join(","));
         }
 
-        let name = original_name.clone().unwrap_or_else(|| fallback_name.to_string());
+        let name = original_name
+            .clone()
+            .unwrap_or_else(|| fallback_name.to_string());
 
         // Extract timestamps from the describe output.
         let created_date = describe.created_date();
-        let created_timestamp = created_date
-            .map(|d| d.secs())
-            .unwrap_or(0);
+        let created_timestamp = created_date.map(|d| d.secs()).unwrap_or(0);
         let created_on = if created_timestamp > 0 {
             chrono::DateTime::from_timestamp(created_timestamp, 0)
                 .map(|dt| dt.to_string())
@@ -451,8 +448,16 @@ impl SecretBackend for AwsSecretBackend {
         }
 
         // include_value: run describe + get_secret_value concurrently.
-        let describe_fut = self.client.describe_secret().secret_id(&aws_full_name).send();
-        let value_fut = self.client.get_secret_value().secret_id(&aws_full_name).send();
+        let describe_fut = self
+            .client
+            .describe_secret()
+            .secret_id(&aws_full_name)
+            .send();
+        let value_fut = self
+            .client
+            .get_secret_value()
+            .secret_id(&aws_full_name)
+            .send();
 
         let (describe, value) = tokio::join!(describe_fut, value_fut);
         let describe = describe.map_err(|e| super::errors::from_describe(name, e))?;
@@ -546,16 +551,12 @@ impl SecretBackend for AwsSecretBackend {
         let mut summaries = Vec::new();
 
         loop {
-            let mut req = self
-                .client
-                .list_secrets()
-                .max_results(100)
-                .filters(
-                    Filter::builder()
-                        .key(FilterNameStringType::Name)
-                        .values(prefix.clone())
-                        .build(),
-                );
+            let mut req = self.client.list_secrets().max_results(100).filters(
+                Filter::builder()
+                    .key(FilterNameStringType::Name)
+                    .values(prefix.clone())
+                    .build(),
+            );
             if let Some(ref t) = next_token {
                 req = req.next_token(t.clone());
             }
@@ -581,10 +582,8 @@ impl SecretBackend for AwsSecretBackend {
                         .find(|t| t.key() == Some(TAG_GROUPS))
                         .and_then(|t| t.value())
                         .unwrap_or("");
-                    let groups: Vec<&str> = groups_str
-                        .split(',')
-                        .filter(|s| !s.is_empty())
-                        .collect();
+                    let groups: Vec<&str> =
+                        groups_str.split(',').filter(|s| !s.is_empty()).collect();
                     if !groups.contains(&group_want) {
                         continue;
                     }
@@ -802,10 +801,7 @@ impl SecretBackend for AwsSecretBackend {
         self.get_secret(vault, name, false).await
     }
 
-    async fn list_deleted_secrets(
-        &self,
-        vault: &str,
-    ) -> Result<Vec<SecretSummary>, BackendError> {
+    async fn list_deleted_secrets(&self, vault: &str) -> Result<Vec<SecretSummary>, BackendError> {
         use crate::backend::aws::encoding::{is_marker, strip_prefix};
         use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
 

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -739,4 +739,49 @@ impl SecretBackend for AwsSecretBackend {
             },
         }
     }
+
+    async fn rollback(
+        &self,
+        vault: &str,
+        name: &str,
+        version: &str,
+    ) -> Result<SecretProperties, BackendError> {
+        use crate::backend::aws::encoding::aws_name;
+        let aws_full_name = aws_name(vault, name);
+
+        // Find which version is currently AWSCURRENT
+        let listed = self
+            .client
+            .list_secret_version_ids()
+            .secret_id(&aws_full_name)
+            .include_deprecated(true)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_list_versions(name, e))?;
+
+        let current_version = listed
+            .versions()
+            .iter()
+            .find(|v| {
+                v.version_stages()
+                    .iter()
+                    .any(|s| s.as_str() == "AWSCURRENT")
+            })
+            .and_then(|v| v.version_id())
+            .map(|s| s.to_string());
+
+        // Move AWSCURRENT label to target version
+        self.client
+            .update_secret_version_stage()
+            .secret_id(&aws_full_name)
+            .version_stage("AWSCURRENT")
+            .move_to_version_id(version)
+            .set_remove_from_version_id(current_version)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_update_stage(name, e))?;
+
+        // Fetch and return the current secret properties
+        self.get_secret(vault, name, false).await
+    }
 }

--- a/src/backend/aws/vaults.rs
+++ b/src/backend/aws/vaults.rs
@@ -246,26 +246,39 @@ impl AwsVaultBackend {
         use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
 
         let prefix = format!("{name}/");
-        let out = self
-            .client
-            .list_secrets()
-            .max_results(100)
-            .filters(
-                Filter::builder()
-                    .key(FilterNameStringType::Name)
-                    .values(prefix.clone())
-                    .build(),
-            )
-            .send()
-            .await
-            .map_err(super::errors::from_list)?;
 
-        let non_marker: Vec<String> = out
-            .secret_list()
-            .iter()
-            .filter_map(|e| e.name().map(|s| s.to_string()))
-            .filter(|n| !is_marker(n) && strip_prefix(name, n).is_some())
-            .collect();
+        // Paginate through all secrets in this vault prefix.
+        let mut next_token: Option<String> = None;
+        let mut non_marker: Vec<String> = Vec::new();
+        loop {
+            let mut req = self
+                .client
+                .list_secrets()
+                .max_results(100)
+                .filters(
+                    Filter::builder()
+                        .key(FilterNameStringType::Name)
+                        .values(prefix.clone())
+                        .build(),
+                );
+            if let Some(ref t) = next_token {
+                req = req.next_token(t.clone());
+            }
+            let out = req.send().await.map_err(super::errors::from_list)?;
+
+            for entry in out.secret_list() {
+                if let Some(n) = entry.name() {
+                    if !is_marker(n) && strip_prefix(name, n).is_some() {
+                        non_marker.push(n.to_string());
+                    }
+                }
+            }
+
+            next_token = out.next_token().map(|s| s.to_string());
+            if next_token.is_none() {
+                break;
+            }
+        }
 
         if !non_marker.is_empty() && !force {
             return Err(BackendError::Conflict(format!(

--- a/src/backend/aws/vaults.rs
+++ b/src/backend/aws/vaults.rs
@@ -1,0 +1,1 @@
+//! `AwsVaultBackend` impl `VaultBackend`. See Tasks 29-33.

--- a/src/backend/aws/vaults.rs
+++ b/src/backend/aws/vaults.rs
@@ -4,6 +4,9 @@ use crate::backend::VaultBackend;
 use crate::backend::error::BackendError;
 use crate::vault::models::{VaultCreateRequest, VaultProperties, VaultSummary};
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+use aws_sdk_secretsmanager::types::Tag;
+use chrono::Utc;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 pub struct AwsVaultBackend {
@@ -22,9 +25,70 @@ impl VaultBackend for AwsVaultBackend {
 
     async fn create_vault(
         &self,
-        _request: VaultCreateRequest,
+        request: VaultCreateRequest,
     ) -> Result<VaultProperties, BackendError> {
-        Err(BackendError::Unsupported("create_vault not yet implemented".into()))
+        use crate::backend::aws::encoding::marker_name;
+        use crate::backend::aws::metadata::{TAG_TYPE, TAG_VALUE_VAULT_MARKER};
+
+        let marker = marker_name(&request.name);
+        let mut tags: Vec<Tag> = Vec::new();
+        tags.push(
+            Tag::builder()
+                .key(TAG_TYPE)
+                .value(TAG_VALUE_VAULT_MARKER)
+                .build(),
+        );
+        tags.push(
+            Tag::builder()
+                .key("xv:vault_name")
+                .value(&request.name)
+                .build(),
+        );
+        tags.push(
+            Tag::builder()
+                .key("xv:created_at")
+                .value(Utc::now().to_rfc3339())
+                .build(),
+        );
+        if let Some(ref user_tags) = request.tags {
+            for (k, v) in user_tags {
+                if !k.starts_with("xv:") {
+                    tags.push(Tag::builder().key(k).value(v).build());
+                }
+            }
+        }
+
+        self.client
+            .create_secret()
+            .name(&marker)
+            .secret_string("{}")
+            .description(format!("xv vault marker for '{}'", request.name))
+            .set_tags(Some(tags))
+            .send()
+            .await
+            .map_err(super::errors::from_create)?;
+
+        // Build VaultProperties manually with all fields
+        let now = Utc::now();
+        Ok(VaultProperties {
+            id: format!("vault-{}", request.name),
+            name: request.name.clone(),
+            location: request.location.clone(),
+            resource_group: request.resource_group.clone(),
+            subscription_id: request.subscription_id.clone(),
+            tenant_id: String::new(),
+            uri: format!("https://{}.vault.aws.net/", request.name),
+            enabled_for_deployment: request.enabled_for_deployment.unwrap_or(false),
+            enabled_for_disk_encryption: request.enabled_for_disk_encryption.unwrap_or(false),
+            enabled_for_template_deployment: request.enabled_for_template_deployment.unwrap_or(false),
+            soft_delete_retention_in_days: request.soft_delete_retention_in_days.unwrap_or(30),
+            purge_protection: request.purge_protection.unwrap_or(false),
+            sku: request.sku.clone().unwrap_or_else(|| "standard".to_string()),
+            access_policies: request.access_policies.clone().unwrap_or_default(),
+            created_at: now,
+            tags: request.tags.clone().unwrap_or_default(),
+            enable_rbac_authorization: Some(false),
+        })
     }
 
     async fn get_vault(&self, _name: &str) -> Result<VaultProperties, BackendError> {

--- a/src/backend/aws/vaults.rs
+++ b/src/backend/aws/vaults.rs
@@ -188,6 +188,37 @@ impl VaultBackend for AwsVaultBackend {
     async fn delete_vault(&self, name: &str) -> Result<(), BackendError> {
         self.delete_vault_internal(name, false).await
     }
+
+    async fn update_vault(
+        &self,
+        name: &str,
+        request: crate::vault::models::VaultUpdateRequest,
+    ) -> Result<VaultProperties, BackendError> {
+        use crate::backend::aws::encoding::marker_name;
+
+        let marker = marker_name(name);
+
+        // Update tags if provided
+        if let Some(ref new_tags) = request.tags {
+            let tag_list: Vec<Tag> = new_tags
+                .iter()
+                .filter(|(k, _)| !k.starts_with("xv:"))
+                .map(|(k, v)| Tag::builder().key(k).value(v).build())
+                .collect();
+            if !tag_list.is_empty() {
+                self.client
+                    .tag_resource()
+                    .secret_id(&marker)
+                    .set_tags(Some(tag_list))
+                    .send()
+                    .await
+                    .map_err(super::errors::from_tag)?;
+            }
+        }
+
+        // Fetch updated vault properties
+        self.get_vault(name).await
+    }
 }
 
 impl AwsVaultBackend {

--- a/src/backend/aws/vaults.rs
+++ b/src/backend/aws/vaults.rs
@@ -1,10 +1,10 @@
 //! `AwsVaultBackend` impl `VaultBackend`.
 
-use crate::backend::VaultBackend;
 use crate::backend::error::BackendError;
+use crate::backend::VaultBackend;
 use crate::vault::models::{VaultCreateRequest, VaultProperties, VaultSummary};
-use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 use aws_sdk_secretsmanager::types::Tag;
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 use chrono::Utc;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -80,10 +80,15 @@ impl VaultBackend for AwsVaultBackend {
             uri: format!("https://{}.vault.aws.net/", request.name),
             enabled_for_deployment: request.enabled_for_deployment.unwrap_or(false),
             enabled_for_disk_encryption: request.enabled_for_disk_encryption.unwrap_or(false),
-            enabled_for_template_deployment: request.enabled_for_template_deployment.unwrap_or(false),
+            enabled_for_template_deployment: request
+                .enabled_for_template_deployment
+                .unwrap_or(false),
             soft_delete_retention_in_days: request.soft_delete_retention_in_days.unwrap_or(30),
             purge_protection: request.purge_protection.unwrap_or(false),
-            sku: request.sku.clone().unwrap_or_else(|| "standard".to_string()),
+            sku: request
+                .sku
+                .clone()
+                .unwrap_or_else(|| "standard".to_string()),
             access_policies: request.access_policies.clone().unwrap_or_default(),
             created_at: now,
             tags: request.tags.clone().unwrap_or_default(),
@@ -94,7 +99,8 @@ impl VaultBackend for AwsVaultBackend {
     async fn get_vault(&self, name: &str) -> Result<VaultProperties, BackendError> {
         use crate::backend::aws::encoding::marker_name;
         let marker = marker_name(name);
-        let describe = self.client
+        let describe = self
+            .client
             .describe_secret()
             .secret_id(&marker)
             .send()
@@ -156,11 +162,22 @@ impl VaultBackend for AwsVaultBackend {
         let mut summaries: Vec<VaultSummary> = Vec::new();
 
         loop {
-            let mut req = self.client
+            let mut req = self
+                .client
                 .list_secrets()
                 .max_results(100)
-                .filters(Filter::builder().key(FilterNameStringType::TagKey).values(TAG_TYPE).build())
-                .filters(Filter::builder().key(FilterNameStringType::TagValue).values(TAG_VALUE_VAULT_MARKER).build());
+                .filters(
+                    Filter::builder()
+                        .key(FilterNameStringType::TagKey)
+                        .values(TAG_TYPE)
+                        .build(),
+                )
+                .filters(
+                    Filter::builder()
+                        .key(FilterNameStringType::TagValue)
+                        .values(TAG_VALUE_VAULT_MARKER)
+                        .build(),
+                );
             if let Some(t) = &next_token {
                 req = req.next_token(t.clone());
             }
@@ -180,7 +197,9 @@ impl VaultBackend for AwsVaultBackend {
                 }
             }
             next_token = out.next_token().map(|s| s.to_string());
-            if next_token.is_none() { break; }
+            if next_token.is_none() {
+                break;
+            }
         }
         Ok(summaries)
     }
@@ -222,24 +241,27 @@ impl VaultBackend for AwsVaultBackend {
 }
 
 impl AwsVaultBackend {
-    pub async fn delete_vault_internal(
-        &self,
-        name: &str,
-        force: bool,
-    ) -> Result<(), BackendError> {
+    pub async fn delete_vault_internal(&self, name: &str, force: bool) -> Result<(), BackendError> {
         use crate::backend::aws::encoding::{is_marker, marker_name, strip_prefix};
         use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
 
         let prefix = format!("{name}/");
-        let out = self.client
+        let out = self
+            .client
             .list_secrets()
             .max_results(100)
-            .filters(Filter::builder().key(FilterNameStringType::Name).values(prefix.clone()).build())
+            .filters(
+                Filter::builder()
+                    .key(FilterNameStringType::Name)
+                    .values(prefix.clone())
+                    .build(),
+            )
             .send()
             .await
             .map_err(super::errors::from_list)?;
 
-        let non_marker: Vec<String> = out.secret_list()
+        let non_marker: Vec<String> = out
+            .secret_list()
             .iter()
             .filter_map(|e| e.name().map(|s| s.to_string()))
             .filter(|n| !is_marker(n) && strip_prefix(name, n).is_some())

--- a/src/backend/aws/vaults.rs
+++ b/src/backend/aws/vaults.rs
@@ -91,12 +91,98 @@ impl VaultBackend for AwsVaultBackend {
         })
     }
 
-    async fn get_vault(&self, _name: &str) -> Result<VaultProperties, BackendError> {
-        Err(BackendError::Unsupported("get_vault not yet implemented".into()))
+    async fn get_vault(&self, name: &str) -> Result<VaultProperties, BackendError> {
+        use crate::backend::aws::encoding::marker_name;
+        let marker = marker_name(name);
+        let describe = self.client
+            .describe_secret()
+            .secret_id(&marker)
+            .send()
+            .await
+            .map_err(|e| match super::errors::from_describe(name, e) {
+                BackendError::NotFound { .. } => BackendError::VaultNotFound {
+                    name: name.to_string(),
+                    suggestion: None,
+                },
+                other => other,
+            })?;
+
+        // Build VaultProperties manually from describe output
+        let tags_list = describe.tags();
+        let mut tags: HashMap<String, String> = HashMap::new();
+        let mut vault_name = name.to_string();
+        let mut created_at = Utc::now();
+
+        for tag in tags_list {
+            if let (Some(key), Some(value)) = (tag.key(), tag.value()) {
+                if key == "xv:vault_name" {
+                    vault_name = value.to_string();
+                } else if key == "xv:created_at" {
+                    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(value) {
+                        created_at = dt.with_timezone(&Utc);
+                    }
+                } else if !key.starts_with("xv:") {
+                    tags.insert(key.to_string(), value.to_string());
+                }
+            }
+        }
+
+        Ok(VaultProperties {
+            id: format!("vault-{}", name),
+            name: vault_name,
+            location: "aws".to_string(),
+            resource_group: "default".to_string(),
+            subscription_id: "default".to_string(),
+            tenant_id: String::new(),
+            uri: format!("https://{}.vault.aws.net/", name),
+            enabled_for_deployment: false,
+            enabled_for_disk_encryption: false,
+            enabled_for_template_deployment: false,
+            soft_delete_retention_in_days: 30,
+            purge_protection: false,
+            sku: "standard".to_string(),
+            access_policies: Vec::new(),
+            created_at,
+            tags,
+            enable_rbac_authorization: Some(false),
+        })
     }
 
     async fn list_vaults(&self) -> Result<Vec<VaultSummary>, BackendError> {
-        Err(BackendError::Unsupported("list_vaults not yet implemented".into()))
+        use crate::backend::aws::metadata::{TAG_TYPE, TAG_VALUE_VAULT_MARKER};
+        use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
+
+        let mut next_token: Option<String> = None;
+        let mut summaries: Vec<VaultSummary> = Vec::new();
+
+        loop {
+            let mut req = self.client
+                .list_secrets()
+                .max_results(100)
+                .filters(Filter::builder().key(FilterNameStringType::TagKey).values(TAG_TYPE).build())
+                .filters(Filter::builder().key(FilterNameStringType::TagValue).values(TAG_VALUE_VAULT_MARKER).build());
+            if let Some(t) = &next_token {
+                req = req.next_token(t.clone());
+            }
+
+            let out = req.send().await.map_err(super::errors::from_list)?;
+            for entry in out.secret_list() {
+                let aws_full_name = entry.name().unwrap_or("");
+                if let Some(idx) = aws_full_name.rfind("/.xv-vault") {
+                    let vault = &aws_full_name[..idx];
+                    summaries.push(VaultSummary {
+                        name: vault.to_string(),
+                        location: "aws".to_string(),
+                        resource_group: "default".to_string(),
+                        status: "Active".to_string(),
+                        created_at: chrono::Utc::now().format("%Y-%m-%d %H:%M").to_string(),
+                    });
+                }
+            }
+            next_token = out.next_token().map(|s| s.to_string());
+            if next_token.is_none() { break; }
+        }
+        Ok(summaries)
     }
 
     async fn delete_vault(&self, _name: &str) -> Result<(), BackendError> {

--- a/src/backend/aws/vaults.rs
+++ b/src/backend/aws/vaults.rs
@@ -1,1 +1,41 @@
-//! `AwsVaultBackend` impl `VaultBackend`. See Tasks 29-33.
+//! `AwsVaultBackend` impl `VaultBackend`.
+
+use crate::backend::VaultBackend;
+use crate::backend::error::BackendError;
+use crate::vault::models::{VaultCreateRequest, VaultProperties, VaultSummary};
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+use std::sync::Arc;
+
+pub struct AwsVaultBackend {
+    pub(crate) client: Arc<SecretsManagerClient>,
+}
+
+impl AwsVaultBackend {
+    pub fn new(client: Arc<SecretsManagerClient>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait::async_trait]
+impl VaultBackend for AwsVaultBackend {
+    // Required methods — real impls added in Tasks 23-26.
+
+    async fn create_vault(
+        &self,
+        _request: VaultCreateRequest,
+    ) -> Result<VaultProperties, BackendError> {
+        Err(BackendError::Unsupported("create_vault not yet implemented".into()))
+    }
+
+    async fn get_vault(&self, _name: &str) -> Result<VaultProperties, BackendError> {
+        Err(BackendError::Unsupported("get_vault not yet implemented".into()))
+    }
+
+    async fn list_vaults(&self) -> Result<Vec<VaultSummary>, BackendError> {
+        Err(BackendError::Unsupported("list_vaults not yet implemented".into()))
+    }
+
+    async fn delete_vault(&self, _name: &str) -> Result<(), BackendError> {
+        Err(BackendError::Unsupported("delete_vault not yet implemented".into()))
+    }
+}

--- a/src/backend/aws/vaults.rs
+++ b/src/backend/aws/vaults.rs
@@ -185,7 +185,63 @@ impl VaultBackend for AwsVaultBackend {
         Ok(summaries)
     }
 
-    async fn delete_vault(&self, _name: &str) -> Result<(), BackendError> {
-        Err(BackendError::Unsupported("delete_vault not yet implemented".into()))
+    async fn delete_vault(&self, name: &str) -> Result<(), BackendError> {
+        self.delete_vault_internal(name, false).await
+    }
+}
+
+impl AwsVaultBackend {
+    pub async fn delete_vault_internal(
+        &self,
+        name: &str,
+        force: bool,
+    ) -> Result<(), BackendError> {
+        use crate::backend::aws::encoding::{is_marker, marker_name, strip_prefix};
+        use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
+
+        let prefix = format!("{name}/");
+        let out = self.client
+            .list_secrets()
+            .max_results(100)
+            .filters(Filter::builder().key(FilterNameStringType::Name).values(prefix.clone()).build())
+            .send()
+            .await
+            .map_err(super::errors::from_list)?;
+
+        let non_marker: Vec<String> = out.secret_list()
+            .iter()
+            .filter_map(|e| e.name().map(|s| s.to_string()))
+            .filter(|n| !is_marker(n) && strip_prefix(name, n).is_some())
+            .collect();
+
+        if !non_marker.is_empty() && !force {
+            return Err(BackendError::Conflict(format!(
+                "vault '{name}' contains {} secret(s); pass --force to delete them all",
+                non_marker.len()
+            )));
+        }
+
+        if force {
+            for full_name in &non_marker {
+                self.client
+                    .delete_secret()
+                    .secret_id(full_name)
+                    .recovery_window_in_days(30)
+                    .send()
+                    .await
+                    .map_err(|e| super::errors::from_delete(full_name, e))?;
+            }
+        }
+
+        let marker = marker_name(name);
+        self.client
+            .delete_secret()
+            .secret_id(&marker)
+            .force_delete_without_recovery(true)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_delete(&marker, e))?;
+
+        Ok(())
     }
 }

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -111,6 +111,16 @@ fn meta_to_properties(meta: &SecretMeta, value: Option<Zeroizing<String>>) -> Se
         .version
         .strip_prefix('v')
         .and_then(|s| s.parse::<u32>().ok());
+    let mut tags = meta.tags.clone();
+    if !meta.groups.is_empty() {
+        tags.insert("groups".to_string(), meta.groups.join(","));
+    }
+    if let Some(note) = meta.note.as_ref().filter(|n| !n.is_empty()) {
+        tags.insert("note".to_string(), note.clone());
+    }
+    if let Some(folder) = meta.folder.as_ref().filter(|f| !f.is_empty()) {
+        tags.insert("folder".to_string(), folder.clone());
+    }
 
     SecretProperties {
         name: meta.name.clone(),
@@ -124,7 +134,7 @@ fn meta_to_properties(meta: &SecretMeta, value: Option<Zeroizing<String>>) -> Se
         enabled: meta.enabled,
         expires_on: meta.expires_on,
         not_before: meta.not_before,
-        tags: meta.tags.clone(),
+        tags,
         content_type: meta.content_type.clone(),
         recovery_level: None,
     }

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -1007,12 +1007,10 @@ mod tests {
             .delete_secret("default", "restore-me")
             .await
             .unwrap();
-        assert!(
-            !backend
-                .secret_exists("default", "restore-me")
-                .await
-                .unwrap()
-        );
+        assert!(!backend
+            .secret_exists("default", "restore-me")
+            .await
+            .unwrap());
 
         // Restore
         let restored = backend
@@ -1022,12 +1020,10 @@ mod tests {
         assert_eq!(restored.name, "restore-me");
 
         // Should exist again
-        assert!(
-            backend
-                .secret_exists("default", "restore-me")
-                .await
-                .unwrap()
-        );
+        assert!(backend
+            .secret_exists("default", "restore-me")
+            .await
+            .unwrap());
 
         // Value should be recoverable
         let got = backend
@@ -1143,12 +1139,10 @@ mod tests {
             .set_secret("default", make_request("exists-test", "val"))
             .await
             .unwrap();
-        assert!(
-            backend
-                .secret_exists("default", "exists-test")
-                .await
-                .unwrap()
-        );
+        assert!(backend
+            .secret_exists("default", "exists-test")
+            .await
+            .unwrap());
     }
 
     #[tokio::test]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -16,6 +16,8 @@
 //! [`BackendRegistry`] for runtime backend resolution.
 
 pub mod azure;
+#[cfg(feature = "aws")]
+pub mod aws;
 pub mod error;
 #[cfg(feature = "file-ops")]
 pub mod file;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -88,8 +88,27 @@ pub enum NameCharset {
     AlphanumericHyphen,
     /// Any printable character (the backend encodes as needed).
     Unrestricted,
+    /// AWS Secrets Manager: `[a-zA-Z0-9/_+=.@-]`.
+    AwsRelaxed,
     /// Custom validation function.
     Custom(fn(&str) -> bool),
+}
+
+impl NameCharset {
+    /// Returns true if `name` is valid under this charset.
+    pub fn is_valid(&self, name: &str) -> bool {
+        match self {
+            Self::AlphanumericHyphen => name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-'),
+            Self::Unrestricted => true,
+            Self::AwsRelaxed => name.chars().all(|c| {
+                c.is_ascii_alphanumeric()
+                    || matches!(c, '/' | '_' | '+' | '=' | '.' | '@' | '-')
+            }),
+            Self::Custom(f) => f(name),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -205,5 +224,22 @@ mod tests {
     #[test]
     fn backend_kind_aws_displays_as_aws() {
         assert_eq!(format!("{}", BackendKind::Aws), "aws");
+    }
+
+    #[test]
+    fn aws_relaxed_charset_accepts_aws_chars() {
+        let cs = NameCharset::AwsRelaxed;
+        assert!(cs.is_valid("myproj/db-password"));
+        assert!(cs.is_valid("api_key+v2"));
+        assert!(cs.is_valid("alice@example.com"));
+        assert!(cs.is_valid("v1.2.3"));
+    }
+
+    #[test]
+    fn aws_relaxed_charset_rejects_invalid_chars() {
+        let cs = NameCharset::AwsRelaxed;
+        assert!(!cs.is_valid("has space"));
+        assert!(!cs.is_valid("has*star"));
+        assert!(!cs.is_valid("has(paren)"));
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -15,9 +15,9 @@
 //! See also: [`BackendError`] for the backend-agnostic error type, and
 //! [`BackendRegistry`] for runtime backend resolution.
 
-pub mod azure;
 #[cfg(feature = "aws")]
 pub mod aws;
+pub mod azure;
 pub mod error;
 #[cfg(feature = "file-ops")]
 pub mod file;
@@ -100,13 +100,10 @@ impl NameCharset {
     /// Returns true if `name` is valid under this charset.
     pub fn is_valid(&self, name: &str) -> bool {
         match self {
-            Self::AlphanumericHyphen => name
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '-'),
+            Self::AlphanumericHyphen => name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),
             Self::Unrestricted => true,
             Self::AwsRelaxed => name.chars().all(|c| {
-                c.is_ascii_alphanumeric()
-                    || matches!(c, '/' | '_' | '+' | '=' | '.' | '@' | '-')
+                c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '+' | '=' | '.' | '@' | '-')
             }),
             Self::Custom(f) => f(name),
         }
@@ -220,7 +217,10 @@ mod tests {
     fn backend_kind_parses_aws() {
         assert_eq!(BackendKind::from_str("aws").unwrap(), BackendKind::Aws);
         assert_eq!(BackendKind::from_str("AWS").unwrap(), BackendKind::Aws);
-        assert_eq!(BackendKind::from_str("secretsmanager").unwrap(), BackendKind::Aws);
+        assert_eq!(
+            BackendKind::from_str("secretsmanager").unwrap(),
+            BackendKind::Aws
+        );
     }
 
     #[test]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -47,6 +47,8 @@ pub enum BackendKind {
     Azure,
     /// Local age-encrypted file backend (Phase 2).
     Local,
+    /// AWS Secrets Manager backend (Phase 3).
+    Aws,
 }
 
 impl std::fmt::Display for BackendKind {
@@ -54,6 +56,7 @@ impl std::fmt::Display for BackendKind {
         match self {
             Self::Azure => write!(f, "azure"),
             Self::Local => write!(f, "local"),
+            Self::Aws => write!(f, "aws"),
         }
     }
 }
@@ -65,8 +68,9 @@ impl std::str::FromStr for BackendKind {
         match s.to_lowercase().as_str() {
             "azure" | "az" | "keyvault" => Ok(Self::Azure),
             "local" | "file" | "age" => Ok(Self::Local),
+            "aws" | "secretsmanager" | "asm" => Ok(Self::Aws),
             _ => Err(format!(
-                "unknown backend kind: {s}. Valid options: azure, local"
+                "unknown backend kind: {s}. Valid options: azure, local, aws"
             )),
         }
     }
@@ -184,4 +188,22 @@ pub trait Backend: Send + Sync {
 
     /// Validate configuration and connectivity. Called once at startup.
     async fn health_check(&self) -> Result<(), BackendError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn backend_kind_parses_aws() {
+        assert_eq!(BackendKind::from_str("aws").unwrap(), BackendKind::Aws);
+        assert_eq!(BackendKind::from_str("AWS").unwrap(), BackendKind::Aws);
+        assert_eq!(BackendKind::from_str("secretsmanager").unwrap(), BackendKind::Aws);
+    }
+
+    #[test]
+    fn backend_kind_aws_displays_as_aws() {
+        assert_eq!(format!("{}", BackendKind::Aws), "aws");
+    }
 }

--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -76,9 +76,13 @@ impl BackendRegistry {
                             .into(),
                     )
                 })?;
-                // We need an async runtime. The registry is sync; use a runtime handle.
-                let backend = tokio::runtime::Handle::current()
-                    .block_on(super::aws::AwsBackend::new(aws_cfg, None, None))?;
+                // block_in_place is safe to call from inside a tokio multi-thread
+                // runtime (unlike Handle::block_on which panics if a runtime is
+                // already active on the current thread).
+                let backend = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current()
+                        .block_on(super::aws::AwsBackend::new(aws_cfg, None, None))
+                })?;
                 Ok(Self::new(Arc::new(backend)))
             }
             #[cfg(not(feature = "aws"))]
@@ -99,8 +103,10 @@ impl BackendRegistry {
         match entry {
             #[cfg(feature = "aws")]
             NBE::Aws(aws_cfg) => {
-                let backend = tokio::runtime::Handle::current()
-                    .block_on(super::aws::AwsBackend::new(aws_cfg, None, None))?;
+                let backend = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current()
+                        .block_on(super::aws::AwsBackend::new(aws_cfg, None, None))
+                })?;
                 Ok(Self::new(Arc::new(backend)))
             }
             #[cfg(not(feature = "aws"))]

--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -40,14 +40,19 @@ impl BackendRegistry {
     /// Build a registry from the loaded [`Config`].
     ///
     /// The active backend is determined by `config.backend` (defaulting to
-    /// `"azure"` when absent). For Azure, an [`AzureBackend`] is created
-    /// using the existing auth provider. For Local, an error is returned
-    /// because the local backend is not yet implemented.
+    /// `"azure"` when absent). Named backends in `config.named_backends` are
+    /// checked first; if a matching entry is found it is instantiated directly.
     ///
     /// [`AzureBackend`]: super::azure::AzureBackend
     pub fn from_config(config: &Config) -> Result<Self, BackendError> {
-        let kind: BackendKind = config
-            .effective_backend_name()
+        let backend_name = config.effective_backend_name();
+
+        // Resolve named-backend entry first if applicable
+        if let Some(entry) = config.named_backends.get(backend_name) {
+            return Self::from_named_entry(backend_name, entry);
+        }
+
+        let kind: BackendKind = backend_name
             .parse()
             .map_err(|e: String| BackendError::Internal(e))?;
 
@@ -63,10 +68,48 @@ impl BackendRegistry {
                 let backend = super::local::LocalBackend::new(config.local.as_ref())?;
                 Ok(Self::new(Arc::new(backend)))
             }
+            #[cfg(feature = "aws")]
             BackendKind::Aws => {
-                Err(BackendError::Internal(
-                    "AWS Secrets Manager backend not yet implemented".to_string(),
-                ))
+                let aws_cfg = config.aws.as_ref().ok_or_else(|| {
+                    BackendError::Internal(
+                        "[aws] config block missing — set backend = \"aws\" with [aws] block"
+                            .into(),
+                    )
+                })?;
+                // We need an async runtime. The registry is sync; use a runtime handle.
+                let backend = tokio::runtime::Handle::current()
+                    .block_on(super::aws::AwsBackend::new(aws_cfg, None, None))?;
+                Ok(Self::new(Arc::new(backend)))
+            }
+            #[cfg(not(feature = "aws"))]
+            BackendKind::Aws => Err(BackendError::Internal(
+                "AWS backend not compiled in: rebuild with --features aws".into(),
+            )),
+        }
+    }
+
+    fn from_named_entry(
+        name: &str,
+        entry: &crate::config::settings::NamedBackendEntry,
+    ) -> Result<Self, BackendError> {
+        use crate::config::settings::NamedBackendEntry as NBE;
+        // `name` is used in the not(feature = "aws") error path below.
+        // When aws is compiled in, Rust sees it unused — suppress the lint.
+        let _ = name;
+        match entry {
+            #[cfg(feature = "aws")]
+            NBE::Aws(aws_cfg) => {
+                let backend = tokio::runtime::Handle::current()
+                    .block_on(super::aws::AwsBackend::new(aws_cfg, None, None))?;
+                Ok(Self::new(Arc::new(backend)))
+            }
+            #[cfg(not(feature = "aws"))]
+            NBE::Aws(_) => Err(BackendError::Internal(format!(
+                "named backend '{name}' is aws but binary built without --features aws"
+            ))),
+            NBE::Local(local_cfg) => {
+                let backend = super::local::LocalBackend::new(Some(local_cfg))?;
+                Ok(Self::new(Arc::new(backend)))
             }
         }
     }
@@ -172,5 +215,19 @@ mod tests {
         };
         let result = BackendRegistry::from_config(&config);
         assert!(result.is_err());
+    }
+
+    #[cfg(feature = "aws")]
+    #[tokio::test]
+    async fn from_config_aws_requires_aws_block() {
+        let config = Config {
+            backend: Some("aws".to_string()),
+            aws: None,
+            ..Default::default()
+        };
+        let result = BackendRegistry::from_config(&config);
+        assert!(result.is_err());
+        let err_str = result.unwrap_err().to_string();
+        assert!(err_str.contains("[aws]") || err_str.contains("aws"), "got: {err_str}");
     }
 }

--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -63,6 +63,11 @@ impl BackendRegistry {
                 let backend = super::local::LocalBackend::new(config.local.as_ref())?;
                 Ok(Self::new(Arc::new(backend)))
             }
+            BackendKind::Aws => {
+                Err(BackendError::Internal(
+                    "AWS Secrets Manager backend not yet implemented".to_string(),
+                ))
+            }
         }
     }
 

--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -228,6 +228,9 @@ mod tests {
         let result = BackendRegistry::from_config(&config);
         assert!(result.is_err());
         let err_str = result.unwrap_err().to_string();
-        assert!(err_str.contains("[aws]") || err_str.contains("aws"), "got: {err_str}");
+        assert!(
+            err_str.contains("[aws]") || err_str.contains("aws"),
+            "got: {err_str}"
+        );
     }
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -128,6 +128,14 @@ pub struct Cli {
     )]
     pub credential_type: Option<String>,
 
+    /// Override the AWS profile for this invocation (only honored when active backend is aws)
+    #[arg(long, global = true)]
+    pub aws_profile: Option<String>,
+
+    /// Override the AWS region for this invocation (only honored when active backend is aws)
+    #[arg(long, global = true)]
+    pub region: Option<String>,
+
     /// Show global options in help output
     #[arg(long)]
     pub show_options: bool,
@@ -1134,6 +1142,30 @@ impl Cli {
 
             config.azure_credential_priority =
                 AzureCredentialType::from_str(&cred_type).map_err(CrosstacheError::config)?;
+        }
+
+        // Apply --aws-profile CLI flag into config.aws
+        if let Some(ref p) = self.aws_profile {
+            if let Some(ref mut aws) = config.aws {
+                aws.profile = Some(p.clone());
+            } else {
+                config.aws = Some(crate::config::settings::AwsConfig {
+                    profile: Some(p.clone()),
+                    ..Default::default()
+                });
+            }
+        }
+
+        // Apply --region CLI flag into config.aws
+        if let Some(ref r) = self.region {
+            if let Some(ref mut aws) = config.aws {
+                aws.region = Some(r.clone());
+            } else {
+                config.aws = Some(crate::config::settings::AwsConfig {
+                    region: Some(r.clone()),
+                    ..Default::default()
+                });
+            }
         }
 
         match self.command {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1536,8 +1536,15 @@ impl Cli {
                 overwrite,
             } => {
                 crate::cli::migrate_ops::execute_migrate(
-                    from, to, vault, filter, dry_run,
-                    on_conflict, force_replace, concurrency, overwrite,
+                    from,
+                    to,
+                    vault,
+                    filter,
+                    dry_run,
+                    on_conflict,
+                    force_replace,
+                    concurrency,
+                    overwrite,
                     config,
                 )
                 .await

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -22,6 +22,22 @@ fn get_version() -> &'static str {
     built_info::PKG_VERSION
 }
 
+#[derive(Debug, Clone, clap::ValueEnum, PartialEq, Eq)]
+pub enum OnConflict {
+    /// Skip secrets that already exist in the target (default)
+    Skip,
+    /// Overwrite the target value, replacing the metadata
+    Replace,
+    /// Abort the migration on first conflict
+    Fail,
+}
+
+impl Default for OnConflict {
+    fn default() -> Self {
+        Self::Skip
+    }
+}
+
 /// Determine if options should be hidden based on environment or command line
 fn should_hide_options() -> bool {
     // Check if --show-options is present in command line args
@@ -696,10 +712,10 @@ pub enum Commands {
     },
     /// Migrate secrets between backends
     Migrate {
-        /// Source backend (azure, local)
+        /// Source backend (azure, local, aws)
         #[arg(long)]
         from: String,
-        /// Target backend (azure, local)
+        /// Target backend (azure, local, aws)
         #[arg(long)]
         to: String,
         /// Only migrate secrets from this vault
@@ -711,8 +727,17 @@ pub enum Commands {
         /// Preview what would be migrated without making changes
         #[arg(long)]
         dry_run: bool,
-        /// Overwrite secrets that already exist in the target
+        /// Behavior when a secret already exists in the target
+        #[arg(long, value_enum, default_value_t = OnConflict::Skip)]
+        on_conflict: OnConflict,
+        /// Ignore migration tags and replace targets unconditionally
         #[arg(long)]
+        force_replace: bool,
+        /// Concurrent transfers (default 8)
+        #[arg(long, default_value = "8")]
+        concurrency: usize,
+        /// DEPRECATED: use --on-conflict replace instead
+        #[arg(long, hide = true)]
         overwrite: bool,
     },
     /// Open the read-only terminal browser. Requires --features tui at build time.
@@ -1505,10 +1530,15 @@ impl Cli {
                 vault,
                 filter,
                 dry_run,
+                on_conflict,
+                force_replace,
+                concurrency,
                 overwrite,
             } => {
                 crate::cli::migrate_ops::execute_migrate(
-                    from, to, vault, filter, dry_run, overwrite, config,
+                    from, to, vault, filter, dry_run,
+                    on_conflict, force_replace, concurrency, overwrite,
+                    config,
                 )
                 .await
             }
@@ -1740,6 +1770,9 @@ mod tests {
                 vault,
                 filter,
                 dry_run,
+                on_conflict,
+                force_replace,
+                concurrency,
                 overwrite,
             } => {
                 assert_eq!(from, "azure");
@@ -1748,6 +1781,9 @@ mod tests {
                 assert_eq!(filter, Some("db-*".to_string()));
                 assert!(dry_run);
                 assert!(overwrite);
+                assert_eq!(on_conflict, OnConflict::Skip);
+                assert!(!force_replace);
+                assert_eq!(concurrency, 8);
             }
             _ => panic!("Expected Migrate command"),
         }
@@ -1765,6 +1801,9 @@ mod tests {
                 vault,
                 filter,
                 dry_run,
+                on_conflict,
+                force_replace,
+                concurrency,
                 overwrite,
             } => {
                 assert_eq!(from, "local");
@@ -1773,6 +1812,9 @@ mod tests {
                 assert_eq!(filter, None);
                 assert!(!dry_run);
                 assert!(!overwrite);
+                assert_eq!(on_conflict, OnConflict::Skip);
+                assert!(!force_replace);
+                assert_eq!(concurrency, 8);
             }
             _ => panic!("Expected Migrate command"),
         }

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -121,7 +121,7 @@ pub(crate) fn extract_claims_from_token(token: &str) -> Result<TokenClaims> {
     }
 
     let payload = parts[1];
-    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
     // Azure AD JWT tokens use base64url encoding (RFC 4648 §5), no padding
     let decoded = URL_SAFE_NO_PAD
         .decode(payload)

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -3,11 +3,12 @@
 //! Implements `xv migrate --from <backend> --to <backend>`, which copies
 //! secrets from one backend to another while preserving metadata.
 
-use crate::backend::{Backend, BackendKind, BackendRegistry};
+use crate::backend::{Backend, BackendError, BackendKind, BackendRegistry};
 use crate::config::settings::Config;
 use crate::error::{CrosstacheError, Result};
 use crate::secret::manager::SecretRequest;
 use crate::utils::output;
+use futures::stream::{self, StreamExt};
 use std::sync::Arc;
 use zeroize::Zeroizing;
 
@@ -124,6 +125,54 @@ fn build_request_from_props(
     }
 }
 
+async fn migrate_one(
+    source: &Arc<dyn Backend>,
+    target: &Arc<dyn Backend>,
+    vault: &str,
+    name: &str,
+    force_replace: bool,
+    source_name_for_tag: &str,
+) -> std::result::Result<String, (String, String)> {
+    // Fetch full props with value
+    let props = source
+        .secrets()
+        .get_secret(vault, name, true)
+        .await
+        .map_err(|e| (name.to_string(), format!("get_secret: {e}")))?;
+
+    // Idempotency check
+    if !force_replace {
+        if let Ok(existing) = target.secrets().get_secret(vault, name, false).await {
+            if let Some(prev_from) = existing.tags.get(TAG_MIGRATED_FROM) {
+                let expected = format!("{}:{}:{}", source_name_for_tag, vault, props.version);
+                if prev_from == &expected {
+                    return Err((name.to_string(), format!("__skip__{}", name)));
+                }
+            }
+        }
+    }
+
+    let request = build_request_from_props(&props, source_name_for_tag, vault);
+
+    // Retry with exponential backoff on RateLimited
+    let mut attempt = 0u32;
+    loop {
+        match target.secrets().set_secret(vault, request.clone()).await {
+            Ok(_) => return Ok(name.to_string()),
+            Err(BackendError::RateLimited { retry_after_secs }) if attempt < 5 => {
+                let wait = retry_after_secs
+                    .map(std::time::Duration::from_secs)
+                    .unwrap_or_else(|| {
+                        std::time::Duration::from_millis(500 * 2u64.pow(attempt))
+                    });
+                tokio::time::sleep(wait).await;
+                attempt += 1;
+            }
+            Err(e) => return Err((name.to_string(), format!("set_secret: {e}"))),
+        }
+    }
+}
+
 /// Create a backend instance for the given kind.
 fn create_backend(kind: BackendKind, config: &Config) -> Result<Arc<dyn Backend>> {
     match kind {
@@ -206,8 +255,6 @@ pub(crate) async fn execute_migrate(
     } else {
         on_conflict
     };
-    // concurrency will be wired in Task 33
-    let _ = concurrency;
     // 1. Parse backend kinds
     let from_kind: BackendKind = from
         .parse()
@@ -307,57 +354,60 @@ pub(crate) async fn execute_migrate(
         return Ok(());
     }
 
+    // 6. Migrate secrets concurrently with backoff retry
+    let source_name_tag = source.name().to_string();
+    let source_arc = source.clone();
+    let target_arc = target.clone();
+    let vault_clone = vault_name.clone();
+
+    let results: Vec<_> = stream::iter(names_to_process.iter().map(|name| {
+        let source = source_arc.clone();
+        let target = target_arc.clone();
+        let vault = vault_clone.clone();
+        let name = name.clone();
+        let src_tag = source_name_tag.clone();
+        async move {
+            migrate_one(&source, &target, &vault, &name, force_replace, &src_tag).await
+        }
+    }))
+    .buffer_unordered(concurrency)
+    .collect()
+    .await;
+
     let mut migrated = 0usize;
     let mut skipped = 0usize;
+    let mut errors: Vec<(String, String)> = Vec::new();
 
-    // 6. Migrate each secret
-    for name in &names_to_process {
-        // Get secret with value from source
-        let props = source
-            .secrets()
-            .get_secret(&vault_name, name, true)
-            .await
-            .map_err(|e| {
-                CrosstacheError::Unknown(format!(
-                    "Failed to get secret '{}' from source: {e}",
-                    name
-                ))
-            })?;
-
-        // Idempotency check: skip if already migrated from the same source version
-        if !force_replace {
-            if let Ok(existing) = target.secrets().get_secret(&vault_name, name, false).await {
-                if let Some(prev_from) = existing.tags.get(TAG_MIGRATED_FROM) {
-                    let expected = format!("{}:{}:{}", source.name(), vault_name, props.version);
-                    if prev_from == &expected {
-                        println!("  [skip] {} — already migrated (same source version)", name);
-                        skipped += 1;
-                        continue;
-                    }
-                }
-            }
-        }
-
-        let request = build_request_from_props(&props, source.name(), &vault_name);
-
-        // Set secret in target
-        match target.secrets().set_secret(&vault_name, request).await {
-            Ok(_) => {
+    for r in results {
+        match r {
+            Ok(name) => {
                 println!("  [ok] {}", name);
                 migrated += 1;
             }
-            Err(e) => {
-                println!("  [error] {} — {}", name, e);
+            Err((name, msg)) if msg.starts_with("__skip__") => {
+                println!("  [skip] {} — already migrated (same source version)", name);
                 skipped += 1;
+            }
+            Err((name, msg)) => {
+                println!("  [error] {} — {}", name, msg);
+                errors.push((name, msg));
             }
         }
     }
 
     // 7. Print summary
-    output::success(&format!(
-        "Migrated {} secret(s) ({} skipped)",
-        migrated, skipped
-    ));
+    println!();
+    if !errors.is_empty() {
+        output::warn(&format!(
+            "Migrated {} secret(s), {} skipped, {} error(s)",
+            migrated, skipped, errors.len()
+        ));
+    } else {
+        output::success(&format!(
+            "Migrated {} secret(s) ({} skipped)",
+            migrated, skipped
+        ));
+    }
 
     Ok(())
 }

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -15,6 +15,14 @@ use zeroize::Zeroizing;
 const TAG_MIGRATED_FROM: &str = "xv:migrated_from";
 const TAG_MIGRATED_AT: &str = "xv:migrated_at";
 
+/// Outcome of a single secret migration attempt.
+enum MigrateOutcome {
+    /// Secret was successfully copied to the target backend.
+    Migrated(String),
+    /// Secret was already migrated (same source version exists in target).
+    Skipped(String),
+}
+
 struct MigrationDiff {
     to_migrate: Vec<String>,
     conflicts: Vec<String>,
@@ -138,7 +146,7 @@ async fn migrate_one(
     name: &str,
     force_replace: bool,
     source_name_for_tag: &str,
-) -> std::result::Result<String, (String, String)> {
+) -> std::result::Result<MigrateOutcome, (String, String)> {
     // Fetch full props with value
     let props = source
         .secrets()
@@ -152,7 +160,7 @@ async fn migrate_one(
             if let Some(prev_from) = existing.tags.get(TAG_MIGRATED_FROM) {
                 let expected = format!("{}:{}:{}", source_name_for_tag, vault, props.version);
                 if prev_from == &expected {
-                    return Err((name.to_string(), format!("__skip__{}", name)));
+                    return Ok(MigrateOutcome::Skipped(name.to_string()));
                 }
             }
         }
@@ -164,7 +172,7 @@ async fn migrate_one(
     let mut attempt = 0u32;
     loop {
         match target.secrets().set_secret(vault, request.clone()).await {
-            Ok(_) => return Ok(name.to_string()),
+            Ok(_) => return Ok(MigrateOutcome::Migrated(name.to_string())),
             Err(BackendError::RateLimited { retry_after_secs }) if attempt < 5 => {
                 let wait = retry_after_secs
                     .map(std::time::Duration::from_secs)
@@ -178,7 +186,7 @@ async fn migrate_one(
 }
 
 /// Create a backend instance for the given kind.
-fn create_backend(kind: BackendKind, config: &Config) -> Result<Arc<dyn Backend>> {
+async fn create_backend(kind: BackendKind, config: &Config) -> Result<Arc<dyn Backend>> {
     match kind {
         BackendKind::Azure => {
             let auth_provider =
@@ -205,11 +213,12 @@ fn create_backend(kind: BackendKind, config: &Config) -> Result<Arc<dyn Backend>
                     "[aws] config block missing — set backend = \"aws\" or pass --aws-profile",
                 )
             })?;
-            let backend = tokio::runtime::Handle::current()
-                .block_on(crate::backend::aws::AwsBackend::new(aws_cfg, None, None))
-                .map_err(|e| {
-                    CrosstacheError::Unknown(format!("Failed to create AWS backend: {e}"))
-                })?;
+            let backend =
+                crate::backend::aws::AwsBackend::new(aws_cfg, None, None)
+                    .await
+                    .map_err(|e| {
+                        CrosstacheError::Unknown(format!("Failed to create AWS backend: {e}"))
+                    })?;
             Ok(Arc::new(backend))
         }
         #[cfg(not(feature = "aws"))]
@@ -276,8 +285,8 @@ pub(crate) async fn execute_migrate(
     }
 
     // 2. Create both backends
-    let source = create_backend(from_kind, &config)?;
-    let target = create_backend(to_kind, &config)?;
+    let source = create_backend(from_kind, &config).await?;
+    let target = create_backend(to_kind, &config).await?;
 
     // 3. Resolve vault name
     let vault_name = resolve_vault_name(&vault, &config)?;
@@ -396,11 +405,11 @@ pub(crate) async fn execute_migrate(
 
     for r in results {
         match r {
-            Ok(name) => {
+            Ok(MigrateOutcome::Migrated(name)) => {
                 println!("  [ok] {}", name);
                 migrated += 1;
             }
-            Err((name, msg)) if msg.starts_with("__skip__") => {
+            Ok(MigrateOutcome::Skipped(name)) => {
                 println!("  [skip] {} — already migrated (same source version)", name);
                 skipped += 1;
             }

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -32,6 +32,11 @@ fn create_backend(kind: BackendKind, config: &Config) -> Result<Arc<dyn Backend>
                 })?;
             Ok(Arc::new(backend))
         }
+        BackendKind::Aws => {
+            Err(CrosstacheError::Unknown(
+                "AWS Secrets Manager backend not yet implemented".to_string(),
+            ))
+        }
     }
 }
 

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -213,12 +213,11 @@ async fn create_backend(kind: BackendKind, config: &Config) -> Result<Arc<dyn Ba
                     "[aws] config block missing — set backend = \"aws\" or pass --aws-profile",
                 )
             })?;
-            let backend =
-                crate::backend::aws::AwsBackend::new(aws_cfg, None, None)
-                    .await
-                    .map_err(|e| {
-                        CrosstacheError::Unknown(format!("Failed to create AWS backend: {e}"))
-                    })?;
+            let backend = crate::backend::aws::AwsBackend::new(aws_cfg, None, None)
+                .await
+                .map_err(|e| {
+                    CrosstacheError::Unknown(format!("Failed to create AWS backend: {e}"))
+                })?;
             Ok(Arc::new(backend))
         }
         #[cfg(not(feature = "aws"))]
@@ -429,6 +428,10 @@ pub(crate) async fn execute_migrate(
             skipped,
             errors.len()
         ));
+        return Err(CrosstacheError::Unknown(format!(
+            "Migration failed for {} secret(s)",
+            errors.len()
+        )));
     } else {
         output::success(&format!(
             "Migrated {} secret(s) ({} skipped)",

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -11,6 +11,78 @@ use crate::utils::output;
 use std::sync::Arc;
 use zeroize::Zeroizing;
 
+struct MigrationDiff {
+    to_migrate: Vec<String>,
+    conflicts: Vec<String>,
+}
+
+async fn compute_diff(
+    source: &Arc<dyn Backend>,
+    target: &Arc<dyn Backend>,
+    vault: &str,
+    filter: Option<&str>,
+) -> Result<MigrationDiff> {
+    let source_secrets = source
+        .secrets()
+        .list_secrets(vault, None)
+        .await
+        .map_err(|e| {
+            CrosstacheError::Unknown(format!(
+                "Failed to list secrets from {} backend: {e}",
+                source.name()
+            ))
+        })?;
+
+    let filtered: Vec<String> = match filter {
+        Some(pattern) => {
+            let glob = globset::Glob::new(pattern)
+                .map_err(|e| CrosstacheError::invalid_argument(format!("Invalid glob pattern: {e}")))?
+                .compile_matcher();
+            source_secrets
+                .into_iter()
+                .filter(|s| glob.is_match(&s.name))
+                .map(|s| s.name)
+                .collect()
+        }
+        None => source_secrets.into_iter().map(|s| s.name).collect(),
+    };
+
+    let mut to_migrate = Vec::new();
+    let mut conflicts = Vec::new();
+
+    for name in filtered {
+        match target.secrets().secret_exists(vault, &name).await {
+            Ok(true) => conflicts.push(name),
+            Ok(false) => to_migrate.push(name),
+            Err(e) => {
+                tracing::debug!("secret_exists check failed for {name}: {e}; assuming new");
+                to_migrate.push(name);
+            }
+        }
+    }
+    Ok(MigrationDiff { to_migrate, conflicts })
+}
+
+fn print_diff_summary(
+    diff: &MigrationDiff,
+    source_name: &str,
+    target_name: &str,
+    vault: &str,
+    on_conflict: &crate::cli::commands::OnConflict,
+    dry_run: bool,
+) {
+    println!();
+    println!("Source: {}:{}", source_name, vault);
+    println!("Target: {}:{}", target_name, vault);
+    println!();
+    println!("  to migrate:    {} secret(s)", diff.to_migrate.len());
+    println!("  conflict:      {} secret(s) (target already has same name)", diff.conflicts.len());
+    println!();
+    println!("On conflict: {:?}", on_conflict);
+    println!("Dry run? {}", if dry_run { "yes" } else { "no" });
+    println!();
+}
+
 /// Create a backend instance for the given kind.
 fn create_backend(kind: BackendKind, config: &Config) -> Result<Arc<dyn Backend>> {
     match kind {
@@ -167,80 +239,38 @@ pub(crate) async fn execute_migrate(
         }
     }
 
-    // 5. List secrets from source
-    let secrets = source
-        .secrets()
-        .list_secrets(&vault_name, None)
-        .await
-        .map_err(|e| {
-            CrosstacheError::Unknown(format!(
-                "Failed to list secrets from {} backend: {e}",
-                source.name()
-            ))
-        })?;
+    // 5. Compute diff (list + filter + conflict detection)
+    let diff = compute_diff(&source, &target, &vault_name, filter.as_deref()).await?;
+    print_diff_summary(&diff, source.name(), target.name(), &vault_name, &on_conflict, dry_run);
 
-    if secrets.is_empty() {
-        output::info("No secrets found in the source vault.");
+    if dry_run {
         return Ok(());
     }
 
-    // 6. Apply filter if specified
-    let filtered_secrets: Vec<_> = if let Some(ref pattern) = filter {
-        let glob = globset::Glob::new(pattern)
-            .map_err(|e| CrosstacheError::invalid_argument(format!("Invalid glob pattern: {e}")))?
-            .compile_matcher();
-        secrets
-            .into_iter()
-            .filter(|s| glob.is_match(&s.name))
-            .collect()
-    } else {
-        secrets
-    };
-
-    if filtered_secrets.is_empty() {
-        output::info("No secrets matched the filter pattern.");
-        return Ok(());
+    // Honor --on-conflict fail
+    if !diff.conflicts.is_empty() && on_conflict == crate::cli::commands::OnConflict::Fail {
+        return Err(CrosstacheError::Unknown(format!(
+            "{} conflict(s) detected; aborting (--on-conflict fail)",
+            diff.conflicts.len()
+        )));
     }
 
-    output::info(&format!(
-        "Found {} secret(s) to migrate",
-        filtered_secrets.len()
-    ));
+    // Build list of names to process
+    let mut names_to_process: Vec<String> = diff.to_migrate.clone();
+    if on_conflict == crate::cli::commands::OnConflict::Replace {
+        names_to_process.extend(diff.conflicts.clone());
+    }
+
+    if names_to_process.is_empty() {
+        output::info("No secrets to migrate.");
+        return Ok(());
+    }
 
     let mut migrated = 0usize;
     let mut skipped = 0usize;
 
-    // 7. Migrate each secret
-    for summary in &filtered_secrets {
-        let name = &summary.name;
-
-        if dry_run {
-            println!("  [dry-run] Would migrate: {}", name);
-            migrated += 1;
-            continue;
-        }
-
-        // Check if secret already exists in target
-        if on_conflict != crate::cli::commands::OnConflict::Replace {
-            match target.secrets().secret_exists(&vault_name, name).await {
-                Ok(true) => {
-                    if on_conflict == crate::cli::commands::OnConflict::Fail {
-                        return Err(CrosstacheError::Unknown(format!(
-                            "Conflict: '{}' already exists in target (--on-conflict fail)",
-                            name
-                        )));
-                    }
-                    println!("  [skip] {} — already exists in target", name);
-                    skipped += 1;
-                    continue;
-                }
-                Ok(false) => {}
-                Err(_) => {
-                    // If existence check fails, proceed anyway
-                }
-            }
-        }
-
+    // 6. Migrate each secret
+    for name in &names_to_process {
         // Get secret with value from source
         let props = source
             .secrets()
@@ -289,19 +319,11 @@ pub(crate) async fn execute_migrate(
         }
     }
 
-    // 8. Print summary
-    println!();
-    if dry_run {
-        output::success(&format!(
-            "Dry run complete: {} secret(s) would be migrated",
-            migrated
-        ));
-    } else {
-        output::success(&format!(
-            "Migrated {} secret(s) ({} skipped)",
-            migrated, skipped
-        ));
-    }
+    // 7. Print summary
+    output::success(&format!(
+        "Migrated {} secret(s) ({} skipped)",
+        migrated, skipped
+    ));
 
     Ok(())
 }

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -80,9 +80,21 @@ pub(crate) async fn execute_migrate(
     vault: Option<String>,
     filter: Option<String>,
     dry_run: bool,
-    overwrite: bool,
+    on_conflict: crate::cli::commands::OnConflict,
+    force_replace: bool,
+    concurrency: usize,
+    legacy_overwrite: bool,
     config: Config,
 ) -> Result<()> {
+    // Compatibility shim: --overwrite -> --on-conflict replace + warn
+    let on_conflict = if legacy_overwrite {
+        eprintln!("warning: --overwrite is deprecated; use --on-conflict replace");
+        crate::cli::commands::OnConflict::Replace
+    } else {
+        on_conflict
+    };
+    // force_replace and concurrency will be wired in Tasks 32-33
+    let _ = (force_replace, concurrency);
     // 1. Parse backend kinds
     let from_kind: BackendKind = from
         .parse()
@@ -208,10 +220,16 @@ pub(crate) async fn execute_migrate(
             continue;
         }
 
-        // Check if secret already exists in target (unless overwrite is set)
-        if !overwrite {
+        // Check if secret already exists in target
+        if on_conflict != crate::cli::commands::OnConflict::Replace {
             match target.secrets().secret_exists(&vault_name, name).await {
                 Ok(true) => {
+                    if on_conflict == crate::cli::commands::OnConflict::Fail {
+                        return Err(CrosstacheError::Unknown(format!(
+                            "Conflict: '{}' already exists in target (--on-conflict fail)",
+                            name
+                        )));
+                    }
                     println!("  [skip] {} — already exists in target", name);
                     skipped += 1;
                     continue;

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -32,11 +32,22 @@ fn create_backend(kind: BackendKind, config: &Config) -> Result<Arc<dyn Backend>
                 })?;
             Ok(Arc::new(backend))
         }
+        #[cfg(feature = "aws")]
         BackendKind::Aws => {
-            Err(CrosstacheError::Unknown(
-                "AWS Secrets Manager backend not yet implemented".to_string(),
-            ))
+            let aws_cfg = config.aws.as_ref().ok_or_else(|| {
+                CrosstacheError::config(
+                    "[aws] config block missing — set backend = \"aws\" or pass --aws-profile",
+                )
+            })?;
+            let backend = tokio::runtime::Handle::current()
+                .block_on(crate::backend::aws::AwsBackend::new(aws_cfg, None, None))
+                .map_err(|e| CrosstacheError::Unknown(format!("Failed to create AWS backend: {e}")))?;
+            Ok(Arc::new(backend))
         }
+        #[cfg(not(feature = "aws"))]
+        BackendKind::Aws => Err(CrosstacheError::Unknown(
+            "AWS backend not compiled in: rebuild with --features aws".into(),
+        )),
     }
 }
 

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -109,6 +109,16 @@ fn build_request_from_props(
     vault: &str,
 ) -> SecretRequest {
     let mut tags = props.tags.clone();
+    let groups = tags.remove("groups").map(|groups| {
+        groups
+            .split(',')
+            .map(str::trim)
+            .filter(|group| !group.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    });
+    let note = tags.remove("note").filter(|note| !note.is_empty());
+    let folder = tags.remove("folder").filter(|folder| !folder.is_empty());
     tags.insert(
         TAG_MIGRATED_FROM.into(),
         format!("{}:{}:{}", source_name, vault, props.version),
@@ -133,9 +143,9 @@ fn build_request_from_props(
         expires_on: props.expires_on,
         not_before: props.not_before,
         tags: if tags.is_empty() { None } else { Some(tags) },
-        groups: None,
-        note: None,
-        folder: None,
+        groups,
+        note,
+        folder,
     }
 }
 
@@ -262,6 +272,12 @@ pub(crate) async fn execute_migrate(
     legacy_overwrite: bool,
     config: Config,
 ) -> Result<()> {
+    if concurrency == 0 {
+        return Err(CrosstacheError::invalid_argument(
+            "--concurrency must be at least 1",
+        ));
+    }
+
     // Compatibility shim: --overwrite -> --on-conflict replace + warn
     let on_conflict = if legacy_overwrite {
         eprintln!("warning: --overwrite is deprecated; use --on-conflict replace");
@@ -446,6 +462,7 @@ pub(crate) async fn execute_migrate(
 mod tests {
     use super::*;
     use crate::config::settings::LocalConfig;
+    use std::collections::HashMap;
     use tempfile::TempDir;
 
     #[test]
@@ -490,6 +507,73 @@ mod tests {
         let from_kind: BackendKind = "local".parse().unwrap();
         let to_kind: BackendKind = "local".parse().unwrap();
         assert_eq!(from_kind, to_kind);
+    }
+
+    #[test]
+    fn build_request_promotes_metadata_tags_to_request_fields() {
+        let mut tags = HashMap::new();
+        tags.insert("groups".to_string(), "db, prod".to_string());
+        tags.insert("note".to_string(), "primary database password".to_string());
+        tags.insert("folder".to_string(), "infra/database".to_string());
+        tags.insert("owner".to_string(), "platform".to_string());
+
+        let props = crate::secret::manager::SecretProperties {
+            name: "db-password".to_string(),
+            original_name: "db-password".to_string(),
+            value: Some(Zeroizing::new("secret-value".to_string())),
+            version: "v7".to_string(),
+            version_number: Some(7),
+            created_timestamp: 0,
+            created_on: String::new(),
+            updated_on: String::new(),
+            enabled: true,
+            expires_on: None,
+            not_before: None,
+            tags,
+            content_type: "text/plain".to_string(),
+            recovery_level: None,
+        };
+
+        let request = build_request_from_props(&props, "local", "default");
+
+        assert_eq!(
+            request.groups,
+            Some(vec!["db".to_string(), "prod".to_string()])
+        );
+        assert_eq!(request.note.as_deref(), Some("primary database password"));
+        assert_eq!(request.folder.as_deref(), Some("infra/database"));
+        let request_tags = request.tags.unwrap();
+        assert_eq!(
+            request_tags.get("owner").map(String::as_str),
+            Some("platform")
+        );
+        assert_eq!(
+            request_tags.get(TAG_MIGRATED_FROM).map(String::as_str),
+            Some("local:default:v7")
+        );
+        assert!(!request_tags.contains_key("groups"));
+        assert!(!request_tags.contains_key("note"));
+        assert!(!request_tags.contains_key("folder"));
+    }
+
+    #[tokio::test]
+    async fn execute_migrate_rejects_zero_concurrency() {
+        let result = execute_migrate(
+            "local".to_string(),
+            "aws".to_string(),
+            Some("default".to_string()),
+            None,
+            false,
+            crate::cli::commands::OnConflict::Skip,
+            false,
+            0,
+            false,
+            Config::default(),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("concurrency"));
     }
 
     #[tokio::test]

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -11,6 +11,9 @@ use crate::utils::output;
 use std::sync::Arc;
 use zeroize::Zeroizing;
 
+const TAG_MIGRATED_FROM: &str = "xv:migrated_from";
+const TAG_MIGRATED_AT: &str = "xv:migrated_at";
+
 struct MigrationDiff {
     to_migrate: Vec<String>,
     conflicts: Vec<String>,
@@ -81,6 +84,44 @@ fn print_diff_summary(
     println!("On conflict: {:?}", on_conflict);
     println!("Dry run? {}", if dry_run { "yes" } else { "no" });
     println!();
+}
+
+fn build_request_from_props(
+    props: &crate::secret::manager::SecretProperties,
+    source_name: &str,
+    vault: &str,
+) -> SecretRequest {
+    let mut tags = props.tags.clone();
+    tags.insert(
+        TAG_MIGRATED_FROM.into(),
+        format!("{}:{}:{}", source_name, vault, props.version),
+    );
+    tags.insert(TAG_MIGRATED_AT.into(), chrono::Utc::now().to_rfc3339());
+
+    SecretRequest {
+        name: props.original_name.clone(),
+        value: Zeroizing::new(
+            props.value.as_ref()
+                .map(|v| v.as_str().to_string())
+                .unwrap_or_default(),
+        ),
+        content_type: if props.content_type.is_empty() {
+            None
+        } else {
+            Some(props.content_type.clone())
+        },
+        enabled: Some(props.enabled),
+        expires_on: props.expires_on,
+        not_before: props.not_before,
+        tags: if tags.is_empty() {
+            None
+        } else {
+            Some(tags)
+        },
+        groups: None,
+        note: None,
+        folder: None,
+    }
 }
 
 /// Create a backend instance for the given kind.
@@ -165,8 +206,8 @@ pub(crate) async fn execute_migrate(
     } else {
         on_conflict
     };
-    // force_replace and concurrency will be wired in Tasks 32-33
-    let _ = (force_replace, concurrency);
+    // concurrency will be wired in Task 33
+    let _ = concurrency;
     // 1. Parse backend kinds
     let from_kind: BackendKind = from
         .parse()
@@ -283,28 +324,21 @@ pub(crate) async fn execute_migrate(
                 ))
             })?;
 
-        // Build SecretRequest from source properties
-        let value = props.value.unwrap_or_else(|| Zeroizing::new(String::new()));
-        let request = SecretRequest {
-            name: props.original_name.clone(),
-            value,
-            content_type: if props.content_type.is_empty() {
-                None
-            } else {
-                Some(props.content_type.clone())
-            },
-            enabled: Some(props.enabled),
-            expires_on: props.expires_on,
-            not_before: props.not_before,
-            tags: if props.tags.is_empty() {
-                None
-            } else {
-                Some(props.tags.clone())
-            },
-            groups: None,
-            note: None,
-            folder: None,
-        };
+        // Idempotency check: skip if already migrated from the same source version
+        if !force_replace {
+            if let Ok(existing) = target.secrets().get_secret(&vault_name, name, false).await {
+                if let Some(prev_from) = existing.tags.get(TAG_MIGRATED_FROM) {
+                    let expected = format!("{}:{}:{}", source.name(), vault_name, props.version);
+                    if prev_from == &expected {
+                        println!("  [skip] {} — already migrated (same source version)", name);
+                        skipped += 1;
+                        continue;
+                    }
+                }
+            }
+        }
+
+        let request = build_request_from_props(&props, source.name(), &vault_name);
 
         // Set secret in target
         match target.secrets().set_secret(&vault_name, request).await {

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -254,6 +254,15 @@ fn resolve_vault_name(vault_flag: &Option<String>, config: &Config) -> Result<St
             }
         }
     }
+    // Try AWS config default_vault
+    #[cfg(feature = "aws")]
+    if let Some(ref aws) = config.aws {
+        if let Some(ref dv) = aws.default_vault {
+            if !dv.is_empty() {
+                return Ok(dv.clone());
+            }
+        }
+    }
     Err(CrosstacheError::config(
         "No vault specified. Use --vault to specify the vault to migrate.",
     ))
@@ -493,6 +502,20 @@ mod tests {
         };
         let result = resolve_vault_name(&None, &config);
         assert_eq!(result.unwrap(), "local-vault");
+    }
+
+    #[cfg(feature = "aws")]
+    #[test]
+    fn resolve_vault_name_from_aws_config() {
+        let config = Config {
+            aws: Some(crate::config::settings::AwsConfig {
+                default_vault: Some("aws-vault".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = resolve_vault_name(&None, &config);
+        assert_eq!(result.unwrap(), "aws-vault");
     }
 
     #[test]

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -40,7 +40,9 @@ async fn compute_diff(
     let filtered: Vec<String> = match filter {
         Some(pattern) => {
             let glob = globset::Glob::new(pattern)
-                .map_err(|e| CrosstacheError::invalid_argument(format!("Invalid glob pattern: {e}")))?
+                .map_err(|e| {
+                    CrosstacheError::invalid_argument(format!("Invalid glob pattern: {e}"))
+                })?
                 .compile_matcher();
             source_secrets
                 .into_iter()
@@ -64,7 +66,10 @@ async fn compute_diff(
             }
         }
     }
-    Ok(MigrationDiff { to_migrate, conflicts })
+    Ok(MigrationDiff {
+        to_migrate,
+        conflicts,
+    })
 }
 
 fn print_diff_summary(
@@ -80,7 +85,10 @@ fn print_diff_summary(
     println!("Target: {}:{}", target_name, vault);
     println!();
     println!("  to migrate:    {} secret(s)", diff.to_migrate.len());
-    println!("  conflict:      {} secret(s) (target already has same name)", diff.conflicts.len());
+    println!(
+        "  conflict:      {} secret(s) (target already has same name)",
+        diff.conflicts.len()
+    );
     println!();
     println!("On conflict: {:?}", on_conflict);
     println!("Dry run? {}", if dry_run { "yes" } else { "no" });
@@ -102,7 +110,9 @@ fn build_request_from_props(
     SecretRequest {
         name: props.original_name.clone(),
         value: Zeroizing::new(
-            props.value.as_ref()
+            props
+                .value
+                .as_ref()
                 .map(|v| v.as_str().to_string())
                 .unwrap_or_default(),
         ),
@@ -114,11 +124,7 @@ fn build_request_from_props(
         enabled: Some(props.enabled),
         expires_on: props.expires_on,
         not_before: props.not_before,
-        tags: if tags.is_empty() {
-            None
-        } else {
-            Some(tags)
-        },
+        tags: if tags.is_empty() { None } else { Some(tags) },
         groups: None,
         note: None,
         folder: None,
@@ -162,9 +168,7 @@ async fn migrate_one(
             Err(BackendError::RateLimited { retry_after_secs }) if attempt < 5 => {
                 let wait = retry_after_secs
                     .map(std::time::Duration::from_secs)
-                    .unwrap_or_else(|| {
-                        std::time::Duration::from_millis(500 * 2u64.pow(attempt))
-                    });
+                    .unwrap_or_else(|| std::time::Duration::from_millis(500 * 2u64.pow(attempt)));
                 tokio::time::sleep(wait).await;
                 attempt += 1;
             }
@@ -203,7 +207,9 @@ fn create_backend(kind: BackendKind, config: &Config) -> Result<Arc<dyn Backend>
             })?;
             let backend = tokio::runtime::Handle::current()
                 .block_on(crate::backend::aws::AwsBackend::new(aws_cfg, None, None))
-                .map_err(|e| CrosstacheError::Unknown(format!("Failed to create AWS backend: {e}")))?;
+                .map_err(|e| {
+                    CrosstacheError::Unknown(format!("Failed to create AWS backend: {e}"))
+                })?;
             Ok(Arc::new(backend))
         }
         #[cfg(not(feature = "aws"))]
@@ -329,7 +335,14 @@ pub(crate) async fn execute_migrate(
 
     // 5. Compute diff (list + filter + conflict detection)
     let diff = compute_diff(&source, &target, &vault_name, filter.as_deref()).await?;
-    print_diff_summary(&diff, source.name(), target.name(), &vault_name, &on_conflict, dry_run);
+    print_diff_summary(
+        &diff,
+        source.name(),
+        target.name(),
+        &vault_name,
+        &on_conflict,
+        dry_run,
+    );
 
     if dry_run {
         return Ok(());
@@ -360,19 +373,22 @@ pub(crate) async fn execute_migrate(
     let target_arc = target.clone();
     let vault_clone = vault_name.clone();
 
-    let results: Vec<_> = stream::iter(names_to_process.iter().map(|name| {
-        let source = source_arc.clone();
-        let target = target_arc.clone();
-        let vault = vault_clone.clone();
-        let name = name.clone();
-        let src_tag = source_name_tag.clone();
-        async move {
-            migrate_one(&source, &target, &vault, &name, force_replace, &src_tag).await
-        }
-    }))
-    .buffer_unordered(concurrency)
-    .collect()
-    .await;
+    let results: Vec<_> =
+        stream::iter(
+            names_to_process.iter().map(|name| {
+                let source = source_arc.clone();
+                let target = target_arc.clone();
+                let vault = vault_clone.clone();
+                let name = name.clone();
+                let src_tag = source_name_tag.clone();
+                async move {
+                    migrate_one(&source, &target, &vault, &name, force_replace, &src_tag).await
+                }
+            }),
+        )
+        .buffer_unordered(concurrency)
+        .collect()
+        .await;
 
     let mut migrated = 0usize;
     let mut skipped = 0usize;
@@ -400,7 +416,9 @@ pub(crate) async fn execute_migrate(
     if !errors.is_empty() {
         output::warn(&format!(
             "Migrated {} secret(s), {} skipped, {} error(s)",
-            migrated, skipped, errors.len()
+            migrated,
+            skipped,
+            errors.len()
         ));
     } else {
         output::success(&format!(

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -3850,6 +3850,7 @@ mod tests {
             match self.kind {
                 BackendKind::Azure => "azure",
                 BackendKind::Local => "local",
+                BackendKind::Aws => "aws",
             }
         }
 

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -1442,7 +1442,7 @@ pub(crate) async fn execute_secret_find_direct(
     // ── Trait-based path (non-Azure backends) ──────────────────────────
     if use_trait_path(registry) {
         let reg = registry.expect("use_trait_path guarantees Some");
-        use crate::utils::fuzzy::{CandidateItem, FuzzyField, score_matches};
+        use crate::utils::fuzzy::{score_matches, CandidateItem, FuzzyField};
 
         // Parse --in fields
         let mut fields: Vec<FuzzyField> = vec![FuzzyField::Name];
@@ -1576,7 +1576,7 @@ async fn execute_secret_find(
     config: &Config,
 ) -> Result<()> {
     use crate::config::ContextManager;
-    use crate::utils::fuzzy::{CandidateItem, FuzzyField, score_matches};
+    use crate::utils::fuzzy::{score_matches, CandidateItem, FuzzyField};
 
     // Parse --in fields first so argument errors fire before vault resolution.
     let mut fields: Vec<FuzzyField> = vec![FuzzyField::Name];
@@ -3372,7 +3372,7 @@ async fn execute_secret_share(
             page_size,
             pager,
         } => {
-            use crate::utils::pagination::{Pagination, paginate_slice, pagination_footer_text};
+            use crate::utils::pagination::{paginate_slice, pagination_footer_text, Pagination};
             use std::fmt::Write as _;
 
             let mut roles = vault_manager

--- a/src/cli/vault_ops.rs
+++ b/src/cli/vault_ops.rs
@@ -57,7 +57,7 @@ pub(crate) async fn execute_vault_command(
             } => {
                 use crate::utils::format::TableFormatter;
                 use crate::utils::pagination::{
-                    Pagination, paginate_slice, pagination_footer_text,
+                    paginate_slice, pagination_footer_text, Pagination,
                 };
 
                 let vaults = vaults_backend.list_vaults().await?;
@@ -345,7 +345,7 @@ async fn execute_vault_list(
 ) -> Result<()> {
     use crate::cache::{CacheKey, CacheManager};
     use crate::utils::format::TableFormatter;
-    use crate::utils::pagination::{Pagination, paginate_slice, pagination_footer_text};
+    use crate::utils::pagination::{paginate_slice, pagination_footer_text, Pagination};
     use crate::vault::models::VaultSummary;
 
     let cache_manager = CacheManager::from_config(config);
@@ -1104,7 +1104,7 @@ async fn execute_vault_share(
             page_size,
             pager,
         } => {
-            use crate::utils::pagination::{Pagination, paginate_slice, pagination_footer_text};
+            use crate::utils::pagination::{paginate_slice, pagination_footer_text, Pagination};
             use std::fmt::Write as _;
 
             let resource_group =

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -32,6 +32,11 @@ pub struct InitConfig {
     pub blob_container_name: String,
     #[allow(dead_code)]
     pub create_storage_account: bool,
+    /// Which backend was chosen: "azure", "local", or "aws"
+    pub backend_choice: String,
+    pub aws_region: Option<String>,
+    pub aws_profile: Option<String>,
+    pub aws_default_vault: Option<String>,
 }
 
 impl ConfigInitializer {
@@ -52,6 +57,7 @@ impl ConfigInitializer {
         let backend_options = vec![
             "Azure Key Vault (cloud-based, requires Azure subscription)".to_string(),
             "Local (age-encrypted files, offline, no cloud account needed)".to_string(),
+            "AWS Secrets Manager (cloud-based, requires AWS account)".to_string(),
         ];
         let backend_index = self.prompt.select(
             "Which secrets backend would you like to use?",
@@ -61,6 +67,10 @@ impl ConfigInitializer {
 
         if backend_index == 1 {
             return self.run_local_setup().await;
+        }
+
+        if backend_index == 2 {
+            return self.run_aws_setup().await;
         }
 
         // Azure flow (unchanged)
@@ -130,6 +140,10 @@ impl ConfigInitializer {
             storage_account_name: storage_account,
             blob_container_name: container_name,
             create_storage_account: blob_storage_configured,
+            backend_choice: "azure".to_string(),
+            aws_region: None,
+            aws_profile: None,
+            aws_default_vault: None,
         };
 
         // Create and save the configuration
@@ -236,6 +250,119 @@ impl ConfigInitializer {
         }
 
         Ok(config)
+    }
+
+    /// Run the simplified AWS backend setup.
+    async fn run_aws_setup(&self) -> Result<Config> {
+        let mut init_config = InitConfig {
+            subscription_id: String::new(),
+            tenant_id: String::new(),
+            default_resource_group: String::new(),
+            default_location: String::new(),
+            default_vault: None,
+            create_test_vault: false,
+            storage_account_name: String::new(),
+            blob_container_name: String::new(),
+            create_storage_account: false,
+            backend_choice: "aws".to_string(),
+            aws_region: None,
+            aws_profile: None,
+            aws_default_vault: None,
+        };
+
+        self.init_aws_backend(&mut init_config).await?;
+
+        let aws_default_vault = init_config
+            .aws_default_vault
+            .clone()
+            .unwrap_or_else(|| "default".to_string());
+
+        let config = Config {
+            backend: Some("aws".to_string()),
+            aws: Some(crate::config::settings::AwsConfig {
+                region: init_config.aws_region.clone(),
+                profile: init_config.aws_profile.clone(),
+                default_vault: init_config.aws_default_vault.clone(),
+                endpoint_url: None,
+            }),
+            local: None,
+            named_backends: std::collections::HashMap::new(),
+            subscription_id: String::new(),
+            tenant_id: String::new(),
+            default_vault: aws_default_vault.clone(),
+            default_resource_group: String::new(),
+            default_location: String::new(),
+            output_json: false,
+            runtime_output_format: crate::utils::format::OutputFormat::Auto,
+            template: None,
+            no_color: false,
+            debug: false,
+            cache_enabled: true,
+            cache_ttl_secs: 900,
+            blob_config: None,
+            azure_credential_priority: crate::config::settings::AzureCredentialType::Default,
+            clipboard_timeout: 30,
+            gen_default_charset: None,
+            env_flag: None,
+        };
+
+        self.save_config(&config).await?;
+
+        output::success("AWS backend setup completed!");
+        println!();
+        println!(
+            "  Region:        {}",
+            init_config.aws_region.as_deref().unwrap_or("us-east-1")
+        );
+        println!(
+            "  Profile:       {}",
+            init_config.aws_profile.as_deref().unwrap_or("default")
+        );
+        println!("  Default vault: {aws_default_vault}");
+
+        Ok(config)
+    }
+
+    /// Collect AWS-specific settings from the user.
+    async fn init_aws_backend(&self, init_config: &mut InitConfig) -> Result<()> {
+        use dialoguer::Input;
+
+        println!();
+        output::step("Step 1/3: AWS Region");
+        let region: String = Input::new()
+            .with_prompt("AWS region")
+            .default(
+                std::env::var("AWS_REGION")
+                    .unwrap_or_else(|_| "us-east-1".to_string()),
+            )
+            .interact_text()
+            .map_err(|e| CrosstacheError::config(format!("Region prompt failed: {e}")))?;
+
+        println!();
+        output::step("Step 2/3: AWS Profile");
+        let profile: String = Input::new()
+            .with_prompt("AWS profile")
+            .default(
+                std::env::var("AWS_PROFILE")
+                    .unwrap_or_else(|_| "default".to_string()),
+            )
+            .interact_text()
+            .map_err(|e| CrosstacheError::config(format!("Profile prompt failed: {e}")))?;
+
+        println!();
+        output::step("Step 3/3: Default Vault");
+        let default_vault: String = Input::new()
+            .with_prompt("Default vault (prefix)")
+            .default("default".to_string())
+            .interact_text()
+            .map_err(|e| CrosstacheError::config(format!("Vault prompt failed: {e}")))?;
+
+        init_config.aws_region = Some(region);
+        init_config.aws_profile = Some(profile);
+        init_config.aws_default_vault = Some(default_vault);
+        init_config.backend_choice = "aws".to_string();
+
+        Ok(())
     }
 
     /// Detect Azure environment and handle issues
@@ -905,8 +1032,20 @@ impl ConfigInitializer {
             None
         };
 
+        let (backend_field, aws_config) = if init_config.backend_choice == "aws" {
+            let aws = crate::config::settings::AwsConfig {
+                region: init_config.aws_region.clone(),
+                profile: init_config.aws_profile.clone(),
+                default_vault: init_config.aws_default_vault.clone(),
+                endpoint_url: None,
+            };
+            (Some("aws".to_string()), Some(aws))
+        } else {
+            (None, None)
+        };
+
         Ok(Config {
-            backend: None,
+            backend: backend_field,
             subscription_id: init_config.subscription_id,
             tenant_id: init_config.tenant_id,
             default_vault: init_config.default_vault.unwrap_or_default(),
@@ -922,7 +1061,7 @@ impl ConfigInitializer {
             blob_config,
             azure_credential_priority: crate::config::settings::AzureCredentialType::Default,
             local: None,
-            aws: None,
+            aws: aws_config,
             named_backends: std::collections::HashMap::new(),
             clipboard_timeout: 30,
             gen_default_charset: None,
@@ -1029,6 +1168,10 @@ mod tests {
             storage_account_name: "teststorage".to_string(),
             blob_container_name: "test-container".to_string(),
             create_storage_account: true,
+            backend_choice: "azure".to_string(),
+            aws_region: None,
+            aws_profile: None,
+            aws_default_vault: None,
         };
 
         assert_eq!(init_config.subscription_id, "test-sub");

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -203,6 +203,7 @@ impl ConfigInitializer {
             backend: Some("local".to_string()),
             local: Some(local_config),
             aws: None,
+            named_backends: std::collections::HashMap::new(),
             // Azure fields get sensible empty defaults
             subscription_id: String::new(),
             tenant_id: String::new(),
@@ -922,6 +923,7 @@ impl ConfigInitializer {
             azure_credential_priority: crate::config::settings::AzureCredentialType::Default,
             local: None,
             aws: None,
+            named_backends: std::collections::HashMap::new(),
             clipboard_timeout: 30,
             gen_default_charset: None,
             env_flag: None,

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -202,6 +202,7 @@ impl ConfigInitializer {
         let config = Config {
             backend: Some("local".to_string()),
             local: Some(local_config),
+            aws: None,
             // Azure fields get sensible empty defaults
             subscription_id: String::new(),
             tenant_id: String::new(),
@@ -920,6 +921,7 @@ impl ConfigInitializer {
             blob_config,
             azure_credential_priority: crate::config::settings::AzureCredentialType::Default,
             local: None,
+            aws: None,
             clipboard_timeout: 30,
             gen_default_charset: None,
             env_flag: None,

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -331,10 +331,7 @@ impl ConfigInitializer {
         output::step("Step 1/3: AWS Region");
         let region: String = Input::new()
             .with_prompt("AWS region")
-            .default(
-                std::env::var("AWS_REGION")
-                    .unwrap_or_else(|_| "us-east-1".to_string()),
-            )
+            .default(std::env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".to_string()))
             .interact_text()
             .map_err(|e| CrosstacheError::config(format!("Region prompt failed: {e}")))?;
 
@@ -342,10 +339,7 @@ impl ConfigInitializer {
         output::step("Step 2/3: AWS Profile");
         let profile: String = Input::new()
             .with_prompt("AWS profile")
-            .default(
-                std::env::var("AWS_PROFILE")
-                    .unwrap_or_else(|_| "default".to_string()),
-            )
+            .default(std::env::var("AWS_PROFILE").unwrap_or_else(|_| "default".to_string()))
             .interact_text()
             .map_err(|e| CrosstacheError::config(format!("Profile prompt failed: {e}")))?;
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -56,6 +56,19 @@ pub struct AwsConfig {
     pub default_vault: Option<String>,
 }
 
+/// A named backend entry in `Config.named_backends`. Each entry is a
+/// fully-self-contained backend configuration tagged with its type.
+///
+/// Used for multi-region AWS, multi-tenant Azure, etc.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum NamedBackendEntry {
+    Aws(AwsConfig),
+    Local(LocalConfig),
+    // Azure intentionally omitted from this enum for now; existing
+    // top-level Azure fields handle the single-instance case.
+}
+
 /// Azure credential type priority for authentication
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -183,6 +196,11 @@ pub struct Config {
     #[tabled(skip)]
     #[serde(default)]
     pub aws: Option<AwsConfig>,
+    /// Named backend instances for multi-region / multi-tenant use.
+    /// Active backend selected via `Config.backend` matching a key here.
+    #[tabled(skip)]
+    #[serde(default)]
+    pub named_backends: std::collections::HashMap<String, NamedBackendEntry>,
     /// Seconds before clipboard is automatically cleared (0 to disable)
     #[tabled(rename = "Clipboard Timeout")]
     #[serde(default = "default_clipboard_timeout")]
@@ -233,6 +251,7 @@ impl Default for Config {
             azure_credential_priority: AzureCredentialType::Default,
             local: None,
             aws: None,
+            named_backends: std::collections::HashMap::new(),
             clipboard_timeout: default_clipboard_timeout(),
             gen_default_charset: None,
             env_flag: None,
@@ -646,7 +665,7 @@ pub async fn init_default_config() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{NamedBackendEntry, *};
 
     #[test]
     fn test_azure_credential_type_from_str() {
@@ -836,5 +855,36 @@ mod tests {
             ..Default::default()
         };
         assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn named_backends_deserializes_aws_entry() {
+        let toml_str = r#"
+backend = "aws-east"
+debug = false
+subscription_id = ""
+default_vault = ""
+default_resource_group = "Vaults"
+default_location = "eastus"
+tenant_id = ""
+output_json = false
+no_color = false
+
+[named_backends.aws-east]
+type = "aws"
+region = "us-east-1"
+profile = "prod"
+default_vault = "myproj-kv"
+"#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.backend.as_deref(), Some("aws-east"));
+        let entry = cfg.named_backends.get("aws-east").unwrap();
+        match entry {
+            NamedBackendEntry::Aws(aws) => {
+                assert_eq!(aws.region.as_deref(), Some("us-east-1"));
+                assert_eq!(aws.profile.as_deref(), Some("prod"));
+            }
+            _ => panic!("expected Aws variant"),
+        }
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -34,6 +34,28 @@ pub struct LocalConfig {
     pub default_vault: Option<String>,
 }
 
+/// Configuration for the AWS Secrets Manager backend.
+///
+/// Lives under `[aws]` in `xv.conf`. Only relevant when `backend = "aws"`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AwsConfig {
+    /// AWS region, e.g. `us-east-1`. Falls through to `AWS_REGION` env var.
+    #[serde(default)]
+    pub region: Option<String>,
+
+    /// AWS profile name. Falls through to `AWS_PROFILE`. Defaults to "default".
+    #[serde(default)]
+    pub profile: Option<String>,
+
+    /// Optional endpoint URL override. Used for LocalStack and other AWS-compatible APIs.
+    #[serde(default)]
+    pub endpoint_url: Option<String>,
+
+    /// Default vault name (= prefix) used when no `--vault` / context is set.
+    #[serde(default)]
+    pub default_vault: Option<String>,
+}
+
 /// Azure credential type priority for authentication
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -156,6 +178,11 @@ pub struct Config {
     #[tabled(skip)]
     #[serde(default)]
     pub local: Option<LocalConfig>,
+    /// Configuration for the AWS Secrets Manager backend.
+    /// Only relevant when `backend = "aws"`.
+    #[tabled(skip)]
+    #[serde(default)]
+    pub aws: Option<AwsConfig>,
     /// Seconds before clipboard is automatically cleared (0 to disable)
     #[tabled(rename = "Clipboard Timeout")]
     #[serde(default = "default_clipboard_timeout")]
@@ -205,6 +232,7 @@ impl Default for Config {
             blob_config: None,
             azure_credential_priority: AzureCredentialType::Default,
             local: None,
+            aws: None,
             clipboard_timeout: default_clipboard_timeout(),
             gen_default_charset: None,
             env_flag: None,
@@ -219,17 +247,28 @@ impl Config {
     }
 
     pub fn validate(&self) -> Result<()> {
-        // Azure-specific fields are only required when using the Azure backend.
-        if self.effective_backend_name() == "azure" {
+        let backend = self.effective_backend_name();
+        if backend == "azure" {
             if self.subscription_id.is_empty() {
                 return Err(CrosstacheError::config("Subscription ID is required"));
             }
-
             if self.tenant_id.is_empty() {
                 return Err(CrosstacheError::config("Tenant ID is required"));
             }
         }
-
+        if backend == "aws" {
+            let aws = self.aws.as_ref().ok_or_else(|| {
+                CrosstacheError::config("[aws] config block is required when backend = \"aws\"")
+            })?;
+            if aws.region.is_none()
+                && std::env::var("AWS_REGION").is_err()
+                && std::env::var("AWS_DEFAULT_REGION").is_err()
+            {
+                return Err(CrosstacheError::config(
+                    "AWS region required: set [aws].region in config or AWS_REGION env var",
+                ));
+            }
+        }
         Ok(())
     }
 
@@ -773,5 +812,29 @@ mod tests {
         let config: Config = toml::from_str(toml).unwrap();
         assert!(config.cache_enabled);
         assert_eq!(config.cache_ttl_secs, 900);
+    }
+
+    #[test]
+    fn validate_requires_aws_block_when_backend_is_aws() {
+        let cfg = Config {
+            backend: Some("aws".into()),
+            aws: None,
+            ..Default::default()
+        };
+        let err = cfg.validate().unwrap_err();
+        assert!(err.to_string().contains("aws"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_passes_when_aws_block_present_with_region() {
+        let cfg = Config {
+            backend: Some("aws".into()),
+            aws: Some(AwsConfig {
+                region: Some("us-east-1".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_ok());
     }
 }

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -184,3 +184,35 @@ async fn get_secret_not_found_maps_to_backend_not_found() {
         "expected NotFound error, got: {result:?}"
     );
 }
+
+#[tokio::test]
+async fn list_secrets_paginates_and_filters_marker() {
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+    use aws_sdk_secretsmanager::types::SecretListEntry;
+    use crosstache::backend::SecretBackend;
+
+    // Page 1: marker + one real secret, with next_token
+    let page1 = mock!(Client::list_secrets).then_output(|| {
+        ListSecretsOutput::builder()
+            .secret_list(SecretListEntry::builder().name("myproj-kv/.xv-vault").build())
+            .secret_list(SecretListEntry::builder().name("myproj-kv/db-password").build())
+            .next_token("tok1")
+            .build()
+    });
+    // Page 2: one more secret, no next_token
+    let page2 = mock!(Client::list_secrets).then_output(|| {
+        ListSecretsOutput::builder()
+            .secret_list(SecretListEntry::builder().name("myproj-kv/api-key").build())
+            .build()
+    });
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&page1, &page2]);
+    let backend = aws_secret_backend(client);
+
+    let secrets = backend.list_secrets("myproj-kv", None).await.unwrap();
+    let names: Vec<String> = secrets.iter().map(|s| s.name.clone()).collect();
+    assert_eq!(names.len(), 2);
+    assert!(names.contains(&"db-password".to_string()));
+    assert!(names.contains(&"api-key".to_string()));
+    assert!(!names.contains(&".xv-vault".to_string()), "marker should be excluded");
+}

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -424,3 +424,49 @@ async fn rollback_moves_awscurrent_to_target_version() {
 
     backend.rollback("myproj-kv", "db-password", "v2").await.unwrap();
 }
+
+#[tokio::test]
+async fn restore_secret_calls_aws_restore() {
+    use aws_sdk_secretsmanager::operation::restore_secret::RestoreSecretOutput;
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use crosstache::backend::SecretBackend;
+
+    let restore = mock!(Client::restore_secret)
+        .match_requests(|req| req.secret_id() == Some("myproj-kv/db-password"))
+        .then_output(|| RestoreSecretOutput::builder().build());
+    // restore_secret calls get_secret at the end which calls describe_secret
+    let describe = mock!(Client::describe_secret)
+        .then_output(|| DescribeSecretOutput::builder().name("myproj-kv/db-password").build());
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&restore, &describe]);
+    let backend = aws_secret_backend(client);
+
+    let result = backend.restore_secret("myproj-kv", "db-password").await.unwrap();
+    assert_eq!(result.name, "db-password");
+}
+
+#[tokio::test]
+async fn list_deleted_secrets_filters_to_deleted_only() {
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+    use aws_sdk_secretsmanager::primitives::DateTime;
+    use aws_sdk_secretsmanager::types::SecretListEntry;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::list_secrets).then_output(|| {
+        ListSecretsOutput::builder()
+            .secret_list(SecretListEntry::builder().name("myproj-kv/active").build())
+            .secret_list(
+                SecretListEntry::builder()
+                    .name("myproj-kv/deleted-one")
+                    .deleted_date(DateTime::from_secs(1_700_000_000))
+                    .build(),
+            )
+            .build()
+    });
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+
+    let deleted = backend.list_deleted_secrets("myproj-kv").await.unwrap();
+    let names: Vec<String> = deleted.iter().map(|s| s.name.clone()).collect();
+    assert_eq!(names, vec!["deleted-one".to_string()]);
+}

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -1,0 +1,35 @@
+//! Hermetic AWS backend tests using aws-smithy-mocks-experimental.
+//!
+//! Each test builds a mock SecretsManager client by stubbing per-operation
+//! responses, then exercises the `AwsSecretBackend` / `AwsVaultBackend`
+//! against it. No AWS credentials, no network — fully deterministic.
+
+#![cfg(feature = "aws")]
+#![allow(deprecated)] // aws-smithy-mocks-experimental is deprecated but still functional
+
+use aws_sdk_secretsmanager::Client;
+use aws_smithy_mocks_experimental::{mock, mock_client, RuleMode};
+use crosstache::backend::aws::{secrets::AwsSecretBackend, vaults::AwsVaultBackend};
+use std::sync::Arc;
+
+/// Build an `AwsSecretBackend` directly around a mock client.
+pub fn aws_secret_backend(client: Client) -> AwsSecretBackend {
+    AwsSecretBackend::new(Arc::new(client))
+}
+
+/// Build an `AwsVaultBackend` directly around a mock client.
+pub fn aws_vault_backend(client: Client) -> AwsVaultBackend {
+    AwsVaultBackend::new(Arc::new(client))
+}
+
+#[tokio::test]
+async fn smoke_health_check_with_empty_list() {
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+
+    let rule = mock!(Client::list_secrets)
+        .then_output(|| ListSecretsOutput::builder().build());
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+    backend.health_check().await.expect("health check should pass");
+}

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -216,3 +216,35 @@ async fn list_secrets_paginates_and_filters_marker() {
     assert!(names.contains(&"api-key".to_string()));
     assert!(!names.contains(&".xv-vault".to_string()), "marker should be excluded");
 }
+
+#[tokio::test]
+async fn delete_secret_uses_recovery_window() {
+    use aws_sdk_secretsmanager::operation::delete_secret::DeleteSecretOutput;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::delete_secret)
+        .match_requests(|req| {
+            req.secret_id() == Some("myproj-kv/db-password")
+                && req.recovery_window_in_days() == Some(30)
+                && req.force_delete_without_recovery() != Some(true)
+        })
+        .then_output(|| DeleteSecretOutput::builder().build());
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+    backend.delete_secret("myproj-kv", "db-password").await.unwrap();
+}
+
+#[tokio::test]
+async fn purge_secret_forces_immediate_delete() {
+    use aws_sdk_secretsmanager::operation::delete_secret::DeleteSecretOutput;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::delete_secret)
+        .match_requests(|req| req.force_delete_without_recovery() == Some(true))
+        .then_output(|| DeleteSecretOutput::builder().build());
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+    backend.purge_secret("myproj-kv", "db-password").await.unwrap();
+}

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -616,3 +616,44 @@ async fn list_vaults_paginates() {
     assert!(names.contains(&"vault1".to_string()));
     assert!(names.contains(&"vault2".to_string()));
 }
+
+#[tokio::test]
+async fn delete_vault_refuses_when_secrets_exist() {
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+    use aws_sdk_secretsmanager::types::SecretListEntry;
+    use crosstache::backend::VaultBackend;
+    use crosstache::backend::error::BackendError;
+
+    let rule = mock!(Client::list_secrets).then_output(|| {
+        ListSecretsOutput::builder()
+            .secret_list(SecretListEntry::builder().name("myproj-kv/.xv-vault").build())
+            .secret_list(SecretListEntry::builder().name("myproj-kv/db-password").build())
+            .build()
+    });
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_vault_backend(client);
+
+    let err = backend.delete_vault("myproj-kv").await.unwrap_err();
+    assert!(matches!(err, BackendError::Conflict(_)), "got: {err:?}");
+}
+
+#[tokio::test]
+async fn delete_vault_succeeds_when_only_marker_exists() {
+    use aws_sdk_secretsmanager::operation::delete_secret::DeleteSecretOutput;
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+    use aws_sdk_secretsmanager::types::SecretListEntry;
+    use crosstache::backend::VaultBackend;
+
+    let list = mock!(Client::list_secrets).then_output(|| {
+        ListSecretsOutput::builder()
+            .secret_list(SecretListEntry::builder().name("myproj-kv/.xv-vault").build())
+            .build()
+    });
+    let delete = mock!(Client::delete_secret)
+        .match_requests(|req| req.secret_id() == Some("myproj-kv/.xv-vault"))
+        .then_output(|| DeleteSecretOutput::builder().build());
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&list, &delete]);
+    let backend = aws_vault_backend(client);
+    backend.delete_vault("myproj-kv").await.unwrap();
+}

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -290,3 +290,66 @@ async fn secret_exists_false_on_not_found() {
             .unwrap()
     );
 }
+
+#[tokio::test]
+async fn set_secret_update_path_when_already_exists() {
+    use aws_sdk_secretsmanager::operation::create_secret::CreateSecretError;
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use aws_sdk_secretsmanager::operation::put_secret_value::PutSecretValueOutput;
+    use aws_sdk_secretsmanager::operation::tag_resource::TagResourceOutput;
+    use aws_sdk_secretsmanager::operation::untag_resource::UntagResourceOutput;
+    use aws_sdk_secretsmanager::operation::update_secret::UpdateSecretOutput;
+    use aws_sdk_secretsmanager::types::error::ResourceExistsException;
+    use crosstache::backend::SecretBackend;
+    use crosstache::secret::manager::SecretRequest;
+    use zeroize::Zeroizing;
+
+    // create_secret returns ResourceExistsException — triggers update path.
+    let create_err = mock!(Client::create_secret).then_error(|| {
+        CreateSecretError::ResourceExistsException(
+            ResourceExistsException::builder()
+                .message("already exists")
+                .build(),
+        )
+    });
+    // put_secret_value — new version.
+    let put_value = mock!(Client::put_secret_value)
+        .then_output(|| PutSecretValueOutput::builder().version_id("v2").build());
+    // update_secret — description update (note is Some).
+    let update_secret_mock =
+        mock!(Client::update_secret).then_output(|| UpdateSecretOutput::builder().build());
+    // describe_secret — fetch existing tags (empty).
+    let describe =
+        mock!(Client::describe_secret).then_output(|| DescribeSecretOutput::builder().build());
+    // untag_resource — no-op because describe returned no tags; not called when key list is empty.
+    // tag_resource — apply new tags.
+    let tag = mock!(Client::tag_resource).then_output(|| TagResourceOutput::builder().build());
+
+    let client = mock_client!(
+        aws_sdk_secretsmanager,
+        RuleMode::Sequential,
+        &[&create_err, &put_value, &update_secret_mock, &describe, &tag]
+    );
+    let backend = aws_secret_backend(client);
+
+    let request = SecretRequest {
+        name: "db-password".to_string(),
+        value: Zeroizing::new("new-secret-value".to_string()),
+        content_type: None,
+        enabled: None,
+        expires_on: None,
+        not_before: None,
+        tags: None,
+        groups: None,
+        note: Some("updated note".to_string()),
+        folder: None,
+    };
+
+    let result = backend
+        .set_secret("myproj-kv", request)
+        .await
+        .expect("set_secret update path should succeed");
+
+    assert_eq!(result.version, "v2");
+    assert_eq!(result.name, "db-password");
+}

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -74,3 +74,113 @@ async fn set_secret_create_writes_to_aws() {
     assert_eq!(result.name, "db-password");
     assert_eq!(result.version, "v1");
 }
+
+#[tokio::test]
+async fn get_secret_no_value_returns_metadata_only() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use aws_sdk_secretsmanager::types::Tag;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::describe_secret)
+        .match_requests(|req| req.secret_id() == Some("myproj-kv/api-key"))
+        .then_output(|| {
+            DescribeSecretOutput::builder()
+                .name("myproj-kv/api-key")
+                .description("API key for service")
+                .tags(
+                    Tag::builder()
+                        .key("xv:original_name")
+                        .value("api-key")
+                        .build(),
+                )
+                .build()
+        });
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+
+    let result = backend
+        .get_secret("myproj-kv", "api-key", false)
+        .await
+        .expect("get_secret should succeed");
+
+    assert_eq!(result.name, "api-key");
+    assert!(result.value.is_none(), "value should be absent when include_value=false");
+}
+
+#[tokio::test]
+async fn get_secret_with_value_includes_value() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use aws_sdk_secretsmanager::operation::get_secret_value::GetSecretValueOutput;
+    use aws_sdk_secretsmanager::types::Tag;
+    use crosstache::backend::SecretBackend;
+
+    let describe_rule = mock!(Client::describe_secret)
+        .match_requests(|req| req.secret_id() == Some("myproj-kv/db-password"))
+        .then_output(|| {
+            DescribeSecretOutput::builder()
+                .name("myproj-kv/db-password")
+                .tags(
+                    Tag::builder()
+                        .key("xv:original_name")
+                        .value("db-password")
+                        .build(),
+                )
+                .build()
+        });
+
+    let value_rule = mock!(Client::get_secret_value)
+        .match_requests(|req| req.secret_id() == Some("myproj-kv/db-password"))
+        .then_output(|| {
+            GetSecretValueOutput::builder()
+                .name("myproj-kv/db-password")
+                .version_id("v1")
+                .secret_string("super-secret-value")
+                .build()
+        });
+
+    let client = mock_client!(
+        aws_sdk_secretsmanager,
+        RuleMode::Sequential,
+        &[&describe_rule, &value_rule]
+    );
+    let backend = aws_secret_backend(client);
+
+    let result = backend
+        .get_secret("myproj-kv", "db-password", true)
+        .await
+        .expect("get_secret with value should succeed");
+
+    assert_eq!(result.name, "db-password");
+    let value = result.value.expect("value should be present when include_value=true");
+    assert_eq!(value.as_str(), "super-secret-value");
+}
+
+#[tokio::test]
+async fn get_secret_not_found_maps_to_backend_not_found() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretError;
+    use aws_sdk_secretsmanager::types::error::ResourceNotFoundException;
+    use crosstache::backend::SecretBackend;
+    use crosstache::backend::error::BackendError;
+
+    let rule = mock!(Client::describe_secret)
+        .then_error(|| {
+            DescribeSecretError::ResourceNotFoundException(
+                ResourceNotFoundException::builder()
+                    .message("Secret not found")
+                    .build(),
+            )
+        });
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+
+    let result = backend
+        .get_secret("myproj-kv", "missing-secret", false)
+        .await;
+
+    assert!(
+        matches!(result, Err(BackendError::NotFound { .. })),
+        "expected NotFound error, got: {result:?}"
+    );
+}

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -353,3 +353,38 @@ async fn set_secret_update_path_when_already_exists() {
     assert_eq!(result.version, "v2");
     assert_eq!(result.name, "db-password");
 }
+
+#[tokio::test]
+async fn list_versions_returns_history() {
+    use aws_sdk_secretsmanager::operation::list_secret_version_ids::ListSecretVersionIdsOutput;
+    use aws_sdk_secretsmanager::types::SecretVersionsListEntry;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::list_secret_version_ids).then_output(|| {
+        ListSecretVersionIdsOutput::builder()
+            .versions(
+                SecretVersionsListEntry::builder()
+                    .version_id("v1")
+                    .build()
+            )
+            .versions(
+                SecretVersionsListEntry::builder()
+                    .version_id("v2")
+                    .build()
+            )
+            .build()
+    });
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+
+    let versions = backend
+        .list_versions("myproj-kv", "db-password")
+        .await
+        .unwrap();
+
+    assert_eq!(versions.len(), 2);
+    let ids: Vec<String> = versions.iter().map(|v| v.version.clone()).collect();
+    assert!(ids.contains(&"v1".to_string()));
+    assert!(ids.contains(&"v2".to_string()));
+}

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -26,12 +26,14 @@ pub fn aws_vault_backend(client: Client) -> AwsVaultBackend {
 async fn smoke_health_check_with_empty_list() {
     use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
 
-    let rule = mock!(Client::list_secrets)
-        .then_output(|| ListSecretsOutput::builder().build());
+    let rule = mock!(Client::list_secrets).then_output(|| ListSecretsOutput::builder().build());
 
     let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
     let backend = aws_secret_backend(client);
-    backend.health_check().await.expect("health check should pass");
+    backend
+        .health_check()
+        .await
+        .expect("health check should pass");
 }
 
 #[tokio::test]
@@ -105,7 +107,10 @@ async fn get_secret_no_value_returns_metadata_only() {
         .expect("get_secret should succeed");
 
     assert_eq!(result.name, "api-key");
-    assert!(result.value.is_none(), "value should be absent when include_value=false");
+    assert!(
+        result.value.is_none(),
+        "value should be absent when include_value=false"
+    );
 }
 
 #[tokio::test]
@@ -152,7 +157,9 @@ async fn get_secret_with_value_includes_value() {
         .expect("get_secret with value should succeed");
 
     assert_eq!(result.name, "db-password");
-    let value = result.value.expect("value should be present when include_value=true");
+    let value = result
+        .value
+        .expect("value should be present when include_value=true");
     assert_eq!(value.as_str(), "super-secret-value");
 }
 
@@ -160,17 +167,16 @@ async fn get_secret_with_value_includes_value() {
 async fn get_secret_not_found_maps_to_backend_not_found() {
     use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretError;
     use aws_sdk_secretsmanager::types::error::ResourceNotFoundException;
-    use crosstache::backend::SecretBackend;
     use crosstache::backend::error::BackendError;
+    use crosstache::backend::SecretBackend;
 
-    let rule = mock!(Client::describe_secret)
-        .then_error(|| {
-            DescribeSecretError::ResourceNotFoundException(
-                ResourceNotFoundException::builder()
-                    .message("Secret not found")
-                    .build(),
-            )
-        });
+    let rule = mock!(Client::describe_secret).then_error(|| {
+        DescribeSecretError::ResourceNotFoundException(
+            ResourceNotFoundException::builder()
+                .message("Secret not found")
+                .build(),
+        )
+    });
 
     let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
     let backend = aws_secret_backend(client);
@@ -194,8 +200,16 @@ async fn list_secrets_paginates_and_filters_marker() {
     // Page 1: marker + one real secret, with next_token
     let page1 = mock!(Client::list_secrets).then_output(|| {
         ListSecretsOutput::builder()
-            .secret_list(SecretListEntry::builder().name("myproj-kv/.xv-vault").build())
-            .secret_list(SecretListEntry::builder().name("myproj-kv/db-password").build())
+            .secret_list(
+                SecretListEntry::builder()
+                    .name("myproj-kv/.xv-vault")
+                    .build(),
+            )
+            .secret_list(
+                SecretListEntry::builder()
+                    .name("myproj-kv/db-password")
+                    .build(),
+            )
             .next_token("tok1")
             .build()
     });
@@ -206,7 +220,11 @@ async fn list_secrets_paginates_and_filters_marker() {
             .build()
     });
 
-    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&page1, &page2]);
+    let client = mock_client!(
+        aws_sdk_secretsmanager,
+        RuleMode::Sequential,
+        &[&page1, &page2]
+    );
     let backend = aws_secret_backend(client);
 
     let secrets = backend.list_secrets("myproj-kv", None).await.unwrap();
@@ -214,7 +232,10 @@ async fn list_secrets_paginates_and_filters_marker() {
     assert_eq!(names.len(), 2);
     assert!(names.contains(&"db-password".to_string()));
     assert!(names.contains(&"api-key".to_string()));
-    assert!(!names.contains(&".xv-vault".to_string()), "marker should be excluded");
+    assert!(
+        !names.contains(&".xv-vault".to_string()),
+        "marker should be excluded"
+    );
 }
 
 #[tokio::test]
@@ -232,7 +253,10 @@ async fn delete_secret_uses_recovery_window() {
 
     let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
     let backend = aws_secret_backend(client);
-    backend.delete_secret("myproj-kv", "db-password").await.unwrap();
+    backend
+        .delete_secret("myproj-kv", "db-password")
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -246,7 +270,10 @@ async fn purge_secret_forces_immediate_delete() {
 
     let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
     let backend = aws_secret_backend(client);
-    backend.purge_secret("myproj-kv", "db-password").await.unwrap();
+    backend
+        .purge_secret("myproj-kv", "db-password")
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -260,10 +287,7 @@ async fn secret_exists_true_when_describe_succeeds() {
     let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
     let backend = aws_secret_backend(client);
 
-    assert!(backend
-        .secret_exists("myproj-kv", "db")
-        .await
-        .unwrap());
+    assert!(backend.secret_exists("myproj-kv", "db").await.unwrap());
 }
 
 #[tokio::test]
@@ -283,12 +307,7 @@ async fn secret_exists_false_on_not_found() {
     let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
     let backend = aws_secret_backend(client);
 
-    assert!(
-        !backend
-            .secret_exists("myproj-kv", "missing")
-            .await
-            .unwrap()
-    );
+    assert!(!backend.secret_exists("myproj-kv", "missing").await.unwrap());
 }
 
 #[tokio::test]
@@ -328,7 +347,13 @@ async fn set_secret_update_path_when_already_exists() {
     let client = mock_client!(
         aws_sdk_secretsmanager,
         RuleMode::Sequential,
-        &[&create_err, &put_value, &update_secret_mock, &describe, &tag]
+        &[
+            &create_err,
+            &put_value,
+            &update_secret_mock,
+            &describe,
+            &tag
+        ]
     );
     let backend = aws_secret_backend(client);
 
@@ -362,16 +387,8 @@ async fn list_versions_returns_history() {
 
     let rule = mock!(Client::list_secret_version_ids).then_output(|| {
         ListSecretVersionIdsOutput::builder()
-            .versions(
-                SecretVersionsListEntry::builder()
-                    .version_id("v1")
-                    .build()
-            )
-            .versions(
-                SecretVersionsListEntry::builder()
-                    .version_id("v2")
-                    .build()
-            )
+            .versions(SecretVersionsListEntry::builder().version_id("v1").build())
+            .versions(SecretVersionsListEntry::builder().version_id("v2").build())
             .build()
     });
 
@@ -391,9 +408,9 @@ async fn list_versions_returns_history() {
 
 #[tokio::test]
 async fn rollback_moves_awscurrent_to_target_version() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
     use aws_sdk_secretsmanager::operation::list_secret_version_ids::ListSecretVersionIdsOutput;
     use aws_sdk_secretsmanager::operation::update_secret_version_stage::UpdateSecretVersionStageOutput;
-    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
     use aws_sdk_secretsmanager::types::SecretVersionsListEntry;
     use crosstache::backend::SecretBackend;
 
@@ -416,32 +433,52 @@ async fn rollback_moves_awscurrent_to_target_version() {
         })
         .then_output(|| UpdateSecretVersionStageOutput::builder().build());
     // rollback calls get_secret(vault, name, false) at the end which calls describe_secret
-    let describe = mock!(Client::describe_secret)
-        .then_output(|| DescribeSecretOutput::builder().name("myproj-kv/db-password").build());
+    let describe = mock!(Client::describe_secret).then_output(|| {
+        DescribeSecretOutput::builder()
+            .name("myproj-kv/db-password")
+            .build()
+    });
 
-    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&list, &update_stage, &describe]);
+    let client = mock_client!(
+        aws_sdk_secretsmanager,
+        RuleMode::Sequential,
+        &[&list, &update_stage, &describe]
+    );
     let backend = aws_secret_backend(client);
 
-    backend.rollback("myproj-kv", "db-password", "v2").await.unwrap();
+    backend
+        .rollback("myproj-kv", "db-password", "v2")
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
 async fn restore_secret_calls_aws_restore() {
-    use aws_sdk_secretsmanager::operation::restore_secret::RestoreSecretOutput;
     use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use aws_sdk_secretsmanager::operation::restore_secret::RestoreSecretOutput;
     use crosstache::backend::SecretBackend;
 
     let restore = mock!(Client::restore_secret)
         .match_requests(|req| req.secret_id() == Some("myproj-kv/db-password"))
         .then_output(|| RestoreSecretOutput::builder().build());
     // restore_secret calls get_secret at the end which calls describe_secret
-    let describe = mock!(Client::describe_secret)
-        .then_output(|| DescribeSecretOutput::builder().name("myproj-kv/db-password").build());
+    let describe = mock!(Client::describe_secret).then_output(|| {
+        DescribeSecretOutput::builder()
+            .name("myproj-kv/db-password")
+            .build()
+    });
 
-    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&restore, &describe]);
+    let client = mock_client!(
+        aws_sdk_secretsmanager,
+        RuleMode::Sequential,
+        &[&restore, &describe]
+    );
     let backend = aws_secret_backend(client);
 
-    let result = backend.restore_secret("myproj-kv", "db-password").await.unwrap();
+    let result = backend
+        .restore_secret("myproj-kv", "db-password")
+        .await
+        .unwrap();
     assert_eq!(result.name, "db-password");
 }
 
@@ -511,12 +548,14 @@ async fn create_vault_writes_marker_secret() {
 async fn get_vault_returns_vault_not_found_when_marker_missing() {
     use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretError;
     use aws_sdk_secretsmanager::types::error::ResourceNotFoundException;
-    use crosstache::backend::VaultBackend;
     use crosstache::backend::error::BackendError;
+    use crosstache::backend::VaultBackend;
 
     let rule = mock!(Client::describe_secret).then_error(|| {
         DescribeSecretError::ResourceNotFoundException(
-            ResourceNotFoundException::builder().message("not found").build(),
+            ResourceNotFoundException::builder()
+                .message("not found")
+                .build(),
         )
     });
     let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
@@ -571,8 +610,16 @@ async fn list_vaults_finds_all_markers() {
 
     let rule = mock!(Client::list_secrets).then_output(|| {
         ListSecretsOutput::builder()
-            .secret_list(SecretListEntry::builder().name("myproj-kv/.xv-vault").build())
-            .secret_list(SecretListEntry::builder().name("staging-kv/.xv-vault").build())
+            .secret_list(
+                SecretListEntry::builder()
+                    .name("myproj-kv/.xv-vault")
+                    .build(),
+            )
+            .secret_list(
+                SecretListEntry::builder()
+                    .name("staging-kv/.xv-vault")
+                    .build(),
+            )
             .build()
     });
     let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
@@ -621,13 +668,21 @@ async fn list_vaults_paginates() {
 async fn delete_vault_refuses_when_secrets_exist() {
     use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
     use aws_sdk_secretsmanager::types::SecretListEntry;
-    use crosstache::backend::VaultBackend;
     use crosstache::backend::error::BackendError;
+    use crosstache::backend::VaultBackend;
 
     let rule = mock!(Client::list_secrets).then_output(|| {
         ListSecretsOutput::builder()
-            .secret_list(SecretListEntry::builder().name("myproj-kv/.xv-vault").build())
-            .secret_list(SecretListEntry::builder().name("myproj-kv/db-password").build())
+            .secret_list(
+                SecretListEntry::builder()
+                    .name("myproj-kv/.xv-vault")
+                    .build(),
+            )
+            .secret_list(
+                SecretListEntry::builder()
+                    .name("myproj-kv/db-password")
+                    .build(),
+            )
             .build()
     });
     let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
@@ -646,14 +701,22 @@ async fn delete_vault_succeeds_when_only_marker_exists() {
 
     let list = mock!(Client::list_secrets).then_output(|| {
         ListSecretsOutput::builder()
-            .secret_list(SecretListEntry::builder().name("myproj-kv/.xv-vault").build())
+            .secret_list(
+                SecretListEntry::builder()
+                    .name("myproj-kv/.xv-vault")
+                    .build(),
+            )
             .build()
     });
     let delete = mock!(Client::delete_secret)
         .match_requests(|req| req.secret_id() == Some("myproj-kv/.xv-vault"))
         .then_output(|| DeleteSecretOutput::builder().build());
 
-    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&list, &delete]);
+    let client = mock_client!(
+        aws_sdk_secretsmanager,
+        RuleMode::Sequential,
+        &[&list, &delete]
+    );
     let backend = aws_vault_backend(client);
     backend.delete_vault("myproj-kv").await.unwrap();
 }
@@ -701,7 +764,11 @@ async fn update_vault_updates_tags() {
                 .build()
         });
 
-    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&tag, &describe]);
+    let client = mock_client!(
+        aws_sdk_secretsmanager,
+        RuleMode::Sequential,
+        &[&tag, &describe]
+    );
     let backend = aws_vault_backend(client);
 
     let mut tags = HashMap::new();

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -470,3 +470,39 @@ async fn list_deleted_secrets_filters_to_deleted_only() {
     let names: Vec<String> = deleted.iter().map(|s| s.name.clone()).collect();
     assert_eq!(names, vec!["deleted-one".to_string()]);
 }
+
+#[tokio::test]
+async fn create_vault_writes_marker_secret() {
+    use aws_sdk_secretsmanager::operation::create_secret::CreateSecretOutput;
+    use crosstache::backend::VaultBackend;
+    use crosstache::vault::models::VaultCreateRequest;
+
+    let rule = mock!(Client::create_secret)
+        .match_requests(|req| req.name() == Some("myproj-kv/.xv-vault"))
+        .then_output(|| {
+            CreateSecretOutput::builder()
+                .name("myproj-kv/.xv-vault")
+                .build()
+        });
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_vault_backend(client);
+
+    let request = VaultCreateRequest {
+        name: "myproj-kv".to_string(),
+        location: "eastus".to_string(),
+        resource_group: "my-rg".to_string(),
+        subscription_id: "sub-123".to_string(),
+        sku: None,
+        enabled_for_deployment: None,
+        enabled_for_disk_encryption: None,
+        enabled_for_template_deployment: None,
+        soft_delete_retention_in_days: None,
+        purge_protection: None,
+        tags: None,
+        access_policies: None,
+    };
+
+    let result = backend.create_vault(request).await.unwrap();
+    assert_eq!(result.name, "myproj-kv");
+}

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -33,3 +33,44 @@ async fn smoke_health_check_with_empty_list() {
     let backend = aws_secret_backend(client);
     backend.health_check().await.expect("health check should pass");
 }
+
+#[tokio::test]
+async fn set_secret_create_writes_to_aws() {
+    use aws_sdk_secretsmanager::operation::create_secret::CreateSecretOutput;
+    use crosstache::backend::SecretBackend;
+    use crosstache::secret::manager::SecretRequest;
+    use zeroize::Zeroizing;
+
+    let rule = mock!(Client::create_secret)
+        .match_requests(|req| req.name() == Some("myproj-kv/db-password"))
+        .then_output(|| {
+            CreateSecretOutput::builder()
+                .name("myproj-kv/db-password")
+                .version_id("v1")
+                .build()
+        });
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+
+    let request = SecretRequest {
+        name: "db-password".to_string(),
+        value: Zeroizing::new("super-secret".to_string()),
+        content_type: None,
+        enabled: None,
+        expires_on: None,
+        not_before: None,
+        tags: None,
+        groups: None,
+        note: None,
+        folder: None,
+    };
+
+    let result = backend
+        .set_secret("myproj-kv", request)
+        .await
+        .expect("set_secret should succeed");
+
+    assert_eq!(result.name, "db-password");
+    assert_eq!(result.version, "v1");
+}

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -657,3 +657,67 @@ async fn delete_vault_succeeds_when_only_marker_exists() {
     let backend = aws_vault_backend(client);
     backend.delete_vault("myproj-kv").await.unwrap();
 }
+
+#[tokio::test]
+async fn update_vault_updates_tags() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use aws_sdk_secretsmanager::operation::tag_resource::TagResourceOutput;
+    use aws_sdk_secretsmanager::types::Tag;
+    use crosstache::backend::VaultBackend;
+    use crosstache::vault::models::VaultUpdateRequest;
+    use std::collections::HashMap;
+
+    let tag = mock!(Client::tag_resource)
+        .match_requests(|req| {
+            // Verify that tag_resource was called with the marker secret and tags
+            req.secret_id() == Some("myproj-kv/.xv-vault")
+        })
+        .then_output(|| TagResourceOutput::builder().build());
+
+    // update_vault calls get_vault at the end which calls describe_secret
+    let describe = mock!(Client::describe_secret)
+        .match_requests(|req| req.secret_id() == Some("myproj-kv/.xv-vault"))
+        .then_output(|| {
+            DescribeSecretOutput::builder()
+                .name("myproj-kv/.xv-vault")
+                .tags(
+                    Tag::builder()
+                        .key("xv:vault_name")
+                        .value("myproj-kv")
+                        .build(),
+                )
+                .tags(
+                    Tag::builder()
+                        .key("xv:created_at")
+                        .value("2026-05-13T10:00:00+00:00")
+                        .build(),
+                )
+                .tags(
+                    Tag::builder()
+                        .key("environment")
+                        .value("production")
+                        .build(),
+                )
+                .build()
+        });
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&tag, &describe]);
+    let backend = aws_vault_backend(client);
+
+    let mut tags = HashMap::new();
+    tags.insert("environment".to_string(), "production".to_string());
+
+    let request = VaultUpdateRequest {
+        enabled_for_deployment: None,
+        enabled_for_disk_encryption: None,
+        enabled_for_template_deployment: None,
+        soft_delete_retention_in_days: None,
+        purge_protection: None,
+        tags: Some(tags),
+        access_policies: None,
+    };
+
+    let result = backend.update_vault("myproj-kv", request).await.unwrap();
+    assert_eq!(result.name, "myproj-kv");
+    assert_eq!(result.id, "vault-myproj-kv");
+}

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -78,6 +78,53 @@ async fn set_secret_create_writes_to_aws() {
 }
 
 #[tokio::test]
+async fn set_secret_preserves_migration_idempotency_tags() {
+    use aws_sdk_secretsmanager::operation::create_secret::CreateSecretOutput;
+    use crosstache::backend::SecretBackend;
+    use crosstache::secret::manager::SecretRequest;
+    use std::collections::HashMap;
+    use zeroize::Zeroizing;
+
+    let rule = mock!(Client::create_secret)
+        .match_requests(|req| {
+            let has_migrated_from = req
+                .tags()
+                .iter()
+                .any(|t| t.key() == Some("xv:migrated_from") && t.value() == Some("local:v1"));
+            let has_migrated_at = req
+                .tags()
+                .iter()
+                .any(|t| t.key() == Some("xv:migrated_at") && t.value() == Some("now"));
+            let drops_unknown_xv = req.tags().iter().all(|t| t.key() != Some("xv:internal"));
+            has_migrated_from && has_migrated_at && drops_unknown_xv
+        })
+        .then_output(|| CreateSecretOutput::builder().version_id("v1").build());
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+
+    let mut tags = HashMap::new();
+    tags.insert("xv:migrated_from".to_string(), "local:v1".to_string());
+    tags.insert("xv:migrated_at".to_string(), "now".to_string());
+    tags.insert("xv:internal".to_string(), "drop-me".to_string());
+
+    let request = SecretRequest {
+        name: "db-password".to_string(),
+        value: Zeroizing::new("super-secret".to_string()),
+        content_type: None,
+        enabled: None,
+        expires_on: None,
+        not_before: None,
+        tags: Some(tags),
+        groups: None,
+        note: None,
+        folder: None,
+    };
+
+    backend.set_secret("myproj-kv", request).await.unwrap();
+}
+
+#[tokio::test]
 async fn get_secret_no_value_returns_metadata_only() {
     use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
     use aws_sdk_secretsmanager::types::Tag;
@@ -95,6 +142,18 @@ async fn get_secret_no_value_returns_metadata_only() {
                         .value("api-key")
                         .build(),
                 )
+                .tags(
+                    Tag::builder()
+                        .key("xv:migrated_from")
+                        .value("local:myproj-kv:v1")
+                        .build(),
+                )
+                .tags(
+                    Tag::builder()
+                        .key("xv:migrated_at")
+                        .value("2026-05-13T21:00:00Z")
+                        .build(),
+                )
                 .build()
         });
 
@@ -110,6 +169,14 @@ async fn get_secret_no_value_returns_metadata_only() {
     assert!(
         result.value.is_none(),
         "value should be absent when include_value=false"
+    );
+    assert_eq!(
+        result.tags.get("xv:migrated_from").map(String::as_str),
+        Some("local:myproj-kv:v1")
+    );
+    assert_eq!(
+        result.tags.get("xv:migrated_at").map(String::as_str),
+        Some("2026-05-13T21:00:00Z")
     );
 }
 
@@ -316,7 +383,6 @@ async fn set_secret_update_path_when_already_exists() {
     use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
     use aws_sdk_secretsmanager::operation::put_secret_value::PutSecretValueOutput;
     use aws_sdk_secretsmanager::operation::tag_resource::TagResourceOutput;
-    use aws_sdk_secretsmanager::operation::untag_resource::UntagResourceOutput;
     use aws_sdk_secretsmanager::operation::update_secret::UpdateSecretOutput;
     use aws_sdk_secretsmanager::types::error::ResourceExistsException;
     use crosstache::backend::SecretBackend;
@@ -506,6 +572,54 @@ async fn list_deleted_secrets_filters_to_deleted_only() {
     let deleted = backend.list_deleted_secrets("myproj-kv").await.unwrap();
     let names: Vec<String> = deleted.iter().map(|s| s.name.clone()).collect();
     assert_eq!(names, vec!["deleted-one".to_string()]);
+}
+
+#[tokio::test]
+async fn list_deleted_secrets_paginates_all_pages() {
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+    use aws_sdk_secretsmanager::primitives::DateTime;
+    use aws_sdk_secretsmanager::types::SecretListEntry;
+    use crosstache::backend::SecretBackend;
+
+    let first_page = mock!(Client::list_secrets)
+        .match_requests(|req| req.next_token().is_none())
+        .then_output(|| {
+            ListSecretsOutput::builder()
+                .secret_list(
+                    SecretListEntry::builder()
+                        .name("myproj-kv/deleted-one")
+                        .deleted_date(DateTime::from_secs(1_700_000_000))
+                        .build(),
+                )
+                .next_token("page-2")
+                .build()
+        });
+    let second_page = mock!(Client::list_secrets)
+        .match_requests(|req| req.next_token() == Some("page-2"))
+        .then_output(|| {
+            ListSecretsOutput::builder()
+                .secret_list(
+                    SecretListEntry::builder()
+                        .name("myproj-kv/deleted-two")
+                        .deleted_date(DateTime::from_secs(1_700_000_001))
+                        .build(),
+                )
+                .build()
+        });
+
+    let client = mock_client!(
+        aws_sdk_secretsmanager,
+        RuleMode::Sequential,
+        &[&first_page, &second_page]
+    );
+    let backend = aws_secret_backend(client);
+
+    let deleted = backend.list_deleted_secrets("myproj-kv").await.unwrap();
+    let names: Vec<String> = deleted.iter().map(|s| s.name.clone()).collect();
+    assert_eq!(
+        names,
+        vec!["deleted-one".to_string(), "deleted-two".to_string()]
+    );
 }
 
 #[tokio::test]

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -154,6 +154,13 @@ async fn get_secret_no_value_returns_metadata_only() {
                         .value("2026-05-13T21:00:00Z")
                         .build(),
                 )
+                .tags(Tag::builder().key("xv:groups").value("api,prod").build())
+                .tags(
+                    Tag::builder()
+                        .key("xv:folder")
+                        .value("services/api")
+                        .build(),
+                )
                 .build()
         });
 
@@ -177,6 +184,18 @@ async fn get_secret_no_value_returns_metadata_only() {
     assert_eq!(
         result.tags.get("xv:migrated_at").map(String::as_str),
         Some("2026-05-13T21:00:00Z")
+    );
+    assert_eq!(
+        result.tags.get("groups").map(String::as_str),
+        Some("api,prod")
+    );
+    assert_eq!(
+        result.tags.get("folder").map(String::as_str),
+        Some("services/api")
+    );
+    assert_eq!(
+        result.tags.get("note").map(String::as_str),
+        Some("API key for service")
     );
 }
 

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -388,3 +388,39 @@ async fn list_versions_returns_history() {
     assert!(ids.contains(&"v1".to_string()));
     assert!(ids.contains(&"v2".to_string()));
 }
+
+#[tokio::test]
+async fn rollback_moves_awscurrent_to_target_version() {
+    use aws_sdk_secretsmanager::operation::list_secret_version_ids::ListSecretVersionIdsOutput;
+    use aws_sdk_secretsmanager::operation::update_secret_version_stage::UpdateSecretVersionStageOutput;
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use aws_sdk_secretsmanager::types::SecretVersionsListEntry;
+    use crosstache::backend::SecretBackend;
+
+    let list = mock!(Client::list_secret_version_ids).then_output(|| {
+        ListSecretVersionIdsOutput::builder()
+            .versions(
+                SecretVersionsListEntry::builder()
+                    .version_id("v3")
+                    .version_stages("AWSCURRENT".to_string())
+                    .build(),
+            )
+            .versions(SecretVersionsListEntry::builder().version_id("v2").build())
+            .build()
+    });
+    let update_stage = mock!(Client::update_secret_version_stage)
+        .match_requests(|req| {
+            req.move_to_version_id() == Some("v2")
+                && req.remove_from_version_id() == Some("v3")
+                && req.version_stage() == Some("AWSCURRENT")
+        })
+        .then_output(|| UpdateSecretVersionStageOutput::builder().build());
+    // rollback calls get_secret(vault, name, false) at the end which calls describe_secret
+    let describe = mock!(Client::describe_secret)
+        .then_output(|| DescribeSecretOutput::builder().name("myproj-kv/db-password").build());
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&list, &update_stage, &describe]);
+    let backend = aws_secret_backend(client);
+
+    backend.rollback("myproj-kv", "db-password", "v2").await.unwrap();
+}

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -506,3 +506,113 @@ async fn create_vault_writes_marker_secret() {
     let result = backend.create_vault(request).await.unwrap();
     assert_eq!(result.name, "myproj-kv");
 }
+
+#[tokio::test]
+async fn get_vault_returns_vault_not_found_when_marker_missing() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretError;
+    use aws_sdk_secretsmanager::types::error::ResourceNotFoundException;
+    use crosstache::backend::VaultBackend;
+    use crosstache::backend::error::BackendError;
+
+    let rule = mock!(Client::describe_secret).then_error(|| {
+        DescribeSecretError::ResourceNotFoundException(
+            ResourceNotFoundException::builder().message("not found").build(),
+        )
+    });
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_vault_backend(client);
+
+    let err = backend.get_vault("missing-vault").await.unwrap_err();
+    assert!(
+        matches!(err, BackendError::VaultNotFound { .. }),
+        "got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn get_vault_returns_vault_properties() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use aws_sdk_secretsmanager::types::Tag;
+    use crosstache::backend::VaultBackend;
+
+    let rule = mock!(Client::describe_secret)
+        .match_requests(|req| req.secret_id() == Some("myproj-kv/.xv-vault"))
+        .then_output(|| {
+            DescribeSecretOutput::builder()
+                .name("myproj-kv/.xv-vault")
+                .tags(
+                    Tag::builder()
+                        .key("xv:vault_name")
+                        .value("myproj-kv")
+                        .build(),
+                )
+                .tags(
+                    Tag::builder()
+                        .key("xv:created_at")
+                        .value("2026-05-13T10:00:00+00:00")
+                        .build(),
+                )
+                .build()
+        });
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_vault_backend(client);
+
+    let vault = backend.get_vault("myproj-kv").await.unwrap();
+    assert_eq!(vault.name, "myproj-kv");
+    assert_eq!(vault.id, "vault-myproj-kv");
+}
+
+#[tokio::test]
+async fn list_vaults_finds_all_markers() {
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+    use aws_sdk_secretsmanager::types::SecretListEntry;
+    use crosstache::backend::VaultBackend;
+
+    let rule = mock!(Client::list_secrets).then_output(|| {
+        ListSecretsOutput::builder()
+            .secret_list(SecretListEntry::builder().name("myproj-kv/.xv-vault").build())
+            .secret_list(SecretListEntry::builder().name("staging-kv/.xv-vault").build())
+            .build()
+    });
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_vault_backend(client);
+
+    let vaults = backend.list_vaults().await.unwrap();
+    let names: Vec<String> = vaults.iter().map(|v| v.name.clone()).collect();
+    assert_eq!(names.len(), 2);
+    assert!(names.contains(&"myproj-kv".to_string()));
+    assert!(names.contains(&"staging-kv".to_string()));
+}
+
+#[tokio::test]
+async fn list_vaults_paginates() {
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+    use aws_sdk_secretsmanager::types::SecretListEntry;
+    use crosstache::backend::VaultBackend;
+
+    let page1 = mock!(Client::list_secrets).then_output(|| {
+        ListSecretsOutput::builder()
+            .secret_list(SecretListEntry::builder().name("vault1/.xv-vault").build())
+            .next_token("tok1")
+            .build()
+    });
+    let page2 = mock!(Client::list_secrets).then_output(|| {
+        ListSecretsOutput::builder()
+            .secret_list(SecretListEntry::builder().name("vault2/.xv-vault").build())
+            .build()
+    });
+
+    let client = mock_client!(
+        aws_sdk_secretsmanager,
+        RuleMode::Sequential,
+        &[&page1, &page2]
+    );
+    let backend = aws_vault_backend(client);
+
+    let vaults = backend.list_vaults().await.unwrap();
+    let names: Vec<String> = vaults.iter().map(|v| v.name.clone()).collect();
+    assert_eq!(names.len(), 2);
+    assert!(names.contains(&"vault1".to_string()));
+    assert!(names.contains(&"vault2".to_string()));
+}

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -248,3 +248,45 @@ async fn purge_secret_forces_immediate_delete() {
     let backend = aws_secret_backend(client);
     backend.purge_secret("myproj-kv", "db-password").await.unwrap();
 }
+
+#[tokio::test]
+async fn secret_exists_true_when_describe_succeeds() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::describe_secret)
+        .then_output(|| DescribeSecretOutput::builder().name("myproj-kv/db").build());
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+
+    assert!(backend
+        .secret_exists("myproj-kv", "db")
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn secret_exists_false_on_not_found() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretError;
+    use aws_sdk_secretsmanager::types::error::ResourceNotFoundException;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::describe_secret).then_error(|| {
+        DescribeSecretError::ResourceNotFoundException(
+            ResourceNotFoundException::builder()
+                .message("not found")
+                .build(),
+        )
+    });
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+
+    assert!(
+        !backend
+            .secret_exists("myproj-kv", "missing")
+            .await
+            .unwrap()
+    );
+}

--- a/tests/aws_localstack_tests.rs
+++ b/tests/aws_localstack_tests.rs
@@ -1,0 +1,152 @@
+//! LocalStack integration tests. Skipped silently when LocalStack is unavailable.
+//!
+//! Enable with: AWS_INTEGRATION_TESTS=1 (and a running LocalStack at AWS_ENDPOINT_URL).
+//!
+//! LocalStack docker quickstart:
+//!   docker run -d --rm --name localstack -p 4566:4566 localstack/localstack
+//!   export AWS_ENDPOINT_URL=http://localhost:4566
+//!   export AWS_ACCESS_KEY_ID=test
+//!   export AWS_SECRET_ACCESS_KEY=test
+//!   export AWS_REGION=us-east-1
+
+#![cfg(feature = "aws")]
+#![allow(dead_code)]
+
+use crosstache::backend::aws::AwsBackend;
+use crosstache::backend::{Backend, SecretBackend, VaultBackend};
+use crosstache::config::settings::AwsConfig;
+use crosstache::secret::manager::SecretRequest;
+use zeroize::Zeroizing;
+
+fn skip_unless_enabled() -> bool {
+    if std::env::var("AWS_INTEGRATION_TESTS").is_err() {
+        eprintln!("AWS_INTEGRATION_TESTS not set — skipping");
+        return true;
+    }
+    if std::env::var("AWS_ENDPOINT_URL").is_err() {
+        eprintln!("AWS_ENDPOINT_URL not set — skipping (LocalStack required)");
+        return true;
+    }
+    false
+}
+
+async fn build_backend() -> AwsBackend {
+    let cfg = AwsConfig {
+        region: Some(
+            std::env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".to_string()),
+        ),
+        endpoint_url: Some(std::env::var("AWS_ENDPOINT_URL").unwrap()),
+        ..Default::default()
+    };
+    AwsBackend::new(&cfg, None, None).await.unwrap()
+}
+
+#[tokio::test]
+async fn localstack_set_get_round_trip() {
+    if skip_unless_enabled() {
+        return;
+    }
+    let backend = build_backend().await;
+
+    let vault = format!("xv-test-{}", uuid::Uuid::new_v4());
+
+    let request = SecretRequest {
+        name: "round-trip-test".into(),
+        value: Zeroizing::new("test-value-42".into()),
+        groups: Some(vec!["test".into()]),
+        content_type: None,
+        enabled: None,
+        expires_on: None,
+        not_before: None,
+        tags: None,
+        note: None,
+        folder: None,
+    };
+    backend.secrets().set_secret(&vault, request).await.unwrap();
+
+    let got = backend
+        .secrets()
+        .get_secret(&vault, "round-trip-test", true)
+        .await
+        .unwrap();
+    assert_eq!(
+        got.value.as_ref().map(|v| v.as_str().to_string()),
+        Some("test-value-42".to_string())
+    );
+    // Groups are stored in tags as "xv:groups"
+    let groups_tag = got.tags.get("xv:groups").map(|s| s.as_str()).unwrap_or("");
+    assert_eq!(groups_tag, "test");
+
+    backend
+        .secrets()
+        .purge_secret(&vault, "round-trip-test")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn localstack_list_paginates() {
+    if skip_unless_enabled() {
+        return;
+    }
+    let backend = build_backend().await;
+    let vault = format!("xv-test-{}", uuid::Uuid::new_v4());
+
+    for i in 0..5 {
+        let request = SecretRequest {
+            name: format!("test-{}", i),
+            value: Zeroizing::new(format!("value-{}", i)),
+            content_type: None,
+            enabled: None,
+            expires_on: None,
+            not_before: None,
+            tags: None,
+            groups: None,
+            note: None,
+            folder: None,
+        };
+        backend.secrets().set_secret(&vault, request).await.unwrap();
+    }
+
+    let listed = backend.secrets().list_secrets(&vault, None).await.unwrap();
+    let names: Vec<String> = listed.iter().map(|s| s.name.clone()).collect();
+    assert_eq!(names.len(), 5);
+    for i in 0..5 {
+        assert!(names.contains(&format!("test-{}", i)));
+    }
+
+    for i in 0..5 {
+        backend
+            .secrets()
+            .purge_secret(&vault, &format!("test-{}", i))
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn localstack_vault_marker_create_list_delete() {
+    if skip_unless_enabled() {
+        return;
+    }
+    use crosstache::vault::models::VaultCreateRequest;
+
+    let backend = build_backend().await;
+    let vault = format!("xv-test-{}", uuid::Uuid::new_v4());
+
+    let vaults = backend.vaults().unwrap();
+
+    vaults
+        .create_vault(VaultCreateRequest {
+            name: vault.clone(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let listed = vaults.list_vaults().await.unwrap();
+    let names: Vec<String> = listed.iter().map(|v| v.name.clone()).collect();
+    assert!(names.contains(&vault));
+
+    vaults.delete_vault(&vault).await.unwrap();
+}

--- a/tests/aws_localstack_tests.rs
+++ b/tests/aws_localstack_tests.rs
@@ -32,9 +32,7 @@ fn skip_unless_enabled() -> bool {
 
 async fn build_backend() -> AwsBackend {
     let cfg = AwsConfig {
-        region: Some(
-            std::env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".to_string()),
-        ),
+        region: Some(std::env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".to_string())),
         endpoint_url: Some(std::env::var("AWS_ENDPOINT_URL").unwrap()),
         ..Default::default()
     };

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -401,3 +401,70 @@ fn tui_subcommand_unknown_when_feature_disabled() {
     // clap returns exit 2 for unknown subcommands.
     assert_eq!(out.status.code(), Some(2));
 }
+
+// -----------------------------------------------------------------------------
+// AWS migration dry-run (LocalStack-gated)
+// -----------------------------------------------------------------------------
+
+#[test]
+#[cfg(feature = "aws")]
+fn migrate_dry_run_against_local_to_aws_shows_summary() {
+    use tempfile::TempDir;
+
+    if std::env::var("AWS_INTEGRATION_TESTS").is_err() {
+        eprintln!("skipping: AWS_INTEGRATION_TESTS not set");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    let xv = env!("CARGO_BIN_EXE_xv");
+
+    // Set up local store with one secret
+    let set_out = Command::new(xv)
+        .args(["--backend", "local", "set", "test-secret", "value123"])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .env("XDG_DATA_HOME", tmp.path().join("data"))
+        .output()
+        .expect("set should succeed");
+    assert!(
+        set_out.status.success(),
+        "set failed: {:?}",
+        String::from_utf8_lossy(&set_out.stderr)
+    );
+
+    // Run migrate dry-run
+    let out = Command::new(xv)
+        .args([
+            "migrate", "--from", "local", "--to", "aws",
+            "--vault", "default", "--dry-run",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .env("XDG_DATA_HOME", tmp.path().join("data"))
+        .env(
+            "AWS_ENDPOINT_URL",
+            std::env::var("AWS_ENDPOINT_URL")
+                .unwrap_or_else(|_| "http://localhost:4566".to_string()),
+        )
+        .env("AWS_REGION", "us-east-1")
+        .env("AWS_ACCESS_KEY_ID", "test")
+        .env("AWS_SECRET_ACCESS_KEY", "test")
+        .output()
+        .expect("migrate should run");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("Source:") || stderr.contains("Source:"),
+        "expected 'Source:' in output; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("Target:") || stderr.contains("Target:"),
+        "expected 'Target:' in output; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("to migrate") || stderr.contains("to migrate"),
+        "expected 'to migrate' counts; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -436,8 +436,14 @@ fn migrate_dry_run_against_local_to_aws_shows_summary() {
     // Run migrate dry-run
     let out = Command::new(xv)
         .args([
-            "migrate", "--from", "local", "--to", "aws",
-            "--vault", "default", "--dry-run",
+            "migrate",
+            "--from",
+            "local",
+            "--to",
+            "aws",
+            "--vault",
+            "default",
+            "--dry-run",
         ])
         .env("HOME", tmp.path())
         .env("XDG_CONFIG_HOME", tmp.path().join("config"))

--- a/tests/migration_round_trip_tests.rs
+++ b/tests/migration_round_trip_tests.rs
@@ -19,8 +19,7 @@ use zeroize::Zeroizing;
 /// Returns `true` when the LocalStack integration environment is NOT configured,
 /// meaning the test should silently skip.
 fn skip_unless_enabled() -> bool {
-    std::env::var("AWS_INTEGRATION_TESTS").is_err()
-        || std::env::var("AWS_ENDPOINT_URL").is_err()
+    std::env::var("AWS_INTEGRATION_TESTS").is_err() || std::env::var("AWS_ENDPOINT_URL").is_err()
 }
 
 /// Extract groups from a `SecretProperties.tags` map (mirrors `SecretInfo::extract_groups`).
@@ -116,7 +115,11 @@ async fn local_to_aws_round_trip() {
             "value mismatch for secret {n}"
         );
         let got_groups = groups_from_tags(&got.tags);
-        assert_eq!(got_groups, vec!["roundtrip"], "groups mismatch for secret {n}");
+        assert_eq!(
+            got_groups,
+            vec!["roundtrip"],
+            "groups mismatch for secret {n}"
+        );
     }
 
     // ---- cleanup AWS side ----

--- a/tests/migration_round_trip_tests.rs
+++ b/tests/migration_round_trip_tests.rs
@@ -1,0 +1,126 @@
+//! Cross-backend migration round-trip tests.
+//!
+//! Tests Local<->AWS today (LocalStack-gated). Azure<->AWS deferred to live tests.
+//!
+//! These tests only run when both `AWS_INTEGRATION_TESTS` and `AWS_ENDPOINT_URL`
+//! env vars are set (i.e. a LocalStack instance is available).
+
+#![cfg(feature = "aws")]
+
+use crosstache::backend::aws::AwsBackend;
+use crosstache::backend::local::LocalBackend;
+use crosstache::backend::Backend;
+use crosstache::config::settings::AwsConfig;
+use crosstache::config::settings::LocalConfig;
+use crosstache::secret::manager::SecretRequest;
+use tempfile::TempDir;
+use zeroize::Zeroizing;
+
+/// Returns `true` when the LocalStack integration environment is NOT configured,
+/// meaning the test should silently skip.
+fn skip_unless_enabled() -> bool {
+    std::env::var("AWS_INTEGRATION_TESTS").is_err()
+        || std::env::var("AWS_ENDPOINT_URL").is_err()
+}
+
+/// Extract groups from a `SecretProperties.tags` map (mirrors `SecretInfo::extract_groups`).
+fn groups_from_tags(tags: &std::collections::HashMap<String, String>) -> Vec<String> {
+    tags.get("groups")
+        .map(|g| {
+            g.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[tokio::test]
+async fn local_to_aws_round_trip() {
+    if skip_unless_enabled() {
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+
+    // ---- set up local backend ----
+    let local_cfg = LocalConfig {
+        store_path: Some(tmp.path().join("store").to_string_lossy().to_string()),
+        key_file: Some(tmp.path().join("key.txt").to_string_lossy().to_string()),
+        default_vault: Some("test-vault".into()),
+    };
+    let local = LocalBackend::new(Some(&local_cfg)).unwrap();
+
+    // ---- set up AWS backend (LocalStack) ----
+    let aws_cfg = AwsConfig {
+        region: Some("us-east-1".into()),
+        endpoint_url: Some(std::env::var("AWS_ENDPOINT_URL").unwrap()),
+        ..Default::default()
+    };
+    let aws = AwsBackend::new(&aws_cfg, None, None).await.unwrap();
+
+    let vault = format!("xv-rt-{}", uuid::Uuid::new_v4());
+
+    // ---- write 3 secrets to local ----
+    for (n, v) in [("a", "1"), ("b", "2"), ("c", "3")] {
+        let request = SecretRequest {
+            name: n.into(),
+            value: Zeroizing::new(v.into()),
+            content_type: None,
+            enabled: None,
+            expires_on: None,
+            not_before: None,
+            tags: None,
+            groups: Some(vec!["roundtrip".into()]),
+            note: None,
+            folder: None,
+        };
+        local.secrets().set_secret(&vault, request).await.unwrap();
+    }
+
+    // ---- read from local, write to AWS ----
+    for n in ["a", "b", "c"] {
+        let props = local.secrets().get_secret(&vault, n, true).await.unwrap();
+        let groups_vec = groups_from_tags(&props.tags);
+        let request = SecretRequest {
+            name: props.name.clone(),
+            value: Zeroizing::new(
+                props
+                    .value
+                    .as_ref()
+                    .map(|v| v.as_str().to_string())
+                    .unwrap_or_default(),
+            ),
+            content_type: None,
+            enabled: None,
+            expires_on: None,
+            not_before: None,
+            tags: None,
+            groups: if groups_vec.is_empty() {
+                None
+            } else {
+                Some(groups_vec)
+            },
+            note: None,
+            folder: None,
+        };
+        aws.secrets().set_secret(&vault, request).await.unwrap();
+    }
+
+    // ---- verify on AWS side ----
+    for (n, expected) in [("a", "1"), ("b", "2"), ("c", "3")] {
+        let got = aws.secrets().get_secret(&vault, n, true).await.unwrap();
+        assert_eq!(
+            got.value.as_ref().map(|v| v.as_str().to_string()),
+            Some(expected.to_string()),
+            "value mismatch for secret {n}"
+        );
+        let got_groups = groups_from_tags(&got.tags);
+        assert_eq!(got_groups, vec!["roundtrip"], "groups mismatch for secret {n}");
+    }
+
+    // ---- cleanup AWS side ----
+    for n in ["a", "b", "c"] {
+        aws.secrets().purge_secret(&vault, n).await.unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

- **AWS Secrets Manager as a third backend** behind the `aws` Cargo feature flag (`xv --backend aws ...`)
- **`xv migrate` hardening** as the marquee feature: `--on-conflict`, `--concurrency`, pre-flight diff, idempotency tags, exponential backoff
- **`xv init` wizard** gains an AWS branch (region, profile, default vault)
- **Global `--aws-profile` and `--region` flags** for per-invocation overrides
- **Documentation**: `docs/migration.md` cross-cloud migration guide, README + FEATURES.md updates

## What's in this PR

### AWS backend (`src/backend/aws/`)
- `mod.rs` — `AwsBackend` + `Backend` trait impl (capabilities, health_check)
- `auth.rs` — SDK client builder via `aws-config` default credential chain
- `secrets.rs` — full `SecretBackend`: CRUD, soft-delete, purge, restore, version history, rollback
- `vaults.rs` — `VaultBackend` via prefix-based virtual vaults (`<vault>/.xv-vault` marker secrets)
- `encoding.rs` — name encoding, marker reservation, `validate_secret_name`
- `metadata.rs` — tag ↔ `SecretProperties` round-trip, tag constants
- `errors.rs` — per-operation `SdkError` → `BackendError` mapping

### Config & CLI
- `src/config/settings.rs` — `AwsConfig`, `NamedBackendEntry`, `Config.named_backends` for multi-region
- `src/backend/registry.rs` — `BackendKind::Aws` arm + named-backend resolution
- `src/cli/commands.rs` — `--aws-profile`, `--region` global flags; `OnConflict` enum; updated `Migrate` variant
- `src/cli/migrate_ops.rs` — full migrate hardening (diff, idempotency, concurrency, backoff)
- `src/config/init.rs` — AWS branch in interactive setup wizard

### Tests
- `tests/aws_backend_tests.rs` — 23 hermetic mock tests (`aws-smithy-mocks-experimental`)
- `tests/aws_localstack_tests.rs` — LocalStack-gated integration tests (skip silently without LocalStack)
- `tests/migration_round_trip_tests.rs` — Local↔AWS round-trip (LocalStack-gated)
- `tests/cli_integration_tests.rs` — dry-run smoke test (LocalStack-gated)

### Docs
- `docs/migration.md` — full cross-cloud migration guide
- `CHANGELOG.md` — v0.10.0 release notes

## Test plan

- [x] `cargo build` — clean (no AWS)
- [x] `cargo build --features aws` — clean
- [x] `cargo test --lib` — 390 passed
- [x] `cargo test --features aws --lib` — 403 passed
- [x] `cargo test --tests` — 22 passed
- [x] `cargo clippy --features aws --all-targets` — 0 errors
- [x] `cargo fmt --check` — clean
- [ ] LocalStack integration tests — run manually with `AWS_INTEGRATION_TESTS=1 AWS_ENDPOINT_URL=http://localhost:4566 cargo test --features aws`
- [ ] RC soak (~1 week) before final `0.10.0` bump

## Breaking changes

- `--overwrite` on `xv migrate` is deprecated (hidden flag, still works with warning). Use `--on-conflict replace` instead.

## Notes

- Binary size with `--features aws`: ~19 MB stripped+LTO (vs 11 MB without). AWS SDK pulls in `hyper`, `tokio-rustls`, `aws-smithy-*`.
- `xv share` and `xv audit` return `Unsupported` on AWS in v0.10 — use AWS IAM / CloudTrail directly.
- Version history transfer (`--with-history`) is deferred to a future phase.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new optional AWS feature and large dependency graph changes (AWS SDK/tokio/rustls stack), which can impact build size, compilation, and runtime TLS/HTTP behavior even if feature-gated.
> 
> **Overview**
> Bumps the crate version to `0.10.0-rc.1` and adds an `aws` feature that pulls in `aws-sdk-secretsmanager`/`aws-config` (plus test-only AWS mock utilities), with corresponding `Cargo.lock` updates.
> 
> Adds/updates documentation (`README.md`, `docs/FEATURES.md`, new `docs/migration.md`, new `CHANGELOG.md`) to describe AWS Secrets Manager backend configuration, multi-region named backends, and the hardened `xv migrate` interface (including `--on-conflict` replacing deprecated `--overwrite`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f66ffbce5f6b340737de65169141569a5116eb70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->