### PR TITLE
feat(aws): implement xv audit via CloudTrail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-cloudtrail"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd81ebaf83622705249d1e935a6d37f275e6ab27cf78e595fa94300297abefb9"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.4.1",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-secretsmanager"
 version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1581,7 @@ dependencies = [
  "arboard",
  "async-trait",
  "aws-config",
+ "aws-sdk-cloudtrail",
  "aws-sdk-secretsmanager",
  "aws-smithy-mocks-experimental",
  "aws-smithy-runtime-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ azure_mgmt_storage = "0.21"
 
 # AWS SDK - feature-gated under `aws`
 aws-sdk-secretsmanager = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio", "behavior-version-latest"] }
+aws-sdk-cloudtrail = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio", "behavior-version-latest"] }
 aws-config = { version = "1", optional = true, features = ["behavior-version-latest"] }
 aws-smithy-runtime-api = { version = "1", optional = true }
 
@@ -105,7 +106,7 @@ zip = "2"
 default = ["file-ops"]
 file-ops = []
 tui = []
-aws = ["dep:aws-sdk-secretsmanager", "dep:aws-config", "dep:aws-smithy-runtime-api"]
+aws = ["dep:aws-sdk-secretsmanager", "dep:aws-sdk-cloudtrail", "dep:aws-config", "dep:aws-smithy-runtime-api"]
 
 [build-dependencies]
 built = { version = "0.7", features = ["git2", "chrono"] }

--- a/src/backend/audit.rs
+++ b/src/backend/audit.rs
@@ -1,0 +1,52 @@
+//! Audit log abstraction.
+//!
+//! Backends that can surface an audit trail (e.g. AWS via CloudTrail)
+//! implement [`AuditBackend`] and expose it through
+//! [`Backend::audit()`](super::Backend::audit). The CLI renders
+//! [`AuditEvent`] rows in the same table/JSON shapes as the Azure
+//! Activity Log path.
+//!
+//! Azure currently keeps its legacy Activity Log client in
+//! `cli::system_ops` and does not implement this trait.
+
+use async_trait::async_trait;
+
+use super::error::BackendError;
+
+/// A single audit log event, backend-agnostic.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AuditEvent {
+    /// When the event occurred.
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    /// Operation name (e.g. `GetSecretValue`).
+    pub operation: String,
+    /// User-facing secret name (vault prefix already stripped).
+    pub resource_name: String,
+    /// Principal that performed the operation (username or ARN).
+    pub caller: String,
+    /// Outcome: `Succeeded` or the backend's error code.
+    pub status: String,
+    /// Source IP address, when the backend records one.
+    pub source_ip: Option<String>,
+    /// Backend-assigned unique event ID.
+    pub event_id: String,
+}
+
+/// Audit log operations for backends that support them.
+#[async_trait]
+pub trait AuditBackend: Send + Sync {
+    /// Fetch recent events for every secret in the vault, newest first.
+    async fn get_vault_events(
+        &self,
+        vault: &str,
+        days: u32,
+    ) -> Result<Vec<AuditEvent>, BackendError>;
+
+    /// Fetch recent events for a single secret, newest first.
+    async fn get_secret_events(
+        &self,
+        vault: &str,
+        secret_name: &str,
+        days: u32,
+    ) -> Result<Vec<AuditEvent>, BackendError>;
+}

--- a/src/backend/aws/audit.rs
+++ b/src/backend/aws/audit.rs
@@ -174,8 +174,9 @@ fn normalize_secret_id(id: &str) -> Option<String> {
 }
 
 /// Resolve the full (vault-prefixed) secret name an event refers to, trying
