### PR TITLE
fix(cli): POSIX-escape env export values (P3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - **Local backend: soft-delete trash collisions (P2, data loss)** — Trash entries are now keyed by `<encoded_name>@<unix-millis>` instead of name alone, so `xv delete <X>`, recreate, delete again no longer clobbers previously trashed material. A same-name+same-timestamp collision is rejected with a clear error instead of overwriting. Recover restores the most recent trash entry; legacy un-suffixed trash entries from older versions remain listable and recoverable; purge removes all trash snapshots for a name.
+- **Env export escaping** — `xv vault export --format env` now emits POSIX single-quoted values (`KEY='val'`, embedded single quotes escaped as `'\''`), so values containing newlines, `#`, `$`, quotes, spaces, or backslashes survive shell `source`/`eval` byte-for-byte. Secrets whose derived env name is not a valid shell identifier are skipped with a warning on stderr.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -137,6 +137,8 @@ batch with bounded concurrency + retry.
 longest secret length.
 
 ### P3 — Env export emits unescaped `KEY=value`
+> **Resolved in Unreleased** — env export now emits POSIX single-quoted values (`KEY='val'`, embedded single quotes escaped as `'\''`); keys that are not valid shell identifiers are skipped with a warning on stderr. Round-trip through `sh` source verified byte-for-byte in tests.
+
 `src/cli/vault_ops.rs:644`. POSIX single-quote escaping or
 dotenv-quoted output; add tests for newlines, `#`, `$`, quotes.
 

--- a/src/cli/vault_ops.rs
+++ b/src/cli/vault_ops.rs
@@ -526,6 +526,24 @@ async fn execute_vault_purge(
     Ok(())
 }
 
+/// Quote a value for POSIX shell single-quoting: wrap in `'...'` with
+/// embedded single quotes escaped as `'\''`. Round-trips byte-for-byte
+/// through `sh` `source`/`eval`.
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+/// A valid shell identifier: `[A-Za-z_][A-Za-z0-9_]*`.
+fn is_valid_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn format_env_line(key: &str, value: &str) -> String {
+    format!("{key}={}", shell_single_quote(value))
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn execute_vault_export(
     _vault_manager: &VaultManager,
@@ -641,7 +659,14 @@ async fn execute_vault_export(
                                     .to_uppercase()
                                     .replace("-", "_")
                                     .replace(".", "_");
-                                env_lines.push(format!("{env_name}={}", value.as_str()));
+                                if is_valid_env_key(&env_name) {
+                                    env_lines.push(format_env_line(&env_name, value.as_str()));
+                                } else {
+                                    eprintln!(
+                                        "Warning: Skipping secret '{}' — derived env name '{}' is not a valid shell identifier",
+                                        secret.original_name, env_name
+                                    );
+                                }
                             }
                         }
                         Err(e) => {
@@ -1149,4 +1174,148 @@ async fn execute_vault_share(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_env_line, is_valid_env_key, shell_single_quote};
+
+    fn adversarial_values() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("V_NEWLINE", "line1\nline2"),
+            ("V_HASH", "abc#def"),
+            ("V_DOLLAR", "$HOME and ${PATH}"),
+            ("V_SINGLE_QUOTE", "it's a 'test'"),
+            ("V_DOUBLE_QUOTE", "say \"hello\""),
+            ("V_BACKSLASH", "back\\slash\\\\double"),
+            ("V_SPACES", "  leading and trailing  "),
+            ("V_EMPTY", ""),
+            ("V_BACKTICK", "`whoami`"),
+            ("V_MIXED", "a'b\"c$d`e\\f\ng#h"),
+        ]
+    }
+
+    #[test]
+    fn quote_newline() {
+        assert_eq!(shell_single_quote("a\nb"), "'a\nb'");
+    }
+
+    #[test]
+    fn quote_hash() {
+        assert_eq!(shell_single_quote("a#b"), "'a#b'");
+    }
+
+    #[test]
+    fn quote_dollar() {
+        assert_eq!(shell_single_quote("$HOME"), "'$HOME'");
+    }
+
+    #[test]
+    fn quote_single_quote() {
+        assert_eq!(shell_single_quote("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn quote_double_quote() {
+        assert_eq!(shell_single_quote("a\"b"), "'a\"b'");
+    }
+
+    #[test]
+    fn quote_backslash() {
+        assert_eq!(shell_single_quote("a\\b"), "'a\\b'");
+    }
+
+    #[test]
+    fn quote_spaces() {
+        assert_eq!(shell_single_quote(" a b "), "' a b '");
+    }
+
+    #[test]
+    fn quote_empty() {
+        assert_eq!(shell_single_quote(""), "''");
+    }
+
+    #[test]
+    fn format_env_line_quotes_value() {
+        assert_eq!(format_env_line("KEY", "v'al"), "KEY='v'\\''al'");
+    }
+
+    #[test]
+    fn valid_env_keys() {
+        assert!(is_valid_env_key("FOO"));
+        assert!(is_valid_env_key("_FOO"));
+        assert!(is_valid_env_key("FOO_BAR_2"));
+        assert!(is_valid_env_key("f"));
+    }
+
+    #[test]
+    fn invalid_env_keys() {
+        assert!(!is_valid_env_key(""));
+        assert!(!is_valid_env_key("2FOO"));
+        assert!(!is_valid_env_key("FOO-BAR"));
+        assert!(!is_valid_env_key("FOO BAR"));
+        assert!(!is_valid_env_key("FOO.BAR"));
+        assert!(!is_valid_env_key("FOO$"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn round_trip_through_sh() {
+        use std::process::Command;
+
+        for (key, value) in adversarial_values() {
+            let script = format!("{}\nprintf %s \"${key}\"", format_env_line(key, value));
+            let output = Command::new("sh")
+                .arg("-c")
+                .arg(&script)
+                .output()
+                .expect("failed to run sh");
+            assert!(
+                output.status.success(),
+                "sh failed for {key}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert_eq!(
+                output.stdout,
+                value.as_bytes(),
+                "round-trip mismatch for {key}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn round_trip_whole_file_via_dot_source() {
+        use std::io::Write;
+        use std::process::Command;
+
+        let values = adversarial_values();
+        let mut file_body = String::from("# Exported from vault 'test' on 2026-01-01\n");
+        for (key, value) in &values {
+            file_body.push_str(&format_env_line(key, value));
+            file_body.push('\n');
+        }
+
+        let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        tmp.write_all(file_body.as_bytes()).expect("write");
+
+        for (key, value) in &values {
+            let script = format!(". {}\nprintf %s \"${key}\"", tmp.path().display());
+            let output = Command::new("sh")
+                .arg("-c")
+                .arg(&script)
+                .output()
+                .expect("failed to run sh");
+            assert!(
+                output.status.success(),
+                "sourcing failed for {key}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert_eq!(
+                output.stdout,
+                value.as_bytes(),
+                "round-trip mismatch for {key}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Env export now emits POSIX-safe single-quoted values (embedded single quotes escaped), so `source`/`eval` of the output reproduces original values byte-for-byte.
- Handles adversarial values: newlines, `#`, `$`, single/double quotes, backslashes, leading/trailing spaces, empty strings.
- ROADMAP item "P3 — Env export emits unescaped KEY=value" marked resolved; CHANGELOG entry under v0.11.1.

## Testing
- Unit tests for each adversarial value class plus a shell round-trip test (generate export, source in `sh -c`, assert byte-identical env).
- Full `cargo test` green, `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean (verified independently of the autopilot run).

Roadmap: ROADMAP.md § P3 — Env export emits unescaped KEY=value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-format change only in vault_ops env output; improves shell safety with no auth or persistence changes, though scripts that parsed unquoted export lines may need adjustment.
> 
> **Overview**
> **`xv vault export --format env`** no longer emits raw `KEY=value` lines. Values are wrapped in POSIX single quotes with embedded `'` escaped as `'\''`, so `source`/`eval` reproduces secret bytes even when they contain newlines, `#`, `$`, quotes, spaces, or backslashes.
> 
> Secrets whose derived env name fails `[A-Za-z_][A-Za-z0-9_]*` validation are **omitted** with a stderr warning instead of emitting invalid shell assignments.
> 
> **CHANGELOG** (Unreleased) and **ROADMAP** mark the P3 “unescaped env export” item resolved. **Tests** cover quoting helpers, key validation, and Unix `sh` round-trips (per-line and whole exported file).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2554d9200d39f018661f59ff9854a85afadac79d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->