### PR TITLE
fix(aws): classify credential failures as auth errors (UX-REVIEW §P0-2)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,13 +25,6 @@ new feature work in this lane — only blockers found during rc soak.
 
 ## Near-term (v0.11.x)
 
-### P0 — AWS auth failures surface as network timeouts
-Source: `docs/UX-REVIEW.md` §P0-2. Missing/invalid AWS credentials produce
-generic `reqwest` timeouts instead of a "credentials not configured" message
-with the standard remediation pointers (`aws configure`, `AWS_PROFILE`, IAM
-role chain). Partially addressed in `#206` but needs verification across all
-AWS code paths (list, get, migrate).
-
 ### P0 — Default build silently cannot use AWS
 Source: `docs/UX-REVIEW.md` §P0-3. A binary built without `--features aws`
 accepts `--backend aws` flags and only fails deep in the call stack with an

--- a/docs/UX-REVIEW.md
+++ b/docs/UX-REVIEW.md
@@ -95,6 +95,8 @@ match a `.xv.toml` env with a targeted message:
 
 ### 2. AWS auth failures are reported as network timeouts
 
+> **Resolved in v0.11.0** (PR fix/aws-healthcheck-auth-classification) — `health_check` and all SDK error mappers now classify credential-resolution failures as `xv-auth-failed` with the `aws configure` remediation hint; defensive matching also catches non-user `DispatchFailure`/`ConstructionFailure` paths whose source chain mentions credential providers.
+
 Problem: when AWS credentials cannot be resolved, `xv` returns `xv-network` and
 claims `timeout or dispatch failure`. This hides the real fix: configure usable
 AWS SDK credentials.

--- a/src/backend/aws/errors.rs
+++ b/src/backend/aws/errors.rs
@@ -24,6 +24,51 @@ fn generic<E: std::fmt::Display>(op: &str, e: E) -> BackendError {
     BackendError::Internal(format!("aws {op}: {e}"))
 }
 
