### PR TITLE
fix: resolve CI lint failures (cargo fmt + clippy)

### DIFF
--- a/src/backend/addressing.rs
+++ b/src/backend/addressing.rs
@@ -64,7 +64,14 @@ impl BackendRef {
             Some(pos) => {
                 let v = rest[..pos].to_string();
                 let sec = &rest[pos + 1..];
-                (v, if sec.is_empty() { None } else { Some(sec.to_string()) })
+                (
+                    v,
+                    if sec.is_empty() {
+                        None
+                    } else {
+                        Some(sec.to_string())
+                    },
+                )
             }
             None => (rest.to_string(), None),
         };
@@ -73,7 +80,11 @@ impl BackendRef {
             return Err(format!("vault name cannot be empty in '{s}'"));
         }
 
-        Ok(BackendRef { backend, vault, secret })
+        Ok(BackendRef {
+            backend,
+            vault,
+            secret,
+        })
     }
 
     /// Parse a migrate endpoint string: `backend` or `backend:vault`.
@@ -89,15 +100,15 @@ impl BackendRef {
         if let Some(colon) = s.find(':') {
             let left = &s[..colon];
             let right = &s[colon + 1..];
-            let kind = left
-                .parse::<BackendKind>()
-                .map_err(|_| format!("unknown backend '{left}' in '{s}': valid values are azure, local, aws"))?;
+            let kind = left.parse::<BackendKind>().map_err(|_| {
+                format!("unknown backend '{left}' in '{s}': valid values are azure, local, aws")
+            })?;
             let vault = right.to_string();
             Ok((kind, if vault.is_empty() { None } else { Some(vault) }))
         } else {
-            let kind = s
-                .parse::<BackendKind>()
-                .map_err(|_| format!("unknown backend '{s}': valid values are azure, local, aws"))?;
+            let kind = s.parse::<BackendKind>().map_err(|_| {
+                format!("unknown backend '{s}': valid values are azure, local, aws")
+            })?;
             Ok((kind, None))
         }
     }
