### PR TITLE
fix(cli): preserve secret bytes exactly on --stdin; add --trim opt-in (P3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Local backend: soft-delete trash collisions (P2, data loss)** — Trash entries are now keyed by `<encoded_name>@<unix-millis>` instead of name alone, so `xv delete <X>`, recreate, delete again no longer clobbers previously trashed material. A same-name+same-timestamp collision is rejected with a clear error instead of overwriting. Recover restores the most recent trash entry; legacy un-suffixed trash entries from older versions remain listable and recoverable; purge removes all trash snapshots for a name.
 - **Env export escaping** — `xv vault export --format env` now emits POSIX single-quoted values (`KEY='val'`, embedded single quotes escaped as `'\''`), so values containing newlines, `#`, `$`, quotes, spaces, or backslashes survive shell `source`/`eval` byte-for-byte. Secrets whose derived env name is not a valid shell identifier are skipped with a warning on stderr.
+- **`--stdin` now preserves secret bytes exactly** (`xv set --stdin`, `xv update --stdin`): values read from stdin are stored byte-for-byte as piped — trailing newlines and leading/trailing whitespace are no longer stripped. Previously values were silently whitespace-trimmed, corrupting secrets where exact bytes matter (e.g. PEM keys, values whose consumers expect a trailing `\n`). Pass the new `--trim` flag (requires `--stdin`) to restore the old behavior of stripping leading/trailing whitespace. Empty stdin input is still rejected. (ROADMAP P3 — "`--stdin` trims whitespace")
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,6 +95,8 @@ again clobbers prior deleted material. Suffix trash entries with
 deletion timestamp; reject on collision.
 
 ### P3 — `--stdin` trims whitespace
+> **Resolved in Unreleased**
+
 `src/cli/secret_ops.rs:51,724`. Corrupts secrets where trailing newlines
 matter. Preserve bytes exactly by default; add explicit `--trim`.
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -273,9 +273,13 @@ pub enum Commands {
         /// Supports @/path/to/file to load value from file (e.g., KEY=@/path/to/file)
         #[arg(required = true, num_args = 1..)]
         args: Vec<String>,
-        /// Read value from stdin instead of prompting (only for single secret)
+        /// Read value from stdin instead of prompting (only for single secret).
+        /// Input bytes are preserved exactly: no trimming or newline stripping
         #[arg(long)]
         stdin: bool,
+        /// Trim leading/trailing whitespace from the value read via --stdin
+        #[arg(long, requires = "stdin")]
+        trim: bool,
         /// Note to attach to the secret(s)
         #[arg(long)]
         note: Option<String>,
@@ -470,9 +474,13 @@ pub enum Commands {
         name: String,
         /// New value (if not provided, will prompt)
         value: Option<String>,
-        /// Read value from stdin
+        /// Read value from stdin.
+        /// Input bytes are preserved exactly: no trimming or newline stripping
         #[arg(long)]
         stdin: bool,
+        /// Trim leading/trailing whitespace from the value read via --stdin
+        #[arg(long, requires = "stdin")]
+        trim: bool,
         /// Tags for the secret in key=value format
         #[arg(short, long, value_parser = parse_key_val::<String, String>)]
         tags: Vec<(String, String)>,
@@ -1229,13 +1237,14 @@ impl Cli {
             Commands::Set {
                 args,
                 stdin,
+                trim,
                 note,
                 folder,
                 expires,
                 not_before,
             } => {
                 crate::cli::secret_ops::execute_secret_set_direct(
-                    args, stdin, note, folder, expires, not_before, config, registry,
+                    args, stdin, trim, note, folder, expires, not_before, config, registry,
                 )
                 .await
             }
@@ -1358,6 +1367,7 @@ impl Cli {
                 name,
                 value,
                 stdin,
+                trim,
                 tags,
                 group,
                 rename,
@@ -1374,6 +1384,7 @@ impl Cli {
                     &name,
                     value,
                     stdin,
+                    trim,
                     tags,
                     group,
                     rename,

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -15,10 +15,28 @@ use crate::utils::pagination::Pagination;
 use std::sync::Arc;
 use zeroize::Zeroizing;
 
+/// Read a secret value from `reader`, preserving the input bytes exactly.
+/// With `trim`, leading/trailing whitespace is stripped (the pre-v0.11.1
+/// default, now opt-in via `--trim`).
+fn read_secret_value<R: std::io::Read>(reader: &mut R, trim: bool) -> Result<String> {
+    let mut buffer = String::new();
+    reader.read_to_string(&mut buffer)?;
+    if trim {
+        Ok(buffer.trim().to_string())
+    } else {
+        Ok(buffer)
+    }
+}
+
+fn read_secret_value_from_stdin(trim: bool) -> Result<String> {
+    read_secret_value(&mut std::io::stdin(), trim)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_secret_set_direct(
     args: Vec<String>,
     stdin: bool,
+    trim: bool,
     note: Option<String>,
     folder: Option<String>,
     expires: Option<String>,
@@ -49,9 +67,7 @@ pub(crate) async fn execute_secret_set_direct(
             // Single secret set
             let name = &args[0];
             let value = if stdin {
-                let mut buffer = String::new();
-                std::io::Read::read_to_string(&mut std::io::stdin(), &mut buffer)?;
-                buffer.trim().to_string()
+                read_secret_value_from_stdin(trim)?
             } else {
                 rpassword::prompt_password(format!("Enter value for secret '{name}': "))?
             };
@@ -743,6 +759,7 @@ pub(crate) async fn execute_secret_update_direct(
     name: &str,
     value: Option<String>,
     stdin: bool,
+    trim: bool,
     tags: Vec<(String, String)>,
     groups: Vec<String>,
     rename: Option<String>,
@@ -764,9 +781,11 @@ pub(crate) async fn execute_secret_update_direct(
 
         // Parse value from stdin if requested
         let resolved_value = if stdin {
-            let mut buffer = String::new();
-            std::io::Read::read_to_string(&mut std::io::stdin(), &mut buffer)?;
-            Some(Zeroizing::new(buffer.trim().to_string()))
+            let stdin_value = read_secret_value_from_stdin(trim)?;
+            if stdin_value.is_empty() {
+                return Err(CrosstacheError::config("Secret value cannot be empty"));
+            }
+            Some(Zeroizing::new(stdin_value))
         } else {
             value.map(Zeroizing::new)
         };
@@ -844,6 +863,7 @@ pub(crate) async fn execute_secret_update_direct(
         None,
         value,
         stdin,
+        trim,
         tags,
         groups,
         rename,
@@ -1250,6 +1270,7 @@ async fn execute_secret_set(
     name: &str,
     vault: Option<String>,
     stdin: bool,
+    trim: bool,
     note: Option<String>,
     folder: Option<String>,
     expires: Option<String>,
@@ -1257,7 +1278,6 @@ async fn execute_secret_set(
     config: &Config,
 ) -> Result<()> {
     use crate::config::ContextManager;
-    use std::io::{self, Read};
 
     // Determine vault name using context resolution
     let vault_name = config.resolve_vault_name(vault).await?;
@@ -1268,9 +1288,7 @@ async fn execute_secret_set(
 
     // Get secret value
     let value = if stdin {
-        let mut buffer = String::new();
-        io::stdin().read_to_string(&mut buffer)?;
-        buffer.trim().to_string()
+        read_secret_value_from_stdin(trim)?
     } else {
         // Use rpassword for secure input
         rpassword::prompt_password(format!("Enter value for secret '{name}': "))?
@@ -2919,6 +2937,7 @@ async fn execute_secret_update(
     vault: Option<String>,
     value: Option<String>,
     stdin: bool,
+    trim: bool,
     tags: Vec<(String, String)>,
     groups: Vec<String>,
     rename: Option<String>,
@@ -2935,7 +2954,6 @@ async fn execute_secret_update(
     use crate::config::ContextManager;
     use crate::secret::manager::SecretUpdateRequest;
     use std::collections::HashMap;
-    use std::io::{self, Read};
 
     // Determine vault name using context resolution
     let vault_name = config.resolve_vault_name(vault).await?;
@@ -2952,13 +2970,11 @@ async fn execute_secret_update(
         }
         Some(Zeroizing::new(v))
     } else if stdin {
-        let mut buffer = String::new();
-        io::stdin().read_to_string(&mut buffer)?;
-        let trimmed = buffer.trim().to_string();
-        if trimmed.is_empty() {
+        let stdin_value = read_secret_value_from_stdin(trim)?;
+        if stdin_value.is_empty() {
             return Err(CrosstacheError::config("Secret value cannot be empty"));
         }
-        Some(Zeroizing::new(trimmed))
+        Some(Zeroizing::new(stdin_value))
     } else {
         None // Don't update value, just metadata
     };
@@ -4246,5 +4262,45 @@ mod tests {
 
         let exit_code = stream_and_mask(child, secrets).unwrap();
         assert_eq!(exit_code, 0);
+    }
+
+    #[test]
+    fn stdin_value_is_byte_exact_by_default() {
+        let pem = "-----BEGIN KEY-----\nabc123\n-----END KEY-----\n";
+        let mut reader = std::io::Cursor::new(pem);
+        assert_eq!(read_secret_value(&mut reader, false).unwrap(), pem);
+    }
+
+    #[test]
+    fn stdin_value_preserves_leading_and_trailing_spaces() {
+        let padded = "  value with spaces  ";
+        let mut reader = std::io::Cursor::new(padded);
+        assert_eq!(read_secret_value(&mut reader, false).unwrap(), padded);
+    }
+
+    #[test]
+    fn stdin_trim_strips_leading_and_trailing_whitespace() {
+        let mut reader = std::io::Cursor::new("\n  value with spaces  \n");
+        assert_eq!(
+            read_secret_value(&mut reader, true).unwrap(),
+            "value with spaces"
+        );
+    }
+
+    #[test]
+    fn stdin_trim_preserves_interior_whitespace() {
+        let mut reader = std::io::Cursor::new("  line1\nline2  ");
+        assert_eq!(
+            read_secret_value(&mut reader, true).unwrap(),
+            "line1\nline2"
+        );
+    }
+
+    #[test]
+    fn stdin_empty_input_yields_empty_string_for_caller_rejection() {
+        let mut reader = std::io::Cursor::new("");
+        assert_eq!(read_secret_value(&mut reader, false).unwrap(), "");
+        let mut reader = std::io::Cursor::new("  \n  ");
+        assert_eq!(read_secret_value(&mut reader, true).unwrap(), "");
     }
 }

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -150,6 +150,29 @@ default_vault = "default"
         let out = self.xv_ok(&["get", name, "--raw"]);
         out.trim().to_string()
     }
+
+    /// Run `xv` with the given args, piping `input` to stdin. Returns the
+    /// raw Output (no success assertion) so callers can check exact bytes
+    /// or expected failures.
+    fn xv_with_stdin(&self, args: &[&str], input: &str) -> std::process::Output {
+        let mut cmd = self.xv();
+        cmd.args(args);
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn().expect("spawn xv");
+        if let Some(ref mut stdin) = child.stdin {
+            stdin.write_all(input.as_bytes()).ok();
+        }
+        child.wait_with_output().expect("wait for xv")
+    }
+
+    /// Get a secret's raw value with bytes preserved exactly (no trimming).
+    /// `xv get --raw` prints the value with no trailing newline appended.
+    fn get_raw_exact(&self, name: &str) -> String {
+        self.xv_ok(&["get", name, "--raw"])
+    }
 }
 
 // ===========================================================================
@@ -715,6 +738,122 @@ fn update_value_via_update() {
 
     let value = env.get_raw("UPD_VAL");
     assert_eq!(value, "new-val");
+}
+
+// ===========================================================================
+// --stdin byte-exactness (P3 fix: no implicit trimming)
+// ===========================================================================
+
+#[test]
+fn stdin_set_preserves_trailing_newline_byte_exact() {
+    let env = TestEnv::new();
+    let pem_like = "-----BEGIN KEY-----\nabc123\n-----END KEY-----\n";
+
+    env.set_secret("PEM_KEY", pem_like);
+    assert_eq!(env.get_raw_exact("PEM_KEY"), pem_like);
+}
+
+#[test]
+fn stdin_set_preserves_leading_and_trailing_spaces() {
+    let env = TestEnv::new();
+    let padded = "  spaced value  ";
+
+    env.set_secret("PADDED", padded);
+    assert_eq!(env.get_raw_exact("PADDED"), padded);
+}
+
+#[test]
+fn stdin_set_with_trim_strips_whitespace() {
+    let env = TestEnv::new();
+
+    env.set_secret_with_args("TRIMMED", "  value with spaces  \n", &["--trim"]);
+    assert_eq!(env.get_raw_exact("TRIMMED"), "value with spaces");
+}
+
+#[test]
+fn stdin_set_empty_input_is_rejected() {
+    let env = TestEnv::new();
+
+    let output = env.xv_with_stdin(&["set", "EMPTY", "--stdin"], "");
+    assert!(
+        !output.status.success(),
+        "empty stdin should be rejected for set"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be empty"),
+        "expected empty-value error, got:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn stdin_set_whitespace_only_with_trim_is_rejected() {
+    let env = TestEnv::new();
+
+    let output = env.xv_with_stdin(&["set", "WS_ONLY", "--stdin", "--trim"], " \n ");
+    assert!(
+        !output.status.success(),
+        "whitespace-only stdin with --trim should be rejected"
+    );
+}
+
+#[test]
+fn trim_flag_requires_stdin() {
+    let env = TestEnv::new();
+
+    let (_, stderr) = env.xv_fail(&["set", "NO_STDIN", "--trim"]);
+    assert!(
+        stderr.contains("--stdin"),
+        "--trim without --stdin should mention the missing flag, got:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn stdin_update_preserves_bytes_exactly() {
+    let env = TestEnv::new();
+    env.set_secret("UPD_STDIN", "initial");
+
+    let new_value = "  updated value\n";
+    let output = env.xv_with_stdin(&["update", "UPD_STDIN", "--stdin"], new_value);
+    assert!(
+        output.status.success(),
+        "update --stdin failed:\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(env.get_raw_exact("UPD_STDIN"), new_value);
+}
+
+#[test]
+fn stdin_update_with_trim_strips_whitespace() {
+    let env = TestEnv::new();
+    env.set_secret("UPD_TRIM", "initial");
+
+    let output = env.xv_with_stdin(&["update", "UPD_TRIM", "--stdin", "--trim"], "  new  \n");
+    assert!(
+        output.status.success(),
+        "update --stdin --trim failed:\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(env.get_raw_exact("UPD_TRIM"), "new");
+}
+
+#[test]
+fn stdin_update_empty_input_is_rejected() {
+    let env = TestEnv::new();
+    env.set_secret("UPD_EMPTY", "initial");
+
+    let output = env.xv_with_stdin(&["update", "UPD_EMPTY", "--stdin"], "");
+    assert!(
+        !output.status.success(),
+        "empty stdin should be rejected for update"
+    );
+
+    // Original value untouched
+    assert_eq!(env.get_raw_exact("UPD_EMPTY"), "initial");
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary
- `--stdin` now preserves input bytes EXACTLY — no whitespace trimming, no newline stripping. Fixes silent corruption of secrets where trailing newlines/spaces matter (PEM keys, exact-byte values).
- New `--trim` flag restores the previous trimming behavior as an explicit opt-in.
- Help text documents both; ROADMAP item "P3 — --stdin trims whitespace" marked resolved; CHANGELOG entry flags the deliberate behavior change under v0.11.1.

## Testing
- New e2e tests: trailing-newline and leading/trailing-space values survive set+get round-trip byte-identical; `--trim` strips as documented; empty-stdin behavior covered. e2e_local_backend suite: 40 passed.
- Full `cargo test` green, `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean (verified independently of the autopilot run).

Roadmap: ROADMAP.md § P3 — `--stdin` trims whitespace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default stdin handling changes stored secret bytes for existing scripts that relied on implicit trimming; `--trim` mitigates but callers must opt in.
> 
> **Overview**
> **`xv set --stdin` and `xv update --stdin` now store stdin byte-for-byte** — trailing newlines and leading/trailing whitespace are no longer stripped. That fixes silent corruption for PEM-like secrets and other values where exact bytes matter.
> 
> A new **`--trim`** flag (requires `--stdin`) restores the previous trim-on-read behavior as an explicit opt-in. Shared helpers **`read_secret_value`** / **`read_secret_value_from_stdin`** centralize this for trait and legacy set/update paths; help text, **CHANGELOG**, and **ROADMAP** (P3) document the deliberate behavior change.
> 
> Unit tests cover default preservation, `--trim`, and empty input; **e2e** tests add stdin piping helpers and round-trip cases for set/update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6a631e5ebc984d359c4c4be3b81166609f74a32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->