### PR TITLE
fix(security-test): add BackendUnavailable to variant_field_names

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -691,6 +691,7 @@ mod tests {
             ("InvalidArgument", vec!["msg"]),
             ("Upgrade", vec!["msg"]),
             ("ScanLeakDetected", vec!["count"]),
+            ("BackendUnavailable", vec!["backend", "reason"]),
             ("Unknown", vec!["msg"]),
             ("EnvNotDefined", vec!["name", "available"]),
         ];


### PR DESCRIPTION
## Background

PR #214 added the `BackendUnavailable { backend, reason }` enum variant (for compile-time-disabled backends, per UX-REVIEW §P0-3) but never appended it to the hand-maintained `variant_field_names` list in the `no_variant_has_a_secret_value_field` security-audit test (src/error.rs:667).

The test's own comment is clear:

> This is a hand-maintained list of variant fields. If you add a variant whose payload could carry a secret value, this test will fail in code review — keep the list updated.

Without the entry, the security audit silently skipped checking `backend` and `reason` against the banned-word list ("value", "secret", "password", "token"). Neither field name is actually banned, so this was a **latent test-coverage bug, not an active secret-leak**.

## Why this slipped through

PR #214 auto-merged ~3 minutes after Bugbot posted this Medium-severity finding, because the v1.1.0 watcher gate filtered on the wrong author login (`cursor[bot]` in GraphQL — actual login there is bare `cursor` without the `[bot]` suffix). Fixed in `github-pr-watcher-crons` v1.2.0 — future PRs will block on unresolved Medium+ findings as intended.

## Change

Add `("BackendUnavailable", vec!["backend", "reason"])` to the audit list, alphabetically adjacent to its sibling entries.

## Verification

- `cargo build`: clean
- `cargo test --lib error::`: 41/41 pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that improves coverage of the banned-field-name check without affecting runtime behavior.
> 
> **Overview**
> Adds `BackendUnavailable` (fields `backend`, `reason`) to the `no_variant_has_a_secret_value_field` hand-maintained `variant_field_names` list in `src/error.rs`, so the banned-token scan also audits this variant’s payload field names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee0b7d3c57ec37a6e5ddf677008bb02f6a460a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->