@@ -259,10 +270,7 @@ mod tests {
     #[test]
     fn migrate_unknown_backend_rejected() {
         let err = BackendRef::parse_migrate_endpoint("gcp").unwrap_err();
-        assert!(
-            err.contains("unknown") || err.contains("gcp"),
-            "got: {err}"
-        );
+        assert!(err.contains("unknown") || err.contains("gcp"), "got: {err}");
     }
 
     #[test]

--- a/src/backend/aws/errors.rs
+++ b/src/backend/aws/errors.rs
@@ -29,9 +29,7 @@ fn handle_sdk<E: std::fmt::Display + std::fmt::Debug, R: std::fmt::Debug>(
     e: SdkError<E, R>,
 ) -> BackendError {
     match e {
-        SdkError::TimeoutError(_) => {
-            BackendError::Network(format!("aws {op}: timeout"))
-        }
+        SdkError::TimeoutError(_) => BackendError::Network(format!("aws {op}: timeout")),
         SdkError::DispatchFailure(ref df) if df.is_user() => {
             // Credential resolution failure — not a network error.
             BackendError::AuthenticationFailed(format!(
@@ -218,7 +216,9 @@ mod tests {
             matches!(err, BackendError::AuthenticationFailed(_)),
             "expected AuthenticationFailed, got: {err:?}"
         );
-        let BackendError::AuthenticationFailed(msg) = err else { unreachable!() };
+        let BackendError::AuthenticationFailed(msg) = err else {
+            unreachable!()
+        };
         assert!(msg.contains("aws configure"), "hint missing: {msg}");
         assert!(msg.contains("AWS_ACCESS_KEY_ID"), "hint missing: {msg}");
     }

--- a/src/backend/aws/vaults.rs
+++ b/src/backend/aws/vaults.rs
@@ -251,16 +251,12 @@ impl AwsVaultBackend {
         let mut next_token: Option<String> = None;
         let mut non_marker: Vec<String> = Vec::new();
         loop {
-            let mut req = self
-                .client
-                .list_secrets()
-                .max_results(100)
-                .filters(
-                    Filter::builder()
-                        .key(FilterNameStringType::Name)
-                        .values(prefix.clone())
-                        .build(),
-                );
+            let mut req = self.client.list_secrets().max_results(100).filters(
+                Filter::builder()
+                    .key(FilterNameStringType::Name)
+                    .values(prefix.clone())
+                    .build(),
+            );
             if let Some(ref t) = next_token {
                 req = req.next_token(t.clone());
             }

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -236,6 +236,7 @@ fn lock_vault(vault_dir: &Path) -> Result<fs::File, BackendError> {
     let lock_path = vault_dir.join(".lock");
     let lock_file = fs::OpenOptions::new()
         .create(true)
+        .truncate(false)
         .write(true)
         .open(&lock_path)
         .map_err(|e| BackendError::Internal(format!("open lock: {e}")))?;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -15,9 +15,9 @@
 //! See also: [`BackendError`] for the backend-agnostic error type, and
 //! [`BackendRegistry`] for runtime backend resolution.
 
+pub mod addressing;
 #[cfg(feature = "aws")]
 pub mod aws;
-pub mod addressing;
 pub mod azure;
 pub mod error;
 #[cfg(feature = "file-ops")]
@@ -100,6 +100,7 @@ pub enum NameCharset {
 
 impl NameCharset {
     /// Returns true if `name` is valid under this charset.
+    #[allow(dead_code)] // public API; currently exercised only by tests
     pub fn is_valid(&self, name: &str) -> bool {
         match self {
             Self::AlphanumericHyphen => name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -22,20 +22,15 @@ fn get_version() -> &'static str {
     built_info::PKG_VERSION
 }
 
-#[derive(Debug, Clone, clap::ValueEnum, PartialEq, Eq)]
+#[derive(Debug, Clone, clap::ValueEnum, PartialEq, Eq, Default)]
 pub enum OnConflict {
     /// Skip secrets that already exist in the target (default)
+    #[default]
     Skip,
     /// Overwrite the target value, replacing the metadata
     Replace,
     /// Abort the migration on first conflict
     Fail,
-}
-
-impl Default for OnConflict {
-    fn default() -> Self {
-        Self::Skip
-    }
 }
 
 /// Determine if options should be hidden based on environment or command line

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -1011,7 +1011,11 @@ async fn execute_env_list(config: &Config) -> Result<()> {
             println!("Project envs (from {}):", path.display());
             println!("  Activated via: xv --env <name> <command>  |  XV_ENV=<name>  |  default_env in .xv.toml");
             for (name, profile) in &proj_cfg.envs {
-                let marker = if active.as_deref() == Some(name.as_str()) { "*" } else { " " };
+                let marker = if active.as_deref() == Some(name.as_str()) {
+                    "*"
+                } else {
+                    " "
+                };
                 let vault = profile.vault.as_deref().unwrap_or("(unset)");
                 let backend = profile.backend.as_deref().unwrap_or("azure");
                 println!("  {marker} {name}  backend={backend}  vault={vault}");

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -427,7 +427,7 @@ pub(crate) fn mask_secrets(text: &str, secrets: &[Zeroizing<String>]) -> String 
     // preventing partial matches. Skip values < 4 chars to avoid masking
     // common short strings.
     let mut sorted: Vec<&Zeroizing<String>> = secrets.iter().collect();
-    sorted.sort_by(|a, b| b.len().cmp(&a.len()));
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.len()));
 
     let mut result = text.to_string();
     for secret in sorted {

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -185,7 +185,11 @@ async fn migrate_one(
     // Retry with exponential backoff on RateLimited
     let mut attempt = 0u32;
     loop {
-        match target.secrets().set_secret(target_vault, request.clone()).await {
+        match target
+            .secrets()
+            .set_secret(target_vault, request.clone())
+            .await
+        {
             Ok(_) => return Ok(MigrateOutcome::Migrated(name.to_string())),
             Err(BackendError::RateLimited { retry_after_secs }) if attempt < 5 => {
                 let wait = retry_after_secs
@@ -257,10 +261,10 @@ pub(crate) async fn execute_migrate(
         on_conflict
     };
     // 1. Parse backend kinds (accepting bare `backend` or `backend:vault` form)
-    let (from_kind, from_vault_override) = BackendRef::parse_migrate_endpoint(&from)
-        .map_err(CrosstacheError::invalid_argument)?;
-    let (to_kind, to_vault_override) = BackendRef::parse_migrate_endpoint(&to)
-        .map_err(CrosstacheError::invalid_argument)?;
+    let (from_kind, from_vault_override) =
+        BackendRef::parse_migrate_endpoint(&from).map_err(CrosstacheError::invalid_argument)?;
+    let (to_kind, to_vault_override) =
+        BackendRef::parse_migrate_endpoint(&to).map_err(CrosstacheError::invalid_argument)?;
 
     // 2. Create both backends
     let source = BackendRegistry::create_for_kind(from_kind, &config)
@@ -346,8 +350,14 @@ pub(crate) async fn execute_migrate(
     }
 
     // 5. Compute diff (list + filter + conflict detection)
-    let diff =
-        compute_diff(&source, &target, &source_vault, &target_vault, filter.as_deref()).await?;
+    let diff = compute_diff(
+        &source,
+        &target,
+        &source_vault,
+        &target_vault,
+        filter.as_deref(),
+    )
+    .await?;
     print_diff_summary(
         &diff,
         source.name(),
@@ -521,8 +531,7 @@ mod tests {
     fn same_backend_different_vault_allowed() {
         let (from_kind, from_vault) =
             BackendRef::parse_migrate_endpoint("local:source-store").unwrap();
-        let (to_kind, to_vault) =
-            BackendRef::parse_migrate_endpoint("local:target-store").unwrap();
+        let (to_kind, to_vault) = BackendRef::parse_migrate_endpoint("local:target-store").unwrap();
         assert_eq!(from_kind, to_kind);
         assert_ne!(from_vault, to_vault);
     }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -1244,6 +1244,7 @@ pub(crate) async fn execute_secret_share_direct(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)] // legacy non-trait impl, superseded by backend-trait path
 async fn execute_secret_set(
     secret_manager: &crate::secret::manager::SecretManager,
     name: &str,
@@ -1330,6 +1331,7 @@ async fn execute_secret_set(
     Ok(())
 }
 
+#[allow(dead_code)] // legacy non-trait impl, superseded by backend-trait path
 async fn execute_secret_get(
     secret_manager: &crate::secret::manager::SecretManager,
     name: &str,
@@ -1793,6 +1795,7 @@ pub(crate) async fn execute_complete_secrets(config: Config) -> Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)] // legacy non-trait impl, superseded by backend-trait path
 async fn execute_secret_history(
     secret_manager: &crate::secret::manager::SecretManager,
     name: &str,
@@ -2070,11 +2073,12 @@ async fn resolve_uri_secret(
     if let Some(backend_kind) = backend_ref.backend {
         if backend_kind != active_kind {
             // Cross-backend: reuse or create a cached backend instance
-            if !cross_backends.contains_key(&backend_kind) {
+            if let std::collections::hash_map::Entry::Vacant(e) = cross_backends.entry(backend_kind)
+            {
                 let b = BackendRegistry::create_for_kind(backend_kind, config)
                     .await
                     .map_err(CrosstacheError::from)?;
-                cross_backends.insert(backend_kind, b);
+                e.insert(b);
             }
             return cross_backends[&backend_kind]
                 .secrets()
@@ -2498,7 +2502,10 @@ async fn execute_secret_inject(
         );
     }
     if !cross_vault_refs.is_empty() {
-        println!("  Cross-vault/backend: {} secret(s)", cross_vault_refs.len());
+        println!(
+            "  Cross-vault/backend: {} secret(s)",
+            cross_vault_refs.len()
+        );
     }
 
     // Get all secrets from the vault
@@ -2670,6 +2677,7 @@ async fn execute_secret_inject(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)] // legacy non-trait impl, superseded by backend-trait path
 async fn execute_secret_list(
     secret_manager: &crate::secret::manager::SecretManager,
     group: Option<String>,
@@ -2855,6 +2863,7 @@ async fn execute_secret_list(
     Ok(all_secrets)
 }
 
+#[allow(dead_code)] // legacy non-trait impl, superseded by backend-trait path
 async fn execute_secret_delete(
     secret_manager: &crate::secret::manager::SecretManager,
     name: &str,
@@ -3493,6 +3502,7 @@ async fn execute_secret_share(
 }
 
 /// Execute bulk secret set operation
+#[allow(dead_code)] // legacy non-trait impl, superseded by backend-trait path
 async fn execute_secret_set_bulk(
     secret_manager: &crate::secret::manager::SecretManager,
     args: Vec<String>,
@@ -3658,6 +3668,7 @@ async fn execute_secret_set_bulk(
 }
 
 /// Execute group delete operation
+#[allow(dead_code)] // legacy non-trait impl, superseded by backend-trait path
 async fn execute_secret_delete_group(
     secret_manager: &crate::secret::manager::SecretManager,
     group_name: &str,

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -63,7 +63,7 @@ pub async fn write_sensitive_file_async(path: &Path, content: &[u8]) -> std::io:
     let content = content.to_vec();
     tokio::task::spawn_blocking(move || write_private(&path, &content))
         .await
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+        .map_err(std::io::Error::other)?
 }
 
 /// Check if a string is a valid GUID/UUID

--- a/tests/config_command_tests.rs
+++ b/tests/config_command_tests.rs
@@ -87,14 +87,25 @@ fn version_lists_compiled_backends() {
     // `xv version` should always mention "azure" and "local" as built-in backends.
     let (mut cmd, _temp) = common::xv_isolated();
     let out = cmd.args(["version"]).output().expect("spawn");
-    assert_eq!(out.status.code(), Some(0), "stderr: {}", common::stderr_str(&out));
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
     let stdout = common::stdout_str(&out);
     assert!(
         stdout.contains("Backends:"),
         "expected Backends: line in version output: {stdout}"
     );
-    assert!(stdout.contains("azure"), "expected azure in backends: {stdout}");
-    assert!(stdout.contains("local"), "expected local in backends: {stdout}");
+    assert!(
+        stdout.contains("azure"),
+        "expected azure in backends: {stdout}"
+    );
+    assert!(
+        stdout.contains("local"),
+        "expected local in backends: {stdout}"
+    );
 }
 
 #[cfg(not(feature = "aws"))]

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -278,7 +278,11 @@ fn context_use_rejects_xv_toml_env_name() {
 fn env_list_shows_xv_toml_project_envs() {
     // `xv env list` with a .xv.toml present should surface project envs.
     let (mut cmd, temp) = xv_isolated();
-    write_xv_toml(temp.path(), "dev", &[("dev", "vault-dev"), ("prod", "vault-prod")]);
+    write_xv_toml(
+        temp.path(),
+        "dev",
+        &[("dev", "vault-dev"), ("prod", "vault-prod")],
+    );
     let out = cmd
         .env("AZURE_SUBSCRIPTION_ID", FAKE_SUB)
         .env("AZURE_TENANT_ID", FAKE_TENANT)
@@ -289,7 +293,10 @@ fn env_list_shows_xv_toml_project_envs() {
     let stdout = stdout_str(&out);
     // Should show the .xv.toml profiles.
     assert!(stdout.contains("dev"), "expected 'dev' in output: {stdout}");
-    assert!(stdout.contains("prod"), "expected 'prod' in output: {stdout}");
+    assert!(
+        stdout.contains("prod"),
+        "expected 'prod' in output: {stdout}"
+    );
     // Should indicate these are activated via --env / XV_ENV.
     assert!(
         stdout.contains("--env") || stdout.contains("XV_ENV"),
@@ -317,7 +324,9 @@ fn env_use_targeted_error_for_xv_toml_env() {
         "expected targeted hint in stderr: {stderr}"
     );
     // Must not just say "not found" with no guidance.
-    let bare_not_found = stderr.contains("not found") &&
-        !stderr.contains("--env") && !stderr.contains(".xv.toml") && !stderr.contains("XV_ENV");
+    let bare_not_found = stderr.contains("not found")
+        && !stderr.contains("--env")
+        && !stderr.contains(".xv.toml")
+        && !stderr.contains("XV_ENV");
     assert!(!bare_not_found, "bare not-found without hint: {stderr}");
 }

--- a/tests/e2e_aws_backend.rs
+++ b/tests/e2e_aws_backend.rs
@@ -152,7 +152,10 @@ async fn poll_list_vaults_contains(backend: &AwsBackend, vault: &str) {
     const MAX_ATTEMPTS: u32 = 12;
     let vaults = backend.vaults().expect("AWS backend exposes vaults");
     for attempt in 1..=MAX_ATTEMPTS {
-        let all = vaults.list_vaults().await.expect("list_vaults should succeed");
+        let all = vaults
+            .list_vaults()
+            .await
+            .expect("list_vaults should succeed");
         if all.iter().any(|v| v.name == vault) {
             return;
         }

--- a/tests/e2e_azure_backend.rs
+++ b/tests/e2e_azure_backend.rs
@@ -54,8 +54,7 @@ async fn azure_backend() -> AzureBackend {
         config.azure_credential_priority.clone(),
     )
     .expect("failed to build Azure credential provider — is the az CLI authenticated?");
-    AzureBackend::new(&config, Arc::new(provider))
-        .expect("failed to construct AzureBackend")
+    AzureBackend::new(&config, Arc::new(provider)).expect("failed to construct AzureBackend")
 }
 
 /// Unique secret name for one test run.


### PR DESCRIPTION
## Summary

The CI **Check, Lint & Test** job has been failing on `main` since the #204/#206/#207 merges — the `cargo fmt --check` step failed, which also masked newer clippy errors (Rust 1.95 promoted several lints). A red `main` blocks the release pipeline.

## Changes
- **`cargo fmt`** — reformat drift across `src/backend/`, `src/cli/`, and `tests/`.
- **`cargo clippy -D warnings`**:
  - Mark 7 legacy `execute_secret_*` functions `#[allow(dead_code)]` — pre-trait implementations superseded by the backend-trait dispatch path. Full removal (~1500 LOC) deferred to a dedicated cleanup PR.
  - Mark `NameCharset::is_valid` `#[allow(dead_code)]` — public API currently exercised only by tests.
  - `OpenOptions`: add explicit `.truncate(false)` to the lock-file open (`clippy::suspicious_open_options`).
  - Use `sort_by_key(Reverse(..))` instead of a manual `sort_by` closure.

No behavior change.

## Verification
- `cargo fmt -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- Full test suite: 427 lib tests + all integration suites, **0 failures** ✅

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly formatting and lint-driven refactors with minimal behavioral impact; only notable functional tweak is explicitly disabling truncation when opening the local vault lock file.
> 
> **Overview**
> Fixes CI failures by applying `cargo fmt` reformatting across backend/CLI/tests and addressing new Clippy warnings.
> 
> Small lint-driven code tweaks include deriving `Default` for `OnConflict`, simplifying a few closures/`map_err` calls, using `sort_by_key(Reverse(..))` for secret masking, and switching cross-backend cache insertion to `HashMap::entry`. Adds targeted `#[allow(dead_code)]` on legacy `execute_secret_*` paths (and `NameCharset::is_valid`) and makes local vault locking safer/clearer with explicit `.truncate(false)` on the lock file open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fecc1ade01de992cb7cd68b22eeeadbdf50b80f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->