-/// the event's resource list first, then `requestParameters.secretId` from
-/// the raw CloudTrail record.
+/// the event's resource list first, then `requestParameters.secretId`, then
+/// `requestParameters.name` (CloudTrail logs `CreateSecret` with `name`
+/// rather than `secretId`) from the raw CloudTrail record.
 fn full_secret_name(event: &Event, raw: &serde_json::Value) -> Option<String> {
     for resource in event.resources() {
         if resource.resource_type() != Some("AWS::SecretsManager::Secret") {
@@ -185,9 +186,10 @@ fn full_secret_name(event: &Event, raw: &serde_json::Value) -> Option<String> {
             return Some(name);
         }
     }
-    raw.get("requestParameters")
-        .and_then(|p| p.get("secretId"))
-        .and_then(|v| v.as_str())
+    let params = raw.get("requestParameters")?;
+    ["secretId", "name"]
+        .iter()
+        .find_map(|key| params.get(key).and_then(|v| v.as_str()))
         .and_then(normalize_secret_id)
 }
 
@@ -396,6 +398,24 @@ mod tests {
             .cloud_trail_event(r#"{"eventName":"ListSecrets"}"#)
             .build();
         assert!(map_event(&event, VAULT, None).is_none());
+    }
+
+    #[test]
+    fn map_event_falls_back_to_request_parameters_name() {
+        // CreateSecret logs requestParameters.name (not secretId); with no
+        // resources list the name fallback must still resolve the secret.
+        let raw = format!(
+            r#"{{"eventName":"CreateSecret","requestParameters":{{"name":"{VAULT}/db-password"}},"userIdentity":{{"arn":"arn:aws:iam::123456789012:user/alice"}}}}"#
+        );
+        let event = Event::builder()
+            .event_id("evt-create")
+            .event_name("CreateSecret")
+            .event_time(AwsDateTime::from_secs(1_780_000_000))
+            .cloud_trail_event(raw)
+            .build();
+        let row = map_event(&event, VAULT, None).expect("CreateSecret event should map");
+        assert_eq!(row.resource_name, "db-password");
+        assert_eq!(row.operation, "CreateSecret");
     }
 
     #[test]

--- a/src/backend/aws/audit.rs
+++ b/src/backend/aws/audit.rs
@@ -1,0 +1,424 @@
+//! CloudTrail-backed audit log for the AWS backend.
+//!
+//! Implements [`AuditBackend`] by calling the CloudTrail `LookupEvents` API
+//! filtered to the Secrets Manager event source, then post-filtering event
+//! resource names by the vault prefix (`vault/secret` naming scheme).
+//!
+//! CloudTrail returns events newest-first and retains 90 days of management
+//! events; `LookupEvents` is rate-limited to 2 requests/second, so pagination
+//! is capped (the cap drops only the oldest events).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use aws_sdk_cloudtrail::primitives::DateTime as AwsDateTime;
+use aws_sdk_cloudtrail::types::{Event, LookupAttribute, LookupAttributeKey};
+use aws_sdk_cloudtrail::Client as CloudTrailClient;
+
+use crate::backend::audit::{AuditBackend, AuditEvent};
+use crate::backend::aws::encoding::strip_prefix;
+use crate::backend::aws::errors;
+use crate::backend::error::BackendError;
+
+/// The CloudTrail event source for AWS Secrets Manager.
+const SECRETS_MANAGER_EVENT_SOURCE: &str = "secretsmanager.amazonaws.com";
+
+/// `LookupEvents` page size (API maximum is 50).
+const PAGE_SIZE: i32 = 50;
+
+/// Pagination ceiling. CloudTrail throttles `LookupEvents` at 2 req/s, so an
+/// unbounded scan of a busy account could take minutes; events arrive
+/// newest-first, so the cap only drops the oldest events in the window.
+const MAX_PAGES: usize = 40;
+
+pub struct AwsAuditBackend {
+    client: Arc<CloudTrailClient>,
+}
+
+impl AwsAuditBackend {
+    pub fn new(client: Arc<CloudTrailClient>) -> Self {
+        Self { client }
+    }
+
+    /// Query CloudTrail for Secrets Manager events in the lookback window,
+    /// keeping only events whose secret belongs to `vault` (and, when given,
+    /// matches `secret_filter`).
+    async fn lookup(
+        &self,
+        vault: &str,
+        secret_filter: Option<&str>,
+        days: u32,
+    ) -> Result<Vec<AuditEvent>, BackendError> {
+        let end_time = chrono::Utc::now();
+        let start_time = end_time - chrono::Duration::days(days as i64);
+
+        let attribute = LookupAttribute::builder()
+            .attribute_key(LookupAttributeKey::EventSource)
+            .attribute_value(SECRETS_MANAGER_EVENT_SOURCE)
+            .build()
+            .map_err(|e| {
+                BackendError::Internal(format!("aws LookupEvents: invalid lookup attribute: {e}"))
+            })?;
+
+        let mut events: Vec<AuditEvent> = Vec::new();
+        let mut next_token: Option<String> = None;
+        let mut pages = 0usize;
+
+        loop {
+            let mut req = self
+                .client
+                .lookup_events()
+                .lookup_attributes(attribute.clone())
+                .start_time(AwsDateTime::from_secs(start_time.timestamp()))
+                .end_time(AwsDateTime::from_secs(end_time.timestamp()))
+                .max_results(PAGE_SIZE);
+            if let Some(ref token) = next_token {
+                req = req.next_token(token);
+            }
+
+            let resp = req.send().await.map_err(errors::from_lookup_events)?;
+
+            for event in resp.events() {
+                if let Some(row) = map_event(event, vault, secret_filter) {
+                    events.push(row);
+                }
+            }
+
+            pages += 1;
+            let new_token = resp.next_token().map(|t| t.to_string());
+            // Defensive: a repeated token would loop forever.
+            if new_token.is_none() || new_token == next_token {
+                break;
+            }
+            if pages >= MAX_PAGES {
+                tracing::warn!(
+                    "CloudTrail returned more than {} pages of Secrets Manager events; \
+                     older events in the {days}-day window were truncated",
+                    MAX_PAGES
+                );
+                break;
+            }
+            next_token = new_token;
+        }
+
+        // CloudTrail already returns newest-first, but make the contract
+        // explicit (and stable across pages).
+        events.sort_by_key(|e| std::cmp::Reverse(e.timestamp));
+        Ok(events)
+    }
+}
+
+#[async_trait]
+impl AuditBackend for AwsAuditBackend {
+    async fn get_vault_events(
+        &self,
+        vault: &str,
+        days: u32,
+    ) -> Result<Vec<AuditEvent>, BackendError> {
+        self.lookup(vault, None, days).await
+    }
+
+    async fn get_secret_events(
+        &self,
+        vault: &str,
+        secret_name: &str,
+        days: u32,
+    ) -> Result<Vec<AuditEvent>, BackendError> {
+        self.lookup(vault, Some(secret_name), days).await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure event -> row mapping helpers (unit-tested, no AWS calls)
+// ---------------------------------------------------------------------------
+
+/// Extract the secret name from a Secrets Manager ARN.
+///
+/// ARNs look like `arn:aws:secretsmanager:<region>:<account>:secret:<name>-XXXXXX`
+/// where AWS appends a random 6-character suffix to the name. Returns the
+/// tail verbatim when no suffix is recognized.
+fn secret_name_from_arn(arn: &str) -> Option<String> {
+    let tail = arn.split(":secret:").nth(1)?;
+    match tail.rsplit_once('-') {
+        Some((name, suffix))
+            if suffix.len() == 6 && suffix.chars().all(|c| c.is_ascii_alphanumeric()) =>
+        {
+            Some(name.to_string())
+        }
+        _ => Some(tail.to_string()),
+    }
+}
+
+/// Normalize an identifier that may be either a full Secrets Manager ARN or
+/// a plain secret name into the plain name.
+fn normalize_secret_id(id: &str) -> Option<String> {
+    if id.starts_with("arn:") {
+        secret_name_from_arn(id)
+    } else {
+        Some(id.to_string())
+    }
+}
+
+/// Resolve the full (vault-prefixed) secret name an event refers to, trying
+/// the event's resource list first, then `requestParameters.secretId` from
+/// the raw CloudTrail record.
+fn full_secret_name(event: &Event, raw: &serde_json::Value) -> Option<String> {
+    for resource in event.resources() {
+        if resource.resource_type() != Some("AWS::SecretsManager::Secret") {
+            continue;
+        }
+        if let Some(name) = resource.resource_name().and_then(normalize_secret_id) {
+            return Some(name);
+        }
+    }
+    raw.get("requestParameters")
+        .and_then(|p| p.get("secretId"))
+        .and_then(|v| v.as_str())
+        .and_then(normalize_secret_id)
+}
+
+/// Map a CloudTrail event to an [`AuditEvent`] row.
+///
+/// Returns `None` when the event has no usable timestamp, refers to no
+/// secret, or its secret is outside the `vault` prefix (or doesn't match
+/// `secret_filter` when one is given).
+fn map_event(event: &Event, vault: &str, secret_filter: Option<&str>) -> Option<AuditEvent> {
+    let raw: serde_json::Value = event
+        .cloud_trail_event()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or(serde_json::Value::Null);
+
+    let inner_name = strip_prefix(vault, &full_secret_name(event, &raw)?)?;
+    if let Some(filter) = secret_filter {
+        if inner_name != filter {
+            return None;
+        }
+    }
+
+    let timestamp = event
+        .event_time()
+        .and_then(|t| chrono::DateTime::from_timestamp(t.secs(), t.subsec_nanos()))
+        .or_else(|| {
+            raw.get("eventTime")
+                .and_then(|v| v.as_str())
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+        })?;
+
+    let operation = event
+        .event_name()
+        .or_else(|| raw.get("eventName").and_then(|v| v.as_str()))
+        .unwrap_or("unknown")
+        .to_string();
+
+    let caller = event
+        .username()
+        .or_else(|| {
+            raw.get("userIdentity")
+                .and_then(|u| u.get("arn"))
+                .and_then(|v| v.as_str())
+        })
+        .or_else(|| {
+            raw.get("userIdentity")
+                .and_then(|u| u.get("principalId"))
+                .and_then(|v| v.as_str())
+        })
+        .unwrap_or("unknown")
+        .to_string();
+
+    let status = raw
+        .get("errorCode")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Succeeded")
+        .to_string();
+
+    let source_ip = raw
+        .get("sourceIPAddress")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let event_id = event
+        .event_id()
+        .or_else(|| raw.get("eventID").and_then(|v| v.as_str()))
+        .unwrap_or("")
+        .to_string();
+
+    Some(AuditEvent {
+        timestamp,
+        operation,
+        resource_name: inner_name,
+        caller,
+        status,
+        source_ip,
+        event_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_cloudtrail::types::Resource;
+
+    const VAULT: &str = "myproj-kv";
+
+    fn arn(full_name: &str) -> String {
+        format!("arn:aws:secretsmanager:us-east-1:123456789012:secret:{full_name}-Ab1Cd2")
+    }
+
+    fn raw_event(error_code: Option<&str>) -> String {
+        let mut v = serde_json::json!({
+            "eventVersion": "1.08",
+            "eventTime": "2026-06-01T12:34:56Z",
+            "eventName": "GetSecretValue",
+            "sourceIPAddress": "203.0.113.7",
+            "userIdentity": { "arn": "arn:aws:iam::123456789012:user/alice" },
+            "requestParameters": { "secretId": format!("{VAULT}/db-password") },
+        });
+        if let Some(code) = error_code {
+            v["errorCode"] = serde_json::json!(code);
+        }
+        v.to_string()
+    }
+
+    fn sample_event() -> Event {
+        Event::builder()
+            .event_id("evt-123")
+            .event_name("GetSecretValue")
+            .event_time(AwsDateTime::from_secs(1_780_000_000))
+            .username("alice")
+            .resources(
+                Resource::builder()
+                    .resource_type("AWS::SecretsManager::Secret")
+                    .resource_name(arn(&format!("{VAULT}/db-password")))
+                    .build(),
+            )
+            .cloud_trail_event(raw_event(None))
+            .build()
+    }
+
+    #[test]
+    fn secret_name_from_arn_strips_random_suffix() {
+        assert_eq!(
+            secret_name_from_arn(&arn("myproj-kv/db-password")),
+            Some("myproj-kv/db-password".to_string())
+        );
+    }
+
+    #[test]
+    fn secret_name_from_arn_keeps_tail_without_suffix() {
+        // No recognizable 6-char alphanumeric suffix — return tail verbatim.
+        assert_eq!(
+            secret_name_from_arn("arn:aws:secretsmanager:us-east-1:1:secret:plain"),
+            Some("plain".to_string())
+        );
+        assert_eq!(secret_name_from_arn("arn:aws:iam::1:user/alice"), None);
+    }
+
+    #[test]
+    fn map_event_extracts_all_fields() {
+        let row = map_event(&sample_event(), VAULT, None).expect("event should map");
+        assert_eq!(row.operation, "GetSecretValue");
+        assert_eq!(row.resource_name, "db-password");
+        assert_eq!(row.caller, "alice");
+        assert_eq!(row.status, "Succeeded");
+        assert_eq!(row.source_ip.as_deref(), Some("203.0.113.7"));
+        assert_eq!(row.event_id, "evt-123");
+        assert_eq!(row.timestamp.timestamp(), 1_780_000_000);
+    }
+
+    #[test]
+    fn map_event_filters_other_vaults() {
+        assert!(map_event(&sample_event(), "other-vault", None).is_none());
+    }
+
+    #[test]
+    fn map_event_applies_secret_filter() {
+        assert!(map_event(&sample_event(), VAULT, Some("db-password")).is_some());
+        assert!(map_event(&sample_event(), VAULT, Some("api-key")).is_none());
+    }
+
+    #[test]
+    fn map_event_reports_error_code_as_status() {
+        let event = Event::builder()
+            .event_id("evt-denied")
+            .event_name("GetSecretValue")
+            .event_time(AwsDateTime::from_secs(1_780_000_000))
+            .username("mallory")
+            .resources(
+                Resource::builder()
+                    .resource_type("AWS::SecretsManager::Secret")
+                    .resource_name(arn(&format!("{VAULT}/db-password")))
+                    .build(),
+            )
+            .cloud_trail_event(raw_event(Some("AccessDenied")))
+            .build();
+        let row = map_event(&event, VAULT, None).expect("event should map");
+        assert_eq!(row.status, "AccessDenied");
+    }
+
+    #[test]
+    fn map_event_falls_back_to_request_parameters() {
+        // No resources list — the secret name comes from
+        // requestParameters.secretId in the raw record.
+        let event = Event::builder()
+            .event_id("evt-456")
+            .event_name("GetSecretValue")
+            .event_time(AwsDateTime::from_secs(1_780_000_000))
+            .cloud_trail_event(raw_event(None))
+            .build();
+        let row = map_event(&event, VAULT, None).expect("event should map");
+        assert_eq!(row.resource_name, "db-password");
+        // No username on the event — caller falls back to userIdentity.arn.
+        assert_eq!(row.caller, "arn:aws:iam::123456789012:user/alice");
+    }
+
+    #[test]
+    fn map_event_drops_events_without_secret() {
+        // ListSecrets-style event: no resources, no secretId.
+        let event = Event::builder()
+            .event_id("evt-789")
+            .event_name("ListSecrets")
+            .event_time(AwsDateTime::from_secs(1_780_000_000))
+            .cloud_trail_event(r#"{"eventName":"ListSecrets"}"#)
+            .build();
+        assert!(map_event(&event, VAULT, None).is_none());
+    }
+
+    #[test]
+    fn map_event_uses_raw_timestamp_when_event_time_missing() {
+        let event = Event::builder()
+            .event_id("evt-raw-ts")
+            .event_name("GetSecretValue")
+            .cloud_trail_event(raw_event(None))
+            .build();
+        let row = map_event(&event, VAULT, None).expect("event should map");
+        assert_eq!(
+            row.timestamp,
+            chrono::DateTime::parse_from_rfc3339("2026-06-01T12:34:56Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc)
+        );
+    }
+
+    #[test]
+    fn map_event_handles_malformed_raw_json() {
+        // Unparseable CloudTrailEvent payload — resource list still resolves
+        // the name; status defaults to Succeeded; no source IP.
+        let event = Event::builder()
+            .event_id("evt-bad-json")
+            .event_name("DeleteSecret")
+            .event_time(AwsDateTime::from_secs(1_780_000_000))
+            .username("alice")
+            .resources(
+                Resource::builder()
+                    .resource_type("AWS::SecretsManager::Secret")
+                    .resource_name(arn(&format!("{VAULT}/db-password")))
+                    .build(),
+            )
+            .cloud_trail_event("{not-json")
+            .build();
+        let row = map_event(&event, VAULT, None).expect("event should map");
+        assert_eq!(row.status, "Succeeded");
+        assert_eq!(row.source_ip, None);
+    }
+}

--- a/src/backend/aws/audit.rs
+++ b/src/backend/aws/audit.rs
@@ -52,13 +52,27 @@ impl AwsAuditBackend {
         let end_time = chrono::Utc::now();
         let start_time = end_time - chrono::Duration::days(days as i64);
 
-        let attribute = LookupAttribute::builder()
-            .attribute_key(LookupAttributeKey::EventSource)
-            .attribute_value(SECRETS_MANAGER_EVENT_SOURCE)
-            .build()
-            .map_err(|e| {
-                BackendError::Internal(format!("aws LookupEvents: invalid lookup attribute: {e}"))
-            })?;
+        // For a single-secret audit, scope the CloudTrail lookup to that
+        // secret's full (vault-prefixed) name via ResourceName. An
+        // EventSource-wide scan pages newest-first across ALL Secrets
+        // Manager activity in the account, so in busy accounts the
+        // MAX_PAGES window could be exhausted before reaching events for
+        // the requested secret. Vault-wide audit keeps the EventSource
+        // scan (CloudTrail allows only one lookup attribute per call) and
+        // filters per event in `map_event`.
+        let attribute = match secret_filter {
+            Some(secret) => LookupAttribute::builder()
+                .attribute_key(LookupAttributeKey::ResourceName)
+                .attribute_value(format!("{vault}/{secret}"))
+                .build(),
+            None => LookupAttribute::builder()
+                .attribute_key(LookupAttributeKey::EventSource)
+                .attribute_value(SECRETS_MANAGER_EVENT_SOURCE)
+                .build(),
+        }
+        .map_err(|e| {
+            BackendError::Internal(format!("aws LookupEvents: invalid lookup attribute: {e}"))
+        })?;
 
         let mut events: Vec<AuditEvent> = Vec::new();
         let mut next_token: Option<String> = None;

--- a/src/backend/aws/auth.rs
+++ b/src/backend/aws/auth.rs
@@ -8,13 +8,15 @@ use crate::backend::aws::config::AwsConfig;
 use crate::backend::error::BackendError;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 
-/// Build a `SecretsManagerClient` from the resolved `AwsConfig` plus
+/// Load the shared AWS `SdkConfig` from the resolved `AwsConfig` plus
 /// per-invocation overrides (region, profile from CLI flags or env vars).
-pub async fn build_client(
+/// Service clients (Secrets Manager, CloudTrail) are built from this one
+/// config so they share credentials, region, and endpoint settings.
+pub async fn load_sdk_config(
     aws_cfg: &AwsConfig,
     region_override: Option<String>,
     profile_override: Option<String>,
-) -> Result<SecretsManagerClient, BackendError> {
+) -> Result<aws_config::SdkConfig, BackendError> {
     let region = region_override
         .or_else(|| aws_cfg.region.clone())
         .or_else(|| std::env::var("AWS_REGION").ok())
@@ -39,6 +41,17 @@ pub async fn build_client(
         }
     }
 
-    let sdk_config = loader.load().await;
+    Ok(loader.load().await)
+}
+
+/// Build a `SecretsManagerClient` from the resolved `AwsConfig` plus
+/// per-invocation overrides (region, profile from CLI flags or env vars).
+#[allow(dead_code)] // Convenience wrapper retained for callers that need only Secrets Manager.
+pub async fn build_client(
+    aws_cfg: &AwsConfig,
+    region_override: Option<String>,
+    profile_override: Option<String>,
+) -> Result<SecretsManagerClient, BackendError> {
+    let sdk_config = load_sdk_config(aws_cfg, region_override, profile_override).await?;
     Ok(SecretsManagerClient::new(&sdk_config))
 }

--- a/src/backend/aws/errors.rs
+++ b/src/backend/aws/errors.rs
@@ -5,6 +5,7 @@
 //! readable and the mapping is exhaustive over the variants we observe.
 
 use crate::backend::error::BackendError;
+use aws_sdk_cloudtrail::operation::lookup_events::LookupEventsError;
 use aws_sdk_secretsmanager::operation::create_secret::CreateSecretError;
 use aws_sdk_secretsmanager::operation::delete_secret::DeleteSecretError;
 use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretError;
@@ -329,6 +330,37 @@ pub fn from_rotate(
     handle_sdk("RotateSecret", e)
 }
 
+/// True when a CloudTrail service error code denotes an IAM authorization
+/// failure. CloudTrail does not model access denial as a typed variant on
+/// `LookupEventsError`, so it surfaces as an unmodeled code in the error
+/// metadata.
+pub(crate) fn is_cloudtrail_access_denied(code: Option<&str>) -> bool {
+    matches!(
+        code,
+        Some("AccessDeniedException") | Some("AccessDenied") | Some("UnauthorizedOperation")
+    )
+}
+
+/// The actionable message shown when the caller lacks CloudTrail read access.
+pub(crate) fn cloudtrail_permission_hint() -> String {
+    "CloudTrail access denied: the current AWS identity lacks the `cloudtrail:LookupEvents` \
+IAM permission required by `xv audit`. Attach a policy that allows cloudtrail:LookupEvents \
+(e.g. the AWSCloudTrail_ReadOnlyAccess managed policy) and retry."
+        .to_string()
+}
+
+pub fn from_lookup_events(e: SdkError<LookupEventsError, Response>) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if is_cloudtrail_access_denied(svc.err().meta().code()) {
+            return BackendError::PermissionDenied(cloudtrail_permission_hint());
+        }
+        if let LookupEventsError::InvalidTimeRangeException(inner) = svc.err() {
+            return BackendError::InvalidArgument(format!("invalid audit time range: {inner}"));
+        }
+    }
+    handle_sdk("LookupEvents", e)
+}
+
 #[cfg(all(test, feature = "aws"))]
 mod tests {
     use super::*;
@@ -389,6 +421,49 @@ mod tests {
             unreachable!()
         };
         assert!(msg.contains("aws configure"), "hint missing: {msg}");
+    }
+
+    #[test]
+    fn cloudtrail_access_denied_codes_classified() {
+        assert!(is_cloudtrail_access_denied(Some("AccessDeniedException")));
+        assert!(is_cloudtrail_access_denied(Some("AccessDenied")));
+        assert!(is_cloudtrail_access_denied(Some("UnauthorizedOperation")));
+        assert!(!is_cloudtrail_access_denied(Some(
+            "InvalidTimeRangeException"
+        )));
+        assert!(!is_cloudtrail_access_denied(None));
+    }
+
+    /// The permission hint must name the exact IAM permission so users can
+    /// fix their policy without digging through AWS docs.
+    #[test]
+    fn cloudtrail_permission_hint_names_iam_permission() {
+        let msg = cloudtrail_permission_hint();
+        assert!(msg.contains("cloudtrail:LookupEvents"), "got: {msg}");
+    }
+
+    #[test]
+    fn lookup_events_credential_failure_maps_to_auth() {
+        let inner = std::io::Error::other("no credentials in chain");
+        let sdk: SdkError<LookupEventsError, HttpResponse> =
+            SdkError::dispatch_failure(ConnectorError::user(Box::new(inner)));
+        let err = from_lookup_events(sdk);
+        assert!(
+            matches!(err, BackendError::AuthenticationFailed(_)),
+            "expected AuthenticationFailed, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn lookup_events_timeout_maps_to_network() {
+        let inner = std::io::Error::new(std::io::ErrorKind::TimedOut, "timed out");
+        let sdk: SdkError<LookupEventsError, HttpResponse> =
+            SdkError::dispatch_failure(ConnectorError::timeout(Box::new(inner)));
+        let err = from_lookup_events(sdk);
+        assert!(
+            matches!(err, BackendError::Network(_)),
+            "expected Network, got: {err:?}"
+        );
     }
 
     /// Regression test: the `health_check` lightweight ping (used at backend

--- a/src/backend/aws/mod.rs
+++ b/src/backend/aws/mod.rs
@@ -1,5 +1,6 @@
 //! AWS Secrets Manager backend.
 
+pub mod audit;
 pub mod auth;
 pub mod config;
 pub mod encoding;
@@ -13,14 +14,17 @@ use std::sync::Arc;
 
 use crate::backend::error::BackendError;
 use crate::backend::{
-    Backend, BackendCapabilities, BackendKind, NameCharset, SecretBackend, VaultBackend,
+    AuditBackend, Backend, BackendCapabilities, BackendKind, NameCharset, SecretBackend,
+    VaultBackend,
 };
 use crate::config::settings::AwsConfig;
+use aws_sdk_cloudtrail::Client as CloudTrailClient;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 
 pub struct AwsBackend {
     secrets_impl: Arc<secrets::AwsSecretBackend>,
     vaults_impl: Arc<vaults::AwsVaultBackend>,
+    audit_impl: Arc<audit::AwsAuditBackend>,
 }
 
 impl AwsBackend {
@@ -31,12 +35,13 @@ impl AwsBackend {
         region_override: Option<String>,
         profile_override: Option<String>,
     ) -> Result<Self, BackendError> {
-        let client: SecretsManagerClient =
-            auth::build_client(aws_cfg, region_override, profile_override).await?;
-        let client = Arc::new(client);
+        let sdk_config = auth::load_sdk_config(aws_cfg, region_override, profile_override).await?;
+        let client = Arc::new(SecretsManagerClient::new(&sdk_config));
+        let cloudtrail = Arc::new(CloudTrailClient::new(&sdk_config));
         Ok(Self {
             secrets_impl: Arc::new(secrets::AwsSecretBackend::new(client.clone())),
             vaults_impl: Arc::new(vaults::AwsVaultBackend::new(client)),
+            audit_impl: Arc::new(audit::AwsAuditBackend::new(cloudtrail)),
         })
     }
 }
@@ -56,7 +61,7 @@ impl Backend for AwsBackend {
             has_vaults: true,
             has_file_storage: false,
             has_rbac: false,
-            has_audit: false,
+            has_audit: true,
             has_versioning: true,
             has_soft_delete: true,
             has_secret_rotation: true,
@@ -76,6 +81,10 @@ impl Backend for AwsBackend {
 
     fn vaults(&self) -> Option<&dyn VaultBackend> {
         Some(self.vaults_impl.as_ref())
+    }
+
+    fn audit(&self) -> Option<&dyn AuditBackend> {
+        Some(self.audit_impl.as_ref())
     }
 
     async fn health_check(&self) -> Result<(), BackendError> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -16,6 +16,7 @@
 //! [`BackendRegistry`] for runtime backend resolution.
 
 pub mod addressing;
+pub mod audit;
 #[cfg(feature = "aws")]
 pub mod aws;
 pub mod azure;
@@ -29,6 +30,7 @@ pub mod vault;
 
 // Re-exports for convenience.
 pub use addressing::BackendRef;
+pub use audit::{AuditBackend, AuditEvent};
 pub use error::BackendError;
 pub use registry::BackendRegistry;
 pub use secret::SecretBackend;
@@ -198,6 +200,15 @@ pub trait Backend: Send + Sync {
 
     /// Access to vault/namespace operations (optional).
     fn vaults(&self) -> Option<&dyn VaultBackend> {
+        None
+    }
+
+    /// Access to audit log operations (optional).
+    ///
+    /// Backends returning `Some` here are dispatched generically by
+    /// `xv audit`; Azure keeps its legacy Activity Log path and returns
+    /// `None`.
+    fn audit(&self) -> Option<&dyn AuditBackend> {
         None
     }
 

--- a/src/cli/system_ops.rs
+++ b/src/cli/system_ops.rs
@@ -273,6 +273,12 @@ pub(crate) async fn execute_audit_command(
                 registry.active().name()
             )));
         }
+        // Backends that implement the audit trait (e.g. AWS via CloudTrail)
+        // are dispatched generically; Azure keeps its legacy Activity Log
+        // path below.
+        if let Some(auditor) = registry.active().audit() {
+            return execute_backend_audit(auditor, name, vault, days, operation, raw, config).await;
+        }
     }
 
     // Create authentication provider — reuse from registry when available
@@ -412,6 +418,102 @@ pub(crate) async fn execute_audit_command(
     }
 
     Ok(())
+}
+
+/// Render audit logs fetched through the backend-agnostic [`AuditBackend`]
+/// trait, mirroring the Azure Activity Log output shapes (table and `--raw`
+/// JSON).
+async fn execute_backend_audit(
+    auditor: &dyn crate::backend::AuditBackend,
+    name: Option<String>,
+    vault: Option<String>,
+    days: u32,
+    operation: Option<String>,
+    raw: bool,
+    config: Config,
+) -> Result<()> {
+    let vault_name = config.resolve_vault_name(vault).await?;
+
+    output::step(&format!("Fetching audit logs for {} days...", days));
+
+    let mut events: Vec<crate::backend::AuditEvent> = if let Some(secret_name) = name {
+        println!("  Secret: {}", secret_name);
+        println!("  Vault: {}", vault_name);
+        auditor
+            .get_secret_events(&vault_name, &secret_name, days)
+            .await?
+    } else {
+        println!("  Vault: {}", vault_name);
+        auditor.get_vault_events(&vault_name, days).await?
+    };
+
+    // Filter by operation if specified
+    if let Some(op_filter) = operation {
+        events.retain(|event| {
+            event
+                .operation
+                .to_lowercase()
+                .contains(&op_filter.to_lowercase())
+        });
+    }
+
+    if events.is_empty() {
+        output::info("No audit log entries found for the specified criteria");
+        return Ok(());
+    }
+
+    println!();
+    output::info(&format!("Found {} audit log entries:\n", events.len()));
+
+    if raw {
+        // Show raw JSON output
+        for event in events {
+            let json_output = serde_json::to_string_pretty(&event).map_err(|e| {
+                CrosstacheError::serialization(format!("Failed to serialize log entry: {}", e))
+            })?;
+            println!("{}", json_output);
+            println!("---");
+        }
+    } else {
+        // Show formatted output (same shape as the Azure table)
+        println!(
+            "{:<20} | {:<25} | {:<20} | {:<30} | {:<10}",
+            "Timestamp", "Operation", "Resource", "Caller", "Status"
+        );
+        println!("{}", "-".repeat(120));
+
+        for event in events {
+            let operation = truncate_column(&event.operation, 25);
+            let resource = truncate_column(&event.resource_name, 20);
+            let caller = truncate_column(&event.caller, 30);
+
+            println!(
+                "{:<20} | {:<25} | {:<20} | {:<30} | {:<10}",
+                event.timestamp.format("%m-%d %H:%M:%S"),
+                operation,
+                resource,
+                caller,
+                event.status
+            );
+        }
+
+        println!();
+        output::hint(
+            "Use --raw to see full details, or --operation <type> to filter by operation type",
+        );
+    }
+
+    Ok(())
+}
+
+/// Truncate a table cell to `max` characters, appending `...` when cut.
+fn truncate_column(value: &str, max: usize) -> String {
+    if value.chars().count() > max {
+        let cut: String = value.chars().take(max.saturating_sub(3)).collect();
+        format!("{cut}...")
+    } else {
+        value.to_string()
+    }
 }
 
 pub(crate) async fn execute_init_command(_config: Config) -> Result<()> {


### PR DESCRIPTION
## Summary
- `xv audit` on the AWS backend reads recent Secrets Manager events via CloudTrail LookupEvents (event source filter + vault-prefix post-filter), mirroring the Azure Activity Log UX and output shapes.
- `has_audit` flipped to true for AWS; missing `cloudtrail:LookupEvents` permission produces an actionable error.
- adds `aws-sdk-cloudtrail` as an optional dep under the `aws` feature.
- (ROADMAP P1 — AWS capability matrix: `xv audit`)

## Verification
- cargo fmt --check; clippy --all-targets (default AND --features aws) -D warnings; cargo test --all-targets (both feature sets, isolated XDG_CONFIG_HOME) — all green, verified independently of the implementing agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New read-only CloudTrail integration and IAM permission surface; vault-wide audit can truncate oldest events in busy accounts due to pagination limits, but secrets CRUD paths are unchanged.
> 
> **Overview**
> **`xv audit` on AWS** now uses CloudTrail `LookupEvents` for Secrets Manager activity, exposed through a new backend-agnostic **`AuditBackend`** / **`AuditEvent`** layer. The CLI routes backends that implement `audit()` through **`execute_backend_audit`**, which reuses the same table and `--raw` JSON layout as Azure; Azure still uses the existing Activity Log client.
> 
> The AWS implementation pages CloudTrail (capped at 40 pages), filters by vault prefix (`vault/secret`), and scopes single-secret queries by **ResourceName** instead of scanning the whole event source. **`has_audit`** is **true** for AWS; missing **`cloudtrail:LookupEvents`** maps to **`PermissionDenied`** with an IAM remediation hint.
> 
> **`aws-sdk-cloudtrail`** is added under the **`aws`** feature. AWS auth now loads a shared **`SdkConfig`** so Secrets Manager and CloudTrail share credentials and region.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8cd41dbf2cd332a1717ce6dc921d652bab80d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->