### PR TITLE
chore: bump version to 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## v0.11.2 — P2 security-hardening completion (2026-06-11)
+
+Closes out all four remaining P2 items from the 2026-05-09 GPT-5.5 code
+review, plus byte-fidelity and data-loss fixes that had been soaking in
+`Unreleased`.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Crosstache Roadmap
 
-> **Last reviewed:** 2026-06-11 · **Latest released version:** `v0.11.1` · **Branch protection:** `main` (all changes via PR)
+> **Last reviewed:** 2026-06-11 · **Latest released version:** `v0.11.2` · **Branch protection:** `main` (all changes via PR)
 
 Single source of truth for **unimplemented** ideas, deferred work, and known
 limitations worth fixing. Anything already shipped lives in [`CHANGELOG.md`](./CHANGELOG.md).


### PR DESCRIPTION
## Summary
- Bump `Cargo.toml` / `Cargo.lock` to 0.11.2.
- CHANGELOG: rename `Unreleased` to **v0.11.2 — P2 security-hardening completion (2026-06-11)**.
- ROADMAP: update latest-released-version banner.

## Release contents
- P2: rename recoverability (#242), blob download streaming (#243), per-call file vault resolution (#244), Azure deleted/backup/restore REST paths (#245), local trash collision fix (#235)
- P3: --stdin byte fidelity (#237), env export escaping (#236), tri-state metadata updates (#238)
- Deps: tar 0.4.46 security bump (#228)
- CI: Windows minisign signing (#234)

## Verification
- cargo fmt --check, clippy --all-targets --features file-ops -D warnings, cargo test --all-targets --features file-ops — all green locally on the release branch.

Release-branch PR; pre-approved auto-merge class once CI green + Bugbot clean. Tag v0.11.2 will be pushed after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version bump only; no runtime code changes in the diff.
> 
> **Overview**
> **Release v0.11.2** — bumps `crosstache` from **0.11.1** to **0.11.2** in `Cargo.toml` and `Cargo.lock`.
> 
> The changelog section formerly labeled **Unreleased** is retitled **v0.11.2 — P2 security-hardening completion (2026-06-11)** with a short intro framing the shipped P2 review items and byte-fidelity/data-loss fixes. `ROADMAP.md` updates the “latest released version” banner to **v0.11.2**.
> 
> No application source changes in this diff; it documents and versions work already on the release branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e38300d12407d9b921c9662b2419b21bc1dd8db8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->