### PR TITLE
fix(security): resolve all 10 findings from 2026-05-28 security review

### DIFF
--- a/docs/security-review-2026-05-28.md
+++ b/docs/security-review-2026-05-28.md
@@ -1,0 +1,412 @@
+# Security Review: crosstache
+
+Date: 2026-05-28  
+Scope: repository-wide review of `/Users/scottzionic/Code/crosstache` at commit `d2cbca7`.
+
+## Scope
+
+- In scope: Rust source under `src/`, install scripts under `scripts/`, and the Python Azure Function and installer under `xfunction/`.
+- Scan mode: repository-wide security review using a generated repository threat model and subagent full-file review by runtime area.
+- Explicit exclusions: tests, docs, generated build artifacts, vendored caches, and runtime validation against live Azure/AWS services.
+- Artifact bundle: `/tmp/codex-security-scans/crosstache/d2cbca7_20260528T213909Z`.
+
+## Scan Summary
+
+| Field | Value |
+|---|---|
+| Scan mode | Repository-wide Codex Security scan |
+| Primary runtime surfaces | Rust `xv` CLI, local/Azure/AWS backends, blob/file operations, leak scanner, install/upgrade flows, Python Azure Function RBAC helper |
+| Worklist coverage | 135 source-like rows generated into `/tmp/codex-security-scans/crosstache/d2cbca7_20260528T213909Z/artifacts/02_discovery/deep_review_input.csv` |
+| Validation mode | Static source-to-sink tracing with subagent full-file receipts; cloud/release-runtime issues were not dynamically exercised |
+| Reportable findings | 10 total: 1 critical, 4 high, 4 medium, 1 low |
+| Main artifact bundle | `/tmp/codex-security-scans/crosstache/d2cbca7_20260528T213909Z` |
+
+## Threat Model
+
+crosstache is a cross-platform command-line secrets manager (`xv`) with local age-encrypted storage, Azure Key Vault/Blob Storage support, optional AWS Secrets Manager support, a leak scanner, self-update/install paths, and an `xfunction/` Azure Function that grants Key Vault and storage RBAC. The most important assets are secret values, local age private keys, cloud identities and authorization context, vault/blob contents, release artifacts, generated config, and process environments created by `xv run`.
+
+The key trust boundaries are local operator input, project `.xv.toml` files, local filesystem paths, cloud metadata and RBAC APIs, remote release assets, terminal output, child-process environments, and HTTP requests to the Azure Function. High-impact failure modes include secret exfiltration, privilege escalation in Azure/AWS, local arbitrary file writes, supply-chain binary replacement, and accidental leakage through logs, stdout, clipboard, or child environments.
+
+## Findings
+
+| # | Severity | Confidence | Finding |
+|---|---|---|---|
+| 1 | Critical | High | [Missing `CreatedByID` tag allows self-service Key Vault Owner assignment](#1-missing-createdbyid-tag-allows-self-service-key-vault-owner-assignment) |
+| 2 | High | High | [`xv upgrade` installs unsigned releases when `.minisig` is missing](#2-xv-upgrade-installs-unsigned-releases-when-minisig-is-missing) |
+| 3 | High | High | [Install scripts continue after checksum verification is unavailable or fails open](#3-install-scripts-continue-after-checksum-verification-is-unavailable-or-fails-open) |
+| 4 | High | High | [Storage RBAC fallback grants roles on unrelated storage accounts](#4-storage-rbac-fallback-grants-roles-on-unrelated-storage-accounts) |
+| 5 | High | Medium | [JWT audience validation is disabled when `EXPECTED_AUDIENCE` is unset](#5-jwt-audience-validation-is-disabled-when-expected_audience-is-unset) |
+| 6 | Medium | High | [Recursive blob download can write outside the output directory for absolute blob names](#6-recursive-blob-download-can-write-outside-the-output-directory-for-absolute-blob-names) |
+| 7 | Medium | Medium | [`xv run` reintroduces parent environment variables after `env_clear`](#7-xv-run-reintroduces-parent-environment-variables-after-env_clear) |
+| 8 | Medium | Medium | [Existing local age key files are accepted without permission or symlink checks](#8-existing-local-age-key-files-are-accepted-without-permission-or-symlink-checks) |
+| 9 | Medium | Medium | [Setup script prints the Azure app registration client secret](#9-setup-script-prints-the-azure-app-registration-client-secret) |
+| 10 | Low | Medium | [Remote blob names and metadata can inject terminal control sequences](#10-remote-blob-names-and-metadata-can-inject-terminal-control-sequences) |
+
+### [1] Missing `CreatedByID` tag allows self-service Key Vault Owner assignment
+
+| Field | Value |
+|---|---|
+| Severity | Critical |
+| Confidence | High |
+| Confidence rationale | Direct code trace shows the missing-tag branch continues into privileged role assignment with no countervailing guard. |
+| Category | Authorization bypass / cloud privilege escalation |
+| CWE | CWE-862 Missing Authorization |
+| Affected lines | `xfunction/function_app.py:202`, `xfunction/function_app.py:337`, `xfunction/function_app.py:368`, `xfunction/function_app.py:374`, `xfunction/VaultRbacProcessor/vault_role_manager.py:178` |
+
+#### Summary
+
+The anonymous HTTP route accepts a bearer token and caller-supplied `resourceUri`, but if the target vault lacks a `CreatedByID` tag the creator check only logs a warning and continues. The same request then assigns Owner and Key Vault Administrator to the authenticated user.
+
+#### Validation
+
+Validation: source tracing shows the missing-tag branch at `function_app.py:337-340` does not return, while mismatch does return 403. The role assignment calls at `function_app.py:368-375` reach `role_assignments.create` in `vault_role_manager.py:178`. No repository counterevidence requires the tag before role assignment.
+
+#### Dataflow
+
+HTTP request `resourceUri` and bearer token -> JWT validation -> `get_vault_info(resource_uri)` -> missing `CreatedByID` warning branch -> `assign_role_to_user` -> Azure `role_assignments.create`.
+
+#### Reachability
+
+Reachability: any tenant-authenticated caller who can reach the Function endpoint and name a Key Vault lacking the tag can ask the function app's privileged identity to grant them roles at that vault scope. Impact depends on the deployed service principal scope, but the code path is a direct control-plane privilege grant.
+
+#### Severity
+
+Critical because the vulnerable path grants cloud control-plane roles across a security boundary with only a valid tenant token and a missing metadata tag. Evidence that deployed service-principal scope is tightly limited to newly created vaults would lower severity.
+
+#### Remediation
+
+Remediation: fail closed when `CreatedByID` is absent or malformed; verify the vault subscription/resource group against an allowed scope; add tests for missing tag, mismatched tag, and matching tag.
+
+### [2] `xv upgrade` installs unsigned releases when `.minisig` is missing
+
+| Field | Value |
+|---|---|
+| Severity | High |
+| Confidence | High |
+| Confidence rationale | Direct code trace shows unsigned release assets continue to checksum, extraction, and binary replacement. |
+| Category | Supply-chain signature verification bypass |
+| CWE | CWE-347 Improper Verification of Cryptographic Signature |
+| Affected lines | `src/cli/upgrade_ops.rs:103`, `src/cli/upgrade_ops.rs:123`, `src/cli/upgrade_ops.rs:128`, `src/cli/upgrade_ops.rs:144` |
+
+#### Summary
+
+`xv upgrade` looks for a minisign signature, but treats a missing `.minisig` asset as a warning and continues to checksum verification and binary replacement. The checksum is downloaded from the same release channel, so it does not provide independent authenticity if the release asset set is compromised.
+
+#### Validation
+
+Validation: the `sig_asset` is optional at `upgrade_ops.rs:105`; the missing-signature branch only warns at `128-130`; `replace_binary` is still reached at `144`. Existing controls are useful only when the signature is present.
+
+#### Dataflow
+
+GitHub release metadata -> optional `.minisig` lookup -> warning-only missing signature branch -> same-channel checksum verification -> archive extraction -> `replace_binary`.
+
+#### Reachability
+
+Any user running `xv upgrade` reaches this flow. An attacker needs compromise of the release channel or ability to influence the asset set, which is exactly the supply-chain boundary signature verification is meant to defend.
+
+#### Severity
+
+High because bypassing release authenticity can install attacker-controlled code for users who invoke the upgrade workflow. Mandatory signatures on every release asset would lower this to a rejected finding.
+
+#### Remediation
+
+Remediation: require `.minisig` for all upgrade installs; fail closed on missing or invalid signatures before checksum/extraction; add tests that unsigned release metadata aborts.
+
+### [3] Install scripts continue after checksum verification is unavailable or fails open
+
+| Field | Value |
+|---|---|
+| Severity | High |
+| Confidence | High |
+| Confidence rationale | Both install scripts have explicit warning/catch paths that continue to install after unavailable verification. |
+| Category | Supply-chain artifact verification fail-open |
+| CWE | CWE-494 Download of Code Without Integrity Check |
+| Affected lines | `scripts/install.sh:201`, `scripts/install.sh:216`, `scripts/install.sh:226`, `scripts/install.sh:248`, `scripts/install.ps1:346`, `scripts/install.ps1:350`, `scripts/install.ps1:362`, `scripts/install.ps1:374` |
+
+#### Summary
+
+The shell and PowerShell installers both allow release installation to continue when checksum retrieval or verification is unavailable. The shell script skips verification for empty checksum files or missing checksum utilities, then extracts and installs. The PowerShell script catches checksum download/verification errors and continues to expand and copy the binary.
+
+#### Validation
+
+Validation: both scripts clearly continue after warning paths. The scripts use HTTPS and compare checksums when available, but the verification mechanism is fail-open and not signature-backed.
+
+#### Dataflow
+
+Release archive download -> checksum download/parse/utility failure -> warning or caught exception -> archive extraction -> binary copy/install -> installed binary execution/version check.
+
+#### Reachability
+
+Any first-time installer user reaches this flow. Attackers need release-channel, network, mirror, or asset tampering capability; the scripts are the bootstrap trust boundary for new installations.
+
+#### Severity
+
+High because bootstrap installer verification fail-open can lead to execution of a malicious `xv` binary. Requiring successful signature verification before extraction would lower or eliminate the issue.
+
+#### Remediation
+
+Remediation: fail closed unless checksum verification succeeds, or preferably verify minisign signatures with an embedded public key; never run the installed binary for verification until authenticity is established.
+
+### [4] Storage RBAC fallback grants roles on unrelated storage accounts
+
+| Field | Value |
+|---|---|
+| Severity | High |
+| Confidence | High |
+| Confidence rationale | Direct code trace shows no-match storage discovery broadens to every resource-group storage account before role assignment. |
+| Category | Authorization scope expansion |
+| CWE | CWE-266 Incorrect Privilege Assignment |
+| Affected lines | `xfunction/function_app.py:380`, `xfunction/StorageRoleManager/storage_role_manager.py:92`, `xfunction/StorageRoleManager/storage_role_manager.py:141`, `xfunction/StorageRoleManager/storage_role_manager.py:246` |
+
+#### Summary
+
+After vault role assignment, the function discovers storage accounts in the vault resource group. If no explicit tag or naming association is found, it falls back to all storage accounts in that resource group, then grants Storage Account Contributor and Storage Blob Data Owner for Owner-equivalent vault grants.
+
+#### Validation
+
+Validation: the broad fallback is explicit at `storage_role_manager.py:92-95`; role mapping and assignment sinks are at `141-146` and `246-253`. The tag/naming checks are not sufficient because no-match broadens rather than denies.
+
+#### Dataflow
+
+Request-selected vault resource ID -> resource group parsed from vault ID -> list storage accounts in group -> no explicit association -> all accounts selected -> storage RBAC assignments created for caller.
+
+#### Reachability
+
+A caller who passes the vault authorization check for one vault in a shared resource group can receive storage roles on peer accounts in that group.
+
+#### Severity
+
+High because the impact is unauthorized cloud storage management/data access beyond the verified vault relationship. Evidence that deployments use one storage account per isolated resource group would lower severity.
+
+#### Remediation
+
+Remediation: remove the all-storage-accounts fallback; require an explicit `AssociatedVault` tag or authoritative mapping; log and skip storage role assignment when no association is found.
+
+### [5] JWT audience validation is disabled when `EXPECTED_AUDIENCE` is unset
+
+| Field | Value |
+|---|---|
+| Severity | High |
+| Confidence | Medium |
+| Confidence rationale | Runtime validation is definitely fail-open when unset, but the Python installer sets the value for its deployment path. |
+| Category | Authentication validation fail-open |
+| CWE | CWE-287 Improper Authentication |
+| Affected lines | `xfunction/function_app.py:112`, `xfunction/function_app.py:140`, `xfunction/scripts/setup-app-registration.ps1:35`, `xfunction/installer/steps/function_app.py:38` |
+
+#### Summary
+
+The Azure Function sets `verify_aud` to `bool(expected_audience)`, so audience validation is disabled when `EXPECTED_AUDIENCE` is absent. The Python installer sets this value, but the PowerShell app-registration setup script configures tenant/client/secret without setting `EXPECTED_AUDIENCE`.
+
+#### Validation
+
+Validation: source tracing confirms `jwt.decode` only receives an audience when the environment value exists. Confidence is medium because the current Python installer mitigates normal deployments, but the runtime code and PowerShell setup remain fail-open.
+
+#### Dataflow
+
+Bearer token -> unverified header key lookup -> `EXPECTED_AUDIENCE` env read -> `verify_aud` set from truthiness -> `jwt.decode` without audience when unset -> RBAC request handling continues.
+
+#### Reachability
+
+Deployments missing `EXPECTED_AUDIENCE` can accept valid tenant tokens minted for other audiences. This materially expands who can reach the RBAC assignment logic.
+
+#### Severity
+
+High because it weakens authentication on a privileged role-granting endpoint, though confidence is medium due the Python installer mitigation. Deployment evidence proving the setting is always enforced would lower severity.
+
+#### Remediation
+
+Remediation: require `EXPECTED_AUDIENCE` at startup and fail requests if missing; set it in every deployment path; add tests that tokens for another audience are rejected.
+
+### [6] Recursive blob download can write outside the output directory for absolute blob names
+
+| Field | Value |
+|---|---|
+| Severity | Medium |
+| Confidence | High |
+| Confidence rationale | Direct code trace shows recursive download misses the absolute-path rejection used by safer sibling paths. |
+| Category | Path traversal / arbitrary local file write |
+| CWE | CWE-22 Path Traversal |
+| Affected lines | `src/cli/file_ops.rs:1381`, `src/cli/file_ops.rs:1391`, `src/cli/file_ops.rs:1399`, `src/cli/file_ops.rs:1473`, `src/utils/helpers.rs:216` |
+
+#### Summary
+
+Recursive download uses `output_path.join(blob_name)` and only rejects `..` components. On Unix, joining an absolute blob name discards the base path. Single and multi-file downloads use `safe_join`, which rejects absolute paths, but recursive download does not.
+
+#### Validation
+
+Validation: the source-to-sink path is blob listing -> `blob_name` -> `output_path.join(blob_name)` -> `std::fs::write`. The nearest control checks only `ParentDir`; `safe_join` demonstrates the intended missing absolute-path control.
+
+#### Dataflow
+
+Cloud blob name from listing -> recursive download local path construction -> parent-directory-only traversal check -> parent directory creation -> `std::fs::write(local_path, content)`.
+
+#### Reachability
+
+A blob writer can create a blob with an absolute-looking name; an operator later running recursive download writes it outside the chosen output tree if the destination does not exist or `--force` is used.
+
+#### Severity
+
+Medium because it is a local arbitrary write triggered through operator download of attacker-controlled blob names, without a proven automatic code-execution path. Evidence of common recursive downloads into sensitive locations would raise severity.
+
+#### Remediation
+
+Remediation: use `safe_join` for recursive downloads before creating parents or writing; reject root/prefix components and Windows absolute paths; add tests for `/tmp/x`, `C:\x`, and `../x` blob names.
+
+### [7] `xv run` reintroduces parent environment variables after `env_clear`
+
+| Field | Value |
+|---|---|
+| Severity | Medium |
+| Confidence | Medium |
+| Confidence rationale | Source order proves the bypass, but exploitation requires attacker influence over the parent environment. |
+| Category | Environment injection / isolation bypass |
+| CWE | CWE-15 External Control of System or Configuration Setting |
+| Affected lines | `src/cli/secret_ops.rs:2126`, `src/cli/secret_ops.rs:2276`, `src/cli/secret_ops.rs:2283`, `src/cli/secret_ops.rs:2293` |
+
+#### Summary
+
+When `inherit_env` is false, `xv run` calls `cmd.env_clear()`. It then iterates the parent environment and re-adds any variable whose value changes after resolving an `xv://...` reference. This lets parent-controlled variables such as loader/runtime settings re-enter the child despite clean-environment mode.
+
+#### Validation
+
+Validation: the bypass is explicit in the order of operations: collect URI refs from all parent env vars, clear the child env, then set changed parent env vars. Exploitability requires attacker influence over the environment that launches `xv`.
+
+#### Dataflow
+
+Parent environment variable containing `xv://...` -> URI reference collection -> secret resolution -> `cmd.env_clear()` -> changed parent variable re-added with secret value.
+
+#### Reachability
+
+An attacker who can influence the shell, wrapper script, CI job, or service environment that invokes `xv run` can reintroduce sensitive child-process variables despite clean mode.
+
+#### Severity
+
+Medium because this breaks an isolation expectation and can affect process behavior, but requires parent-environment influence. Restricting resolution to inherited-env mode would lower the issue to no finding.
+
+#### Remediation
+
+Remediation: only resolve URI references from inherited environment variables when `inherit_env` is true, or require an allowlist of variable names to resolve in clean mode.
+
+### [8] Existing local age key files are accepted without permission or symlink checks
+
+| Field | Value |
+|---|---|
+| Severity | Medium |
+| Confidence | Medium |
+| Confidence rationale | Existing-key load paths lack permission checks, while generated-key paths have stronger controls. |
+| Category | Insecure key file handling |
+| CWE | CWE-732 Incorrect Permission Assignment, CWE-59 Link Following |
+| Affected lines | `src/backend/local/crypto.rs:139`, `src/backend/local/crypto.rs:149`, `src/backend/local/mod.rs:155`, `src/backend/local/mod.rs:167` |
+
+#### Summary
+
+Generated local keys use private writes, but loading an existing key file only checks size and then reads it. The loader does not reject symlinks or group/world-readable private keys.
+
+#### Validation
+
+Validation: no owner/mode/symlink checks were found in the load path. Severity is medium because exploitation generally requires local filesystem access or configuration influence, but the key protects all local backend secrets.
+
+#### Dataflow
+
+Configured key path or `AGE_KEY_FILE` -> local backend initialization -> `load_identity` metadata size check -> `fs::read_to_string` -> identity used for decrypting local secrets and files.
+
+#### Reachability
+
+The relevant attacker is a local user, shared-filesystem actor, or configuration tamperer who can expose or redirect the key file before `xv` loads it.
+
+#### Severity
+
+Medium because compromise of the age identity compromises local backend confidentiality, but the preconditions are local. Enforcing owner-only non-symlink keys would eliminate the issue.
+
+#### Remediation
+
+Remediation: use `symlink_metadata`, reject symlinks, require owner-only permissions on Unix, warn/fail on unexpected owner, and provide a repair command to chmod/chown existing keys.
+
+### [9] Setup script prints the Azure app registration client secret
+
+| Field | Value |
+|---|---|
+| Severity | Medium |
+| Confidence | Medium |
+| Confidence rationale | The script directly prints the generated secret, but the affected path is deployment tooling rather than steady-state runtime. |
+| Category | Secret disclosure in deployment output |
+| CWE | CWE-532 Insertion of Sensitive Information into Log File |
+| Affected lines | `xfunction/scripts/setup-app-registration.ps1:35`, `xfunction/scripts/setup-app-registration.ps1:42` |
+
+#### Summary
+
+The PowerShell setup script writes the generated Azure app registration client secret to Function App settings, then prints the raw secret to the console. This can leak into terminal scrollback, transcripts, CI logs, or shared support output.
+
+#### Validation
+
+Validation: the disclosure is explicit at line 42. Confidence is medium because it is a deployment script rather than the main runtime path, but the printed value is a real credential.
+
+#### Dataflow
+
+`az ad app credential reset` result -> `$secret.password` -> Function App app setting -> `Write-Host Client Secret`.
+
+#### Reachability
+
+Anyone with access to the operator terminal, transcript, CI logs, or copied setup output can recover the client secret and use the app registration within its granted permissions.
+
+#### Severity
+
+Medium because the value is a real cloud credential, but exposure depends on deployment logging practices. Proving the script is only run locally without transcripts would lower severity.
+
+#### Remediation
+
+Remediation: remove the secret from console output; print only secret identifier/expiration; document where to rotate it; prefer secure vault storage.
+
+### [10] Remote blob names and metadata can inject terminal control sequences
+
+| Field | Value |
+|---|---|
+| Severity | Low |
+| Confidence | Medium |
+| Confidence rationale | Source tracing shows raw terminal output, but impact depends on terminal behavior and operator interaction. |
+| Category | Terminal escape injection |
+| CWE | CWE-150 Improper Neutralization of Escape Sequences |
+| Affected lines | `src/cli/file_ops.rs:624`, `src/utils/format.rs:141`, `src/utils/pager.rs:43` |
+
+#### Summary
+
+Remote blob names and metadata are rendered into tables and pager output without control-character neutralization. A malicious blob name containing ANSI or OSC sequences could spoof terminal output or trigger terminal-specific behavior when an operator lists files interactively.
+
+#### Validation
+
+Validation: source tracing shows remote fields copied into display rows, formatted by table rendering, and written verbatim by the pager. Non-TTY JSON output reduces impact, so this is low severity.
+
+#### Dataflow
+
+Remote blob metadata -> display row construction -> table formatting -> pager/stdout raw write to TTY.
+
+#### Reachability
+
+A blob writer can choose names or metadata that an operator later displays in a terminal. The outcome is mostly operator deception or terminal feature abuse, not direct secret compromise.
+
+#### Severity
+
+Low because it affects terminal presentation and requires interactive display of hostile names. Evidence of terminals enabling dangerous OSC handlers by default would raise severity.
+
+#### Remediation
+
+Remediation: sanitize or visibly escape control characters before TTY/table/pager output while preserving raw JSON for scripts.
+
+## Reviewed Surfaces
+
+| Surface | Risk Area | Outcome | Notes |
+|---|---|---|---|
+| Rust cloud backends (`src/backend/azure`, `src/backend/aws`, `src/auth`) | Cloud identity, object naming, URL construction, destructive operations | No issue found | Subagent review found typed backend selection, Azure path/OData escaping, fixed hosts, no shell execution, and recovery/force gates for destructive operations. |
+| Rust local backend (`src/backend/local`) | Key storage, symlink handling, local path traversal | Reported | Key loading and local file download symlink gaps survived; vault and secret path traversal were rejected by validation and encoding controls. |
+| Rust CLI file/blob operations | Path traversal, local overwrite, terminal output | Reported | Recursive download absolute-path handling survived; single/multi download and sync path controls were rejected due `safe_join`/`sync_assert_safe_local_path`. |
+| `xv run` / secret injection | Secret leakage, child environment isolation | Reported | Output masking is present; URI resolution after `env_clear` survived as an isolation bypass. |
+| Leak scanner (`src/scan`) | Secret exposure, regex DoS, hook install | No issue found | Findings do not print matched values; Rust regex avoids backtracking ReDoS; hook body is constant and unmanaged hooks are refused unless forced. |
+| Upgrade/install flows | Signed update, checksum, archive extraction | Reported | Rust archive extraction reads binary bytes by basename, but update/install authenticity checks are fail-open; shell tar extraction remains a secondary file-write concern under the same supply-chain trust break. |
+| Python Azure Function (`xfunction`) | Authn/authz, RBAC assignment, storage role mapping | Reported | Missing creator-tag fail-open, optional audience validation, and broad storage fallback survived. |
+| Python installer Azure CLI wrapper | Command injection, secret redaction | No issue found | `subprocess.run` uses argument arrays with no shell; verbose command output redacts known secret flags/settings. |
+
+## Open Questions And Follow Up
+
+- Confirm deployed Azure Function app settings: whether `EXPECTED_AUDIENCE` is always present, and what subscription/resource-group scope the function app service principal has.
+- Decide whether install scripts should require minisign signatures or be removed in favor of `xv upgrade` once signature enforcement is fail-closed.
+- Add focused regression tests for recursive blob download absolute paths, `xv run` clean environment URI resolution, missing `CreatedByID`, and missing `EXPECTED_AUDIENCE`.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -175,33 +175,29 @@ function Test-Checksum {
         [string]$ChecksumPath
     )
     
+    # Verification is mandatory: installing an unverified archive is never
+    # acceptable, so every failure path below aborts the installation.
     if (-not (Test-Path $ChecksumPath)) {
-        Write-Warning "Checksum file not found, skipping verification"
-        return
+        Write-Error "Checksum file not found. Refusing to install without verification."
     }
-    
+
     try {
         Write-Info "Verifying checksum..."
-        
-        # Wait a moment to ensure file is fully written
-        Start-Sleep -Milliseconds 500
-        
+
         # Check if checksum file has content
         if ((Get-Item $ChecksumPath).Length -eq 0) {
-            Write-Warning "Checksum file is empty, skipping verification"
-            return
+            Write-Error "Checksum file is empty. Refusing to install without verification."
         }
-        
+
         $expectedHash = (Get-Content $ChecksumPath -Raw).Trim() -replace '\r?\n.*', '' -replace '\s.*', ''
-        
+
         if ([string]::IsNullOrWhiteSpace($expectedHash)) {
-            Write-Warning "Could not read valid checksum from file, skipping verification"
-            return
+            Write-Error "Could not read valid checksum from file. Refusing to install without verification."
         }
-        
+
         $actualHash = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLower()
         $expectedHash = $expectedHash.ToLower()
-        
+
         if ($expectedHash -ne $actualHash) {
             Write-Error "Checksum verification failed. Expected: $expectedHash, Got: $actualHash"
         }
@@ -210,7 +206,7 @@ function Test-Checksum {
         }
     }
     catch {
-        Write-Warning "Checksum verification failed: $($_.Exception.Message)"
+        Write-Error "Checksum verification failed: $($_.Exception.Message)"
     }
 }
 
@@ -345,11 +341,11 @@ function Install-crosstache {
         
         try {
             Download-File -Url $checksumUrl -OutFile $checksumPath -Description "checksum"
-            Test-Checksum -FilePath $archivePath -ChecksumPath $checksumPath
         }
         catch {
-            Write-Warning "Could not download or verify checksum: $_"
+            Write-Error "Could not download checksum file: $_. Refusing to install without verification."
         }
+        Test-Checksum -FilePath $archivePath -ChecksumPath $checksumPath
         
         # Create installation directory
         if (-not (Test-Path $InstallDir)) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -199,48 +199,38 @@ download_and_install() {
     info "Downloading $archive_name..."
     if command -v curl >/dev/null 2>&1; then
         curl -sSL "$download_url" -o "$archive_name" || error "Failed to download archive"
-        curl -sSL "$checksum_url" -o "$archive_name.sha256" 2>/dev/null || warning "Could not download checksum"
+        curl -sSL "$checksum_url" -o "$archive_name.sha256" 2>/dev/null || error "Failed to download checksum file. Refusing to install without verification."
     elif command -v wget >/dev/null 2>&1; then
         wget -q "$download_url" -O "$archive_name" || error "Failed to download archive"
-        wget -q "$checksum_url" -O "$archive_name.sha256" 2>/dev/null || warning "Could not download checksum"
+        wget -q "$checksum_url" -O "$archive_name.sha256" 2>/dev/null || error "Failed to download checksum file. Refusing to install without verification."
     fi
-    
-    # Verify checksum if available
-    if [ -f "$archive_name.sha256" ]; then
-        info "Verifying checksum..."
-        
-        # Wait a moment to ensure file is fully written
-        sleep 1
-        
-        # Check if checksum file has content
-        if [ ! -s "$archive_name.sha256" ]; then
-            warning "Checksum file is empty, skipping verification"
-        else
-            # Read the checksum from file
-            expected_checksum=$(cat "$archive_name.sha256" | tr -d '\r\n' | awk '{print $1}')
-            
-            if [ -z "$expected_checksum" ]; then
-                warning "Could not read checksum from file, skipping verification"
-            else
-                # Calculate actual checksum
-                if command -v shasum >/dev/null 2>&1; then
-                    actual_checksum=$(shasum -a 256 "$archive_name" | awk '{print $1}')
-                elif command -v sha256sum >/dev/null 2>&1; then
-                    actual_checksum=$(sha256sum "$archive_name" | awk '{print $1}')
-                else
-                    warning "No checksum utility found, skipping verification"
-                    actual_checksum=""
-                fi
-                
-                if [ -n "$actual_checksum" ]; then
-                    if [ "$expected_checksum" = "$actual_checksum" ]; then
-                        info "Checksum verification passed"
-                    else
-                        error "Checksum verification failed. Expected: $expected_checksum, Got: $actual_checksum"
-                    fi
-                fi
-            fi
-        fi
+
+    # Verify checksum. Verification is mandatory: installing an unverified
+    # archive is never acceptable, so every failure path below is fatal.
+    info "Verifying checksum..."
+
+    if [ ! -s "$archive_name.sha256" ]; then
+        error "Checksum file is missing or empty. Refusing to install without verification."
+    fi
+
+    expected_checksum=$(cat "$archive_name.sha256" | tr -d '\r\n' | awk '{print $1}')
+
+    if [ -z "$expected_checksum" ]; then
+        error "Could not read checksum from file. Refusing to install without verification."
+    fi
+
+    if command -v shasum >/dev/null 2>&1; then
+        actual_checksum=$(shasum -a 256 "$archive_name" | awk '{print $1}')
+    elif command -v sha256sum >/dev/null 2>&1; then
+        actual_checksum=$(sha256sum "$archive_name" | awk '{print $1}')
+    else
+        error "No checksum utility (shasum or sha256sum) found. Refusing to install without verification."
+    fi
+
+    if [ "$expected_checksum" = "$actual_checksum" ]; then
+        info "Checksum verification passed"
+    else
+        error "Checksum verification failed. Expected: $expected_checksum, Got: $actual_checksum"
     fi
     
     # Extract archive

--- a/src/backend/local/crypto.rs
+++ b/src/backend/local/crypto.rs
@@ -137,16 +137,56 @@ pub fn decrypt_from_file(
 /// The file may contain comments (lines starting with `#`) and blank lines;
 /// the first line matching the `AGE-SECRET-KEY-*` pattern is used.
 pub fn load_identity(key_path: &Path) -> Result<age::x25519::Identity, BackendError> {
-    let file_size = fs::metadata(key_path)
-        .map_err(|e| BackendError::Internal(format!("stat key {}: {e}", key_path.display())))?
-        .len();
+    // Open exactly once and inspect metadata through the handle: this rejects
+    // symlinked key paths (O_NOFOLLOW) and closes the stat-then-read TOCTOU
+    // window. The key protects every secret in the local store, so a
+    // group/world-accessible key file is an error, not a warning.
+    #[cfg(unix)]
+    let mut file = {
+        use std::os::unix::fs::OpenOptionsExt;
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(key_path)
+            .map_err(|e| {
+                BackendError::Internal(format!(
+                    "open key {}: {e} (symlinked key files are not allowed)",
+                    key_path.display()
+                ))
+            })?
+    };
+    #[cfg(not(unix))]
+    let mut file = File::open(key_path)
+        .map_err(|e| BackendError::Internal(format!("open key {}: {e}", key_path.display())))?;
+
+    let metadata = file
+        .metadata()
+        .map_err(|e| BackendError::Internal(format!("stat key {}: {e}", key_path.display())))?;
+
+    let file_size = metadata.len();
     if file_size > 1024 {
         return Err(BackendError::Internal(format!(
             "key file {} is too large ({file_size} bytes, max 1024)",
             key_path.display()
         )));
     }
-    let contents = fs::read_to_string(key_path)
+
+    #[cfg(unix)]
+    {
+        let mode = metadata.permissions().mode();
+        if mode & 0o077 != 0 {
+            return Err(BackendError::Internal(format!(
+                "key file {} is group/world-accessible (mode {:03o}); \
+                 run 'chmod 600 {}' to fix",
+                key_path.display(),
+                mode & 0o777,
+                key_path.display()
+            )));
+        }
+    }
+
+    let mut contents = Zeroizing::new(String::new());
+    file.read_to_string(&mut contents)
         .map_err(|e| BackendError::Internal(format!("read key {}: {e}", key_path.display())))?;
 
     for line in contents.lines() {
@@ -321,6 +361,53 @@ mod tests {
     fn load_identity_missing_file() {
         let result = load_identity(Path::new("/nonexistent/key.txt"));
         assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_identity_rejects_symlinked_key() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new().unwrap();
+        let key_path = tmp.path().join("key.txt");
+        let recipients_path = tmp.path().join("recipients.txt");
+        generate_keypair(&key_path, &recipients_path).unwrap();
+
+        let link = tmp.path().join("key-link.txt");
+        symlink(&key_path, &link).unwrap();
+
+        let result = load_identity(&link);
+        assert!(result.is_err(), "symlinked key file must be rejected");
+        if let Err(BackendError::Internal(msg)) = result {
+            assert!(
+                msg.contains("symlink"),
+                "error should mention symlinks: {msg}"
+            );
+        } else {
+            panic!("Expected BackendError::Internal");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_identity_rejects_group_world_readable_key() {
+        let tmp = TempDir::new().unwrap();
+        let key_path = tmp.path().join("key.txt");
+        let recipients_path = tmp.path().join("recipients.txt");
+        generate_keypair(&key_path, &recipients_path).unwrap();
+
+        fs::set_permissions(&key_path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let result = load_identity(&key_path);
+        assert!(result.is_err(), "world-readable key file must be rejected");
+        if let Err(BackendError::Internal(msg)) = result {
+            assert!(
+                msg.contains("chmod 600"),
+                "error should tell user how to fix: {msg}"
+            );
+        } else {
+            panic!("Expected BackendError::Internal");
+        }
     }
 
     #[cfg(unix)]

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -1378,44 +1378,39 @@ async fn execute_file_download_recursive(
     for file_info in &all_files_to_download {
         let blob_name = &file_info.name;
 
-        // Determine local file path
-        let local_path = if flatten {
-            // Flatten: use only filename
+        // Determine local file path.
+        // Security: blob names come from the remote listing and are untrusted.
+        // `safe_join` rejects both `..` components and absolute paths (a plain
+        // `Path::join` would silently discard the base directory for an
+        // absolute blob name like "/etc/cron.d/x"). The check inspects the
+        // name before any filesystem call, so there is no TOCTOU window.
+        let joined = if flatten {
+            // Flatten: use only the final filename component
             let filename = Path::new(blob_name)
                 .file_name()
                 .unwrap_or_default()
-                .to_string_lossy();
-            output_path.join(filename.as_ref())
+                .to_string_lossy()
+                .into_owned();
+            crate::utils::helpers::safe_join(output_path, &filename)
         } else {
             // Preserve structure: use full blob path
-            output_path.join(blob_name)
+            crate::utils::helpers::safe_join(output_path, blob_name)
         };
-
-        // Security: prevent path traversal via malicious blob names (e.g. "../../etc/passwd").
-        // We inspect each component of the blob name BEFORE joining it with the
-        // destination directory so no filesystem call is required and there is no
-        // TOCTOU window.  Any ParentDir (`..`) component is an unambiguous sign of
-        // a traversal attempt and is rejected immediately.
-        {
-            let has_traversal = Path::new(blob_name)
-                .components()
-                .any(|c| c == std::path::Component::ParentDir);
-            if has_traversal {
-                output::warn(&format!(
-                    "Skipping '{}': path traversal detected in blob name",
-                    blob_name
-                ));
+        let local_path = match joined {
+            Ok(path) => path,
+            Err(e) => {
+                output::warn(&format!("Skipping '{blob_name}': {e}"));
                 failure_count += 1;
                 if continue_on_error {
                     mp.advance_overall(blob_name);
                     continue;
                 } else {
                     return Err(CrosstacheError::config(format!(
-                        "Path traversal detected in blob name: {blob_name}"
+                        "Unsafe blob name '{blob_name}': {e}"
                     )));
                 }
             }
-        }
+        };
 
         let local_path_str = local_path.to_string_lossy().to_string();
 

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2119,21 +2119,27 @@ async fn execute_secret_run(
     let mut context_manager = ContextManager::load().await.unwrap_or_default();
     let _ = context_manager.update_usage(&vault_name).await;
 
-    // Parse current environment for xv:// URI references (supports optional backend prefix)
+    // Parse current environment for xv:// URI references (supports optional backend prefix).
+    // Only done when the parent environment is inherited: in clean-env mode
+    // (`inherit_env == false`) parent variables never reach the child, and
+    // resolving/re-adding them would silently reintroduce parent-controlled
+    // variables after `env_clear()` — an isolation bypass.
     let mut uri_refs: Vec<(String, BackendRef)> = Vec::new(); // (original_uri, parsed_ref)
     let uri_regex = Regex::new(r"xv://([^/\s]+)/([^/\s]+)").unwrap();
 
-    for (_env_name, env_value) in std::env::vars() {
-        for captures in uri_regex.captures_iter(&env_value) {
-            let vault_part = captures.get(1).map_or("", |m| m.as_str());
-            let secret_part = captures.get(2).map_or("", |m| m.as_str());
-            let uri_key = format!("xv://{vault_part}/{secret_part}");
-            if uri_refs.iter().any(|(uri, _)| uri == &uri_key) {
-                continue;
-            }
-            match BackendRef::parse(&format!("{vault_part}/{secret_part}")) {
-                Ok(r) => uri_refs.push((uri_key, r)),
-                Err(e) => output::warn(&format!("Skipping invalid URI '{uri_key}': {e}")),
+    if inherit_env {
+        for (_env_name, env_value) in std::env::vars() {
+            for captures in uri_regex.captures_iter(&env_value) {
+                let vault_part = captures.get(1).map_or("", |m| m.as_str());
+                let secret_part = captures.get(2).map_or("", |m| m.as_str());
+                let uri_key = format!("xv://{vault_part}/{secret_part}");
+                if uri_refs.iter().any(|(uri, _)| uri == &uri_key) {
+                    continue;
+                }
+                match BackendRef::parse(&format!("{vault_part}/{secret_part}")) {
+                    Ok(r) => uri_refs.push((uri_key, r)),
+                    Err(e) => output::warn(&format!("Skipping invalid URI '{uri_key}': {e}")),
+                }
             }
         }
     }
@@ -2278,8 +2284,10 @@ async fn execute_secret_run(
     }
     cmd.envs(&env_vars);
 
-    // Resolve URI references in existing environment variables
-    if !uri_values.is_empty() {
+    // Resolve URI references in existing environment variables.
+    // `uri_values` is only populated when `inherit_env` is true (see the scan
+    // above), so this never re-adds parent variables after `env_clear()`.
+    if inherit_env && !uri_values.is_empty() {
         for (env_name, env_value) in std::env::vars() {
             let mut resolved_value = env_value.clone();
 

--- a/src/cli/upgrade_ops.rs
+++ b/src/cli/upgrade_ops.rs
@@ -100,9 +100,22 @@ pub(crate) async fn execute_upgrade_command(check: bool, force: bool) -> Result<
             ))
         })?;
 
-    // Look for minisig signature file
+    // Require the minisig signature file. All releases since v0.11.0 are signed
+    // in CI; a latest release without a signature is either tampered with or
+    // misconfigured, and must never be installed (the .sha256 file comes from
+    // the same channel as the archive, so it is not an authenticity control).
     let sig_name = format!("{asset_name}.minisig");
-    let sig_asset = release.assets.iter().find(|a| a.name == sig_name);
+    let sig_asset = release
+        .assets
+        .iter()
+        .find(|a| a.name == sig_name)
+        .ok_or_else(|| {
+            CrosstacheError::upgrade(format!(
+                "Release v{latest} has no signature file ({sig_name}). \
+                 Refusing to install an unsigned release. \
+                 If this is unexpected, report it at https://github.com/{GITHUB_REPO}/issues"
+            ))
+        })?;
 
     // Validate size
     if archive_asset.size > MAX_ASSET_SIZE {
@@ -120,15 +133,9 @@ pub(crate) async fn execute_upgrade_command(check: bool, force: bool) -> Result<
         download_asset(&checksum_asset.browser_download_url, checksum_asset.size).await?;
 
     // Signature verification (before checksum)
-    if let Some(sig_asset) = sig_asset {
-        let sig_bytes = download_asset(&sig_asset.browser_download_url, sig_asset.size).await?;
-        verify_signature(&archive_bytes, &sig_bytes)?;
-        output::success("Signature verified");
-    } else {
-        output::warn(
-            "Release is not signed. Signature verification will be required in a future version.",
-        );
-    }
+    let sig_bytes = download_asset(&sig_asset.browser_download_url, sig_asset.size).await?;
+    verify_signature(&archive_bytes, &sig_bytes)?;
+    output::success("Signature verified");
 
     // Verify checksum
     let checksum_text = String::from_utf8_lossy(&checksum_bytes);

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -15,9 +15,37 @@ use std::io::stdout;
 use std::io::IsTerminal;
 use std::sync::LazyLock;
 use tabled::{
-    settings::{object::Rows, Alignment, Color, Modify, Padding, Style, Width},
+    settings::{
+        object::{Rows, Segment},
+        Alignment, Color, Format, Modify, Padding, Style, Width,
+    },
     Table, Tabled,
 };
+
+/// Visibly escape control characters in untrusted display text so
+/// remote-supplied values (blob names, metadata, tags) cannot inject terminal
+/// escape sequences into TTY output. Covers C0 controls, DEL, and C1 controls
+/// (e.g. U+009B CSI). Newlines and tabs are kept: they only affect layout,
+/// not terminal state. Machine-readable formats (JSON/YAML/CSV) are left
+/// untouched so scripts see the raw values.
+fn sanitize_control_chars(input: &str) -> String {
+    fn is_dangerous(c: char) -> bool {
+        c.is_control() && c != '\n' && c != '\t'
+    }
+    if !input.chars().any(is_dangerous) {
+        return input.to_string();
+    }
+    input
+        .chars()
+        .map(|c| {
+            if is_dangerous(c) {
+                format!("\\x{:02X}", c as u32)
+            } else {
+                c.to_string()
+            }
+        })
+        .collect()
+}
 
 /// Regex for template placeholders: {{field_name}} with optional whitespace.
 /// Field names may contain word characters and spaces.
@@ -141,6 +169,9 @@ impl TableFormatter {
     fn format_as_table<T: Tabled>(&self, data: &[T]) -> Result<String> {
         let mut table = Table::new(data);
 
+        // Neutralize terminal escape sequences in untrusted cell content
+        table.with(Modify::new(Segment::all()).with(Format::content(sanitize_control_chars)));
+
         // Apply styling
         table
             .with(Style::rounded())
@@ -191,6 +222,8 @@ impl TableFormatter {
     /// Format data as plain text
     fn format_as_plain<T: Tabled>(&self, data: &[T]) -> Result<String> {
         let mut table = Table::new(data);
+        // Neutralize terminal escape sequences in untrusted cell content
+        table.with(Modify::new(Segment::all()).with(Format::content(sanitize_control_chars)));
         table.with(Style::ascii()).with(Padding::new(1, 1, 0, 0));
         Ok(table.to_string())
     }
@@ -380,6 +413,44 @@ mod tests {
     use super::*;
     use serde::Serialize;
     use tabled::Tabled;
+
+    #[test]
+    fn sanitize_escapes_ansi_and_c1_controls() {
+        // ANSI color/OSC injection via ESC
+        assert_eq!(
+            sanitize_control_chars("evil\x1b[31mred\x1b]0;title\x07"),
+            "evil\\x1B[31mred\\x1B]0;title\\x07"
+        );
+        // C1 CSI (U+009B) is a single-char escape sequence on many terminals
+        assert_eq!(sanitize_control_chars("a\u{9b}31mb"), "a\\x9B31mb");
+        // Newlines and tabs are layout, not terminal state — preserved
+        assert_eq!(sanitize_control_chars("a\nb\tc"), "a\nb\tc");
+        // Clean strings pass through unchanged
+        assert_eq!(
+            sanitize_control_chars("plain-name_1.txt"),
+            "plain-name_1.txt"
+        );
+    }
+
+    #[test]
+    fn table_output_neutralizes_escape_sequences() {
+        let data = vec![TestData {
+            name: "blob\x1b]8;;http://evil\x07link".to_string(),
+            value: "v".to_string(),
+            status: "ok".to_string(),
+        }];
+        let formatter = TableFormatter::new(OutputFormat::Table, true, None);
+        let out = formatter.format_table(&data).unwrap();
+        assert!(
+            !out.contains('\x1b'),
+            "table output must not contain raw ESC"
+        );
+        assert!(
+            !out.contains('\x07'),
+            "table output must not contain raw BEL"
+        );
+        assert!(out.contains("\\x1B"), "escaped form should be visible");
+    }
 
     #[derive(Debug, Clone, Serialize, Tabled)]
     struct TestData {

--- a/xfunction/CLAUDE.md
+++ b/xfunction/CLAUDE.md
@@ -70,11 +70,10 @@ func azure functionapp publish <function-app-name>
 ## Storage Integration Details
 
 ### Storage Account Discovery Strategy
-The function automatically discovers storage accounts associated with a Key Vault using three strategies:
+The function discovers storage accounts associated with a Key Vault by scanning the vault's resource group for **explicit** associations only (accounts with no association are never granted roles):
 
-1. **Resource Group Strategy (Primary)**: Finds all storage accounts in the same resource group as the vault
-2. **Tag-Based Association (Secondary)**: Looks for storage accounts with `AssociatedVault` tag matching the vault name
-3. **Naming Convention (Fallback)**: Identifies storage accounts with names containing the vault name using patterns:
+1. **Tag-Based Association (Primary)**: Looks for storage accounts with `AssociatedVault` tag matching the vault name
+2. **Naming Convention (Secondary)**: Identifies storage accounts with names containing the vault name using patterns:
    - `{vault-name}storage`
    - `{vault-name}stor`
    - `stor{vault-name}`

--- a/xfunction/StorageRoleManager/storage_role_manager.py
+++ b/xfunction/StorageRoleManager/storage_role_manager.py
@@ -89,10 +89,17 @@ class StorageRoleManager:
                         storage_accounts.append(account.id)
                         continue
 
-                # If no specific associations found, include all storage accounts in the resource group
+                # Never broaden to unassociated accounts: granting roles on every
+                # storage account in a shared resource group would hand the caller
+                # access far beyond the vault relationship that was verified.
                 if not storage_accounts and accounts_in_rg:
-                    logging.info(f"No explicit associations found, including all storage accounts in resource group")
-                    storage_accounts = [account.id for account in accounts_in_rg]
+                    logging.warning(
+                        "No storage accounts explicitly associated with vault %s "
+                        "(via AssociatedVault tag or naming convention); skipping "
+                        "storage role assignment for the %d unassociated account(s) "
+                        "in resource group %s",
+                        vault_name, len(accounts_in_rg), resource_group,
+                    )
 
             except Exception as ex:
                 logging.error(f"Error listing storage accounts in resource group: {str(ex)}")

--- a/xfunction/function_app.py
+++ b/xfunction/function_app.py
@@ -111,6 +111,20 @@ def _validate_jwt(token: str) -> Dict[str, Any]:
     expected_issuer = _get_expected_issuer(tenant_id)
     expected_audience = os.environ.get("EXPECTED_AUDIENCE")
 
+    # Fail closed on missing validation configuration: a token minted for any
+    # audience (or any tenant, if the issuer is also unknown) must never be
+    # accepted by this privileged role-granting endpoint.
+    if not expected_audience:
+        raise jwt.InvalidTokenError(
+            "Server misconfiguration: EXPECTED_AUDIENCE is not set; "
+            "refusing to validate tokens without audience verification"
+        )
+    if not expected_issuer:
+        raise jwt.InvalidTokenError(
+            "Server misconfiguration: AZURE_TENANT_ID / AZURE_AD_ISSUER is not set; "
+            "refusing to validate tokens without issuer verification"
+        )
+
     # Read unverified header to get kid and algorithm
     unverified_header = jwt.get_unverified_header(token)
     kid = unverified_header.get("kid")
@@ -140,19 +154,16 @@ def _validate_jwt(token: str) -> Dict[str, Any]:
     decode_options: Dict[str, Any] = {
         "verify_signature": True,
         "verify_exp": True,
-        "verify_aud": bool(expected_audience),
-        "verify_iss": bool(expected_issuer),
+        "verify_aud": True,
+        "verify_iss": True,
     }
 
     decode_kwargs: Dict[str, Any] = {
         "algorithms": [algorithm],
         "options": decode_options,
+        "issuer": expected_issuer,
+        "audience": expected_audience,
     }
-
-    if expected_issuer:
-        decode_kwargs["issuer"] = expected_issuer
-    if expected_audience:
-        decode_kwargs["audience"] = expected_audience
 
     decoded = jwt.decode(token, public_key, **decode_kwargs)
     return decoded
@@ -335,8 +346,18 @@ async def direct_vault_rbac_processor(req: func.HttpRequest) -> func.HttpRespons
             logging.info(f"Current user ID from token: {user_id}")
             
             if not creator_id:
-                logging.warning("Vault does not have CreatedByID tag, cannot verify creator")
-                # Continue with role assignment but log the warning
+                logging.error(
+                    "Vault does not have a CreatedByID tag; refusing role assignment "
+                    "because the creator cannot be verified"
+                )
+                return func.HttpResponse(
+                    json.dumps({
+                        "error": "Unauthorized: vault has no CreatedByID tag, creator cannot be verified",
+                        "userId": user_id
+                    }),
+                    status_code=403,
+                    mimetype="application/json"
+                )
             elif creator_id.lower() != user_id.lower():
                 logging.error(f"User {user_id} is not the creator of the vault (creator is {creator_id})")
                 return func.HttpResponse(

--- a/xfunction/local.settings.json.example
+++ b/xfunction/local.settings.json.example
@@ -6,6 +6,6 @@
     "AZURE_TENANT_ID": "<your-tenant-id>",
     "AZURE_CLIENT_ID": "<your-app-registration-client-id>",
     "AZURE_CLIENT_SECRET": "<your-app-registration-client-secret>",
-    "EXPECTED_AUDIENCE": "<optional-audience-for-jwt-validation>"
+    "EXPECTED_AUDIENCE": "<required-jwt-audience-usually-the-app-registration-client-id>"
   }
 }

--- a/xfunction/scripts/setup-app-registration.ps1
+++ b/xfunction/scripts/setup-app-registration.ps1
@@ -32,13 +32,13 @@ az ad app permission admin-consent --id $app.appId
 
 # Update function app settings
 Write-Host "Updating Function App settings..."
-az functionapp config appsettings set --name $FunctionAppName --resource-group $ResourceGroup --settings "AZURE_CLIENT_ID=$($app.appId)" "AZURE_CLIENT_SECRET=$($secret.password)" "AZURE_TENANT_ID=$($secret.tenant)"
+az functionapp config appsettings set --name $FunctionAppName --resource-group $ResourceGroup --settings "AZURE_CLIENT_ID=$($app.appId)" "AZURE_CLIENT_SECRET=$($secret.password)" "AZURE_TENANT_ID=$($secret.tenant)" "EXPECTED_AUDIENCE=$($app.appId)"
 
 Write-Host "`n----------------------------------------"
 Write-Host "App Registration Setup Complete!"
 Write-Host "----------------------------------------"
 Write-Host "Application (client) ID: $($app.appId)"
 Write-Host "Directory (tenant) ID: $($secret.tenant)"
-Write-Host "Client Secret: $($secret.password)"
+Write-Host "Client Secret: stored in Function App setting AZURE_CLIENT_SECRET (not displayed; expires $($secret.endDateTime))"
 Write-Host "`nThese values have been automatically added to your Function App settings."
-Write-Host "Please save these values securely for your records."
+Write-Host "If you need the secret value elsewhere, rotate it with 'az ad app credential reset' rather than reusing this one."

--- a/xfunction/tests/test_direct_rbac_processor.py
+++ b/xfunction/tests/test_direct_rbac_processor.py
@@ -278,6 +278,7 @@ class TestDirectVaultRbacProcessor(unittest.TestCase):
         # Setup mocks
         mock_validate_jwt.return_value = self.valid_token_payload
         mock_manager = AsyncMock()
+        mock_manager.get_vault_info = AsyncMock(return_value=self.mock_vault_info)
         mock_manager.assign_role_to_user = AsyncMock(side_effect=[False, True])
         mock_vault_role_manager_class.return_value = mock_manager
         mock_storage_manager = AsyncMock()
@@ -383,21 +384,26 @@ class TestDirectVaultRbacProcessor(unittest.TestCase):
     @patch('function_app.StorageRoleManager')
     @patch('function_app.VaultRoleManager')
     def test_vault_missing_creator_tag(self, mock_vault_role_manager_class, mock_storage_role_manager_class, mock_validate_jwt):
-        """Test when vault doesn't have a CreatedByID tag."""
+        """A vault without a CreatedByID tag must be refused (fail closed).
+
+        If the tag is missing the creator cannot be verified, so role
+        assignment must NOT proceed — otherwise any tenant-authenticated
+        caller could self-assign Owner on an untagged vault.
+        """
         # Setup mocks
         mock_vault_role_manager_class.return_value = self.mock_manager
         mock_storage_manager = AsyncMock()
         mock_storage_manager.discover_associated_storage_accounts = AsyncMock(return_value=[])
         mock_storage_role_manager_class.return_value = mock_storage_manager
         mock_validate_jwt.return_value = self.valid_token_payload
-        
+
         # Create vault info without CreatedByID tag
         no_creator_vault_info = self.mock_vault_info.copy()
         no_creator_vault_info['tags'] = {
             "CreatedAt": "2023-03-31T12:00:00Z"
         }
         self.mock_manager.get_vault_info = AsyncMock(return_value=no_creator_vault_info)
-        
+
         # Create request
         req = func.HttpRequest(
             method='POST',
@@ -405,18 +411,18 @@ class TestDirectVaultRbacProcessor(unittest.TestCase):
             url='/api/assign-roles',
             headers={'Authorization': f'Bearer {self.valid_token}'}
         )
-        
+
         # Call function
         resp = self._run_async_test(direct_vault_rbac_processor(req))
-        
-        # Assert response - should still succeed but with a warning logged
-        self.assertEqual(resp.status_code, 200)
+
+        # Assert response - must be refused
+        self.assertEqual(resp.status_code, 403)
         resp_body = json.loads(resp.get_body())
-        self.assertTrue(resp_body['success'])
-        self.assertFalse(resp_body['isCreator'])
-        
-        # Assert role assignment was attempted
-        self.assertEqual(self.mock_manager.assign_role_to_user.call_count, 2)
+        self.assertIn('error', resp_body)
+        self.assertIn('CreatedByID', resp_body['error'])
+
+        # Assert role assignment was never attempted
+        self.mock_manager.assign_role_to_user.assert_not_called()
 
     @patch('function_app._validate_jwt')
     @patch('function_app.StorageRoleManager')

--- a/xfunction/tests/test_storage_role_manager.py
+++ b/xfunction/tests/test_storage_role_manager.py
@@ -128,7 +128,32 @@ class TestStorageRoleManager(unittest.TestCase):
         self.assertEqual(len(storage_accounts), 2)
         self.assertIn(mock_account1.id, storage_accounts)
         self.assertIn(mock_account2.id, storage_accounts)
-    
+
+    @patch('StorageRoleManager.storage_role_manager.StorageManagementClient')
+    def test_discover_skips_unassociated_accounts(self, mock_storage_client):
+        """Accounts with no explicit association must NOT be selected.
+
+        Regression test: discovery used to fall back to *all* storage accounts
+        in the resource group when nothing matched, which granted the caller
+        roles on unrelated accounts in shared resource groups.
+        """
+        mock_unrelated = Mock()
+        mock_unrelated.id = "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Storage/storageAccounts/somethingelse"
+        mock_unrelated.name = "somethingelse"
+        mock_unrelated.tags = {}
+
+        mock_client_instance = Mock()
+        mock_client_instance.storage_accounts.list_by_resource_group.return_value = [mock_unrelated]
+        mock_storage_client.return_value = mock_client_instance
+
+        vault_resource_id = "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.KeyVault/vaults/testvault"
+
+        storage_accounts = asyncio.run(
+            self.storage_manager.discover_associated_storage_accounts(vault_resource_id)
+        )
+
+        self.assertEqual(storage_accounts, [])
+
     @patch('StorageRoleManager.storage_role_manager.StorageManagementClient')
     def test_discover_storage_accounts_invalid_vault_id(self, mock_storage_client):
         """Test storage account discovery with invalid vault resource ID."""


### PR DESCRIPTION
## Summary

Reviews and fixes every finding from `docs/security-review-2026-05-28.md` (Codex repository-wide scan at `d2cbca7`). Each finding was re-verified against current HEAD before fixing; **all 10 were confirmed legitimate** — none had been addressed by the v0.11.0 security PRs (#222–#225), which covered a different review.

| # | Severity | Finding | Resolution |
|---|----------|---------|------------|
| 1 | Critical | Missing `CreatedByID` tag allowed self-service KV Owner assignment | Fail closed: 403 when the tag is absent (`xfunction/function_app.py`) |
| 2 | High | `xv upgrade` installed unsigned releases when `.minisig` missing | Missing signature asset is now a hard error (`src/cli/upgrade_ops.rs`) |
| 3 | High | Install scripts continued after checksum verification failed/unavailable | Every failure path is now fatal in both `install.sh` and `install.ps1` |
| 4 | High | Storage RBAC fallback granted roles on **all** RG storage accounts | Fallback removed; unassociated accounts are skipped with a warning |
| 5 | High | JWT audience validation disabled when `EXPECTED_AUDIENCE` unset | Audience + issuer config now required to validate any token; `setup-app-registration.ps1` sets `EXPECTED_AUDIENCE` |
| 6 | Medium | Recursive blob download wrote outside output dir for absolute blob names | Routed through `safe_join` (rejects absolute paths and `..`), same as single/multi download |
| 7 | Medium | `xv run` re-added parent env vars after `env_clear` via `xv://` resolution | URI scan/resolution now only runs when `inherit_env` is true |
| 8 | Medium | Age key files loaded without permission/symlink checks (TOCTOU) | Open once with `O_NOFOLLOW`, metadata via handle, reject group/world-accessible modes, read into `Zeroizing` |
| 9 | Medium | Setup script printed the app registration client secret | Secret no longer printed; reports storage location + expiry |
| 10 | Low | Remote blob names/metadata could inject terminal escape sequences | Table/plain output visibly escapes C0/DEL/C1 controls; JSON/YAML/CSV stay raw for scripts |

## Behavior changes to be aware of

- **`install.sh` / `install.ps1` now hard-fail** when the checksum file can't be downloaded, is empty, or no checksum utility exists. Full signature verification remains `xv upgrade`'s job (the scripts can't assume minisign on a fresh machine).
- **Existing local-backend key files with loose permissions (e.g. 0644) are now rejected** with a `chmod 600` instruction. Keys generated by xv were always 0600 and are unaffected.
- **xfunction deployments without `EXPECTED_AUDIENCE` now reject all requests** (previously they silently skipped audience validation). The PowerShell setup script and the Python installer both set it.
- **Untagged vaults can no longer get roles via the function app** — deployments relying on the missing-tag grace path must tag vaults with `CreatedByID`.
- `xfunction/CLAUDE.md` updated: the "all accounts in resource group" discovery strategy is no longer documented as intended behavior.

## Tests

- `cargo test --lib`: 459 passed (includes new regression tests: symlinked key rejection, world-readable key rejection, ANSI/C1 escape neutralization in table output)
- `cargo clippy --all-targets`: no warnings in changed files; `cargo fmt` applied
- xfunction: 20/20 pytest passing — `test_vault_missing_creator_tag` rewritten to assert fail-closed 403; new `test_discover_skips_unassociated_accounts` regression test; `test_role_assignment_failure` given explicit vault fixture (it implicitly relied on the fail-open path)
- `bash -n` and `py_compile` clean; pwsh unavailable locally for ps1 parse check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, cloud privilege assignment, release/install trust boundaries, and local key handling; several changes are breaking for misconfigured deployments (missing tags, audience, loose key permissions) or installs without checksums.
> 
> **Overview**
> Adds **`docs/security-review-2026-05-28.md`** and implements fixes for all **10** findings from that review.
> 
> **Supply chain & install:** `xv upgrade` now **requires** a `.minisig` asset (no warn-and-continue). **`install.sh`** and **`install.ps1`** abort on any checksum download/parse/verify failure instead of skipping verification.
> 
> **Azure Function (`xfunction`):** Vaults **without** a `CreatedByID` tag get **403** (no role assignment). JWT validation **fails closed** when `EXPECTED_AUDIENCE` or issuer config is missing; setup script sets `EXPECTED_AUDIENCE` and **stops printing** the client secret. Storage discovery **no longer** grants RBAC on every account in the resource group when nothing is explicitly associated.
> 
> **Rust CLI / local backend:** Recursive blob downloads use **`safe_join`** (blocks `..` and absolute blob names). **`xv run`** only scans/resolves `xv://` in the parent env when **`inherit_env`** is true. Local age **`load_identity`** uses `O_NOFOLLOW`, permission checks, and `Zeroizing` reads. Table/plain output **escapes** dangerous control chars in untrusted cells (JSON/CSV unchanged).
> 
> Tests and docs were updated for the new fail-closed behavior (e.g. missing creator tag, unassociated storage accounts, key file and escape regressions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61fec475ee625b05ff51e4e39925a03659e73d12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->