### PR TITLE
feat: backend-aware xv context init for AWS/local profiles

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,12 +25,6 @@ new feature work in this lane — only blockers found during rc soak.
 
 ## Near-term (v0.11.x)
 
-### P1 — `xv context init` cannot create AWS or local profiles
-Source: `docs/UX-REVIEW.md` §P1-4. Wizard is still Azure-only despite AWS
-being shipped. Add backend selection to the init flow.
-
----
-
 ## Security hardening
 
 Sourced from `docs/code-review-gpt55.md` (GPT-5.5 code review, 2026-05-09).

--- a/docs/UX-REVIEW.md
+++ b/docs/UX-REVIEW.md
@@ -263,6 +263,8 @@ each value. Also include `backend=<value>` in `context envs` output.
 
 ### 4. `xv context init` cannot create an AWS or local env profile
 
+> **Resolved in v0.11.0** (PR fix/context-init-backend-selection) — `xv context init` now accepts `--backend` (azure/aws/local), writes backend-aware env profiles, and only requires `--resource-group` for Azure.
+
 Problem: `xv context init` is the documented project-config onboarding command,
 but it only accepts env, vault, and resource group. There is no `--backend`,
 `--region`, `--aws-profile`, or AWS prefix/default-vault option for the env it

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1083,7 +1083,8 @@ pub enum ContextCommands {
         /// Resource group for the env (skips interactive prompt if provided)
         #[arg(long)]
         resource_group: Option<String>,
-        /// Backend for the env (azure | aws | local). Defaults to azure.
+        /// Backend for the env (azure | aws | local). When omitted, uses the
+        /// global config backend for prompts and is not written to `.xv.toml`.
         #[arg(long)]
         backend: Option<String>,
         /// Skip prompts entirely; require --vault and --resource-group for azure

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1083,7 +1083,10 @@ pub enum ContextCommands {
         /// Resource group for the env (skips interactive prompt if provided)
         #[arg(long)]
         resource_group: Option<String>,
-        /// Skip prompts entirely; require --vault and --resource-group
+        /// Backend for the env (azure | aws | local). Defaults to azure.
+        #[arg(long)]
+        backend: Option<String>,
+        /// Skip prompts entirely; require --vault and --resource-group for azure
         #[arg(long)]
         non_interactive: bool,
         /// Overwrite an existing .xv.toml

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -758,11 +758,20 @@ pub(crate) async fn execute_context_command(
             env,
             vault,
             resource_group,
+            backend,
             non_interactive,
             force,
         } => {
-            execute_context_init(env, vault, resource_group, non_interactive, force, &config)
-                .await?;
+            execute_context_init(
+                env,
+                vault,
+                resource_group,
+                backend,
+                non_interactive,
+                force,
+                &config,
+            )
+            .await?;
         }
     }
     Ok(())
@@ -1005,6 +1014,7 @@ async fn execute_context_init(
     env_name: String,
     vault_arg: Option<String>,
     rg_arg: Option<String>,
+    backend_arg: Option<String>,
     non_interactive: bool,
     force: bool,
     config: &Config,
@@ -1022,14 +1032,31 @@ async fn execute_context_init(
         )));
     }
 
-    // Resolve vault/RG: explicit flag → interactive prompt → config default
+    let backend = backend_arg.unwrap_or_else(|| "azure".to_string());
+    let backend = match backend.as_str() {
+        "azure" | "aws" | "local" => backend,
+        other => {
+            return Err(CrosstacheError::invalid_argument(format!(
+                "invalid backend '{other}' (expected: azure | aws | local)"
+            )));
+        }
+    };
+
+    // Resolve vault/RG: explicit flag → interactive prompt → config default.
+    // Azure requires resource_group; aws/local do not.
     let (vault, resource_group) = if non_interactive {
         let vault = vault_arg.ok_or_else(|| {
             CrosstacheError::invalid_argument("--non-interactive requires --vault")
         })?;
-        let rg = rg_arg.ok_or_else(|| {
-            CrosstacheError::invalid_argument("--non-interactive requires --resource-group")
-        })?;
+        let rg = if backend == "azure" {
+            Some(rg_arg.ok_or_else(|| {
+                CrosstacheError::invalid_argument(
+                    "--non-interactive requires --resource-group when --backend azure",
+                )
+            })?)
+        } else {
+            rg_arg
+        };
         (vault, rg)
     } else {
         use crate::utils::interactive::InteractivePrompt;
@@ -1046,15 +1073,16 @@ async fn execute_context_init(
             )?,
         };
         let rg = match rg_arg {
-            Some(r) => r,
-            None => prompt.input_text(
+            Some(r) => Some(r),
+            None if backend == "azure" => Some(prompt.input_text(
                 &format!("Resource group for env '{env_name}'"),
                 if !config.default_resource_group.is_empty() {
                     Some(config.default_resource_group.as_str())
                 } else {
                     None
                 },
-            )?,
+            )?),
+            None => None,
         };
         (vault, rg)
     };
