### PR TITLE
fix(local): resolve file vault per operation

### DIFF
--- a/src/backend/azure/files.rs
+++ b/src/backend/azure/files.rs
@@ -31,10 +31,13 @@ impl AzureFileBackend {
     }
 }
 
+/// Azure blob file storage is scoped to one container per storage account,
+/// not per vault, so the `vault` argument is ignored.
 #[async_trait]
 impl FileBackend for AzureFileBackend {
     async fn upload_file(
         &self,
+        _vault: &str,
         request: FileUploadRequest,
         reporter: Option<&dyn ProgressReporter>,
     ) -> Result<FileInfo, BackendError> {
@@ -48,6 +51,7 @@ impl FileBackend for AzureFileBackend {
 
     async fn download_file(
         &self,
+        _vault: &str,
         name: &str,
         reporter: Option<&dyn ProgressReporter>,
     ) -> Result<Vec<u8>, BackendError> {
@@ -62,15 +66,19 @@ impl FileBackend for AzureFileBackend {
             .map_err(map_error)
     }
 
-    async fn list_files(&self, request: FileListRequest) -> Result<Vec<FileInfo>, BackendError> {
+    async fn list_files(
+        &self,
+        _vault: &str,
+        request: FileListRequest,
+    ) -> Result<Vec<FileInfo>, BackendError> {
         self.inner.list_files(request).await.map_err(map_error)
     }
 
-    async fn delete_file(&self, name: &str) -> Result<(), BackendError> {
+    async fn delete_file(&self, _vault: &str, name: &str) -> Result<(), BackendError> {
         self.inner.delete_file(name).await.map_err(map_error)
     }
 
-    async fn get_file_info(&self, name: &str) -> Result<FileInfo, BackendError> {
+    async fn get_file_info(&self, _vault: &str, name: &str) -> Result<FileInfo, BackendError> {
         self.inner.get_file_info(name).await.map_err(map_error)
     }
 }

--- a/src/backend/file.rs
+++ b/src/backend/file.rs
@@ -14,12 +14,19 @@ use super::error::BackendError;
 ///
 /// All methods are required — if a backend exposes `files()`, it must
 /// support the full file lifecycle.
+///
+/// Every method takes the target `vault` per call, mirroring
+/// [`SecretBackend`](super::SecretBackend), so file operations follow the
+/// active vault selection. Backends whose file storage is not vault-scoped
+/// (e.g. Azure, where files live in one blob container per storage account)
+/// may ignore the argument.
 #[allow(dead_code)] // Infrastructure for Phase 2 pluggability — consumed by future backends.
 #[async_trait]
 pub trait FileBackend: Send + Sync {
     /// Upload a file. The optional [`ProgressReporter`] enables progress bars.
     async fn upload_file(
         &self,
+        vault: &str,
         request: FileUploadRequest,
         reporter: Option<&dyn ProgressReporter>,
     ) -> Result<FileInfo, BackendError>;
@@ -27,16 +34,21 @@ pub trait FileBackend: Send + Sync {
     /// Download a file's contents by name.
     async fn download_file(
         &self,
+        vault: &str,
         name: &str,
         reporter: Option<&dyn ProgressReporter>,
     ) -> Result<Vec<u8>, BackendError>;
 
     /// List files matching the request criteria.
-    async fn list_files(&self, request: FileListRequest) -> Result<Vec<FileInfo>, BackendError>;
+    async fn list_files(
+        &self,
+        vault: &str,
+        request: FileListRequest,
+    ) -> Result<Vec<FileInfo>, BackendError>;
 
     /// Delete a file by name.
-    async fn delete_file(&self, name: &str) -> Result<(), BackendError>;
+    async fn delete_file(&self, vault: &str, name: &str) -> Result<(), BackendError>;
 
     /// Get metadata about a file without downloading it.
-    async fn get_file_info(&self, name: &str) -> Result<FileInfo, BackendError>;
+    async fn get_file_info(&self, vault: &str, name: &str) -> Result<FileInfo, BackendError>;
 }

--- a/src/backend/local/files.rs
+++ b/src/backend/local/files.rs
@@ -66,9 +66,11 @@ fn write_file_meta(path: &Path, info: &FileInfo) -> Result<(), BackendError> {
 // ---------------------------------------------------------------------------
 
 /// File-backed file/blob operations using age encryption.
+///
+/// The target vault is supplied per call (see [`FileBackend`]), so one
+/// instance serves every vault in the store.
 pub struct LocalFileBackend {
     store_path: PathBuf,
-    vault: String,
     identity: age::x25519::Identity,
     recipients: Vec<age::x25519::Recipient>,
 }
@@ -77,13 +79,11 @@ impl LocalFileBackend {
     /// Create a new `LocalFileBackend`.
     pub fn new(
         store_path: PathBuf,
-        vault: String,
         identity: age::x25519::Identity,
         recipients: Vec<age::x25519::Recipient>,
     ) -> Self {
         Self {
             store_path,
-            vault,
             identity,
             recipients,
         }
@@ -94,16 +94,17 @@ impl LocalFileBackend {
 impl FileBackend for LocalFileBackend {
     async fn upload_file(
         &self,
+        vault: &str,
         request: FileUploadRequest,
         _reporter: Option<&dyn ProgressReporter>,
     ) -> Result<FileInfo, BackendError> {
-        let fdir = files_dir(&self.store_path, &self.vault)?;
+        let fdir = files_dir(&self.store_path, vault)?;
         create_private_dir(&fdir)
             .map_err(|e| BackendError::Internal(format!("mkdir files: {e}")))?;
 
         let original_size = request.content.len() as u64;
-        let ap = file_age_path(&self.store_path, &self.vault, &request.name)?;
-        let mp = file_meta_path(&self.store_path, &self.vault, &request.name)?;
+        let ap = file_age_path(&self.store_path, vault, &request.name)?;
+        let mp = file_meta_path(&self.store_path, vault, &request.name)?;
 
         // Encrypt and write file content
         crypto::encrypt_to_file(&ap, &request.content, &self.recipients)?;
@@ -129,10 +130,11 @@ impl FileBackend for LocalFileBackend {
 
     async fn download_file(
         &self,
+        vault: &str,
         name: &str,
         _reporter: Option<&dyn ProgressReporter>,
     ) -> Result<Vec<u8>, BackendError> {
-        let ap = file_age_path(&self.store_path, &self.vault, name)?;
+        let ap = file_age_path(&self.store_path, vault, name)?;
         if !ap.exists() {
             return Err(BackendError::NotFound {
                 name: name.to_string(),
@@ -143,8 +145,12 @@ impl FileBackend for LocalFileBackend {
         crypto::decrypt_bytes_from_file(&ap, &self.identity)
     }
 
-    async fn list_files(&self, request: FileListRequest) -> Result<Vec<FileInfo>, BackendError> {
-        let fdir = files_dir(&self.store_path, &self.vault)?;
+    async fn list_files(
+        &self,
+        vault: &str,
+        request: FileListRequest,
+    ) -> Result<Vec<FileInfo>, BackendError> {
+        let fdir = files_dir(&self.store_path, vault)?;
         if !fdir.exists() {
             return Ok(Vec::new());
         }
@@ -192,9 +198,9 @@ impl FileBackend for LocalFileBackend {
         Ok(results)
     }
 
-    async fn delete_file(&self, name: &str) -> Result<(), BackendError> {
-        let ap = file_age_path(&self.store_path, &self.vault, name)?;
-        let mp = file_meta_path(&self.store_path, &self.vault, name)?;
+    async fn delete_file(&self, vault: &str, name: &str) -> Result<(), BackendError> {
+        let ap = file_age_path(&self.store_path, vault, name)?;
+        let mp = file_meta_path(&self.store_path, vault, name)?;
 
         if !ap.exists() && !mp.exists() {
             return Err(BackendError::NotFound {
@@ -215,8 +221,8 @@ impl FileBackend for LocalFileBackend {
         Ok(())
     }
 
-    async fn get_file_info(&self, name: &str) -> Result<FileInfo, BackendError> {
-        let mp = file_meta_path(&self.store_path, &self.vault, name)?;
+    async fn get_file_info(&self, vault: &str, name: &str) -> Result<FileInfo, BackendError> {
+        let mp = file_meta_path(&self.store_path, vault, name)?;
         if !mp.exists() {
             return Err(BackendError::NotFound {
                 name: name.to_string(),
@@ -257,7 +263,7 @@ mod tests {
         )
         .unwrap();
 
-        let backend = LocalFileBackend::new(store, "default".into(), identity, recipients);
+        let backend = LocalFileBackend::new(store, identity, recipients);
         (backend, tmp)
     }
 
@@ -274,27 +280,26 @@ mod tests {
             tags: HashMap::from([("env".into(), "prod".into())]),
         };
 
-        let info = backend.upload_file(request, None).await.unwrap();
+        let info = backend.upload_file("default", request, None).await.unwrap();
         assert_eq!(info.name, "cert.pem");
         assert_eq!(info.content_type, "application/x-pem-file");
         assert!(info.size > 0);
 
         // Download and verify
-        let bytes = backend.download_file("cert.pem", None).await.unwrap();
+        let bytes = backend
+            .download_file("default", "cert.pem", None)
+            .await
+            .unwrap();
         assert_eq!(bytes, b"-----BEGIN CERTIFICATE-----\nMIIBxTCCA...");
     }
 
     #[tokio::test]
     async fn rejects_traversal_vault_name_for_file_writes() {
-        let tmp = TempDir::new().unwrap();
-        let store = tmp.path().to_path_buf();
-        let key_path = tmp.path().join("key.txt");
-        let recipients_path = tmp.path().join("recipients.txt");
-        let (identity, recipients) = generate_keypair(&key_path, &recipients_path).unwrap();
-        let backend = LocalFileBackend::new(store, "../../outside".into(), identity, recipients);
+        let (backend, tmp) = test_file_backend();
 
         let result = backend
             .upload_file(
+                "../../outside",
                 FileUploadRequest {
                     name: "escape.txt".into(),
                     content: b"content".to_vec(),
@@ -309,6 +314,116 @@ mod tests {
 
         assert!(matches!(result, Err(BackendError::InvalidArgument(_))));
         assert!(!tmp.path().join("outside").exists());
+    }
+
+    #[tokio::test]
+    async fn rejects_traversal_vault_name_for_file_reads() {
+        let (backend, _tmp) = test_file_backend();
+
+        for result in [
+            backend
+                .download_file("../../outside", "any.txt", None)
+                .await
+                .map(|_| ()),
+            backend
+                .list_files(
+                    "../../outside",
+                    FileListRequest {
+                        prefix: None,
+                        groups: None,
+                        limit: None,
+                        delimiter: None,
+                    },
+                )
+                .await
+                .map(|_| ()),
+            backend.delete_file("../../outside", "any.txt").await,
+            backend
+                .get_file_info("../../outside", "any.txt")
+                .await
+                .map(|_| ()),
+        ] {
+            assert!(matches!(result, Err(BackendError::InvalidArgument(_))));
+        }
+    }
+
+    #[tokio::test]
+    async fn operations_target_the_requested_vault_not_default() {
+        let (backend, tmp) = test_file_backend();
+
+        let upload = |vault: &'static str, content: &'static [u8]| {
+            let backend = &backend;
+            async move {
+                backend
+                    .upload_file(
+                        vault,
+                        FileUploadRequest {
+                            name: "config.txt".into(),
+                            content: content.to_vec(),
+                            content_type: None,
+                            groups: Vec::new(),
+                            metadata: HashMap::new(),
+                            tags: HashMap::new(),
+                        },
+                        None,
+                    )
+                    .await
+                    .unwrap()
+            }
+        };
+
+        // Same file name uploaded to two non-default vaults with different content.
+        upload("dev", b"dev content").await;
+        upload("prod", b"prod content").await;
+
+        // Each vault stores its files under its own directory; the default
+        // vault's files dir (pre-created by the test helper) stays empty.
+        assert!(tmp.path().join("vaults/dev/files").exists());
+        assert!(tmp.path().join("vaults/prod/files").exists());
+        let mut default_entries = fs::read_dir(tmp.path().join("vaults/default/files")).unwrap();
+        assert!(default_entries.next().is_none());
+
+        // Downloads resolve per vault, not to the default vault.
+        let dev = backend
+            .download_file("dev", "config.txt", None)
+            .await
+            .unwrap();
+        let prod = backend
+            .download_file("prod", "config.txt", None)
+            .await
+            .unwrap();
+        assert_eq!(dev, b"dev content");
+        assert_eq!(prod, b"prod content");
+
+        // Listing and metadata are scoped to the requested vault.
+        let list_req = || FileListRequest {
+            prefix: None,
+            groups: None,
+            limit: None,
+            delimiter: None,
+        };
+        assert_eq!(
+            backend.list_files("dev", list_req()).await.unwrap().len(),
+            1
+        );
+        assert!(backend
+            .list_files("default", list_req())
+            .await
+            .unwrap()
+            .is_empty());
+        backend.get_file_info("prod", "config.txt").await.unwrap();
+        let missing = backend.get_file_info("default", "config.txt").await;
+        assert!(matches!(missing, Err(BackendError::NotFound { .. })));
+
+        // Deleting in one vault leaves the other vault untouched.
+        backend.delete_file("dev", "config.txt").await.unwrap();
+        let gone = backend.download_file("dev", "config.txt", None).await;
+        assert!(matches!(gone, Err(BackendError::NotFound { .. })));
+        let still_there = backend
+            .download_file("prod", "config.txt", None)
+            .await
+            .unwrap();
+        assert_eq!(still_there, b"prod content");
     }
 
     #[tokio::test]
@@ -329,41 +444,50 @@ mod tests {
                 metadata: HashMap::new(),
                 tags: HashMap::new(),
             };
-            backend.upload_file(request, None).await.unwrap();
+            backend.upload_file("default", request, None).await.unwrap();
         }
 
         // List all
         let all = backend
-            .list_files(FileListRequest {
-                prefix: None,
-                groups: None,
-                limit: None,
-                delimiter: None,
-            })
+            .list_files(
+                "default",
+                FileListRequest {
+                    prefix: None,
+                    groups: None,
+                    limit: None,
+                    delimiter: None,
+                },
+            )
             .await
             .unwrap();
         assert_eq!(all.len(), 3);
 
         // Filter by prefix
         let configs = backend
-            .list_files(FileListRequest {
-                prefix: Some("configs/".into()),
-                groups: None,
-                limit: None,
-                delimiter: None,
-            })
+            .list_files(
+                "default",
+                FileListRequest {
+                    prefix: Some("configs/".into()),
+                    groups: None,
+                    limit: None,
+                    delimiter: None,
+                },
+            )
             .await
             .unwrap();
         assert_eq!(configs.len(), 2);
 
         // Filter by group
         let db_files = backend
-            .list_files(FileListRequest {
-                prefix: None,
-                groups: Some(vec!["db".into()]),
-                limit: None,
-                delimiter: None,
-            })
+            .list_files(
+                "default",
+                FileListRequest {
+                    prefix: None,
+                    groups: Some(vec!["db".into()]),
+                    limit: None,
+                    delimiter: None,
+                },
+            )
             .await
             .unwrap();
         assert_eq!(db_files.len(), 1);
@@ -371,12 +495,15 @@ mod tests {
 
         // Limit
         let limited = backend
-            .list_files(FileListRequest {
-                prefix: None,
-                groups: None,
-                limit: Some(2),
-                delimiter: None,
-            })
+            .list_files(
+                "default",
+                FileListRequest {
+                    prefix: None,
+                    groups: None,
+                    limit: Some(2),
+                    delimiter: None,
+                },
+            )
             .await
             .unwrap();
         assert_eq!(limited.len(), 2);
@@ -394,17 +521,23 @@ mod tests {
             metadata: HashMap::new(),
             tags: HashMap::new(),
         };
-        backend.upload_file(request, None).await.unwrap();
+        backend.upload_file("default", request, None).await.unwrap();
 
         // File exists
-        let info = backend.get_file_info("to-delete.txt").await.unwrap();
+        let info = backend
+            .get_file_info("default", "to-delete.txt")
+            .await
+            .unwrap();
         assert_eq!(info.name, "to-delete.txt");
 
         // Delete
-        backend.delete_file("to-delete.txt").await.unwrap();
+        backend
+            .delete_file("default", "to-delete.txt")
+            .await
+            .unwrap();
 
         // Should be gone
-        let result = backend.get_file_info("to-delete.txt").await;
+        let result = backend.get_file_info("default", "to-delete.txt").await;
         assert!(matches!(result, Err(BackendError::NotFound { .. })));
     }
 
@@ -420,9 +553,12 @@ mod tests {
             metadata: HashMap::from([("uploaded_by".into(), "test-agent".into())]),
             tags: HashMap::from([("version".into(), "1.0".into())]),
         };
-        backend.upload_file(request, None).await.unwrap();
+        backend.upload_file("default", request, None).await.unwrap();
 
-        let info = backend.get_file_info("info-test.bin").await.unwrap();
+        let info = backend
+            .get_file_info("default", "info-test.bin")
+            .await
+            .unwrap();
         assert_eq!(info.name, "info-test.bin");
         assert_eq!(info.size, 1024);
         assert_eq!(info.content_type, "application/octet-stream");
@@ -435,7 +571,9 @@ mod tests {
     async fn download_nonexistent_file_returns_not_found() {
         let (backend, _tmp) = test_file_backend();
 
-        let result = backend.download_file("nonexistent.txt", None).await;
+        let result = backend
+            .download_file("default", "nonexistent.txt", None)
+            .await;
         assert!(matches!(result, Err(BackendError::NotFound { .. })));
     }
 
@@ -454,7 +592,7 @@ mod tests {
             metadata: HashMap::new(),
             tags: HashMap::new(),
         };
-        backend.upload_file(request, None).await.unwrap();
+        backend.upload_file("default", request, None).await.unwrap();
 
         let files_dir = tmp.path().join("vaults").join("default").join("files");
         let meta_path = fs::read_dir(&files_dir)

--- a/src/backend/local/mod.rs
+++ b/src/backend/local/mod.rs
@@ -119,12 +119,7 @@ impl LocalBackend {
         let vault_backend = LocalVaultBackend::new(config.store_path.clone());
 
         #[cfg(feature = "file-ops")]
-        let file_backend = LocalFileBackend::new(
-            config.store_path.clone(),
-            config.default_vault.clone(),
-            identity,
-            recipients,
-        );
+        let file_backend = LocalFileBackend::new(config.store_path.clone(), identity, recipients);
 
         Ok(Self {
             config,

--- a/tests/local_backend_integration.rs
+++ b/tests/local_backend_integration.rs
@@ -234,50 +234,139 @@ async fn test_file_storage_roundtrip() {
         metadata: HashMap::from([("env".into(), "prod".into())]),
         tags: HashMap::from([("purpose".into(), "tls".into())]),
     };
-    let info = files.upload_file(upload_req, None).await.unwrap();
+    let info = files
+        .upload_file("default", upload_req, None)
+        .await
+        .unwrap();
     assert_eq!(info.name, "certs/server.pem");
     assert_eq!(info.size, content.len() as u64);
 
     // List files
     let list = files
-        .list_files(FileListRequest {
-            prefix: None,
-            groups: None,
-            limit: None,
-            delimiter: None,
-        })
+        .list_files(
+            "default",
+            FileListRequest {
+                prefix: None,
+                groups: None,
+                limit: None,
+                delimiter: None,
+            },
+        )
         .await
         .unwrap();
     assert_eq!(list.len(), 1);
     assert_eq!(list[0].name, "certs/server.pem");
 
     // Download and verify content matches
-    let downloaded = files.download_file("certs/server.pem", None).await.unwrap();
+    let downloaded = files
+        .download_file("default", "certs/server.pem", None)
+        .await
+        .unwrap();
     assert_eq!(downloaded, content);
 
     // Get file info
-    let file_info = files.get_file_info("certs/server.pem").await.unwrap();
+    let file_info = files
+        .get_file_info("default", "certs/server.pem")
+        .await
+        .unwrap();
     assert_eq!(file_info.name, "certs/server.pem");
     assert_eq!(file_info.content_type, "application/x-pem-file");
 
     // Delete
-    files.delete_file("certs/server.pem").await.unwrap();
+    files
+        .delete_file("default", "certs/server.pem")
+        .await
+        .unwrap();
 
     // Verify gone
     let list = files
-        .list_files(FileListRequest {
-            prefix: None,
-            groups: None,
-            limit: None,
-            delimiter: None,
-        })
+        .list_files(
+            "default",
+            FileListRequest {
+                prefix: None,
+                groups: None,
+                limit: None,
+                delimiter: None,
+            },
+        )
         .await
         .unwrap();
     assert!(list.is_empty());
 
     // Download should fail
-    let err = files.download_file("certs/server.pem", None).await;
+    let err = files
+        .download_file("default", "certs/server.pem", None)
+        .await;
     assert!(matches!(err, Err(BackendError::NotFound { .. })));
+}
+
+/// Regression test for ROADMAP P2: file operations used to be pinned to the
+/// vault captured at backend construction (the default vault), so every
+/// upload landed in `default` regardless of the selected vault.
+#[cfg(feature = "file-ops")]
+#[tokio::test]
+async fn test_file_operations_target_selected_vault() {
+    use crosstache::blob::models::{FileListRequest, FileUploadRequest};
+
+    let tmp = TempDir::new().unwrap();
+    let backend = make_backend(&tmp);
+    let vaults = backend.vaults().expect("local backend has vaults");
+    let files = backend.files().expect("file-ops feature should be enabled");
+
+    vaults.create_vault(vault_req("dev")).await.unwrap();
+    vaults.create_vault(vault_req("prod")).await.unwrap();
+
+    let upload_req = |content: &[u8]| FileUploadRequest {
+        name: "app.env".into(),
+        content: content.to_vec(),
+        content_type: None,
+        groups: Vec::new(),
+        metadata: HashMap::new(),
+        tags: HashMap::new(),
+    };
+    files
+        .upload_file("dev", upload_req(b"DEV=1"), None)
+        .await
+        .unwrap();
+    files
+        .upload_file("prod", upload_req(b"PROD=1"), None)
+        .await
+        .unwrap();
+
+    // Nothing leaked into the default vault.
+    assert!(!tmp.path().join("store/vaults/default/files").exists());
+    let list_req = || FileListRequest {
+        prefix: None,
+        groups: None,
+        limit: None,
+        delimiter: None,
+    };
+    assert!(files
+        .list_files("default", list_req())
+        .await
+        .unwrap()
+        .is_empty());
+
+    // Each vault sees exactly its own copy with its own content.
+    let dev_list = files.list_files("dev", list_req()).await.unwrap();
+    assert_eq!(dev_list.len(), 1);
+    assert_eq!(
+        files.download_file("dev", "app.env", None).await.unwrap(),
+        b"DEV=1"
+    );
+    assert_eq!(
+        files.download_file("prod", "app.env", None).await.unwrap(),
+        b"PROD=1"
+    );
+
+    // Deleting from one vault does not touch the other.
+    files.delete_file("dev", "app.env").await.unwrap();
+    let err = files.get_file_info("dev", "app.env").await;
+    assert!(matches!(err, Err(BackendError::NotFound { .. })));
+    assert_eq!(
+        files.download_file("prod", "app.env", None).await.unwrap(),
+        b"PROD=1"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Extends FileBackend operations to accept a per-call vault, matching SecretBackend semantics.
- Updates the local file backend so operations no longer always target the default vault captured at construction.
- Adds regression coverage for multi-vault local file isolation and traversal rejection.

## Verification
- cargo fmt --check
- cargo clippy --all-targets --features file-ops -- -D warnings
- cargo test --all-targets --features file-ops

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes file storage scoping (correctness fix) and breaks the `FileBackend` trait API; callers must pass vault on every operation.
> 
> **Overview**
> **`FileBackend` now takes a `vault` on every call**, matching `SecretBackend`, so callers can target the active vault instead of whatever was fixed at backend construction.
> 
> **Local file storage** drops the per-instance vault field and routes upload/download/list/delete/info through `vault` into `vaults/<vault>/files/`. **`AzureFileBackend`** adds the parameter but documents that it is ignored (container-scoped storage). **`LocalBackend`** no longer passes `default_vault` when building the file backend.
> 
> Tests and integration coverage are updated for the new signatures, plus regressions for **multi-vault isolation**, **path traversal rejection on read paths**, and the prior bug where uploads always landed in `default`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6093867af28c165e23116886e0f018813b50af9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->