### PR TITLE
fix(ci): sign Windows release archives with minisign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,14 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install minisign
 
+      - name: Install minisign (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          curl -sLO https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.11-win64.zip
+          unzip -j minisign-0.11-win64.zip -d minisign-bin
+          echo "MINISIGN_BIN=./minisign-bin/minisign.exe" >> "$GITHUB_ENV"
+
       - name: Build release binary
         run: cargo build --release --features tui --target ${{ matrix.target }}
 
@@ -164,13 +172,15 @@ jobs:
             shasum -a 256 ${{ matrix.archive-name }} | cut -d ' ' -f 1 > ${{ matrix.archive-name }}.sha256
           fi
 
+      # Signing must run on EVERY platform: `xv upgrade` (>= v0.11.1) refuses
+      # to install a release asset that has no .minisig, so an unsigned
+      # Windows archive would strand Windows users on their current version.
       - name: Sign release archive
-        if: matrix.os != 'windows-latest'
         shell: bash
         run: |
-          echo "$MINISIGN_SECRET_KEY" > /tmp/minisign.key
-          minisign -Sm ${{ matrix.archive-name }} -s /tmp/minisign.key -t "crosstache ${{ github.ref_name }}"
-          rm -f /tmp/minisign.key
+          echo "$MINISIGN_SECRET_KEY" > minisign.key
+          "${MINISIGN_BIN:-minisign}" -Sm ${{ matrix.archive-name }} -s minisign.key -t "crosstache ${{ github.ref_name }}"
+          rm -f minisign.key
         env:
           MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
 


### PR DESCRIPTION
## Summary

The `Sign release archive` step had `if: matrix.os != 'windows-latest'` and no minisign install for the Windows runner, so **every release ships an unsigned `xv-windows-x64.zip`** — confirmed on both v0.11.0 and v0.11.1.

This matters now because v0.11.1's `xv upgrade` (security review finding #2, PR #232) refuses to install a release whose platform archive has no `.minisig`. A Windows user on v0.11.1 cannot upgrade to any future release unless that release signs the Windows zip.

## Changes

- Install minisign 0.11 (win64) on the Windows runner; export `MINISIGN_BIN` via `GITHUB_ENV`
- Run the signing step on all platforms (was Unix-only), invoking `${MINISIGN_BIN:-minisign}`

No change for Linux/macOS signing behavior.

## Verification

Workflow-only change; verified `${{ }}` interpolations are limited to static matrix values and `github.ref_name`. Will verify end-to-end on the next `v*` tag — the release must contain `xv-windows-x64.zip.minisig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; extends existing minisign signing to Windows without altering application code or secrets handling beyond the prior Unix steps.
> 
> **Overview**
> **Release CI now signs the Windows zip** so `xv-windows-x64.zip.minisig` is published alongside other platform assets.
> 
> Adds a **Windows runner step** to fetch minisign 0.11 (win64) and set `MINISIGN_BIN` for the signing command. The **Sign release archive** step no longer skips `windows-latest`; it uses `${MINISIGN_BIN:-minisign}` and writes the key beside the archive (same pattern on all OSes). A workflow comment explains that **v0.11.1+ `xv upgrade` requires a `.minisig`** per platform archive, so leaving Windows unsigned would block upgrades on that platform.
> 
> Linux and macOS signing behavior is unchanged aside from the shared signing script path/key file location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c39dbceef5c9911bf31c2a3a457e343d003c7a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->