### PR TITLE
chore(release): prep v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.11.1 — Security fixes (2026-05-28 security review)
+
+All 10 findings from `docs/security-review-2026-05-28.md` resolved in **#232**.
+
+### Security
+
+- **Critical** — xfunction: a vault without a `CreatedByID` tag is now refused (403) instead of proceeding to Owner/Key Vault Administrator role assignment.
+- **High** — `xv upgrade` refuses to install a release that has no `.minisig` signature asset (previously warn-and-continue). All releases since v0.11.0 are signed in CI.
+- **High** — `install.sh` / `install.ps1` abort on every checksum-verification failure path (missing/empty checksum file, no checksum utility, download failure).
+- **High** — xfunction: storage RBAC discovery no longer falls back to *all* storage accounts in the resource group; accounts without an explicit `AssociatedVault` tag or naming-convention match are skipped.
+- **High** — xfunction: `EXPECTED_AUDIENCE` and issuer configuration are required for JWT validation; tokens are never validated without audience+issuer checks. `setup-app-registration.ps1` now sets `EXPECTED_AUDIENCE`.
+- **Medium** — Recursive blob download routes through `safe_join`, rejecting absolute blob names that previously escaped the output directory.
+- **Medium** — `xv run` only resolves `xv://` references from parent environment variables when `--inherit-env` is active, closing an `env_clear` isolation bypass.
+- **Medium** — Local age key files are opened with `O_NOFOLLOW`, group/world-accessible key files are rejected (with a `chmod 600` hint), the stat→read TOCTOU window is closed, and key material is read into a `Zeroizing` buffer.
+- **Medium** — `setup-app-registration.ps1` no longer prints the client secret to the console.
+- **Low** — Table and plain output visibly escape control characters (C0/DEL/C1) in untrusted content (blob names, metadata, tags); JSON/YAML/CSV output remains raw for scripts.
+
+### Breaking / behavioral notes
+
+- Pre-existing local-backend key files with permissions looser than 0600 are now rejected at load; run `chmod 600 <key-file>` to fix.
+- xfunction deployments must set `EXPECTED_AUDIENCE`; untagged vaults no longer receive role assignments.
+
+---
+
 ## v0.11.0 — Security hardening + dependency triage
 
 ### Security (P2 items from GPT-5.5 review)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"


### PR DESCRIPTION
Version bump 0.11.0 → 0.11.1 and changelog for the security-fix release (all 10 findings from the 2026-05-28 security review, merged in #232).

Tag `v0.11.1` will be pushed after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only change; no runtime code paths modified in this PR.
> 
> **Overview**
> **Release prep for v0.11.1**: bumps the crate version from `0.11.0` to `0.11.1` in `Cargo.toml` and `Cargo.lock`, and adds a **v0.11.1** section to `CHANGELOG.md`.
> 
> The new changelog entry documents the security-fix release tied to **#232** (10 items from `docs/security-review-2026-05-28.md`), including breaking/behavioral notes for operators (e.g. local key file permissions, xfunction `EXPECTED_AUDIENCE` and vault tagging). No application source changes are in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 598daa79e3df62909f2f963281d2a3b3f0570b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->