### PR TITLE
feat(aws): capability-aware share hints

### DIFF
--- a/src/backend/aws/encoding.rs
+++ b/src/backend/aws/encoding.rs
@@ -106,13 +106,13 @@ mod tests {
 
     #[test]
     fn validate_secret_name_rejects_reserved() {
-        assert!(matches!(validate_secret_name(".xv-vault"), Err(_)));
-        assert!(matches!(validate_secret_name(".xv-anything"), Err(_)));
+        assert!(validate_secret_name(".xv-vault").is_err());
+        assert!(validate_secret_name(".xv-anything").is_err());
     }
 
     #[test]
     fn validate_secret_name_rejects_empty() {
-        assert!(matches!(validate_secret_name(""), Err(_)));
+        assert!(validate_secret_name("").is_err());
     }
 
     #[test]

--- a/src/backend/aws/errors.rs
+++ b/src/backend/aws/errors.rs
@@ -260,7 +260,7 @@ mod tests {
     use aws_smithy_runtime_api::client::result::ConnectorError;
 
     fn make_user_dispatch_failure() -> SdkError<ListSecretsError, HttpResponse> {
-        let inner = std::io::Error::new(std::io::ErrorKind::Other, "no credentials in chain");
+        let inner = std::io::Error::other("no credentials in chain");
         SdkError::dispatch_failure(ConnectorError::user(Box::new(inner)))
     }
 
@@ -301,10 +301,7 @@ mod tests {
         // Build a non-user DispatchFailure carrying an inner error whose
         // Display contains a credential-provider hint. `ConnectorError::io`
         // does not set the user flag.
-        let inner = std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "CredentialsNotLoaded: failed to load credentials",
-        );
+        let inner = std::io::Error::other("CredentialsNotLoaded: failed to load credentials");
         let sdk: SdkError<ListSecretsError, HttpResponse> =
             SdkError::dispatch_failure(ConnectorError::io(Box::new(inner)));
         let err = from_list(sdk);

--- a/src/backend/aws/metadata.rs
+++ b/src/backend/aws/metadata.rs
@@ -6,6 +6,7 @@
 pub const TAG_ORIGINAL_NAME: &str = "xv:original_name";
 pub const TAG_GROUPS: &str = "xv:groups";
 pub const TAG_FOLDER: &str = "xv:folder";
+#[allow(dead_code)] // reserved xv: tag key; exercised by the round-trip tests only
 pub const TAG_CREATED_BY: &str = "xv:created_by";
 pub const TAG_CONTENT_TYPE: &str = "xv:content_type";
 pub const TAG_EXPIRES_AT: &str = "xv:expires_at";
@@ -62,7 +63,8 @@ mod tests {
         folder: Option<String>,
         created_by: Option<String>,
         content_type: Option<String>,
-        note: Option<String>, // -> AWS Description, not a tag
+        #[allow(dead_code)] // -> AWS Description, not a tag; never decoded back
+        note: Option<String>,
         expires_at: Option<String>,
         user_tags: HashMap<String, String>,
     }

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -23,6 +23,51 @@ pub(crate) fn use_vault_trait_path(registry: Option<&BackendRegistry>) -> bool {
     registry.is_some_and(|r| r.active().kind() != BackendKind::Azure)
 }
 
+/// Resolve the kind of the backend the user *requested*, from config alone.
+///
+/// Used when no registry exists (backend init failed or was skipped) so that
+/// capability checks still apply to the requested backend instead of silently
+/// falling through to the legacy Azure path. Returns `None` when the name is
+/// not a known backend or named-backend entry.
+pub(crate) fn requested_backend_kind(config: &Config) -> Option<BackendKind> {
+    use crate::config::settings::NamedBackendEntry;
+
+    let name = config.effective_backend_name();
+    if let Some(entry) = config.named_backends.get(name) {
+        return Some(match entry {
+            NamedBackendEntry::Aws(_) => BackendKind::Aws,
+            NamedBackendEntry::Local(_) => BackendKind::Local,
+        });
+    }
+    name.parse().ok()
+}
+
+/// Build the error returned when a share/RBAC operation is attempted on a
+/// backend without RBAC support (`has_rbac: false`).
+///
+/// `operation` is the lowercase noun for the failing surface: "access
+/// sharing" for `xv share`, "vault sharing" for `xv vault share`. AWS points
+/// at the native IAM / resource-policy equivalent; other backends keep the
+/// generic capability message.
+pub(crate) fn share_unsupported_error(
+    kind: BackendKind,
+    backend_name: &str,
+    operation: &str,
+) -> CrosstacheError {
+    match kind {
+        BackendKind::Aws => CrosstacheError::invalid_argument(format!(
+            "{operation} is not supported on the {backend_name} backend: AWS Secrets Manager \
+             manages access through IAM rather than vault RBAC.\n\
+             Grant access with a secret resource policy or an IAM policy instead, e.g.:\n  \
+             aws secretsmanager put-resource-policy --secret-id <secret-name> --resource-policy file://policy.json\n  \
+             aws iam attach-user-policy --user-name <user-name> --policy-arn <policy-arn>"
+        )),
+        _ => CrosstacheError::invalid_argument(format!(
+            "The {backend_name} backend does not support {operation}. Use the azure backend for RBAC."
+        )),
+    }
+}
+
 /// Resolve the vault name for the active backend trait path.
 ///
 /// Azure keeps the legacy resolver semantics: no implicit fallback is allowed,
@@ -437,4 +482,57 @@ pub(crate) fn mask_secrets(text: &str, secrets: &[Zeroizing<String>]) -> String 
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aws_share_error_names_backend_and_suggests_iam() {
+        let err = share_unsupported_error(BackendKind::Aws, "aws", "access sharing");
+        assert_eq!(err.exit_code(), 2);
+        let msg = err.to_string();
+        assert!(msg.contains("aws"), "should name the backend: {msg}");
+        assert!(msg.contains("not supported"), "{msg}");
+        assert!(
+            msg.contains("aws secretsmanager put-resource-policy"),
+            "should include a resource-policy example: {msg}"
+        );
+        assert!(
+            msg.contains("aws iam"),
+            "should include an IAM example: {msg}"
+        );
+    }
+
+    #[test]
+    fn aws_vault_share_error_names_operation() {
+        let err = share_unsupported_error(BackendKind::Aws, "aws", "vault sharing");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("vault sharing is not supported on the aws backend"),
+            "{msg}"
+        );
+        assert!(
+            msg.contains("aws secretsmanager put-resource-policy"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn non_aws_share_error_keeps_generic_message() {
+        let err = share_unsupported_error(BackendKind::Local, "local", "access sharing");
+        assert_eq!(
+            err.to_string(),
+            "Invalid argument: The local backend does not support access sharing. \
+             Use the azure backend for RBAC."
+        );
+
+        let err = share_unsupported_error(BackendKind::Azure, "azure", "vault sharing");
+        assert_eq!(
+            err.to_string(),
+            "Invalid argument: The azure backend does not support vault sharing. \
+             Use the azure backend for RBAC."
+        );
+    }
 }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -4,7 +4,7 @@ use crate::backend::{BackendKind, BackendRef, BackendRegistry};
 use crate::cli::commands::{CharsetType, ShareCommands};
 use crate::cli::helpers::{
     copy_to_clipboard, generate_random_value, get_azure_auth_provider, mask_secrets,
-    resolve_vault_for_trait, schedule_clipboard_clear, use_trait_path,
+    resolve_vault_for_trait, schedule_clipboard_clear, share_unsupported_error, use_trait_path,
 };
 use crate::config::Config;
 use crate::error::{CrosstacheError, Result};
@@ -1249,14 +1249,26 @@ pub(crate) async fn execute_secret_share_direct(
     use crate::auth::provider::AzureAuthProvider;
     use crate::vault::manager::VaultManager;
 
-    // Capability check: sharing requires RBAC support
+    // Capability check: sharing requires RBAC support. When the registry is
+    // missing (the requested backend failed to initialize), resolve the
+    // requested backend from config so non-RBAC backends still get the
+    // capability hint instead of silently using the legacy Azure path.
     if let Some(registry) = registry {
-        let caps = registry.active().capabilities();
-        if !caps.has_rbac {
-            return Err(CrosstacheError::InvalidArgument(format!(
-                "The {} backend does not support access sharing. Use the azure backend for RBAC.",
-                registry.active().name()
-            )));
+        let active = registry.active();
+        if !active.capabilities().has_rbac {
+            return Err(share_unsupported_error(
+                active.kind(),
+                active.name(),
+                "access sharing",
+            ));
+        }
+    } else if let Some(kind) = crate::cli::helpers::requested_backend_kind(&config) {
+        if kind != BackendKind::Azure {
+            return Err(share_unsupported_error(
+                kind,
+                config.effective_backend_name(),
+                "access sharing",
+            ));
         }
     }
 
@@ -3912,6 +3924,12 @@ mod tests {
                 kind: BackendKind::Local,
             }
         }
+
+        fn aws() -> Self {
+            Self {
+                kind: BackendKind::Aws,
+            }
+        }
     }
 
     #[async_trait::async_trait]
@@ -4125,6 +4143,126 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resolved, "local-vault");
+    }
+
+    #[tokio::test]
+    async fn aws_share_grant_returns_capability_hint() {
+        let registry = BackendRegistry::new(Arc::new(TestBackend::aws()));
+        let config = Config {
+            backend: Some("aws".to_string()),
+            ..Default::default()
+        };
+
+        let err = execute_secret_share_direct(
+            ShareCommands::Grant {
+                secret_name: "api-key".to_string(),
+                user: "user@example.com".to_string(),
+                level: "read".to_string(),
+            },
+            config,
+            Some(&registry),
+        )
+        .await
+        .expect_err("share grant on aws must be rejected");
+
+        assert_eq!(err.exit_code(), 2);
+        let msg = err.to_string();
+        assert!(msg.contains("aws"), "should name the backend: {msg}");
+        assert!(msg.contains("not supported"), "{msg}");
+        assert!(
+            msg.contains("aws secretsmanager put-resource-policy"),
+            "should suggest the native equivalent: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn aws_share_list_returns_capability_hint() {
+        let registry = BackendRegistry::new(Arc::new(TestBackend::aws()));
+        let config = Config {
+            backend: Some("aws".to_string()),
+            ..Default::default()
+        };
+
+        let err = execute_secret_share_direct(
+            ShareCommands::List {
+                secret_name: "api-key".to_string(),
+                all: false,
+                page: None,
+                page_size: None,
+                pager: false,
+            },
+            config,
+            Some(&registry),
+        )
+        .await
+        .expect_err("share list on aws must be rejected");
+
+        assert_eq!(err.exit_code(), 2);
+        let msg = err.to_string();
+        assert!(msg.contains("aws"), "should name the backend: {msg}");
+        assert!(msg.contains("not supported"), "{msg}");
+        assert!(
+            msg.contains("aws secretsmanager put-resource-policy"),
+            "should suggest the native equivalent: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_share_error_message_unchanged() {
+        let registry = BackendRegistry::new(Arc::new(TestBackend::local()));
+        let config = Config {
+            backend: Some("local".to_string()),
+            ..Default::default()
+        };
+
+        let err = execute_secret_share_direct(
+            ShareCommands::Revoke {
+                secret_name: "api-key".to_string(),
+                user: "user@example.com".to_string(),
+            },
+            config,
+            Some(&registry),
+        )
+        .await
+        .expect_err("share revoke on local must be rejected");
+
+        assert_eq!(
+            err.to_string(),
+            "Invalid argument: The local backend does not support access sharing. \
+             Use the azure backend for RBAC."
+        );
+    }
+
+    /// When `--backend aws` is requested but backend init failed (e.g. no
+    /// `[aws]` config block), the registry is `None`. Share must still return
+    /// the capability hint rather than fall through to the Azure path.
+    #[tokio::test]
+    async fn aws_share_without_registry_still_returns_capability_hint() {
+        let config = Config {
+            backend: Some("aws".to_string()),
+            ..Default::default()
+        };
+
+        let err = execute_secret_share_direct(
+            ShareCommands::Grant {
+                secret_name: "api-key".to_string(),
+                user: "user@example.com".to_string(),
+                level: "read".to_string(),
+            },
+            config,
+            None,
+        )
+        .await
+        .expect_err("share grant on aws without a registry must be rejected");
+
+        assert_eq!(err.exit_code(), 2);
+        let msg = err.to_string();
+        assert!(msg.contains("aws"), "should name the backend: {msg}");
+        assert!(msg.contains("not supported"), "{msg}");
+        assert!(
+            msg.contains("aws secretsmanager put-resource-policy"),
+            "should suggest the native equivalent: {msg}"
+        );
     }
 
     #[test]

--- a/src/cli/vault_ops.rs
+++ b/src/cli/vault_ops.rs
@@ -3,7 +3,7 @@
 use crate::auth::provider::AzureAuthProvider;
 use crate::backend::BackendRegistry;
 use crate::cli::commands::{VaultCommands, VaultShareCommands};
-use crate::cli::helpers::{get_azure_auth_provider, use_vault_trait_path};
+use crate::cli::helpers::{get_azure_auth_provider, share_unsupported_error, use_vault_trait_path};
 use crate::config::Config;
 use crate::error::{CrosstacheError, Result};
 use crate::utils::format::OutputFormat;
@@ -22,6 +22,20 @@ pub(crate) async fn execute_vault_command(
     // the legacy VaultManager path below.
     if use_vault_trait_path(registry) {
         let reg = registry.expect("use_trait_path guarantees Some");
+
+        // Capability check: `vault share` needs RBAC, not vault CRUD, so it
+        // is answered before resolving general vault support.
+        if let VaultCommands::Share { .. } = command {
+            let active = reg.active();
+            if !active.capabilities().has_rbac {
+                return Err(share_unsupported_error(
+                    active.kind(),
+                    active.name(),
+                    "vault sharing",
+                ));
+            }
+        }
+
         let vaults_backend = reg.active().vaults().ok_or_else(|| {
             CrosstacheError::InvalidArgument(format!(
                 "The {} backend does not support vault operations.",
@@ -114,7 +128,8 @@ pub(crate) async fn execute_vault_command(
             }
             _other => {
                 // Commands not yet supported on non-Azure backends
-                // (Restore, Purge, Export, Import, Update, Share)
+                // (Restore, Purge, Export, Import, Update; Share is answered
+                // by the RBAC capability check above)
                 return Err(CrosstacheError::InvalidArgument(format!(
                     "The {} backend does not support this vault command yet.",
                     reg.active().name(),
@@ -263,14 +278,26 @@ pub(crate) async fn execute_vault_command(
             vault_cache_manager.invalidate(&crate::cache::CacheKey::VaultList);
         }
         VaultCommands::Share { command } => {
-            // Capability check: vault sharing requires RBAC support
+            // Capability check: vault sharing requires RBAC support. With no
+            // registry (requested backend failed to initialize), resolve the
+            // requested backend from config so non-RBAC backends still get
+            // the capability hint instead of the legacy Azure path.
             if let Some(registry) = registry {
-                let caps = registry.active().capabilities();
-                if !caps.has_rbac {
-                    return Err(CrosstacheError::InvalidArgument(format!(
-                        "The {} backend does not support vault sharing. Use the azure backend for RBAC.",
-                        registry.active().name()
-                    )));
+                let active = registry.active();
+                if !active.capabilities().has_rbac {
+                    return Err(share_unsupported_error(
+                        active.kind(),
+                        active.name(),
+                        "vault sharing",
+                    ));
+                }
+            } else if let Some(kind) = crate::cli::helpers::requested_backend_kind(&config) {
+                if kind != crate::backend::BackendKind::Azure {
+                    return Err(share_unsupported_error(
+                        kind,
+                        config.effective_backend_name(),
+                        "vault sharing",
+                    ));
                 }
             }
             execute_vault_share(&vault_manager, &auth_provider, command, &config).await?;

--- a/tests/aws_localstack_tests.rs
+++ b/tests/aws_localstack_tests.rs
@@ -13,7 +13,7 @@
 #![allow(dead_code)]
 
 use crosstache::backend::aws::AwsBackend;
-use crosstache::backend::{Backend, SecretBackend, VaultBackend};
+use crosstache::backend::Backend;
 use crosstache::config::settings::AwsConfig;
 use crosstache::secret::manager::SecretRequest;
 use zeroize::Zeroizing;


### PR DESCRIPTION
## Summary
- All `xv share` / `xv vault share` operations on the AWS backend now exit 2 with a capability error naming the backend and giving a copyable `aws secretsmanager put-resource-policy` example, instead of failing opaquely.
- Local secret-share messages unchanged; vault-share message unified to the share-specific error.
- (ROADMAP P1 — AWS capability matrix: `xv share`)

## Verification
- cargo fmt --check; clippy --all-targets (default AND --features aws) -D warnings; cargo test --all-targets (both feature sets, isolated XDG_CONFIG_HOME) — all green, verified independently of the implementing agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI error-path and messaging changes only; no auth or secret data handling changes, with broad test coverage for AWS/local and no-registry cases.
> 
> **Overview**
> **`xv share` and `xv vault share`** now reject backends without RBAC through shared helpers in `helpers.rs`. **AWS** gets exit code **2** with a message that names the backend and points to **`put-resource-policy`** / IAM examples instead of a generic “use Azure” line. **Local** secret-share wording is unchanged.
> 
> When the backend registry is missing (e.g. AWS init failed), **`requested_backend_kind`** reads the configured backend so share still fails with the right hint instead of falling through to the legacy Azure RBAC path. **Vault share** on the trait path is blocked up front for non-RBAC backends before other vault-command errors.
> 
> Minor hygiene: clippy-friendly test assertions, `std::io::Error::other`, dead-code allows in AWS metadata tests, and a slimmer LocalStack test import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d0445c6a7388fb7211b4ac43b6eb744ead0b78a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->