@@ -1064,10 +1092,10 @@ async fn execute_context_init(
         env_name.clone(),
         EnvProfile {
             vault: Some(vault),
-            resource_group: Some(resource_group),
+            resource_group,
             group: None,
             folder: None,
-            backend: None,
+            backend: Some(backend),
         },
     );
 

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -1032,15 +1032,20 @@ async fn execute_context_init(
         )));
     }
 
-    let backend = backend_arg.unwrap_or_else(|| "azure".to_string());
-    let backend = match backend.as_str() {
-        "azure" | "aws" | "local" => backend,
-        other => {
-            return Err(CrosstacheError::invalid_argument(format!(
-                "invalid backend '{other}' (expected: azure | aws | local)"
-            )));
-        }
+    use crate::config::project::validate_env_profile_backend;
+
+    let profile_backend = if let Some(ref b) = backend_arg {
+        validate_env_profile_backend(b)?;
+        Some(b.as_str())
+    } else {
+        None
     };
+
+    // Effective backend for prompts/validation: explicit --backend, else the
+    // already-resolved global backend (xv.conf / XV_BACKEND / top-level --backend).
+    // Only write a profile backend when --backend was passed — unset inherits
+    // via resolve_effective_backend at runtime.
+    let effective_backend = profile_backend.unwrap_or_else(|| config.effective_backend_name());
 
     // Resolve vault/RG: explicit flag → interactive prompt → config default.
     // Azure requires resource_group; aws/local do not.
@@ -1048,7 +1053,7 @@ async fn execute_context_init(
         let vault = vault_arg.ok_or_else(|| {
             CrosstacheError::invalid_argument("--non-interactive requires --vault")
         })?;
-        let rg = if backend == "azure" {
+        let rg = if effective_backend == "azure" {
             Some(rg_arg.ok_or_else(|| {
                 CrosstacheError::invalid_argument(
                     "--non-interactive requires --resource-group when --backend azure",
@@ -1074,7 +1079,7 @@ async fn execute_context_init(
         };
         let rg = match rg_arg {
             Some(r) => Some(r),
-            None if backend == "azure" => Some(prompt.input_text(
+            None if effective_backend == "azure" => Some(prompt.input_text(
                 &format!("Resource group for env '{env_name}'"),
                 if !config.default_resource_group.is_empty() {
                     Some(config.default_resource_group.as_str())
@@ -1095,7 +1100,7 @@ async fn execute_context_init(
             resource_group,
             group: None,
             folder: None,
-            backend: Some(backend),
+            backend: profile_backend.map(String::from),
         },
     );
 

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -8,6 +8,38 @@ use common::{parse_json_envelope, stderr_str, stdout_str, write_xv_toml, xv_isol
 const FAKE_SUB: &str = "00000000-0000-0000-0000-000000000001";
 const FAKE_TENANT: &str = "00000000-0000-0000-0000-000000000002";
 
+/// Write a minimal global `xv.conf` with `backend = "local"` for isolated tests.
+fn write_local_global_config(temp: &std::path::Path) {
+    let xv_dir = temp.join(".config/xv");
+    std::fs::create_dir_all(&xv_dir).expect("config dir");
+    let store = temp.join("local-store");
+    let key = temp.join("local-key.txt");
+    std::fs::create_dir_all(&store).expect("store dir");
+    let content = format!(
+        r#"backend = "local"
+debug = false
+subscription_id = "{FAKE_SUB}"
+tenant_id = "{FAKE_TENANT}"
+default_vault = "default"
+default_resource_group = ""
+default_location = ""
+output_json = false
+no_color = true
+cache_enabled = false
+cache_ttl_secs = 0
+clipboard_timeout = 0
+
+[local]
+store_path = "{store}"
+key_file = "{key}"
+default_vault = "default"
+"#,
+        store = store.display(),
+        key = key.display(),
+    );
+    std::fs::write(xv_dir.join("xv.conf"), content).expect("write xv.conf");
+}
+
 #[test]
 fn context_init_non_interactive_writes_xv_toml() {
     let (mut cmd, temp) = xv_isolated();
@@ -32,10 +64,42 @@ fn context_init_non_interactive_writes_xv_toml() {
     assert!(content.contains("default_env = \"dev\""));
     assert!(content.contains("vault = \"myvault\""));
     assert!(content.contains("resource_group = \"myrg\""));
-    assert!(content.contains("backend = \"azure\""));
+    assert!(
+        !content.contains("backend ="),
+        "omit profile backend when --backend not passed: {content}"
+    );
 }
 
 #[test]
+fn context_init_non_interactive_inherits_global_backend_without_writing_profile_backend() {
+    let (mut cmd, temp) = xv_isolated();
+    write_local_global_config(temp.path());
+    let out = cmd
+        .env("AZURE_SUBSCRIPTION_ID", FAKE_SUB)
+        .env("AZURE_TENANT_ID", FAKE_TENANT)
+        .args([
+            "context",
+            "init",
+            "--non-interactive",
+            "--vault",
+            "prod-prefix",
+        ])
+        .output()
+        .expect("spawn");
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr_str(&out));
+    let content = std::fs::read_to_string(temp.path().join(".xv.toml")).unwrap();
+    assert!(
+        !content.contains("backend ="),
+        "profile should inherit global backend: {content}"
+    );
+    assert!(
+        !content.contains("resource_group ="),
+        "local backend should not require resource_group: {content}"
+    );
+}
+
+#[test]
+#[cfg(feature = "aws")]
 fn context_init_non_interactive_aws_does_not_require_resource_group() {
     let (mut cmd, temp) = xv_isolated();
     let out = cmd

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -32,6 +32,55 @@ fn context_init_non_interactive_writes_xv_toml() {
     assert!(content.contains("default_env = \"dev\""));
     assert!(content.contains("vault = \"myvault\""));
     assert!(content.contains("resource_group = \"myrg\""));
+    assert!(content.contains("backend = \"azure\""));
+}
+
+#[test]
+fn context_init_non_interactive_aws_does_not_require_resource_group() {
+    let (mut cmd, temp) = xv_isolated();
+    let out = cmd
+        .env("AZURE_SUBSCRIPTION_ID", FAKE_SUB)
+        .env("AZURE_TENANT_ID", FAKE_TENANT)
+        .args([
+            "context",
+            "init",
+            "--non-interactive",
+            "--backend",
+            "aws",
+            "--vault",
+            "prod-prefix",
+        ])
+        .output()
+        .expect("spawn");
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr_str(&out));
+    let content = std::fs::read_to_string(temp.path().join(".xv.toml")).unwrap();
+    assert!(content.contains("backend = \"aws\""), ".xv.toml: {content}");
+    assert!(!content.contains("resource_group ="), ".xv.toml: {content}");
+}
+
+#[test]
+fn context_init_non_interactive_azure_requires_resource_group() {
+    let (mut cmd, _temp) = xv_isolated();
+    let out = cmd
+        .env("AZURE_SUBSCRIPTION_ID", FAKE_SUB)
+        .env("AZURE_TENANT_ID", FAKE_TENANT)
+        .args([
+            "context",
+            "init",
+            "--non-interactive",
+            "--backend",
+            "azure",
+            "--vault",
+            "myvault",
+        ])
+        .output()
+        .expect("spawn");
+    assert_eq!(out.status.code(), Some(2), "stderr: {}", stderr_str(&out));
+    assert!(
+        stderr_str(&out).contains("--resource-group"),
+        "stderr: {}",
+        stderr_str(&out)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `--backend` to `xv context init` (`azure|aws|local`, default `azure`)
- make `context init` write backend-aware env profiles into `.xv.toml`
- require `--resource-group` only for Azure init flows; allow AWS/local without it
- add coverage for AWS non-interactive init and Azure RG requirement
- remove completed Near-term P1 item from `ROADMAP.md`
- annotate `docs/UX-REVIEW.md` §P1-4 with a resolved banner

## Verification
- `cargo build`
- `cargo build --features aws`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib` (after temporary move/restore of `~/.config/xv/context`, per known non-hermetic test note)

Resolves docs/UX-REVIEW.md §P1-4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes `.xv.toml` output semantics for init (fewer persisted fields); behavior is covered by integration tests and aligns with existing backend resolution.
> 
> **Overview**
> **`xv context init`** no longer hard-codes **`azure`** in new `.xv.toml` profiles. Omitting **`--backend`** uses the **resolved global backend** (`xv.conf`, `XV_BACKEND`, etc.) for prompts and validation, and **does not** write a profile `backend` key—runtime inheritance via **`resolve_effective_backend`** applies instead.
> 
> When **`--backend`** is passed, values are validated with **`validate_env_profile_backend`**, persisted on the env profile, and **`--resource-group`** is still required only for **azure** in non-interactive mode. Help text documents this behavior.
> 
> Tests add a **local** global-config fixture and assert profiles **omit** `backend` (and **`resource_group`** for local) unless flags are set; explicit **`--backend aws`** still writes **`backend = "aws"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 362ae5260ada329e7c6d0a3dcfa5f945e81835c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->