### PR TITLE
fix: address Bugbot Medium findings on PR #211 (.xv.toml save permissions + header)

### DIFF
--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -778,9 +778,9 @@ async fn execute_context_init(
     let body = toml::to_string_pretty(&cfg)
         .map_err(|e| CrosstacheError::config(format!("failed to serialize .xv.toml: {e}")))?;
 
-    // Helpful header
-    let header = "# crosstache project config — see https://github.com/bziobnic/crosstache/blob/main/docs/env-profiles.md\n";
-    let full = format!("{header}{body}");
+    // Use the same header `ProjectConfig::save()` writes, so the comment
+    // survives later `xv env use/create/delete` rewrites.
+    let full = format!("{}{body}", crate::config::project::ProjectConfig::HEADER);
 
     tokio::fs::write(&path, full).await?;
     crate::utils::output::success(&format!(

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -168,15 +168,34 @@ pub async fn find_project_config(start: &Path) -> Result<Option<(PathBuf, Projec
 }
 
 impl ProjectConfig {
+    /// Standard header banner prepended to every `.xv.toml` written by
+    /// crosstache (both `xv context init` and `ProjectConfig::save`).
+    ///
+    /// This file is project-scoped and meant to be checked into VCS, so
+    /// the header gives team members a discoverable docs link without
+    /// requiring them to run `--help`.
+    pub const HEADER: &'static str = "# crosstache project config — see https://github.com/bziobnic/crosstache/blob/main/docs/env-profiles.md\n";
+
     /// Serialize this config to TOML and write it to `path`.
+    ///
+    /// `.xv.toml` is project-scoped and intended to be checked into the
+    /// repository, so we use `tokio::fs::write` (respects umask, typically
+    /// 0o644) rather than `write_sensitive_file_async` (forces 0o600).
+    /// Bugbot finding on PR #211: forcing 0o600 broke shared-filesystem
+    /// workflows.
+    ///
+    /// The standard `HEADER` banner is always prepended, so successive
+    /// `save()` calls don't strip the helpful "see docs" pointer that
+    /// `xv context init` writes. Per-user comments inside the file are
+    /// still discarded — this is a documented limitation; users wanting
+    /// comments should edit the file manually outside of `xv env *`.
     pub async fn save(&self, path: &Path) -> Result<()> {
-        let content = toml::to_string_pretty(self)
+        let body = toml::to_string_pretty(self)
             .map_err(|e| CrosstacheError::config(format!(".xv.toml serialize error: {e}")))?;
-        crate::utils::helpers::write_sensitive_file_async(path, content.as_bytes())
-            .await
-            .map_err(|e| {
-                CrosstacheError::config(format!("failed to write {}: {e}", path.display()))
-            })
+        let full = format!("{}{body}", Self::HEADER);
+        tokio::fs::write(path, full).await.map_err(|e| {
+            CrosstacheError::config(format!("failed to write {}: {e}", path.display()))
+        })
     }
 }
 
@@ -577,6 +596,60 @@ resource_group = "rg"
         let dev = loaded.envs.get("dev").expect("env.dev must be present");
         assert_eq!(dev.vault.as_deref(), Some("myvault"));
         assert_eq!(dev.resource_group.as_deref(), Some("myrg"));
+    }
+
+    /// PR #211 Bugbot finding (Medium): `save()` must use umask-respecting
+    /// permissions, not 0o600. `.xv.toml` is project-scoped and intended
+    /// to be committed to VCS / shared on a team filesystem.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn project_config_save_respects_umask_not_0o600() {
+        use std::os::unix::fs::PermissionsExt;
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(".xv.toml");
+        let cfg = ProjectConfig::default();
+        cfg.save(&path).await.expect("save must succeed");
+        let mode = tokio::fs::metadata(&path)
+            .await
+            .expect("stat must succeed")
+            .permissions()
+            .mode()
+            & 0o777;
+        // Default umask is 0o022 → file mode 0o644. Some test environments
+        // run with umask 0o002 → 0o664. Both are world/group-readable, which
+        // is the property we care about. 0o600 is what we're guarding against.
+        assert_ne!(
+            mode, 0o600,
+            ".xv.toml must NOT be 0o600 — see PR #211 Bugbot finding"
+        );
+        assert!(
+            mode & 0o044 != 0,
+            ".xv.toml must be group/world readable (got {mode:o})"
+        );
+    }
+
+    /// PR #211 Bugbot finding (Medium): `save()` must prepend the standard
+    /// HEADER banner so the helpful "see docs" comment written by
+    /// `xv context init` survives every subsequent `xv env use/create/delete`.
+    #[tokio::test]
+    async fn project_config_save_preserves_header() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(".xv.toml");
+        let cfg = ProjectConfig::default();
+        cfg.save(&path).await.expect("save must succeed");
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(
+            content.starts_with(ProjectConfig::HEADER),
+            "saved file must start with HEADER banner; got:\n{content}"
+        );
+        // And re-saving doesn't duplicate the header.
+        cfg.save(&path).await.expect("re-save must succeed");
+        let content2 = tokio::fs::read_to_string(&path).await.unwrap();
+        let header_count = content2.matches(ProjectConfig::HEADER).count();
+        assert_eq!(
+            header_count, 1,
+            "header must appear exactly once after re-save; got {header_count}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Background

PR #211 (`feat/env-rip-replace`) was auto-merged before Cursor Bugbot's review landed (the watcher skill's auto-merge cron didn't gate on Bugbot — fixed in `github-pr-watcher-crons` v1.1.0 alongside this PR). Bugbot posted two **Medium-severity** findings 12 minutes after the merge; this PR addresses both.

## Findings

### 1. `.xv.toml` saved with 0o600 (owner-only)

`ProjectConfig::save()` used `write_sensitive_file_async` which forces `0o600`. But `.xv.toml` is **project-scoped and intended to be committed to the repo / shared on a team filesystem** (per `docs/env-profiles.md`). After any `xv env use/create/delete` the file became owner-only — broke shared-filesystem workflows.

**Fix:** switch `save()` to `tokio::fs::write` (respects umask, typically 0o644). This matches what `execute_context_init` was already doing for the initial write.

### 2. `save()` stripped the header comment from `xv context init`

`toml::to_string_pretty(self)` discards any non-struct content — including the `# crosstache project config — see <docs URL>` header that `xv context init` adds. Running `xv env use prod` immediately after `xv context init` silently stripped the header.

**Fix:** hoist the header into `ProjectConfig::HEADER` constant; `save()` always prepends it. `execute_context_init` now consumes the same constant instead of an inline string literal, so both writers stay in sync forever.

(Per-user comments **inside** the file are still discarded — documented limitation. Users who want comments edit `.xv.toml` manually outside of `xv env *`.)

## Regression tests

- `project_config_save_respects_umask_not_0o600` (unix-only): asserts saved mode is NOT 0o600 and IS group/world-readable.
- `project_config_save_preserves_header`: asserts the HEADER is present after `save()` and is **not duplicated** after a re-save.

## Verification

- `cargo build` (default + `--features aws`): ✅ clean
- `cargo fmt --check`: ✅ clean
- `cargo clippy --all-targets -- -D warnings`: ✅ clean
- `cargo test --lib config::project`: ✅ 33/33 pass

## Related

Cursor watcher skill `github-pr-watcher-crons` upgraded to **v1.1.0** to add a Bugbot gate so future auto-merges block on unresolved Medium+ findings. This race won't repeat.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `.xv.toml` is written (permissions and content prefix), which can affect team workflows and downstream tools that read the file. Scope is limited to project-config persistence and is covered by new regression tests.
> 
> **Overview**
> Ensures `.xv.toml` writes are **team-friendly and stable**: `ProjectConfig::save()` now uses `tokio::fs::write` (umask-respecting, not forced `0o600`) and always prepends a shared `ProjectConfig::HEADER` docs banner.
> 
> `xv context init` now reuses the same `HEADER` constant so later `xv env *` rewrites don’t strip the header comment, and new tests assert the file is not saved as `0o600` (unix) and that the header is present exactly once across re-saves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fcbd3b8a5369fd5d3a30cbb2050125a7845e82a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->