### PR TITLE
fix(security): blob download traversal guard + multi-download collision check (P2)

### DIFF
--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -422,11 +422,26 @@ async fn execute_file_download(
     config: &Config,
 ) -> Result<()> {
     use crate::blob::models::FileDownloadRequest;
+    use crate::utils::helpers::safe_join;
     use std::fs;
     use std::path::Path;
 
-    // Determine output path
-    let output_path = output.unwrap_or_else(|| name.to_string());
+    // Determine output path with traversal guard.
+    // When --output is an existing directory, place the file inside it.
+    // When --output is an explicit file path (caller-resolved), use it directly.
+    // When --output is omitted, derive from blob name anchored at CWD.
+    let output_path: String = match output {
+        Some(ref p) if Path::new(p).is_dir() => {
+            safe_join(Path::new(p), name).map(|pb| pb.to_string_lossy().into_owned())?
+        }
+        Some(p) => p,
+        None => {
+            let cwd = std::env::current_dir().map_err(|e| {
+                CrosstacheError::config(format!("Cannot determine current directory: {e}"))
+            })?;
+            safe_join(&cwd, name).map(|pb| pb.to_string_lossy().into_owned())?
+        }
+    };
 
     // Check if file exists and handle force flag
     if Path::new(&output_path).exists() && !force {
@@ -1146,6 +1161,35 @@ async fn execute_file_upload_multiple(
     Ok(())
 }
 
+/// Resolve the output directory for a multi-file download.
+///
+/// Returns an error if `output` names an existing non-directory path (which would
+/// cause every file to clobber the same destination). Creates the directory if it
+/// doesn't exist yet.
+fn resolve_multi_download_dir(output: Option<&str>) -> Result<PathBuf> {
+    use std::fs;
+    use std::path::Path;
+    match output {
+        Some(p) => {
+            let path = Path::new(p);
+            if path.exists() && !path.is_dir() {
+                return Err(CrosstacheError::invalid_argument(format!(
+                    "--output '{p}' must be a directory when downloading multiple files"
+                )));
+            }
+            if !path.exists() {
+                fs::create_dir_all(path).map_err(|e| {
+                    CrosstacheError::config(format!("Failed to create output directory '{p}': {e}"))
+                })?;
+            }
+            Ok(path.to_path_buf())
+        }
+        None => std::env::current_dir().map_err(|e| {
+            CrosstacheError::config(format!("Cannot determine current directory: {e}"))
+        }),
+    }
+}
+
 async fn execute_file_download_multiple(
     blob_manager: &BlobManager,
     files: Vec<String>,
@@ -1154,13 +1198,44 @@ async fn execute_file_download_multiple(
     continue_on_error: bool,
     config: &Config,
 ) -> Result<()> {
+    use crate::utils::helpers::safe_join;
+
+    let output_dir = resolve_multi_download_dir(output.as_deref())?;
+
     println!("Downloading {} file(s)...", files.len());
 
     let mut success_count = 0;
     let mut error_count = 0;
 
     for file_name in files {
-        match execute_file_download(blob_manager, &file_name, output.clone(), force, config).await {
+        // Compute a unique per-file output path via traversal guard.
+        let per_file_output = match safe_join(&output_dir, &file_name) {
+            Ok(p) => p.to_string_lossy().into_owned(),
+            Err(e) => {
+                eprintln!(
+                    "  {}",
+                    output::format_line(
+                        output::Level::Error,
+                        &format!("{file_name}: {e}"),
+                        output::should_use_rich_stderr(),
+                    )
+                );
+                error_count += 1;
+                if !continue_on_error {
+                    return Err(e);
+                }
+                continue;
+            }
+        };
+        match execute_file_download(
+            blob_manager,
+            &file_name,
+            Some(per_file_output),
+            force,
+            config,
+        )
+        .await
+        {
             Ok(_) => {
                 println!(
                     "  {}",
@@ -2231,6 +2306,72 @@ pub(crate) async fn execute_file_upload_quick(
         config,
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- safe_join integration: traversal and absolute-path rejection ---
+
+    #[test]
+    fn test_single_file_rejects_traversal() {
+        let base = std::path::Path::new("/tmp/base");
+        let err = crate::utils::helpers::safe_join(base, "../escape.txt").unwrap_err();
+        assert!(
+            err.to_string().contains(".."),
+            "error should mention '..': {err}"
+        );
+    }
+
+    #[test]
+    fn test_single_file_rejects_absolute_path() {
+        let base = std::path::Path::new("/tmp/base");
+        let err = crate::utils::helpers::safe_join(base, "/etc/passwd").unwrap_err();
+        assert!(
+            err.to_string().contains("absolute"),
+            "error should mention 'absolute': {err}"
+        );
+    }
+
+    #[test]
+    fn test_single_file_normal_name_resolves_under_base() {
+        let base = std::path::Path::new("/tmp/base");
+        let result = crate::utils::helpers::safe_join(base, "docs/readme.md").unwrap();
+        assert_eq!(result, std::path::Path::new("/tmp/base/docs/readme.md"));
+    }
+
+    // --- resolve_multi_download_dir: directory validation ---
+
+    #[test]
+    fn test_multi_download_rejects_file_as_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("notadir.txt");
+        std::fs::write(&file_path, b"data").unwrap();
+
+        let err = resolve_multi_download_dir(Some(file_path.to_str().unwrap())).unwrap_err();
+        assert!(
+            err.to_string().contains("must be a directory"),
+            "error should say 'must be a directory': {err}"
+        );
+    }
+
+    #[test]
+    fn test_multi_download_creates_and_returns_dir() {
+        let parent = tempfile::tempdir().unwrap();
+        let new_dir = parent.path().join("downloads");
+
+        assert!(!new_dir.exists());
+        let result = resolve_multi_download_dir(Some(new_dir.to_str().unwrap())).unwrap();
+        assert!(result.exists() && result.is_dir());
+    }
+
+    #[test]
+    fn test_multi_download_uses_existing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = resolve_multi_download_dir(Some(dir.path().to_str().unwrap())).unwrap();
+        assert_eq!(result, dir.path());
+    }
 }
 
 /// Quick file download command (alias for file download)

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -422,26 +422,10 @@ async fn execute_file_download(
     config: &Config,
 ) -> Result<()> {
     use crate::blob::models::FileDownloadRequest;
-    use crate::utils::helpers::safe_join;
     use std::fs;
     use std::path::Path;
 
-    // Determine output path with traversal guard.
-    // When --output is an existing directory, place the file inside it.
-    // When --output is an explicit file path (caller-resolved), use it directly.
-    // When --output is omitted, derive from blob name anchored at CWD.
-    let output_path: String = match output {
-        Some(ref p) if Path::new(p).is_dir() => {
-            safe_join(Path::new(p), name).map(|pb| pb.to_string_lossy().into_owned())?
-        }
-        Some(p) => p,
-        None => {
-            let cwd = std::env::current_dir().map_err(|e| {
-                CrosstacheError::config(format!("Cannot determine current directory: {e}"))
-            })?;
-            safe_join(&cwd, name).map(|pb| pb.to_string_lossy().into_owned())?
-        }
-    };
+    let output_path = resolve_single_download_path(name, output.as_deref())?;
 
     // Check if file exists and handle force flag
     if Path::new(&output_path).exists() && !force {
@@ -491,6 +475,27 @@ async fn execute_file_download(
     output::success(&format!("Successfully downloaded file '{name}'"));
 
     Ok(())
+}
+
+fn resolve_single_download_path(name: &str, output: Option<&str>) -> Result<String> {
+    use crate::utils::helpers::safe_join;
+
+    // Determine output path with traversal guard.
+    // When --output is an existing directory, place the file inside it.
+    // When --output is an explicit file path (caller-resolved), use it directly.
+    // When --output is omitted, derive from blob name anchored at CWD.
+    match output {
+        Some(p) if Path::new(p).is_dir() => {
+            safe_join(Path::new(p), name).map(|pb| pb.to_string_lossy().into_owned())
+        }
+        Some(p) => Ok(p.to_string()),
+        None => {
+            let cwd = std::env::current_dir().map_err(|e| {
+                CrosstacheError::config(format!("Cannot determine current directory: {e}"))
+            })?;
+            safe_join(&cwd, name).map(|pb| pb.to_string_lossy().into_owned())
+        }
+    }
 }
 
 fn display_file_list_items(
@@ -2337,7 +2342,7 @@ pub(crate) async fn execute_file_download_quick(
         }
     })?;
 
-    let output_path = output.clone();
+    let final_output_path = resolve_single_download_path(name, output.as_deref())?;
     execute_file_download(
         &blob_manager,
         name,
@@ -2349,7 +2354,6 @@ pub(crate) async fn execute_file_download_quick(
 
     // Handle --open flag: open the downloaded file with the system's default application
     if open {
-        let final_output_path = output_path.unwrap_or_else(|| name.to_string());
         match std::fs::canonicalize(&final_output_path) {
             Ok(path) => {
                 if let Err(e) = opener::open(&path) {
@@ -2399,6 +2403,19 @@ mod tests {
         let base = std::path::Path::new("/tmp/base");
         let result = crate::utils::helpers::safe_join(base, "docs/readme.md").unwrap();
         assert_eq!(result, std::path::Path::new("/tmp/base/docs/readme.md"));
+    }
+
+    #[test]
+    fn test_single_download_output_dir_resolves_to_file_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let result =
+            resolve_single_download_path("docs/readme.md", Some(dir.path().to_str().unwrap()))
+                .unwrap();
+
+        assert_eq!(
+            std::path::Path::new(&result),
+            &dir.path().join("docs/readme.md")
+        );
     }
 
     // --- resolve_multi_download_dir: directory validation ---

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -475,6 +475,17 @@ async fn execute_file_download(
     let content = blob_manager
         .download_file(download_request, reporter.as_ref())
         .await?;
+    // Ensure parent directories exist so blob names with path segments
+    // (e.g. "docs/readme.md") succeed when their parents are not yet created.
+    if let Some(parent) = Path::new(&output_path).parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            fs::create_dir_all(parent).map_err(|e| {
+                CrosstacheError::config(format!(
+                    "Failed to create parent directories for {output_path}: {e}"
+                ))
+            })?;
+        }
+    }
     fs::write(&output_path, content)
         .map_err(|e| CrosstacheError::config(format!("Failed to write file {output_path}: {e}")))?;
     output::success(&format!("Successfully downloaded file '{name}'"));
@@ -2308,6 +2319,55 @@ pub(crate) async fn execute_file_upload_quick(
     .await
 }
 
+/// Quick file download command (alias for file download)
+pub(crate) async fn execute_file_download_quick(
+    name: &str,
+    output: Option<String>,
+    open: bool,
+    config: &Config,
+) -> Result<()> {
+    // Create blob manager
+    let blob_manager = create_blob_manager(config).map_err(|e| {
+        if e.to_string().contains("No storage account configured") {
+            CrosstacheError::config(
+                "No blob storage configured. Run 'xv init' to set up blob storage.",
+            )
+        } else {
+            e
+        }
+    })?;
+
+    let output_path = output.clone();
+    execute_file_download(
+        &blob_manager,
+        name,
+        output,
+        false, // force
+        config,
+    )
+    .await?;
+
+    // Handle --open flag: open the downloaded file with the system's default application
+    if open {
+        let final_output_path = output_path.unwrap_or_else(|| name.to_string());
+        match std::fs::canonicalize(&final_output_path) {
+            Ok(path) => {
+                if let Err(e) = opener::open(&path) {
+                    eprintln!("Warning: could not open file '{}': {}", path.display(), e);
+                }
+            }
+            Err(e) => {
+                eprintln!(
+                    "Warning: could not resolve path '{}': {}",
+                    final_output_path, e
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2372,53 +2432,4 @@ mod tests {
         let result = resolve_multi_download_dir(Some(dir.path().to_str().unwrap())).unwrap();
         assert_eq!(result, dir.path());
     }
-}
-
-/// Quick file download command (alias for file download)
-pub(crate) async fn execute_file_download_quick(
-    name: &str,
-    output: Option<String>,
-    open: bool,
-    config: &Config,
-) -> Result<()> {
-    // Create blob manager
-    let blob_manager = create_blob_manager(config).map_err(|e| {
-        if e.to_string().contains("No storage account configured") {
-            CrosstacheError::config(
-                "No blob storage configured. Run 'xv init' to set up blob storage.",
-            )
-        } else {
-            e
-        }
-    })?;
-
-    let output_path = output.clone();
-    execute_file_download(
-        &blob_manager,
-        name,
-        output,
-        false, // force
-        config,
-    )
-    .await?;
-
-    // Handle --open flag: open the downloaded file with the system's default application
-    if open {
-        let final_output_path = output_path.unwrap_or_else(|| name.to_string());
-        match std::fs::canonicalize(&final_output_path) {
-            Ok(path) => {
-                if let Err(e) = opener::open(&path) {
-                    eprintln!("Warning: could not open file '{}': {}", path.display(), e);
-                }
-            }
-            Err(e) => {
-                eprintln!(
-                    "Warning: could not resolve path '{}': {}",
-                    final_output_path, e
-                );
-            }
-        }
-    }
-
-    Ok(())
 }

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -421,11 +421,20 @@ async fn execute_file_download(
     force: bool,
     config: &Config,
 ) -> Result<()> {
+    let output_path = resolve_single_download_path(name, output.as_deref())?;
+    execute_file_download_to_path(blob_manager, name, output_path, force, config).await
+}
+
+async fn execute_file_download_to_path(
+    blob_manager: &BlobManager,
+    name: &str,
+    output_path: String,
+    force: bool,
+    config: &Config,
+) -> Result<()> {
     use crate::blob::models::FileDownloadRequest;
     use std::fs;
     use std::path::Path;
-
-    let output_path = resolve_single_download_path(name, output.as_deref())?;
 
     // Check if file exists and handle force flag
     if Path::new(&output_path).exists() && !force {
@@ -1243,10 +1252,10 @@ async fn execute_file_download_multiple(
                 continue;
             }
         };
-        match execute_file_download(
+        match execute_file_download_to_path(
             blob_manager,
             &file_name,
-            Some(per_file_output),
+            per_file_output,
             force,
             config,
         )

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -6,7 +6,7 @@
 use crate::error::{CrosstacheError, Result};
 use regex::Regex;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 /// Write bytes to a file with mode 0o600 (owner read/write only).
@@ -209,6 +209,30 @@ pub fn validate_folder_path(folder_path: &str) -> Result<()> {
     Ok(())
 }
 
+/// Safely join an untrusted path component onto a base directory.
+///
+/// Rejects absolute paths and `..` components in `untrusted` to prevent
+/// path traversal from malicious blob names.
+pub fn safe_join(base: &Path, untrusted: &str) -> Result<PathBuf> {
+    let untrusted_path = Path::new(untrusted);
+
+    if untrusted_path.is_absolute() {
+        return Err(CrosstacheError::invalid_argument(format!(
+            "Blob name '{untrusted}' is an absolute path, which is not allowed"
+        )));
+    }
+
+    for component in untrusted_path.components() {
+        if component == std::path::Component::ParentDir {
+            return Err(CrosstacheError::invalid_argument(format!(
+                "Blob name '{untrusted}' contains '..', which is not allowed"
+            )));
+        }
+    }
+
+    Ok(base.join(untrusted_path))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -275,6 +299,32 @@ mod tests {
             .collect::<Vec<_>>()
             .join("/");
         assert!(validate_folder_path(&deep_path).is_err()); // Too deep
+    }
+
+    #[test]
+    fn test_safe_join_rejects_traversal() {
+        let base = std::path::Path::new("/tmp/base");
+        assert!(safe_join(base, "../escape.txt").is_err());
+        assert!(safe_join(base, "subdir/../../escape.txt").is_err());
+        assert!(safe_join(base, "a/../../../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_safe_join_rejects_absolute() {
+        let base = std::path::Path::new("/tmp/base");
+        assert!(safe_join(base, "/etc/passwd").is_err());
+        assert!(safe_join(base, "/absolute/path").is_err());
+    }
+
+    #[test]
+    fn test_safe_join_allows_normal_names() {
+        let base = std::path::Path::new("/tmp/base");
+
+        let result = safe_join(base, "readme.txt").unwrap();
+        assert_eq!(result, std::path::Path::new("/tmp/base/readme.txt"));
+
+        let result = safe_join(base, "docs/readme.md").unwrap();
+        assert_eq!(result, std::path::Path::new("/tmp/base/docs/readme.md"));
     }
 
     #[test]


### PR DESCRIPTION
Resolves ROADMAP P2 — Security hardening. See commit message for full detail.

cargo build / test / fmt --check / clippy -D warnings all pass locally (the only test failures are the two pre-existing non-hermetic `cli::secret_ops::tests::{azure,local}_trait_vault_resolution_*` tests that read `~/.config/xv/context`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem write paths and CLI download behavior; changes are defensive but affect all blob downloads.
> 
> **Overview**
> Hardens blob **download** path handling so untrusted blob names cannot escape the intended output directory.
> 
> Adds **`safe_join`** in `helpers` to reject absolute paths and `..` in blob names before joining to a base directory. Single-file downloads now resolve paths through **`resolve_single_download_path`** (CWD or `--output` dir + name via `safe_join`), write via **`execute_file_download_to_path`**, and **`create_dir_all`** on parent dirs for nested names like `docs/readme.md`.
> 
> Multi-file downloads use **`resolve_multi_download_dir`** (reject `--output` when it is an existing file—avoids clobbering one path), then a **per-file** `safe_join` under that directory instead of reusing one shared `--output` for every blob. Quick download’s **`--open`** uses the same resolved path. Unit tests cover traversal, absolute paths, and multi-download output validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c7cca71b6c54295e08b02630782695722d2c8b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->