### PR TITLE
Add backend field to .xv.toml env profiles

### DIFF
--- a/docs/env-profiles.md
+++ b/docs/env-profiles.md
@@ -15,10 +15,14 @@ vault = "myproj-dev-kv"
 resource_group = "myproj-rg"
 group = "backend"          # optional
 folder = "app/database"    # optional
+backend = "azure"          # optional: azure | local | aws
 
 [env.prod]
 vault = "myproj-prod-kv"
 resource_group = "myproj-prod-rg"
+
+[env.local-dev]
+backend = "local"          # use local age-encrypted backend for this env
 ```
 
 All fields except `[env.<name>]` blocks are optional. New fields (output
@@ -44,6 +48,18 @@ resolves in this order:
 2. The active env's field in `.xv.toml`
 3. The legacy `.xv/context` JSON (deprecated; see below)
 4. The user's global config default
+
+### Backend resolution
+
+The `backend` field in an env profile selects which secrets backend that env
+targets. Resolution order (highest first):
+
+1. `--backend` CLI flag
+2. `backend` field in the active env profile (`.xv.toml`)
+3. `backend` key in the global config file (`xv.conf`) or `XV_BACKEND` env var
+4. Default: `azure`
+
+Valid values: `azure`, `local`, `aws` (canonical names only — aliases like `az`, `file`, or `secretsmanager` are not accepted in `.xv.toml`; named backend keys defined under `[backends.*]` in `xv.conf` are also not supported here).
 
 ## Cross-boundary notice
 

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -791,6 +791,7 @@ async fn execute_context_init(
             resource_group: Some(resource_group),
             group: None,
             folder: None,
+            backend: None,
         },
     );
 

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -49,6 +49,41 @@ pub struct EnvProfile {
     pub group: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub folder: Option<String>,
+    /// Backend to use for this env. Must be one of: `azure`, `local`, `aws`.
+    /// Overrides the global config `backend` key but loses to `--backend` CLI flag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
+}
+
+/// Validate that a backend value from an env profile is a known backend.
+///
+/// Returns `Err` with a descriptive message if `value` is not one of the
+/// recognised canonical names (`azure`, `local`, `aws`).
+pub fn validate_env_profile_backend(value: &str) -> Result<()> {
+    match value {
+        "azure" | "local" | "aws" => Ok(()),
+        other => Err(CrosstacheError::config(format!(
+            "invalid backend {other:?} in .xv.toml env profile — must be one of: azure, local, aws"
+        ))),
+    }
+}
+
+/// Resolve the effective backend name from the four resolution layers.
+///
+/// Precedence (highest first):
+/// 1. `cli_backend`     — explicit `--backend` flag
+/// 2. `profile_backend` — active env profile's `backend` field
+/// 3. `config_backend`  — global config `backend` key (or `XV_BACKEND`)
+/// 4. `"azure"`         — built-in default
+pub fn resolve_effective_backend<'a>(
+    cli_backend: Option<&'a str>,
+    profile_backend: Option<&'a str>,
+    config_backend: Option<&'a str>,
+) -> &'a str {
+    cli_backend
+        .or(profile_backend)
+        .or(config_backend)
+        .unwrap_or("azure")
 }
 
 /// Scanner configuration block for leak detection settings.
@@ -224,6 +259,7 @@ mod tests {
         assert_eq!(p.resource_group, None);
         assert_eq!(p.group, None);
         assert_eq!(p.folder, None);
+        assert_eq!(p.backend, None);
     }
 
     #[test]
@@ -509,6 +545,85 @@ resource_group = "rg"
             Some("using config from /path/a/.xv.toml (env: dev)".to_string()),
         );
         assert_eq!(captured2, None, "second call must be no-op");
+    }
+
+    // --- backend field tests ---
+
+    #[test]
+    fn backend_field_parses() {
+        let toml = r#"
+[env.dev]
+vault = "v"
+resource_group = "rg"
+backend = "aws"
+"#;
+        let cfg = parse_str(toml).expect("must parse");
+        let dev = cfg.envs.get("dev").unwrap();
+        assert_eq!(dev.backend.as_deref(), Some("aws"));
+    }
+
+    #[test]
+    fn backend_field_defaults_to_none() {
+        let toml = r#"
+[env.dev]
+vault = "v"
+resource_group = "rg"
+"#;
+        let cfg = parse_str(toml).expect("must parse");
+        let dev = cfg.envs.get("dev").unwrap();
+        assert_eq!(dev.backend, None);
+    }
+
+    #[test]
+    fn backend_all_valid_values_accepted() {
+        for name in &["azure", "local", "aws"] {
+            assert!(
+                validate_env_profile_backend(name).is_ok(),
+                "expected {name:?} to be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn backend_invalid_value_rejected() {
+        let err = validate_env_profile_backend("gcp").expect_err("must err");
+        assert!(
+            err.to_string().contains("gcp"),
+            "error should name the bad value; got: {err}"
+        );
+        assert!(
+            err.to_string().contains("azure") || err.to_string().contains("must be"),
+            "error should name valid options; got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_effective_backend_cli_wins_over_all() {
+        assert_eq!(
+            resolve_effective_backend(Some("local"), Some("aws"), Some("azure")),
+            "local"
+        );
+    }
+
+    #[test]
+    fn resolve_effective_backend_profile_wins_over_config() {
+        assert_eq!(
+            resolve_effective_backend(None, Some("aws"), Some("azure")),
+            "aws"
+        );
+    }
+
+    #[test]
+    fn resolve_effective_backend_config_wins_over_default() {
+        assert_eq!(
+            resolve_effective_backend(None, None, Some("local")),
+            "local"
+        );
+    }
+
+    #[test]
+    fn resolve_effective_backend_falls_back_to_azure() {
+        assert_eq!(resolve_effective_backend(None, None, None), "azure");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,10 +89,61 @@ async fn run(cli: Cli) -> Result<()> {
     // resolve_resource_group when consulting .xv.toml).
     config.env_flag = cli.env.clone();
 
-    // Apply CLI --backend flag to config (overrides config file and env var).
-    if let Some(ref backend) = cli.backend {
-        config.backend = Some(backend.clone());
-    }
+    // Resolve env-profile backend (validate early; fail before touching Azure).
+    // Precedence: CLI --backend > env-profile backend > config-file backend > "azure".
+    let profile_backend: Option<String> = if cli.backend.is_none() {
+        match std::env::current_dir() {
+            Err(_) => None, // degenerate env — skip project-config walk
+            Ok(cwd) => {
+                if let Ok(Some((path, proj_cfg))) =
+                    crate::config::project::find_project_config(&cwd).await
+                {
+                    if let Ok((name, profile)) =
+                        crate::config::project::resolve_env(&proj_cfg, config.env_flag.as_deref())
+                    {
+                        if let Some(ref b) = profile.backend {
+                            crate::config::project::validate_env_profile_backend(b)?;
+                            // Emit a notice when the project file (especially an
+                            // ancestor directory's) overrides the backend — this
+                            // is the highest-impact override a .xv.toml can make.
+                            if path.parent().map(|p| p != cwd.as_path()).unwrap_or(false) {
+                                if let Some(line) =
+                                    crate::config::project::capture_cross_boundary_notice(
+                                        &path, name,
+                                    )
+                                {
+                                    eprintln!("{line}");
+                                }
+                            }
+                            tracing::debug!(
+                                "backend '{b}' selected by env profile '{name}' in {}",
+                                path.display()
+                            );
+                            Some(b.clone())
+                        } else {
+                            None
+                        }
+                    } else {
+                        // Unknown env name — skip; command handler surfaces the error.
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+        }
+    } else {
+        None
+    };
+
+    config.backend = Some(
+        crate::config::project::resolve_effective_backend(
+            cli.backend.as_deref(),
+            profile_backend.as_deref(),
+            config.backend.as_deref(),
+        )
+        .to_string(),
+    );
 
     // Build the backend registry for commands that talk to a secrets backend.
     // Commands that are purely local (Config, Init, Cache, Context, etc.) skip


### PR DESCRIPTION
## Summary

Roadmap item #2 — adds an optional `backend` field to `.xv.toml` env profiles so `xv --env <name>` can target a non-Azure backend (`azure` | `local` | `aws`). Until now the AWS backend was only reachable via the global `--backend` flag, not via env profiles.

## Changes

- **`src/config/project.rs`** — `EnvProfile` gains `backend: Option<String>` (serde-optional). Two new helpers:
  - `validate_env_profile_backend()` — rejects non-canonical values with a clear error
  - `resolve_effective_backend()` — pure function encoding 4-level precedence: `--backend` flag > env-profile backend > config-file backend > default `azure`
- **`src/main.rs`** — resolves + validates the active profile's backend before any cloud connection (fails fast). Emits a cross-boundary notice when an ancestor `.xv.toml` overrides the backend.
- **`src/cli/config_ops.rs`** — `backend: None` added to an `EnvProfile` literal.
- **`docs/env-profiles.md`** — documents the field, a `[env.local-dev]` example, and the resolution order.

## Verification

- 8 new unit tests (parsing, defaults, all valid values, invalid rejected, all 4 precedence orderings)
- `cargo test --lib` — 400 pass / 0 fail
- `cargo build` — clean
- Reviewed by parallel architecture / security / code-quality passes (OMC autopilot)

🤖 Implemented via Oh My ClaudeCode autopilot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backend selection precedence and validation at startup, which can redirect commands to a different secrets backend and affect where secrets are read/written. Risk is moderated by strict validation of canonical backend names plus added unit tests covering parsing and precedence.
> 
> **Overview**
> Adds an optional `backend` key to `.xv.toml` env profiles so `xv --env <name>` can select `azure`/`local`/`aws` per environment.
> 
> Startup backend selection in `main.rs` is updated to **resolve and validate** the active env profile’s backend (CLI `--backend` still wins), emitting a cross-boundary notice when an ancestor project config overrides the backend; serialization/init code is updated accordingly, and docs/tests are expanded to cover parsing, allowed values, and precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9084fe2b283f01531259dc117338caa9c03d53c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->