### PR TITLE
Add xv-backend-unavailable error code for compile-time-disabled backends (UX-REVIEW §P0-3)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,12 +25,6 @@ new feature work in this lane — only blockers found during rc soak.
 
 ## Near-term (v0.11.x)
 
-### P0 — Default build silently cannot use AWS
-Source: `docs/UX-REVIEW.md` §P0-3. A binary built without `--features aws`
-accepts `--backend aws` flags and only fails deep in the call stack with an
-opaque error. Detect feature absence early; print a one-line "rebuild with
-`--features aws`" hint (partially addressed in `#206`; verify).
-
 ### P1 — Backend selection diagnostics
 Source: `docs/UX-REVIEW.md` §P1-3. Backend can come from global config,
 `.xv.toml`, env vars, or `--backend`. Add `xv config show --resolved` (or

--- a/docs/UX-REVIEW.md
+++ b/docs/UX-REVIEW.md
@@ -127,6 +127,8 @@ Try `aws configure`, set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, or run
 
 ### 3. A default build silently cannot use AWS but does not clearly say so
 
+> **Resolved in v0.11.0** (PR fix/p0-3-backend-unavailable-error-code) — `--backend aws` on a non-AWS build now fails before command dispatch with the dedicated `xv-backend-unavailable` error code (exit 3) and a one-line rebuild hint. `xv version` lists compiled-in backends, and `--backend` help advertises AWS availability per-build.
+
 Problem: AWS is a compile-time feature, but the default binary hides that behind
 a generic backend-registry failure. The explicit "AWS backend not compiled in"
 message exists in source but is swallowed before the command-level error.

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -10,7 +10,7 @@ releases — they are part of the scripting contract.
 | `0`   | Success               | command completed                               |
 | `1`   | Unknown / catch-all   | unrecoverable I/O, JSON parse, regex, etc.      |
 | `2`   | Invalid argument      | bad CLI flag; clap parse failure                |
-| `3`   | Configuration error   | missing required config; invalid config file; env not defined in `.xv.toml` |
+| `3`   | Configuration error   | missing required config; invalid config file; env not defined in `.xv.toml`; backend unavailable (`xv-backend-unavailable`) |
 | `10`  | Secret not found      | `xv get` on a missing secret                    |
 | `11`  | Vault not found       | `xv vault info` on a missing vault              |
 | `12`  | Invalid secret name   | name fails sanitization rules                   |

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,10 @@ pub enum CrosstacheError {
     #[error("Configuration error: {0}")]
     ConfigError(String),
 
+    #[error("Backend '{backend}' is not available: {reason}")]
+    #[allow(dead_code)]
+    BackendUnavailable { backend: String, reason: String },
+
     #[error("Secret not found: {name}")]
     SecretNotFound {
         name: String,
@@ -110,6 +114,7 @@ impl CrosstacheError {
             Self::RateLimited(_) => "xv-rate-limited",
             Self::ConfigError(_) => "xv-config-invalid",
             Self::ConfigLoadError(_) => "xv-config-invalid",
+            Self::BackendUnavailable { .. } => "xv-backend-unavailable",
             Self::SecretNotFound { .. } => "xv-secret-not-found",
             Self::VaultNotFound { .. } => "xv-vault-not-found",
             Self::InvalidSecretName { .. } => "xv-invalid-secret-name",
@@ -141,6 +146,7 @@ impl CrosstacheError {
         match self {
             Self::InvalidArgument(_) => 2,
             Self::ConfigError(_) | Self::ConfigLoadError(_) | Self::EnvNotDefined { .. } => 3,
+            Self::BackendUnavailable { .. } => 3,
 
             Self::SecretNotFound { .. } => 10,
             Self::VaultNotFound { .. } => 11,
@@ -195,6 +201,14 @@ impl CrosstacheError {
 
     pub fn config<S: Into<String>>(msg: S) -> Self {
         Self::ConfigError(msg.into())
+    }
+
+    #[allow(dead_code)]
+    pub fn backend_unavailable<S: Into<String>, R: Into<String>>(backend: S, reason: R) -> Self {
+        Self::BackendUnavailable {
+            backend: backend.into(),
+            reason: reason.into(),
+        }
     }
 
     #[allow(dead_code)]
@@ -498,6 +512,10 @@ mod tests {
             (CrosstacheError::rate_limited("x"), "xv-rate-limited"),
             (CrosstacheError::config("x"), "xv-config-invalid"),
             (
+                CrosstacheError::backend_unavailable("aws", "not compiled in"),
+                "xv-backend-unavailable",
+            ),
+            (
                 CrosstacheError::secret_not_found("x"),
                 "xv-secret-not-found",
             ),
@@ -556,6 +574,10 @@ mod tests {
 
         // 3 — config family
         assert_eq!(CrosstacheError::config("x").exit_code(), 3);
+        assert_eq!(
+            CrosstacheError::backend_unavailable("aws", "x").exit_code(),
+            3
+        );
 
         // 10–19 — not-found family
         assert_eq!(CrosstacheError::secret_not_found("x").exit_code(), 10);

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,8 @@ async fn run(cli: Cli) -> Result<()> {
     // "No backend registry available" message later.
     #[cfg(not(feature = "aws"))]
     if config.effective_backend_name() == "aws" {
-        return Err(CrosstacheError::config(
+        return Err(CrosstacheError::backend_unavailable(
+            "aws",
             "AWS backend is not included in this build. \
 Rebuild with `cargo build --features aws` or install an AWS-enabled binary.",
         ));


### PR DESCRIPTION
## Summary

Resolves `docs/UX-REVIEW.md` §P0-3. Adds the dedicated `xv-backend-unavailable` error code (exit 3, config family) for the case where a binary built without `--features aws` is invoked with `--backend aws`.

The early-exit guard in `src/main.rs` (added in #206) was already catching this case before command dispatch, but surfacing it as the generic `xv-config-invalid`. The UX review explicitly named `xv-backend-unavailable` as the contract code; this PR closes that scripting-contract gap.

## Changes

- **`src/error.rs`**: new `BackendUnavailable { backend, reason }` variant + `backend_unavailable()` constructor; code/exit-code wiring + tests.
- **`src/main.rs`**: P0.3 guard now constructs `BackendUnavailable("aws", ...)` instead of `ConfigError(...)`.
- **`docs/exit-codes.md`**: mention the new code under the config family row.
- **`docs/UX-REVIEW.md`**: §3 resolved banner.
- **`ROADMAP.md`**: remove the resolved P0 item.

## Test plan

- `cargo build` ✅
- `cargo build --features aws` ✅
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib` ✅ (430 passed; the 2 known non-hermetic `secret_ops::tests::*_trait_vault_resolution_*` failures only fire when `~/.config/xv/context` is populated — unrelated to this change)
- New unit tests cover the error code (`xv-backend-unavailable`) and exit code (3) mappings.

## Other P0-3 work already shipped

- Early-exit guard in `src/main.rs` for `--backend aws` on non-AWS builds (#206).
- `xv version` lists compiled-in backends (`Backends: azure, local[, aws]`).
- `--backend` help advertises AWS availability per-build (`azure, local (aws unavailable in this build; rebuild with --features aws)`).

This PR is the final piece — the structured error code for scripts that parse `--format json` envelopes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated change to error modeling and a pre-dispatch AWS feature guard, mainly affecting the surfaced error code/message for one failure case.
> 
> **Overview**
> Ensures requesting `--backend aws` on binaries compiled without the `aws` feature fails early with a dedicated `xv-backend-unavailable` error code (still exit code `3`) and a targeted rebuild hint, instead of the generic `xv-config-invalid`.
> 
> Adds a new `CrosstacheError::BackendUnavailable` variant (with constructor, code/exit-code wiring, and unit tests), updates the config-family exit-code docs, and marks the UX/roadmap P0 item as resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb4e57e748b4714e908767047ab01a1161a55db6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->