### PR TITLE
docs: mark minisign signature verification as resolved

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,13 +36,8 @@ fixing as code drifts.
 > **Resolved in v0.11.0** (PR `fix/p1-local-transactional-secret-writes`) — local secret set/update now stage encrypted payload + metadata to temp files, atomically activate them, then archive the prior version snapshot to prevent archive-then-write data loss on write failure.
 >
 > **Resolved in v0.11.0** (PR `fix/p1-symlink-following-writes`) — `write_private()` and `encrypt_to_file()` now use `O_NOFOLLOW` on Unix to refuse symlink following on sensitive writes. Unit tests verify rejection.
-
-### P1 — `xv upgrade` signature verification
-Source: `docs/superpowers/specs/2026-05-04-upgrade-signature-verification.md`.
-Binary + checksum currently come from the same GitHub Releases endpoint
-(integrity, not authenticity). Embed a minisign public key, sign release
-archives in CI, verify before swap. Spec is design-approved but
-implementation has not landed.
+>
+> **Resolved in v0.11.0** (PR `docs/p1-upgrade-signature-verification-resolved`) — `xv upgrade` now verifies minisign signatures on release archives before installation. Public key embedded in binary; CI signs all releases. Full design in `docs/superpowers/specs/2026-05-04-upgrade-signature-verification.md`.
 
 ### P2 — Local file metadata uses world-readable defaults
 `src/backend/local/files.rs:57`. Switch to `write_private`; assert

--- a/docs/superpowers/specs/2026-05-04-upgrade-signature-verification.md
+++ b/docs/superpowers/specs/2026-05-04-upgrade-signature-verification.md
@@ -1,7 +1,7 @@
 # `xv upgrade` Signature Verification Design
 
-> **Status:** 🟡 Proposed (not yet implemented as of v0.10.0-rc.2) | **Date:** 2026-05-04 | **Author:** Hermes + Scott
-> Tracked in `ROADMAP.md` → "Security hardening".
+> **Status:** ✅ Implemented in **v0.11.0** (2026-05-24). Retained as design history. | **Date:** 2026-05-04 | **Author:** Hermes + Scott
+> Originally tracked in `ROADMAP.md` → "Security hardening".
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the ROADMAP tracking for the P1 upgrade signature verification feature, which is already fully implemented but was still marked as "Proposed" in the spec.

## What's Already Implemented

- ✅ `minisign-verify` dependency added (`Cargo.toml`)
- ✅ Public key embedded in `src/cli/upgrade_ops.rs` (`RELEASE_SIGNING_KEY`)
- ✅ `verify_signature()` function implemented and wired into upgrade flow
- ✅ CI workflow (`.github/workflows/release.yml`) signs all releases with minisign
- ✅ README documents the verification process for users

## Changes in This PR

**Docs only — no code changes:**

1. Updated `docs/superpowers/specs/2026-05-04-upgrade-signature-verification.md` status banner:
   - From: 🟡 Proposed (not yet implemented)
   - To: ✅ Implemented in v0.11.0
2. Removed the P1 item from `ROADMAP.md` and added a "Resolved" banner

## Design Reference

Full design and rationale documented in:
`docs/superpowers/specs/2026-05-04-upgrade-signature-verification.md`

The three-phase implementation plan from the spec (add dep + verify, wire CI, make mandatory) has been completed. Signature verification is now active on all `xv upgrade` operations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No code or release pipeline changes—only ROADMAP and spec status text.
> 
> **Overview**
> **Documentation-only** update to align tracking with shipped behavior: minisign verification for `xv upgrade` is no longer listed as open work.
> 
> `ROADMAP.md` drops the **P1 — `xv upgrade` signature verification** bullet and adds a **Resolved in v0.11.0** note (PR `docs/p1-upgrade-signature-verification-resolved`) stating that upgrades verify minisign signatures before install, with the public key in the binary and CI signing releases.
> 
> The design spec `docs/superpowers/specs/2026-05-04-upgrade-signature-verification.md` banner changes from **Proposed (not yet implemented)** to **Implemented in v0.11.0**, kept as design history with a pointer to the original ROADMAP section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da65c970b15e60ce7af3bd81fb7ae0bdfdb05478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->