### PR TITLE
chore: bump version to 0.10.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"


### PR DESCRIPTION
## Summary

Version bump for the **v0.10.0-rc.2** release tag.

Bumps `Cargo.toml` (and `Cargo.lock`) from `0.10.0-rc.1` to `0.10.0-rc.2`. The release tag will be cut on `main` once this merges.

### Included since v0.10.0-rc.1
- Dependabot security alerts addressed — HIGH-severity `rustls-webpki` CRL-panic DoS removed from production builds; `aws-sdk-secretsmanager` 1.65 → 1.104 (#207)
- P0 UX-REVIEW fixes — env confusion, AWS auth errors, AWS feature gate (#206)
- Backend-prefixed addressing for `xv://` URIs and migrate (#204)
- `backend` field in `.xv.toml` env profiles (#203)

### Verification
- `cargo build --release --features aws` ✅
- Full test suite: 448 lib tests + all integration suites passing, 0 failures ✅

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a metadata-only version bump in `Cargo.toml`/`Cargo.lock` with no functional code changes.
> 
> **Overview**
> Bumps the `crosstache` crate version from `0.10.0-rc.1` to `0.10.0-rc.2` in `Cargo.toml` and updates `Cargo.lock` accordingly for the release tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5e7003e33bd0902f2d4d2445281ec71f38873fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->