### PR TITLE
fix: P0 UX-REVIEW findings — env confusion, AWS auth errors, AWS feature gate

### DIFF
--- a/src/backend/aws/errors.rs
+++ b/src/backend/aws/errors.rs
@@ -29,8 +29,19 @@ fn handle_sdk<E: std::fmt::Display + std::fmt::Debug, R: std::fmt::Debug>(
     e: SdkError<E, R>,
 ) -> BackendError {
     match e {
-        SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) => {
-            BackendError::Network(format!("aws {op}: timeout or dispatch failure"))
+        SdkError::TimeoutError(_) => {
+            BackendError::Network(format!("aws {op}: timeout"))
+        }
+        SdkError::DispatchFailure(ref df) if df.is_user() => {
+            // Credential resolution failure — not a network error.
+            BackendError::AuthenticationFailed(format!(
+                "No AWS credentials resolved (operation: {op}). \
+Try `aws configure`, set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, \
+or run `eval \"$(aws configure export-credentials --format env)\"` after `aws login`."
+            ))
+        }
+        SdkError::DispatchFailure(_) => {
+            BackendError::Network(format!("aws {op}: dispatch failure"))
         }
         SdkError::ServiceError(svc) => BackendError::Internal(format!("aws {op}: {}", svc.err())),
         other => generic(op, format!("{other:?}")),
@@ -182,6 +193,44 @@ pub fn from_update_stage(
         }
     }
     handle_sdk("UpdateSecretVersionStage", e)
+}
+
+#[cfg(all(test, feature = "aws"))]
+mod tests {
+    use super::*;
+    use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
+    use aws_smithy_runtime_api::client::result::ConnectorError;
+
+    fn make_user_dispatch_failure() -> SdkError<ListSecretsError, HttpResponse> {
+        let inner = std::io::Error::new(std::io::ErrorKind::Other, "no credentials in chain");
+        SdkError::dispatch_failure(ConnectorError::user(Box::new(inner)))
+    }
+
+    fn make_timeout_error() -> SdkError<ListSecretsError, HttpResponse> {
+        let inner = std::io::Error::new(std::io::ErrorKind::TimedOut, "timed out");
+        SdkError::dispatch_failure(ConnectorError::timeout(Box::new(inner)))
+    }
+
+    #[test]
+    fn dispatch_failure_user_maps_to_auth_error() {
+        let err = from_list(make_user_dispatch_failure());
+        assert!(
+            matches!(err, BackendError::AuthenticationFailed(_)),
+            "expected AuthenticationFailed, got: {err:?}"
+        );
+        let BackendError::AuthenticationFailed(msg) = err else { unreachable!() };
+        assert!(msg.contains("aws configure"), "hint missing: {msg}");
+        assert!(msg.contains("AWS_ACCESS_KEY_ID"), "hint missing: {msg}");
+    }
+
+    #[test]
+    fn dispatch_failure_timeout_maps_to_network() {
+        let err = from_list(make_timeout_error());
+        assert!(
+            matches!(err, BackendError::Network(_)),
+            "expected Network, got: {err:?}"
+        );
+    }
 }
 
 pub fn from_tag(e: SdkError<TagResourceError, Response>) -> BackendError {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -115,7 +115,20 @@ pub struct Cli {
     pub env: Option<String>,
 
     /// Secrets backend to use (overrides config file and XV_BACKEND env var).
-    /// Valid values: azure, local.
+    /// Valid values: azure, local, aws.
+    #[cfg(feature = "aws")]
+    #[arg(
+        long,
+        global = true,
+        value_name = "BACKEND",
+        env = "XV_BACKEND",
+        hide = should_hide_options()
+    )]
+    pub backend: Option<String>,
+
+    /// Secrets backend to use (overrides config file and XV_BACKEND env var).
+    /// Valid values: azure, local (aws unavailable in this build; rebuild with --features aws).
+    #[cfg(not(feature = "aws"))]
     #[arg(
         long,
         global = true,

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -1075,9 +1075,9 @@ async fn execute_env_use(name: &str, _config: &Config) -> Result<()> {
             if proj_cfg.envs.contains_key(name) {
                 return Err(CrosstacheError::config(format!(
                     "No legacy user profile named '{name}'.\n\
-Found project env '{name}' in {} — activate it with:\n\
-  xv --env {name} <command>\n\
-  XV_ENV={name} xv <command>\n\
+Found project env '{name}' in {} — activate it with:\n  \
+xv --env {name} <command>\n  \
+XV_ENV={name} xv <command>\n\
 Or set `default_env = \"{name}\"` in .xv.toml.\n\
 (Legacy `xv env use` manages user-scoped profiles, not .xv.toml envs.)",
                     path.display()

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -538,6 +538,17 @@ async fn execute_context_use(
 ) -> Result<()> {
     use crate::config::{ContextManager, VaultContext};
 
+    // P0.1: If the name matches a .xv.toml env profile, reject with a targeted hint.
+    let cwd = std::env::current_dir()?;
+    if let Ok(Some((_path, proj_cfg))) = crate::config::project::find_project_config(&cwd).await {
+        if proj_cfg.envs.contains_key(vault_name) {
+            return Err(CrosstacheError::config(format!(
+                "'{vault_name}' is an env profile in .xv.toml, not a vault name. \
+Use `xv --env {vault_name} <command>` to activate it, or set XV_ENV={vault_name} in your shell."
+            )));
+        }
+    }
+
     let mut context_manager = if local {
         // Create local context
         ContextManager::new_local()?
@@ -984,17 +995,44 @@ pub(crate) async fn execute_env_command(command: EnvCommands, config: Config) ->
     }
 }
 
-async fn execute_env_list(_config: &Config) -> Result<()> {
+async fn execute_env_list(config: &Config) -> Result<()> {
     let manager = EnvironmentProfileManager::load().await?;
 
+    // P0.1: Always show .xv.toml project envs first (activated via --env / XV_ENV).
+    let cwd = std::env::current_dir()?;
+    let project_env_names: Vec<String> = if let Ok(Some((path, proj_cfg))) =
+        crate::config::project::find_project_config(&cwd).await
+    {
+        if !proj_cfg.envs.is_empty() {
+            let active = crate::config::project::resolve_env(&proj_cfg, config.env_flag.as_deref())
+                .ok()
+                .map(|(name, _)| name.to_string());
+
+            println!("Project envs (from {}):", path.display());
+            println!("  Activated via: xv --env <name> <command>  |  XV_ENV=<name>  |  default_env in .xv.toml");
+            for (name, profile) in &proj_cfg.envs {
+                let marker = if active.as_deref() == Some(name.as_str()) { "*" } else { " " };
+                let vault = profile.vault.as_deref().unwrap_or("(unset)");
+                let backend = profile.backend.as_deref().unwrap_or("azure");
+                println!("  {marker} {name}  backend={backend}  vault={vault}");
+            }
+            println!();
+        }
+        proj_cfg.envs.keys().cloned().collect()
+    } else {
+        Vec::new()
+    };
+
     if manager.profiles.is_empty() {
-        output::info("No environment profiles found.");
-        println!("Create one with: xv env create <name> --vault <vault> --group <group>");
+        if project_env_names.is_empty() {
+            output::info("No environment profiles found.");
+            println!("Create one with: xv env create <name> --vault <vault> --group <group>");
+        }
         return Ok(());
     }
 
-    println!("Environment Profiles:");
-    println!("────────────────────");
+    println!("Legacy user profiles (activated via: xv env use <name>):");
+    println!("────────────────────────────────────────────────────────");
 
     for (name, profile) in &manager.profiles {
         let current_marker = if manager.current_profile.as_ref() == Some(name) {
@@ -1027,6 +1065,26 @@ async fn execute_env_list(_config: &Config) -> Result<()> {
 
 async fn execute_env_use(name: &str, _config: &Config) -> Result<()> {
     let mut manager = EnvironmentProfileManager::load().await?;
+
+    // P0.1: When the legacy lookup would fail, check whether the name exists as a
+    // .xv.toml env profile and emit a targeted hint instead of the generic "not found".
+    if !manager.profiles.contains_key(name) {
+        let cwd = std::env::current_dir()?;
+        if let Ok(Some((path, proj_cfg))) = crate::config::project::find_project_config(&cwd).await
+        {
+            if proj_cfg.envs.contains_key(name) {
+                return Err(CrosstacheError::config(format!(
+                    "No legacy user profile named '{name}'.\n\
+Found project env '{name}' in {} — activate it with:\n\
+  xv --env {name} <command>\n\
+  XV_ENV={name} xv <command>\n\
+Or set `default_env = \"{name}\"` in .xv.toml.\n\
+(Legacy `xv env use` manages user-scoped profiles, not .xv.toml envs.)",
+                    path.display()
+                )));
+            }
+        }
+    }
 
     // Get profile data before using (to avoid borrow checker issues)
     let (vault_name, resource_group, subscription_id) = {

--- a/src/cli/system_ops.rs
+++ b/src/cli/system_ops.rs
@@ -532,11 +532,18 @@ async fn execute_secret_info_from_root(
 pub(crate) async fn execute_version_command() -> Result<()> {
     let build_info = super::commands::get_build_info();
 
+    // P0.3: List compiled-in backends so users can see whether aws is available.
+    let mut backends = vec!["azure", "local"];
+    if cfg!(feature = "aws") {
+        backends.push("aws");
+    }
+
     println!("crosstache Rust CLI");
     println!("===================");
     println!("Version:      {}", build_info.version);
     println!("Git Hash:     {}", build_info.git_hash);
     println!("Git Branch:   {}", build_info.git_branch);
+    println!("Backends:     {}", backends.join(", "));
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,17 @@ async fn run(cli: Cli) -> Result<()> {
         .to_string(),
     );
 
+    // P0.3: Emit a clear error before dispatch when AWS is requested on a build
+    // that was compiled without --features aws, rather than surfacing a generic
+    // "No backend registry available" message later.
+    #[cfg(not(feature = "aws"))]
+    if config.effective_backend_name() == "aws" {
+        return Err(CrosstacheError::config(
+            "AWS backend is not included in this build. \
+Rebuild with `cargo build --features aws` or install an AWS-enabled binary.",
+        ));
+    }
+
     // Build the backend registry for commands that talk to a secrets backend.
     // Commands that are purely local (Config, Init, Cache, Context, etc.) skip
     // this entirely.  For commands that *may* need the backend we attempt

--- a/tests/config_command_tests.rs
+++ b/tests/config_command_tests.rs
@@ -79,3 +79,43 @@ fn config_help_documents_subcommands() {
     assert!(stdout.contains("path"));
     assert!(stdout.contains("set"));
 }
+
+// ── P0.3 tests ───────────────────────────────────────────────────────────────
+
+#[test]
+fn version_lists_compiled_backends() {
+    // `xv version` should always mention "azure" and "local" as built-in backends.
+    let (mut cmd, _temp) = common::xv_isolated();
+    let out = cmd.args(["version"]).output().expect("spawn");
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(
+        stdout.contains("Backends:"),
+        "expected Backends: line in version output: {stdout}"
+    );
+    assert!(stdout.contains("azure"), "expected azure in backends: {stdout}");
+    assert!(stdout.contains("local"), "expected local in backends: {stdout}");
+}
+
+#[cfg(not(feature = "aws"))]
+#[test]
+fn backend_aws_on_default_build_gives_clear_error() {
+    // On a build without --features aws, `xv --backend aws list` must return a
+    // targeted error rather than the generic "No backend registry available" message.
+    let (mut cmd, _temp) = common::xv_isolated();
+    let out = cmd
+        .args(["--backend", "aws", "list"])
+        .output()
+        .expect("spawn");
+    assert_ne!(out.status.code(), Some(0), "should have failed");
+    let stderr = common::stderr_str(&out);
+    assert!(
+        stderr.contains("AWS backend") || stderr.contains("--features aws"),
+        "expected AWS build hint in stderr: {stderr}"
+    );
+    // Must not say "No backend registry available" (the old generic message).
+    assert!(
+        !stderr.contains("No backend registry available"),
+        "must not emit generic registry error: {stderr}"
+    );
+}

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -244,3 +244,80 @@ fn xv_toml_in_ancestor_emits_cross_boundary_notice() {
         "cross-boundary notice expected on stderr: {stderr}"
     );
 }
+
+// ── P0.1 tests ───────────────────────────────────────────────────────────────
+
+#[test]
+fn context_use_rejects_xv_toml_env_name() {
+    // `xv context use dev` when .xv.toml has [env.dev] must fail with a
+    // targeted message instead of silently creating a vault named "dev".
+    let (mut cmd, temp) = xv_isolated();
+    write_xv_toml(temp.path(), "dev", &[("dev", "real-dev-vault")]);
+    let out = cmd
+        .env("AZURE_SUBSCRIPTION_ID", FAKE_SUB)
+        .env("AZURE_TENANT_ID", FAKE_TENANT)
+        .args(["context", "use", "dev"])
+        .output()
+        .expect("spawn");
+    // Must be an error.
+    assert_ne!(out.status.code(), Some(0), "should have failed");
+    let stderr = stderr_str(&out);
+    // Must mention that "dev" is an env profile, not a vault.
+    assert!(
+        stderr.contains("env profile") || stderr.contains("--env"),
+        "expected targeted env-profile hint in stderr: {stderr}"
+    );
+    // Must not say "Switched to vault 'dev'".
+    assert!(
+        !stderr.contains("Switched to vault"),
+        "must not have silently created vault context: {stderr}"
+    );
+}
+
+#[test]
+fn env_list_shows_xv_toml_project_envs() {
+    // `xv env list` with a .xv.toml present should surface project envs.
+    let (mut cmd, temp) = xv_isolated();
+    write_xv_toml(temp.path(), "dev", &[("dev", "vault-dev"), ("prod", "vault-prod")]);
+    let out = cmd
+        .env("AZURE_SUBSCRIPTION_ID", FAKE_SUB)
+        .env("AZURE_TENANT_ID", FAKE_TENANT)
+        .args(["env", "list"])
+        .output()
+        .expect("spawn");
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr_str(&out));
+    let stdout = stdout_str(&out);
+    // Should show the .xv.toml profiles.
+    assert!(stdout.contains("dev"), "expected 'dev' in output: {stdout}");
+    assert!(stdout.contains("prod"), "expected 'prod' in output: {stdout}");
+    // Should indicate these are activated via --env / XV_ENV.
+    assert!(
+        stdout.contains("--env") || stdout.contains("XV_ENV"),
+        "expected activation hint in output: {stdout}"
+    );
+}
+
+#[test]
+fn env_use_targeted_error_for_xv_toml_env() {
+    // `xv env use dev` when dev exists only in .xv.toml should produce a
+    // targeted hint rather than a bare "not found" error.
+    let (mut cmd, temp) = xv_isolated();
+    write_xv_toml(temp.path(), "dev", &[("dev", "real-dev-vault")]);
+    let out = cmd
+        .env("AZURE_SUBSCRIPTION_ID", FAKE_SUB)
+        .env("AZURE_TENANT_ID", FAKE_TENANT)
+        .args(["env", "use", "dev"])
+        .output()
+        .expect("spawn");
+    assert_ne!(out.status.code(), Some(0), "should have failed");
+    let stderr = stderr_str(&out);
+    // Must mention .xv.toml or --env as the correct path.
+    assert!(
+        stderr.contains(".xv.toml") || stderr.contains("--env") || stderr.contains("XV_ENV"),
+        "expected targeted hint in stderr: {stderr}"
+    );
+    // Must not just say "not found" with no guidance.
+    let bare_not_found = stderr.contains("not found") &&
+        !stderr.contains("--env") && !stderr.contains(".xv.toml") && !stderr.contains("XV_ENV");
+    assert!(!bare_not_found, "bare not-found without hint: {stderr}");
+}


### PR DESCRIPTION
Implements the three **P0 (Critical)** findings from `docs/UX-REVIEW.md` (added in #205). Non-destructive — no command removals or breaking renames.

## P0.1 — Three conflicting "environment" systems
- `xv context use <name>` now rejects a name that matches a `.xv.toml` `[env.*]` profile, with a targeted error pointing to `xv --env <name>` / `XV_ENV` — instead of silently creating a vault context for a nonexistent vault.
- `xv env list` surfaces `.xv.toml` project envs (with backend + activation method) alongside legacy user profiles.
- `xv env use` returns a targeted hint (`--env` / `XV_ENV` / `default_env`) when a name exists only in `.xv.toml`, instead of a bare "not found".

## P0.2 — AWS auth failures mis-reported as network errors
- `SdkError::DispatchFailure` with `df.is_user()` (credential-resolution failure) now maps to `AuthenticationFailed` with an actionable hint (`aws configure`, `AWS_ACCESS_KEY_ID`, `aws configure export-credentials`). True network dispatch failures still map to `Network`.

## P0.3 — Default build silently can't use AWS
- On a build without `--features aws`, `--backend aws` now fails **before command dispatch** with a clear "rebuild with `--features aws`" message.
- `--backend` help text is feature-conditional (shows AWS availability).
- `xv version` prints a `Backends:` line listing compiled-in backends.

## Verification
- Both `cargo build` and `cargo build --features aws` compile clean.
- New tests: 3 P0.1 integration, 2 P0.3 integration, 2 P0.2 AWS unit — **all pass**.
- Full suite: 425 passed (default) / 448 passed (aws).
- 3 OMC validators (architect / security / code-review) approved.

### Pre-existing unrelated failures
2 tests in `cli::secret_ops::tests` (`*_vault_resolution_*`) fail because they read the developer's real `~/.config/xv` config instead of an isolated dir. **Verified present on clean `main`** with these changes stashed — not introduced here. Worth a separate test-isolation fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes alter CLI control flow and error classification (AWS dispatch failures now map to authentication vs network) and add feature-gated behavior that can change how commands fail on non-AWS builds.
> 
> **Overview**
> Addresses several UX footguns around **env vs context vs legacy profiles**: `xv context use` now rejects names that match `.xv.toml` env profiles with a targeted `--env`/`XV_ENV` hint, `xv env list` now shows project envs from `.xv.toml` ahead of legacy user profiles, and `xv env use` emits a guided error when the name exists only in `.xv.toml`.
> 
> Improves AWS ergonomics by reclassifying `SdkError::DispatchFailure` credential-resolution errors as `AuthenticationFailed` (with actionable setup hints) while keeping timeouts/real dispatch failures as `Network`, with new unit tests.
> 
> Hardens AWS feature gating: `--backend` help text and `xv version` now reflect compiled-in backends, and non-`aws` builds fail early with a clear “rebuild with `--features aws`” error when `aws` is selected, backed by new integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd0523506a5c06c1ce0a9748ec0aa83492d51dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->