### PR TITLE
feat(config): add `xv config show --resolved` for backend diagnostics

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,11 +25,6 @@ new feature work in this lane — only blockers found during rc soak.
 
 ## Near-term (v0.11.x)
 
-### P1 — Backend selection diagnostics
-Source: `docs/UX-REVIEW.md` §P1-3. Backend can come from global config,
-`.xv.toml`, env vars, or `--backend`. Add `xv config show --resolved` (or
-similar) that prints which source won, with precedence rules.
-
 ### P1 — `xv context init` cannot create AWS or local profiles
 Source: `docs/UX-REVIEW.md` §P1-4. Wizard is still Azure-only despite AWS
 being shipped. Add backend selection to the init flow.

--- a/docs/UX-REVIEW.md
+++ b/docs/UX-REVIEW.md
@@ -230,6 +230,8 @@ matching `.xv.toml` profile and print the exact command to use.
 
 ### 3. Backend selection is split across global config, `.xv.toml`, env vars, and flags with no diagnostic
 
+> **Resolved in v0.11.0** (PR fix/config-show-resolved) — `xv config show --resolved` now prints the effective backend, env, vault, and resource group with the source of each (CLI flag / env var / `.xv.toml` profile / global config / built-in). Precedence summary printed beneath the table.
+
 Problem: backend resolution is powerful but invisible. The effective backend
 can come from `--backend`, active `.xv.toml` env, global `xv.conf`, `XV_BACKEND`,
 or the Azure default. Help and error output rarely say which layer won.

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1005,7 +1005,17 @@ pub enum ShareCommands {
 #[derive(Subcommand)]
 pub enum ConfigCommands {
     /// Show current configuration
-    Show,
+    Show {
+        /// Show the *effective* (resolved) backend/env/vault/RG and the source
+        /// of each (CLI flag / env var / `.xv.toml` profile / global config /
+        /// built-in default).
+        ///
+        /// Use this when `xv` picks a backend you didn't expect — backend
+        /// resolution layers across `--backend`, `.xv.toml`, `XV_BACKEND`, and
+        /// global config, and this flag prints which layer won.
+        #[arg(long)]
+        resolved: bool,
+    },
     /// Set a configuration value
     Set {
         /// Setting name

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -14,8 +14,12 @@ use zeroize::Zeroizing;
 
 pub(crate) async fn execute_config_command(command: ConfigCommands, config: Config) -> Result<()> {
     match command {
-        ConfigCommands::Show => {
-            execute_config_show(&config).await?;
+        ConfigCommands::Show { resolved } => {
+            if resolved {
+                execute_config_show_resolved(&config).await?;
+            } else {
+                execute_config_show(&config).await?;
+            }
         }
         ConfigCommands::Set { key, value } => {
             execute_config_set(&key, &value, config).await?;
@@ -171,6 +175,265 @@ async fn execute_config_show(config: &Config) -> Result<()> {
 async fn execute_config_path() -> Result<()> {
     let config_path = Config::get_config_path()?;
     println!("{}", config_path.display());
+    Ok(())
+}
+
+/// `xv config show --resolved` — prints the effective active backend,
+/// env, vault, and resource group AND the source layer of each value.
+///
+/// Resolution layers (per `config::project::resolve_effective_backend`):
+///   1. `--backend` CLI flag
+///   2. active `.xv.toml` env profile's `backend` field
+///   3. global config `backend` key (or `XV_BACKEND` env var, which loads
+///      into the same field)
+///   4. built-in default (`azure`)
+///
+/// We can't introspect the CLI flag from here (the value already collapsed
+/// into `config.backend` in `main::run`), so we replay the resolution by
+/// looking at the same inputs `main` did:
+///   - `XV_BACKEND` env var (if set, the global config's backend came from
+///     there)
+///   - active `.xv.toml` env profile
+///   - global config file
+async fn execute_config_show_resolved(config: &Config) -> Result<()> {
+    use crate::config::project;
+    use crate::utils::format::format_table;
+    use tabled::{Table, Tabled};
+
+    #[derive(Tabled, serde::Serialize)]
+    struct Row {
+        #[tabled(rename = "Setting")]
+        setting: String,
+        #[tabled(rename = "Value")]
+        value: String,
+        #[tabled(rename = "Source")]
+        source: String,
+    }
+
+    // --- Discover the active .xv.toml (if any) ---
+    let cwd = std::env::current_dir().ok();
+    let project_hit = if let Some(ref c) = cwd {
+        project::find_project_config(c).await.ok().flatten()
+    } else {
+        None
+    };
+
+    // Resolve active env profile (if a .xv.toml was found).
+    let (project_path, active_env_name, active_profile) = match &project_hit {
+        Some((path, cfg)) => match project::resolve_env(cfg, config.env_flag.as_deref()) {
+            Ok((name, profile)) => (
+                Some(path.clone()),
+                Some(name.to_string()),
+                Some(profile.clone()),
+            ),
+            Err(_) => (Some(path.clone()), None, None),
+        },
+        None => (None, None, None),
+    };
+
+    // --- Backend resolution ---
+    // We can't see the original `--backend` flag here, but we CAN see the
+    // post-resolution value in `config.backend` and the inputs that fed
+    // resolve_effective_backend. Walk the precedence ladder ourselves to
+    // attribute the win to the highest source whose value matches.
+    let xv_backend_env = std::env::var("XV_BACKEND").ok();
+    let profile_backend = active_profile
+        .as_ref()
+        .and_then(|p| p.backend.as_deref().map(String::from));
+    let effective_backend = config.effective_backend_name().to_string();
+
+    let backend_source = if let Some(ref pb) = profile_backend {
+        if pb == &effective_backend {
+            format!(
+                ".xv.toml [env.{}] backend",
+                active_env_name.as_deref().unwrap_or("?")
+            )
+        } else {
+            // Profile said one thing, effective is different → only `--backend`
+            // (which outranks profile) can explain that.
+            "--backend flag (overrides .xv.toml profile)".to_string()
+        }
+    } else if let Some(ref env_val) = xv_backend_env {
+        if env_val == &effective_backend {
+            "XV_BACKEND env var".to_string()
+        } else {
+            // XV_BACKEND said one thing, effective is different → --backend
+            // CLI flag overrode it.
+            "--backend flag (overrides XV_BACKEND)".to_string()
+        }
+    } else if config.backend.is_some() {
+        // Came from the on-disk global config OR --backend; we can't
+        // distinguish those two from here without plumbing the CLI value
+        // through. Be honest about the ambiguity.
+        "global config `backend` (or --backend flag)".to_string()
+    } else {
+        "built-in default".to_string()
+    };
+
+    // --- Vault resolution ---
+    // Mirrors Config::resolve_vault_name precedence:
+    //   1. CLI vault arg (not visible here)
+    //   2. .xv.toml profile.vault
+    //   3. ContextManager.current_vault()
+    //   4. config.default_vault
+    let context_manager = crate::config::ContextManager::load()
+        .await
+        .unwrap_or_default();
+
+    let (vault_value, vault_source) =
+        if let Some(v) = active_profile.as_ref().and_then(|p| p.vault.as_deref()) {
+            (
+                v.to_string(),
+                format!(
+                    ".xv.toml [env.{}] vault",
+                    active_env_name.as_deref().unwrap_or("?")
+                ),
+            )
+        } else if let Some(v) = context_manager.current_vault() {
+            (
+                v.to_string(),
+                context_manager.scope_description().to_string(),
+            )
+        } else if !config.default_vault.is_empty() {
+            (
+                config.default_vault.clone(),
+                "global config `default_vault`".to_string(),
+            )
+        } else {
+            ("<unset>".to_string(), "(none)".to_string())
+        };
+
+    // --- Resource group resolution ---
+    let (rg_value, rg_source) = if let Some(rg) = active_profile
+        .as_ref()
+        .and_then(|p| p.resource_group.as_deref())
+    {
+        (
+            rg.to_string(),
+            format!(
+                ".xv.toml [env.{}] resource_group",
+                active_env_name.as_deref().unwrap_or("?")
+            ),
+        )
+    } else if !config.default_resource_group.is_empty() {
+        (
+            config.default_resource_group.clone(),
+            "global config `default_resource_group`".to_string(),
+        )
+    } else {
+        ("<unset>".to_string(), "(none)".to_string())
+    };
+
+    // --- Build the resolution table ---
+    let mut rows: Vec<Row> = Vec::new();
+
+    rows.push(Row {
+        setting: "backend".to_string(),
+        value: effective_backend.clone(),
+        source: backend_source,
+    });
+
+    rows.push(Row {
+        setting: "env".to_string(),
+        value: active_env_name
+            .clone()
+            .unwrap_or_else(|| "(none)".to_string()),
+        source: match (&project_path, &active_env_name) {
+            (Some(p), Some(_)) => match std::env::var("XV_ENV") {
+                Ok(_) => "XV_ENV env var".to_string(),
+                Err(_) => match (config.env_flag.as_deref(), &project_hit) {
+                    (Some(_), _) => "--env CLI flag".to_string(),
+                    (None, Some((_, cfg))) if cfg.default_env.is_some() => {
+                        format!(".xv.toml default_env ({})", p.display())
+                    }
+                    _ => format!(".xv.toml ({})", p.display()),
+                },
+            },
+            (Some(_), None) => "(.xv.toml present but no env resolved)".to_string(),
+            (None, _) => "(no .xv.toml found)".to_string(),
+        },
+    });
+
+    rows.push(Row {
+        setting: "vault".to_string(),
+        value: vault_value,
+        source: vault_source,
+    });
+
+    rows.push(Row {
+        setting: "resource_group".to_string(),
+        value: rg_value,
+        source: rg_source,
+    });
+
+    // Backend-specific extras: region/profile for AWS; storage_account for Azure.
+    if effective_backend == "aws" {
+        let (region_val, region_src) = match std::env::var("AWS_REGION") {
+            Ok(v) if !v.is_empty() => (v, "AWS_REGION env var".to_string()),
+            _ => match std::env::var("AWS_DEFAULT_REGION") {
+                Ok(v) if !v.is_empty() => (v, "AWS_DEFAULT_REGION env var".to_string()),
+                _ => match config.aws.as_ref().and_then(|a| a.region.clone()) {
+                    Some(r) => (r, "global config `aws.region`".to_string()),
+                    None => ("<unset>".to_string(), "(none)".to_string()),
+                },
+            },
+        };
+        rows.push(Row {
+            setting: "aws_region".to_string(),
+            value: region_val,
+            source: region_src,
+        });
+        let (prof_val, prof_src) = match std::env::var("AWS_PROFILE") {
+            Ok(v) if !v.is_empty() => (v, "AWS_PROFILE env var".to_string()),
+            _ => match config.aws.as_ref().and_then(|a| a.profile.clone()) {
+                Some(p) => (p, "global config `aws.profile`".to_string()),
+                None => ("<unset>".to_string(), "(none)".to_string()),
+            },
+        };
+        rows.push(Row {
+            setting: "aws_profile".to_string(),
+            value: prof_val,
+            source: prof_src,
+        });
+    } else if effective_backend == "azure" {
+        let blob = config.get_blob_config();
+        if !blob.storage_account.is_empty() {
+            rows.push(Row {
+                setting: "storage_account".to_string(),
+                value: blob.storage_account,
+                source: "global config `blob.storage_account`".to_string(),
+            });
+        }
+        if !config.subscription_id.is_empty() {
+            rows.push(Row {
+                setting: "subscription_id".to_string(),
+                value: config.subscription_id.clone(),
+                source: "global config `subscription_id`".to_string(),
+            });
+        }
+    }
+
+    if config.output_json {
+        let json = serde_json::to_string_pretty(&rows).map_err(|e| {
+            CrosstacheError::serialization(format!("Failed to serialize resolved config: {e}"))
+        })?;
+        println!("{json}");
+    } else {
+        if let Some(p) = &project_path {
+            println!("Project config: {}", p.display());
+        } else {
+            println!("Project config: (none — no .xv.toml found)");
+        }
+        let table = Table::new(&rows);
+        println!("{}", format_table(table, config.no_color));
+        println!();
+        println!("Precedence (highest → lowest):");
+        println!("  backend         : --backend flag > .xv.toml profile > XV_BACKEND / global config > built-in (azure)");
+        println!("  env             : XV_ENV > --env flag > .xv.toml default_env");
+        println!("  vault           : --vault arg > .xv.toml profile.vault > context > global default_vault");
+        println!("  resource_group  : --resource-group > .xv.toml profile.resource_group > global default_resource_group");
+    }
+
     Ok(())
 }
 

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -401,14 +401,19 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
     });
 
     // Backend-specific extras: region/profile for AWS; storage_account for Azure.
+    //
+    // Resolution order must match `backend::aws::auth::build_client`:
+    //   region:  CLI --region > config aws.region > AWS_REGION > AWS_DEFAULT_REGION
+    //   profile: CLI --profile > config aws.profile > AWS_PROFILE (via SDK chain)
+    // `--resolved` has no CLI flags in scope, so it reports the remaining order.
     if effective_backend == "aws" {
-        let (region_val, region_src) = match std::env::var("AWS_REGION") {
-            Ok(v) if !v.is_empty() => (v, "AWS_REGION env var".to_string()),
-            _ => match std::env::var("AWS_DEFAULT_REGION") {
-                Ok(v) if !v.is_empty() => (v, "AWS_DEFAULT_REGION env var".to_string()),
-                _ => match config.aws.as_ref().and_then(|a| a.region.clone()) {
-                    Some(r) => (r, "global config `aws.region`".to_string()),
-                    None => ("<unset>".to_string(), "(none)".to_string()),
+        let (region_val, region_src) = match config.aws.as_ref().and_then(|a| a.region.clone()) {
+            Some(r) => (r, "global config `aws.region`".to_string()),
+            None => match std::env::var("AWS_REGION") {
+                Ok(v) if !v.is_empty() => (v, "AWS_REGION env var".to_string()),
+                _ => match std::env::var("AWS_DEFAULT_REGION") {
+                    Ok(v) if !v.is_empty() => (v, "AWS_DEFAULT_REGION env var".to_string()),
+                    _ => ("<unset>".to_string(), "(none)".to_string()),
                 },
             },
         };
@@ -417,11 +422,11 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
             value: region_val,
             source: region_src,
         });
-        let (prof_val, prof_src) = match std::env::var("AWS_PROFILE") {
-            Ok(v) if !v.is_empty() => (v, "AWS_PROFILE env var".to_string()),
-            _ => match config.aws.as_ref().and_then(|a| a.profile.clone()) {
-                Some(p) => (p, "global config `aws.profile`".to_string()),
-                None => ("<unset>".to_string(), "(none)".to_string()),
+        let (prof_val, prof_src) = match config.aws.as_ref().and_then(|a| a.profile.clone()) {
+            Some(p) => (p, "global config `aws.profile`".to_string()),
+            None => match std::env::var("AWS_PROFILE") {
+                Ok(v) if !v.is_empty() => (v, "AWS_PROFILE env var".to_string()),
+                _ => ("<unset>".to_string(), "(none)".to_string()),
             },
         };
         rows.push(Row {

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -218,93 +218,122 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
         None
     };
 
-    // Resolve active env profile (if a .xv.toml was found).
-    let (project_path, active_env_name, active_profile) = match &project_hit {
+    // Resolve active env profile (if a .xv.toml was found). Track WHY
+    // resolution failed when it did — Bugbot finding on PR #216 (Medium):
+    // displaying vault/RG values that real commands won't use is worse
+    // than showing nothing.
+    let (project_path, active_env_name, active_profile, env_resolve_err) = match &project_hit {
         Some((path, cfg)) => match project::resolve_env(cfg, config.env_flag.as_deref()) {
             Ok((name, profile)) => (
                 Some(path.clone()),
                 Some(name.to_string()),
                 Some(profile.clone()),
+                None,
             ),
-            Err(_) => (Some(path.clone()), None, None),
+            Err(e) => (Some(path.clone()), None, None, Some(format!("{e}"))),
         },
-        None => (None, None, None),
+        None => (None, None, None, None),
     };
 
     // --- Backend resolution ---
-    // We can't see the original `--backend` flag here, but we CAN see the
-    // post-resolution value in `config.backend` and the inputs that fed
-    // resolve_effective_backend. Walk the precedence ladder ourselves to
-    // attribute the win to the highest source whose value matches.
+    // Precedence per resolve_effective_backend:
+    //   1. --backend CLI flag (if actually on the cmdline)
+    //   2. clap's `env = XV_BACKEND` populates cli.backend (== Some(env_val))
+    //   3. .xv.toml [env.<active>] backend
+    //   4. global config backend (xv.conf on disk)
+    //   5. built-in default "azure"
+    //
+    // Bugbot findings #1/#2 on PR #216: the v1 logic infer-by-string-match
+    // got CLI/env/profile confused when values coincided, and labeled the
+    // built-in default as "global config" because main.rs always overwrites
+    // `config.backend` with the resolved value. Fix by reading the original
+    // sources (cli_backend, cli_backend_was_arg, disk_backend) stashed in
+    // main.rs BEFORE the overwrite, plus XV_BACKEND directly.
     let xv_backend_env = std::env::var("XV_BACKEND").ok();
     let profile_backend = active_profile
         .as_ref()
         .and_then(|p| p.backend.as_deref().map(String::from));
     let effective_backend = config.effective_backend_name().to_string();
 
-    let backend_source = if let Some(ref pb) = profile_backend {
+    let backend_source = if config.cli_backend_was_arg && config.cli_backend.is_some() {
+        // --backend was explicitly passed; it wins over everything below.
+        "--backend CLI flag".to_string()
+    } else if let Some(ref pb) = profile_backend {
+        // Profile is next in precedence (it outranks env + global config).
         if pb == &effective_backend {
             format!(
                 ".xv.toml [env.{}] backend",
                 active_env_name.as_deref().unwrap_or("?")
             )
         } else {
-            // Profile said one thing, effective is different → only `--backend`
-            // (which outranks profile) can explain that.
-            "--backend flag (overrides .xv.toml profile)".to_string()
+            // Shouldn't happen — profile is set but effective differs and
+            // no CLI override fired. Be honest.
+            format!("<unexpected: profile={pb} effective={effective_backend}>")
         }
     } else if let Some(ref env_val) = xv_backend_env {
         if env_val == &effective_backend {
             "XV_BACKEND env var".to_string()
         } else {
-            // XV_BACKEND said one thing, effective is different → --backend
-            // CLI flag overrode it.
-            "--backend flag (overrides XV_BACKEND)".to_string()
+            format!("<unexpected: XV_BACKEND={env_val} effective={effective_backend}>")
         }
-    } else if config.backend.is_some() {
-        // Came from the on-disk global config OR --backend; we can't
-        // distinguish those two from here without plumbing the CLI value
-        // through. Be honest about the ambiguity.
-        "global config `backend` (or --backend flag)".to_string()
+    } else if let Some(ref dv) = config.disk_backend {
+        // No CLI, no profile, no env — value came from the on-disk config.
+        if dv == &effective_backend {
+            "global config `backend`".to_string()
+        } else {
+            format!("<unexpected: disk={dv} effective={effective_backend}>")
+        }
     } else {
+        // No source set anything — falling back to built-in default.
         "built-in default".to_string()
     };
 
-    // --- Vault resolution ---
-    // Mirrors Config::resolve_vault_name precedence:
-    //   1. CLI vault arg (not visible here)
-    //   2. .xv.toml profile.vault
-    //   3. ContextManager.current_vault()
-    //   4. config.default_vault
+    // --- Vault & resource_group resolution ---
+    // Bugbot finding #4 on PR #216: if .xv.toml exists but resolve_env
+    // failed (unknown XV_ENV / --env), real commands error out via
+    // `resolve_vault_name`. Showing the global-config or context fallback
+    // here misrepresents what `xv list` would actually use. Surface the
+    // env error instead.
     let context_manager = crate::config::ContextManager::load()
         .await
         .unwrap_or_default();
 
-    let (vault_value, vault_source) =
-        if let Some(v) = active_profile.as_ref().and_then(|p| p.vault.as_deref()) {
-            (
-                v.to_string(),
-                format!(
-                    ".xv.toml [env.{}] vault",
-                    active_env_name.as_deref().unwrap_or("?")
-                ),
-            )
-        } else if let Some(v) = context_manager.current_vault() {
-            (
-                v.to_string(),
-                context_manager.scope_description().to_string(),
-            )
-        } else if !config.default_vault.is_empty() {
-            (
-                config.default_vault.clone(),
-                "global config `default_vault`".to_string(),
-            )
-        } else {
-            ("<unset>".to_string(), "(none)".to_string())
-        };
+    let (vault_value, vault_source) = if let Some(ref err) = env_resolve_err {
+        (
+            "<error>".to_string(),
+            format!("env resolution failed: {err}"),
+        )
+    } else if let Some(v) = active_profile.as_ref().and_then(|p| p.vault.as_deref()) {
+        (
+            v.to_string(),
+            format!(
+                ".xv.toml [env.{}] vault",
+                active_env_name.as_deref().unwrap_or("?")
+            ),
+        )
+    } else if let Some(v) = context_manager.current_vault() {
+        (
+            v.to_string(),
+            context_manager.scope_description().to_string(),
+        )
+    } else if !config.default_vault.is_empty() {
+        (
+            config.default_vault.clone(),
+            "global config `default_vault`".to_string(),
+        )
+    } else {
+        ("<unset>".to_string(), "(none)".to_string())
+    };
 
-    // --- Resource group resolution ---
-    let (rg_value, rg_source) = if let Some(rg) = active_profile
+    // Bugbot finding #3 on PR #216: real `Config::resolve_resource_group`
+    // precedence is .xv.toml → context → global config. The display
+    // previously skipped the context layer. Mirror the real resolver.
+    let (rg_value, rg_source) = if env_resolve_err.is_some() {
+        (
+            "<error>".to_string(),
+            "env resolution failed (see vault row)".to_string(),
+        )
+    } else if let Some(rg) = active_profile
         .as_ref()
         .and_then(|p| p.resource_group.as_deref())
     {
@@ -314,6 +343,11 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
                 ".xv.toml [env.{}] resource_group",
                 active_env_name.as_deref().unwrap_or("?")
             ),
+        )
+    } else if let Some(rg) = context_manager.current_resource_group() {
+        (
+            rg.to_string(),
+            context_manager.scope_description().to_string(),
         )
     } else if !config.default_resource_group.is_empty() {
         (

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -236,6 +236,9 @@ impl ConfigInitializer {
             clipboard_timeout: 30,
             gen_default_charset: None,
             env_flag: None,
+            cli_backend: None,
+            cli_backend_was_arg: false,
+            disk_backend: None,
         };
 
         self.save_config(&config).await?;
@@ -304,6 +307,9 @@ impl ConfigInitializer {
             clipboard_timeout: 30,
             gen_default_charset: None,
             env_flag: None,
+            cli_backend: None,
+            cli_backend_was_arg: false,
+            disk_backend: None,
         };
 
         self.save_config(&config).await?;
@@ -1060,6 +1066,9 @@ impl ConfigInitializer {
             clipboard_timeout: 30,
             gen_default_charset: None,
             env_flag: None,
+            cli_backend: None,
+            cli_backend_was_arg: false,
+            disk_backend: None,
         })
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -217,6 +217,36 @@ pub struct Config {
     #[serde(skip)]
     #[tabled(skip)]
     pub env_flag: Option<String>,
+
+    /// Original `--backend` CLI flag value, BEFORE `resolve_effective_backend`
+    /// collapses every layer into `self.backend`. Set once in main.rs from
+    /// `cli.backend.clone()`. Used only by `xv config show --resolved` to
+    /// attribute the winning layer correctly when CLI/profile/env values
+    /// happen to coincide.
+    ///
+    /// Note: clap auto-populates `cli.backend` from `XV_BACKEND` too, so this
+    /// alone cannot distinguish CLI from env var — `cli_backend_was_arg`
+    /// is required for that.
+    #[serde(skip)]
+    #[tabled(skip)]
+    pub cli_backend: Option<String>,
+
+    /// `true` when `--backend` was passed on the command line (vs. populated
+    /// from `XV_BACKEND` via clap's `env = ...`). Set in main.rs by checking
+    /// `std::env::args_os()`. Lets `--resolved` distinguish "won by CLI flag"
+    /// from "won by env var" even when both supply the same string.
+    #[serde(skip)]
+    #[tabled(skip)]
+    pub cli_backend_was_arg: bool,
+
+    /// Backend value loaded from the on-disk global config (`xv.conf`), BEFORE
+    /// main.rs overwrites `self.backend` with the resolved value. Set once
+    /// in main.rs by snapshotting `config.backend` immediately after
+    /// `Config::load_or_create`. Used only by `xv config show --resolved`
+    /// to detect the "no source set anything → built-in default" case.
+    #[serde(skip)]
+    #[tabled(skip)]
+    pub disk_backend: Option<String>,
 }
 
 fn default_clipboard_timeout() -> u64 {
@@ -255,6 +285,9 @@ impl Default for Config {
             clipboard_timeout: default_clipboard_timeout(),
             gen_default_charset: None,
             env_flag: None,
+            cli_backend: None,
+            cli_backend_was_arg: false,
+            disk_backend: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,16 @@ async fn run(cli: Cli) -> Result<()> {
         None
     };
 
+    // Snapshot the on-disk backend value BEFORE resolution overwrites it, plus
+    // the original CLI flag and whether `--backend` was actually passed
+    // (vs. populated by clap from XV_BACKEND via `env = "XV_BACKEND"`).
+    // `xv config show --resolved` reads these to attribute precedence
+    // correctly when values across layers coincide.
+    config.disk_backend = config.backend.clone();
+    config.cli_backend = cli.backend.clone();
+    config.cli_backend_was_arg = std::env::args_os()
+        .any(|a| a == "--backend" || a.to_string_lossy().starts_with("--backend="));
+
     config.backend = Some(
         crate::config::project::resolve_effective_backend(
             cli.backend.as_deref(),


### PR DESCRIPTION
## Summary

Resolves docs/UX-REVIEW.md §P1-3 / §3 — *Backend selection is split across global config, .xv.toml, env vars, and flags with no diagnostic.*

Backend resolution layers across four sources (`--backend` flag, active `.xv.toml` env profile, `XV_BACKEND` env var, global config) and previously there was no way to see which one won. This is the single highest-friction point in the Azure↔AWS switching workflow.

## Changes

- Add `--resolved` flag to `xv config show`.
- Output prints the **effective** backend, active env, vault, and resource group, with the **source** of each value (CLI flag / env var / `.xv.toml` profile / global config / built-in default).
- Backend-specific extras: `aws_region` + `aws_profile` for AWS; `storage_account` + `subscription_id` for Azure.
- Output respects `--format json`.
- A short precedence cheat-sheet is printed beneath the table so users can confirm "is this what I expected?" without rereading docs.

## Example

```
$ XV_BACKEND=local xv config show --resolved
Project config: (none — no .xv.toml found)
╭────────────────┬────────────────┬────────────────────────────────────────╮
│    Setting     │     Value      │                 Source                 │
├────────────────┼────────────────┼────────────────────────────────────────┤
│ backend        │ local          │ XV_BACKEND env var                     │
│ env            │ (none)         │ (no .xv.toml found)                    │
│ vault          │ kv-scottzionic │ Global                                 │
│ resource_group │ Vaults         │ global config `default_resource_group` │
╰────────────────┴────────────────┴────────────────────────────────────────╯

Precedence (highest → lowest):
  backend         : --backend flag > .xv.toml profile > XV_BACKEND / global config > built-in (azure)
  ...
```

## Docs & roadmap

- Removed the "Backend selection diagnostics" P1 item from `ROADMAP.md`.
- Added a *Resolved in v0.11.0* banner to `docs/UX-REVIEW.md §3`.

## Verification

- `cargo build` + `cargo build --features aws` — clean.
- `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --lib` — only the two known non-hermetic context-fallback tests fail (documented in autopilot brief).
- Manual smoke: default backend, `XV_BACKEND=local`, and JSON output all behave as expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new config-resolution reporting that depends on correctly mirroring precedence across CLI/env/project/global layers; mistakes could mislead users during backend/env selection but does not change the actual resolution logic used for commands.
> 
> **Overview**
> Adds `xv config show --resolved` to print the **effective** backend/env/vault/resource group along with the **source layer** that provided each value (CLI flag, env var, `.xv.toml` profile, global config, or built-in default), with optional backend-specific extras for AWS (`aws_region`, `aws_profile`) and Azure (`storage_account`, `subscription_id`).
> 
> To make attribution accurate when values coincide, `main.rs` now snapshots the pre-resolution backend inputs (`cli_backend`, whether `--backend` was explicitly passed, and the on-disk `disk_backend`) into new non-serialized `Config` fields; `config show --resolved` uses these plus env/profile/context lookups and emits an error row when project env resolution fails. Docs are updated to mark the UX review item as resolved and the roadmap item removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 075a62e3d5bca8849b723d0d15e5c0c9be9035c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->