+/// Build the standard credential-remediation hint shown when the AWS SDK
+/// cannot resolve credentials. Centralised so every code path (per-operation
+/// SdkError handlers, the lightweight `health_check`, and any future
+/// non-SdkError wrappers) prints the same actionable text.
+pub(crate) fn aws_credentials_hint(op: &str) -> String {
+    format!(
+        "No AWS credentials resolved (operation: {op}). \
+Try `aws configure`, set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, \
+or run `eval \"$(aws configure export-credentials --format env)\"` after `aws login`."
+    )
+}
+
+/// Walk an error's source chain looking for tell-tale strings produced by the
+/// AWS credential providers (e.g. `CredentialsNotLoaded`, "no credentials",
+/// "ProviderError", "credentials provider"). Used as a defensive fallback for
+/// SdkError variants — notably `ConstructionFailure` and edge-case
+/// `DispatchFailure`s where `is_user()` may be false but the underlying cause
+/// is still credential resolution.
+fn looks_like_credential_error(err: &(dyn std::error::Error + 'static)) -> bool {
+    fn matches(s: &str) -> bool {
+        let lower = s.to_ascii_lowercase();
+        lower.contains("credentialsnotloaded")
+            || lower.contains("no credentials")
+            || lower.contains("credentials not loaded")
+            || lower.contains("credentials provider")
+            || lower.contains("providererror")
+            || lower.contains("provider error")
+            || lower.contains("no credentials in chain")
+            || lower.contains("failed to load credentials")
+    }
+    let mut cur: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    let mut depth = 0;
+    while let Some(e) = cur {
+        if matches(&e.to_string()) {
+            return true;
+        }
+        depth += 1;
+        if depth > 16 {
+            break;
+        }
+        cur = e.source();
+    }
+    false
+}
+
 fn handle_sdk<E: std::fmt::Display + std::fmt::Debug, R: std::fmt::Debug>(
     op: &str,
     e: SdkError<E, R>,
@@ -32,14 +77,29 @@ fn handle_sdk<E: std::fmt::Display + std::fmt::Debug, R: std::fmt::Debug>(
         SdkError::TimeoutError(_) => BackendError::Network(format!("aws {op}: timeout")),
         SdkError::DispatchFailure(ref df) if df.is_user() => {
             // Credential resolution failure — not a network error.
-            BackendError::AuthenticationFailed(format!(
-                "No AWS credentials resolved (operation: {op}). \
-Try `aws configure`, set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, \
-or run `eval \"$(aws configure export-credentials --format env)\"` after `aws login`."
-            ))
+            BackendError::AuthenticationFailed(aws_credentials_hint(op))
+        }
+        SdkError::DispatchFailure(ref df)
+            if df
+                .as_connector_error()
+                .map(|c| looks_like_credential_error(c))
+                .unwrap_or(false) =>
+        {
+            // Defensive: some SDK versions/transports route credential
+            // failures through DispatchFailure without flagging `is_user()`.
+            BackendError::AuthenticationFailed(aws_credentials_hint(op))
         }
         SdkError::DispatchFailure(_) => {
             BackendError::Network(format!("aws {op}: dispatch failure"))
+        }
+        SdkError::ConstructionFailure(ref _cf)
+            if format!("{e:?}").to_ascii_lowercase().contains("credential") =>
+        {
+            // Credential providers can fail before the request is dispatched
+            // (e.g. missing profile, invalid IMDS response), surfacing as a
+            // ConstructionFailure. Classify as auth so users get the hint
+            // instead of an opaque "Internal" error.
+            BackendError::AuthenticationFailed(aws_credentials_hint(op))
         }
         SdkError::ServiceError(svc) => BackendError::Internal(format!("aws {op}: {}", svc.err())),
         other => generic(op, format!("{other:?}")),
@@ -229,6 +289,53 @@ mod tests {
         assert!(
             matches!(err, BackendError::Network(_)),
             "expected Network, got: {err:?}"
+        );
+    }
+
+    /// Regression test for `docs/UX-REVIEW.md` §P0-2: a credential-resolution
+    /// failure whose payload doesn't have `is_user()` set must still map to
+    /// `AuthenticationFailed` so the user sees the `aws configure` hint
+    /// instead of a "dispatch failure" / "network" message.
+    #[test]
+    fn dispatch_failure_with_credentials_string_maps_to_auth() {
+        // Build a non-user DispatchFailure carrying an inner error whose
+        // Display contains a credential-provider hint. `ConnectorError::io`
+        // does not set the user flag.
+        let inner = std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "CredentialsNotLoaded: failed to load credentials",
+        );
+        let sdk: SdkError<ListSecretsError, HttpResponse> =
+            SdkError::dispatch_failure(ConnectorError::io(Box::new(inner)));
+        let err = from_list(sdk);
+        assert!(
+            matches!(err, BackendError::AuthenticationFailed(_)),
+            "expected AuthenticationFailed, got: {err:?}"
+        );
+        let BackendError::AuthenticationFailed(msg) = err else {
+            unreachable!()
+        };
+        assert!(msg.contains("aws configure"), "hint missing: {msg}");
+    }
+
+    /// Regression test: the `health_check` lightweight ping (used at backend
+    /// construction time and by `xv list` precondition checks) used to map
+    /// every SDK error to `BackendError::Network`, masking credential
+    /// failures. It must now route through `from_list` and surface
+    /// `AuthenticationFailed` for credential-resolution failures.
+    #[tokio::test]
+    async fn health_check_classifies_credential_errors_as_auth() {
+        // We can't easily build a real SecretsManagerClient that fails in a
+        // specific way without spinning up a mock, so instead we mirror the
+        // call site by piping the same SdkError variants through `from_list`
+        // (the mapper now used inside `health_check`) and asserting on the
+        // classification. This is a contract test — `health_check`'s
+        // production code path is `req.send().await.map_err(from_list)`, so
+        // any mapper change is caught here.
+        let err = from_list(make_user_dispatch_failure());
+        assert!(
+            matches!(err, BackendError::AuthenticationFailed(_)),
+            "health_check would have returned: {err:?}"
         );
     }
 }

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -24,13 +24,19 @@ impl AwsSecretBackend {
     }
 
     /// Lightweight health check: list secrets with limit=1.
+    ///
+    /// Routes errors through the standard per-operation mapping
+    /// (`super::errors::from_list`) so that credential-resolution failures
+    /// surface as `BackendError::AuthenticationFailed` with the
+    /// `aws configure` remediation hint — not as a generic network error.
+    /// See `docs/UX-REVIEW.md` §P0-2.
     pub async fn health_check(&self) -> Result<(), BackendError> {
         self.client
             .list_secrets()
             .max_results(1)
             .send()
             .await
-            .map_err(|e| BackendError::Network(format!("aws health check: {e}")))?;
+            .map_err(super::errors::from_list)?;
         Ok(())
     }
 


### PR DESCRIPTION
Resolves `docs/UX-REVIEW.md` §P0-2 (the second open P0 from the v0.10.0-rc.2 UX deep-dive). Follow-up to #206, which added the initial `is_user()` classification but left two gaps.

## Problem

A binary built with `--features aws`, pointed at an AWS profile but lacking resolvable SDK credentials, was returning:

```
error[xv-network]: Network error: aws ListSecrets: timeout or dispatch failure
exit=30
```

This sent users toward DNS / proxy / AWS-health investigations instead of the actual fix: configure SDK credentials.

## Gaps closed

1. **`AwsSecretBackend::health_check`** mapped every SDK error to `BackendError::Network("aws health check: …")`, completely bypassing the per-operation mapper in `super::errors`. Credential failures at construction/healthcheck time — a common path — surfaced as network errors with no remediation.

2. **`handle_sdk` only inspected `DispatchFailure::is_user()`**. Some SDK transports / versions route credential failures through `DispatchFailure` without setting `is_user()`, and credential providers can fail at **construction time** (before request dispatch), producing `ConstructionFailure`. Both fell through to the generic "dispatch failure" / opaque `Internal` arms.

## Changes

* Extract `aws_credentials_hint(op)` so the `aws configure` / `AWS_ACCESS_KEY_ID` / `aws configure export-credentials` text lives in one place.
* Add `looks_like_credential_error(&dyn Error)` — walks the error source chain (bounded depth 16) looking for tell-tale provider strings: `CredentialsNotLoaded`, `credentials provider`, `ProviderError`, `no credentials in chain`, `failed to load credentials`, etc.
* `handle_sdk` now matches three credential-failure shapes, in order:
  - `DispatchFailure` with `is_user() == true` (existing fast path).
  - `DispatchFailure` whose inner `ConnectorError` chain looks like a credential error (defensive fallback).
  - `ConstructionFailure` whose Debug output mentions "credential" (pre-dispatch provider failure).
* `health_check` now uses `super::errors::from_list` (which delegates to `handle_sdk`) instead of its bespoke Network wrapper. A doc comment cross-references `docs/UX-REVIEW.md` §P0-2.

## Tests

* New `dispatch_failure_with_credentials_string_maps_to_auth` — non-user `DispatchFailure` carrying a "CredentialsNotLoaded" inner error now maps to `AuthenticationFailed` with the `aws configure` hint.
* New `health_check_classifies_credential_errors_as_auth` — contract test asserting the mapper chosen by `health_check` (`from_list`) classifies credential failures correctly. Catches any future change that re-bypasses the per-op mapper.
* Existing `dispatch_failure_user_maps_to_auth_error` and `dispatch_failure_timeout_maps_to_network` continue to pass.

## Verification

* `cargo build` + `cargo build --features aws`: clean.
* `cargo fmt --check` + `cargo clippy -- -D warnings` (CI matrix): clean.
* `cargo test --features aws --lib backend::aws`: **23 passed**.
* `cargo test --lib`: **428 passed**; the only failures are the 2 known non-hermetic `cli::secret_ops::tests::*_vault_resolution_*` tests that read the developer's real `~/.config/xv` (pre-existing, tracked separately).

## UX after fix

```
$ xv --backend aws list
error[xv-auth-failed]: No AWS credentials resolved (operation: ListSecrets).
Try `aws configure`, set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY,
or run `eval "$(aws configure export-credentials --format env)"` after `aws login`.
```

## Roadmap / docs

* `ROADMAP.md`: removed the §P0 "AWS auth failures surface as network timeouts" block from `Near-term (v0.11.x)`.
* `docs/UX-REVIEW.md` §P0-2: added a `> **Resolved in v0.11.0**` banner pointing at this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts AWS SDK error classification and the backend `health_check` error mapping, which could change user-visible error codes/messages and potentially misclassify some edge-case transport failures as auth issues.
> 
> **Overview**
> Fixes AWS credential-resolution failures being surfaced as generic network/timeout errors by **standardizing and expanding AWS SDK error mapping** to return `BackendError::AuthenticationFailed` with a consistent remediation hint.
> 
> `AwsSecretBackend::health_check` now routes failures through the same per-operation mapper (instead of wrapping everything as `Network`), and new regression tests cover non-`is_user()` `DispatchFailure` and `ConstructionFailure` credential paths. Docs/roadmap are updated to mark UX-REVIEW §P0-2 as resolved and remove the corresponding near-term item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f23ce1163df52d6581dd9a3985e97b5870b76ce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->