### PR TITLE
feat(aws): native rotation via RotateSecret

### DIFF
--- a/src/backend/aws/errors.rs
+++ b/src/backend/aws/errors.rs
@@ -287,12 +287,27 @@ pub fn from_rotate(
                 }
             }
             RotateSecretError::InvalidRequestException(inner) => {
-                // Most commonly: no rotation Lambda is associated with the
-                // secret, so there is nothing for AWS to invoke.
-                return BackendError::InvalidArgument(format!(
-                    "{inner}. {}",
-                    rotation_lambda_hint(secret_id)
-                ));
+                // InvalidRequestException covers several failure modes
+                // (secret deleted/being deleted, rotation already in
+                // progress, no Lambda configured, ...). Only append the
+                // configure-a-Lambda hint when the message actually says
+                // no rotation Lambda is associated; otherwise surface the
+                // real error untouched. (`message()` is an inherent method
+                // on the modeled exception type; no trait import needed.)
+                let msg = inner.message().unwrap_or_default().to_lowercase();
+                let no_lambda = msg.contains("lambda")
+                    && (msg.contains("no rotation")
+                        || msg.contains("not configured")
+                        || msg.contains("no lambda")
+                        || msg.contains("rotation lambda arn"));
+                return if no_lambda {
+                    BackendError::InvalidArgument(format!(
+                        "{inner}. {}",
+                        rotation_lambda_hint(secret_id)
+                    ))
+                } else {
+                    BackendError::InvalidArgument(inner.to_string())
+                };
             }
             RotateSecretError::InvalidParameterException(inner) => {
                 return BackendError::InvalidArgument(inner.to_string())

--- a/src/backend/aws/errors.rs
+++ b/src/backend/aws/errors.rs
@@ -13,6 +13,7 @@ use aws_sdk_secretsmanager::operation::list_secret_version_ids::ListSecretVersio
 use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsError;
 use aws_sdk_secretsmanager::operation::put_secret_value::PutSecretValueError;
 use aws_sdk_secretsmanager::operation::restore_secret::RestoreSecretError;
+use aws_sdk_secretsmanager::operation::rotate_secret::RotateSecretError;
 use aws_sdk_secretsmanager::operation::tag_resource::TagResourceError;
 use aws_sdk_secretsmanager::operation::untag_resource::UntagResourceError;
 use aws_sdk_secretsmanager::operation::update_secret::UpdateSecretError;
@@ -253,6 +254,66 @@ pub fn from_update_stage(
     handle_sdk("UpdateSecretVersionStage", e)
 }
 
+pub fn from_tag(e: SdkError<TagResourceError, Response>) -> BackendError {
+    handle_sdk("TagResource", e)
+}
+
+pub fn from_untag(e: SdkError<UntagResourceError, Response>) -> BackendError {
+    handle_sdk("UntagResource", e)
+}
+
+/// Remediation hint shown when `RotateSecret` is rejected because the secret
+/// has no rotation Lambda configured (AWS reports this as
+/// `InvalidRequestException`).
+pub(crate) fn rotation_lambda_hint(secret_id: &str) -> String {
+    format!(
+        "No rotation Lambda appears to be configured for this secret. \
+Configure one with `aws secretsmanager rotate-secret --secret-id {secret_id} \
+--rotation-lambda-arn <lambda-arn>`, then retry `xv rotate --native`."
+    )
+}
+
+pub fn from_rotate(
+    name: &str,
+    secret_id: &str,
+    e: SdkError<RotateSecretError, Response>,
+) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        match svc.err() {
+            RotateSecretError::ResourceNotFoundException(_) => {
+                return BackendError::NotFound {
+                    name: name.to_string(),
+                    suggestion: None,
+                }
+            }
+            RotateSecretError::InvalidRequestException(inner) => {
+                // Most commonly: no rotation Lambda is associated with the
+                // secret, so there is nothing for AWS to invoke.
+                return BackendError::InvalidArgument(format!(
+                    "{inner}. {}",
+                    rotation_lambda_hint(secret_id)
+                ));
+            }
+            RotateSecretError::InvalidParameterException(inner) => {
+                return BackendError::InvalidArgument(inner.to_string())
+            }
+            other => {
+                // AccessDenied is not a modeled variant on RotateSecretError;
+                // it arrives as an unmodeled service error. Classify by code
+                // so users get a permissions message instead of "Internal".
+                use aws_sdk_secretsmanager::error::ProvideErrorMetadata;
+                if other.code() == Some("AccessDeniedException") {
+                    return BackendError::PermissionDenied(format!(
+                        "secretsmanager:RotateSecret denied for '{name}': {}",
+                        other.message().unwrap_or("access denied")
+                    ));
+                }
+            }
+        }
+    }
+    handle_sdk("RotateSecret", e)
+}
+
 #[cfg(all(test, feature = "aws"))]
 mod tests {
     use super::*;
@@ -335,12 +396,12 @@ mod tests {
             "health_check would have returned: {err:?}"
         );
     }
-}
 
-pub fn from_tag(e: SdkError<TagResourceError, Response>) -> BackendError {
-    handle_sdk("TagResource", e)
-}
-
-pub fn from_untag(e: SdkError<UntagResourceError, Response>) -> BackendError {
-    handle_sdk("UntagResource", e)
+    #[test]
+    fn rotation_lambda_hint_includes_cli_remediation() {
+        let hint = rotation_lambda_hint("myproj-kv/db-password");
+        assert!(hint.contains("aws secretsmanager rotate-secret"), "{hint}");
+        assert!(hint.contains("--secret-id myproj-kv/db-password"), "{hint}");
+        assert!(hint.contains("--rotation-lambda-arn"), "{hint}");
+    }
 }

--- a/src/backend/aws/mod.rs
+++ b/src/backend/aws/mod.rs
@@ -59,7 +59,7 @@ impl Backend for AwsBackend {
             has_audit: false,
             has_versioning: true,
             has_soft_delete: true,
-            has_secret_rotation: false,
+            has_secret_rotation: true,
             has_groups: true,
             has_folders: true,
             has_notes: true,

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -904,4 +904,21 @@ impl SecretBackend for AwsSecretBackend {
 
         Ok(summaries)
     }
+
+    /// Trigger AWS Secrets Manager native rotation (`RotateSecret`), which
+    /// invokes the rotation Lambda configured on the secret.
+    ///
+    /// Success means AWS accepted the rotation request — the Lambda runs
+    /// asynchronously, so the new version appears only once it completes.
+    async fn native_rotate(&self, vault: &str, name: &str) -> Result<(), BackendError> {
+        use crate::backend::aws::encoding::aws_name;
+        let aws_full_name = aws_name(vault, name);
+        self.client
+            .rotate_secret()
+            .secret_id(&aws_full_name)
+            .send()
+            .await
+            .map_err(|e| super::errors::from_rotate(name, &aws_full_name, e))?;
+        Ok(())
+    }
 }

--- a/src/backend/secret.rs
+++ b/src/backend/secret.rs
@@ -124,4 +124,13 @@ pub trait SecretBackend: Send + Sync {
     ) -> Result<SecretProperties, BackendError> {
         Err(BackendError::Unsupported("restore from backup".into()))
     }
+
+    /// Trigger the backend's native rotation mechanism for a secret.
+    ///
+    /// On AWS this calls `RotateSecret`, which invokes the rotation Lambda
+    /// configured on the secret. Success means the rotation request was
+    /// accepted — the rotation itself may complete asynchronously.
+    async fn native_rotate(&self, _vault: &str, _name: &str) -> Result<(), BackendError> {
+        Err(BackendError::Unsupported("native rotation".into()))
+    }
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -416,6 +416,13 @@ pub enum Commands {
         /// Custom generator script path (overrides charset and length)
         #[arg(long)]
         generator: Option<String>,
+        /// Use the backend's native rotation instead of generating a value
+        /// locally. On AWS this calls RotateSecret, which invokes the
+        /// secret's configured rotation Lambda; the rotation completes
+        /// asynchronously. Errors on backends without native rotation.
+        /// Generation flags (--length, --charset) are ignored.
+        #[arg(long, conflicts_with_all = ["generator", "show_value"])]
+        native: bool,
         /// Show the generated value (default: hidden for security)
         #[arg(long)]
         show_value: bool,
@@ -1323,11 +1330,12 @@ impl Cli {
                 length,
                 charset,
                 generator,
+                native,
                 show_value,
                 force,
             } => {
                 crate::cli::secret_ops::execute_secret_rotate_direct(
-                    &name, length, charset, generator, show_value, force, config, registry,
+                    &name, length, charset, generator, native, show_value, force, config, registry,
                 )
                 .await
             }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -720,6 +720,16 @@ pub(crate) async fn execute_secret_rotate_direct(
     Ok(())
 }
 
+/// Capability error for `xv rotate --native` on a backend without native
+/// rotation support.
+fn rotate_native_unsupported_error(backend_name: &str) -> CrosstacheError {
+    CrosstacheError::InvalidArgument(format!(
+        "The {backend_name} backend does not support native rotation. Native rotation is \
+         currently available on the aws backend only; without --native, 'xv rotate' generates \
+         a new value client-side on any backend."
+    ))
+}
+
 /// Trigger the backend's native rotation mechanism (`xv rotate --native`).
 ///
 /// Unlike the default rotate path (which generates a new value client-side
@@ -734,7 +744,18 @@ async fn execute_secret_rotate_native(
 ) -> Result<()> {
     use crate::utils::interactive::InteractivePrompt;
 
+    // Capability check: native rotation requires backend support. When the
+    // registry is missing (the requested backend failed to initialize),
+    // resolve the requested backend from config so non-rotation backends
+    // still get the capability hint instead of a generic config error.
     let Some(reg) = registry else {
+        if let Some(kind) = crate::cli::helpers::requested_backend_kind(&config) {
+            if kind != BackendKind::Aws {
+                return Err(rotate_native_unsupported_error(
+                    config.effective_backend_name(),
+                ));
+            }
+        }
         return Err(CrosstacheError::config(
             "No backend registry available. Run 'xv config show' to check your configuration.",
         ));
@@ -743,12 +764,7 @@ async fn execute_secret_rotate_native(
     // Capability check: native rotation requires backend support
     let caps = reg.active().capabilities();
     if !caps.has_secret_rotation {
-        return Err(CrosstacheError::InvalidArgument(format!(
-            "The {} backend does not support native rotation. Native rotation is currently \
-             available on the aws backend only; without --native, 'xv rotate' generates a new \
-             value client-side on any backend.",
-            reg.active().name()
-        )));
+        return Err(rotate_native_unsupported_error(reg.active().name()));
     }
 
     let vault_name = resolve_vault_for_trait(&config, registry).await?;
@@ -4366,6 +4382,28 @@ mod tests {
         let err = execute_secret_rotate_native("db-password", true, config, Some(&registry))
             .await
             .expect_err("non-rotation backend must reject --native");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("does not support native rotation"),
+            "unexpected error: {msg}"
+        );
+        assert!(msg.contains("local"), "should name the backend: {msg}");
+    }
+
+    /// When `--backend local` is requested but backend init failed (registry
+    /// is `None`), `--native` must still return the capability hint rather
+    /// than a generic "no backend registry" config error.
+    #[tokio::test]
+    async fn rotate_native_without_registry_still_returns_capability_hint() {
+        let config = Config {
+            backend: Some("local".to_string()),
+            default_vault: String::new(),
+            ..Default::default()
+        };
+
+        let err = execute_secret_rotate_native("db-password", true, config, None)
+            .await
+            .expect_err("non-rotation backend without a registry must reject --native");
         let msg = err.to_string();
         assert!(
             msg.contains("does not support native rotation"),

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -682,11 +682,17 @@ pub(crate) async fn execute_secret_rotate_direct(
     length: usize,
     charset: CharsetType,
     generator: Option<String>,
+    native: bool,
     show_value: bool,
     force: bool,
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
+    // ── Native rotation path (--native) ─────────────────────────────────
+    if native {
+        return execute_secret_rotate_native(name, force, config, registry).await;
+    }
+
     let auth_provider = get_azure_auth_provider(registry, &config)?;
 
     // Create secret manager
@@ -710,6 +716,77 @@ pub(crate) async fn execute_secret_rotate_direct(
         let cache_manager = crate::cache::CacheManager::from_config(&config);
         cache_manager.invalidate(&crate::cache::CacheKey::SecretsList { vault_name });
     }
+
+    Ok(())
+}
+
+/// Trigger the backend's native rotation mechanism (`xv rotate --native`).
+///
+/// Unlike the default rotate path (which generates a new value client-side
+/// and writes it as a new version), this delegates rotation entirely to the
+/// backend — on AWS, `RotateSecret` invokes the rotation Lambda configured
+/// on the secret and completes asynchronously.
+async fn execute_secret_rotate_native(
+    name: &str,
+    force: bool,
+    config: Config,
+    registry: Option<&BackendRegistry>,
+) -> Result<()> {
+    use crate::utils::interactive::InteractivePrompt;
+
+    let Some(reg) = registry else {
+        return Err(CrosstacheError::config(
+            "No backend registry available. Run 'xv config show' to check your configuration.",
+        ));
+    };
+
+    // Capability check: native rotation requires backend support
+    let caps = reg.active().capabilities();
+    if !caps.has_secret_rotation {
+        return Err(CrosstacheError::InvalidArgument(format!(
+            "The {} backend does not support native rotation. Native rotation is currently \
+             available on the aws backend only; without --native, 'xv rotate' generates a new \
+             value client-side on any backend.",
+            reg.active().name()
+        )));
+    }
+
+    let vault_name = resolve_vault_for_trait(&config, registry).await?;
+
+    // Confirm rotation unless force flag is used (mirrors the default path)
+    if !force {
+        let prompt = InteractivePrompt::new();
+        let confirm = prompt.confirm(
+            &format!(
+                "Are you sure you want to trigger native rotation for secret '{name}'? \
+                 This invokes the rotation mechanism configured on the backend."
+            ),
+            false,
+        )?;
+
+        if !confirm {
+            println!("Rotation cancelled.");
+            return Ok(());
+        }
+    }
+
+    output::step(&format!("Requesting native rotation for secret: {name}"));
+    reg.active()
+        .secrets()
+        .native_rotate(&vault_name, name)
+        .await?;
+
+    output::success(&format!("Rotation request accepted for secret '{name}'"));
+    println!(
+        "Rotation runs asynchronously — the backend's rotation function creates the new \
+         version once it completes."
+    );
+    output::hint(&format!(
+        "Use 'xv history {name}' to check for the new version"
+    ));
+
+    // Invalidate the secrets list cache for the resolved vault
+    invalidate_trait_secret_cache(&config, &vault_name);
 
     Ok(())
 }
@@ -3985,6 +4062,18 @@ mod tests {
         ) -> std::result::Result<crate::secret::manager::SecretProperties, BackendError> {
             Err(BackendError::Unsupported("test backend".into()))
         }
+
+        async fn native_rotate(
+            &self,
+            _vault: &str,
+            _name: &str,
+        ) -> std::result::Result<(), BackendError> {
+            if self.kind == BackendKind::Aws {
+                Ok(())
+            } else {
+                Err(BackendError::Unsupported("native rotation".into()))
+            }
+        }
     }
 
     #[async_trait::async_trait]
@@ -4009,7 +4098,7 @@ mod tests {
                 has_audit: false,
                 has_versioning: true,
                 has_soft_delete: true,
-                has_secret_rotation: false,
+                has_secret_rotation: self.kind == BackendKind::Aws,
                 has_groups: true,
                 has_folders: true,
                 has_notes: true,
@@ -4263,6 +4352,40 @@ mod tests {
             msg.contains("aws secretsmanager put-resource-policy"),
             "should suggest the native equivalent: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn rotate_native_rejected_on_backend_without_rotation_capability() {
+        let registry = BackendRegistry::new(Arc::new(TestBackend::local()));
+        let config = Config {
+            backend: Some("local".to_string()),
+            default_vault: String::new(),
+            ..Default::default()
+        };
+
+        let err = execute_secret_rotate_native("db-password", true, config, Some(&registry))
+            .await
+            .expect_err("non-rotation backend must reject --native");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("does not support native rotation"),
+            "unexpected error: {msg}"
+        );
+        assert!(msg.contains("local"), "should name the backend: {msg}");
+    }
+
+    #[tokio::test]
+    async fn rotate_native_accepted_on_backend_with_rotation_capability() {
+        let registry = BackendRegistry::new(Arc::new(TestBackend::aws()));
+        let config = Config {
+            backend: Some("aws".to_string()),
+            default_vault: "test-vault".to_string(),
+            ..Default::default()
+        };
+
+        execute_secret_rotate_native("db-password", true, config, Some(&registry))
+            .await
+            .expect("capable backend should accept native rotation");
     }
 
     #[test]

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -921,3 +921,94 @@ async fn update_vault_updates_tags() {
     assert_eq!(result.name, "myproj-kv");
     assert_eq!(result.id, "vault-myproj-kv");
 }
+
+// ---------------------------------------------------------------------------
+// Native rotation (`RotateSecret`)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn native_rotate_sends_rotate_secret_for_encoded_name() {
+    use aws_sdk_secretsmanager::operation::rotate_secret::RotateSecretOutput;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::rotate_secret)
+        .match_requests(|req| req.secret_id() == Some("myproj-kv/db-password"))
+        .then_output(|| {
+            RotateSecretOutput::builder()
+                .name("myproj-kv/db-password")
+                .version_id("v2")
+                .build()
+        });
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+
+    backend
+        .native_rotate("myproj-kv", "db-password")
+        .await
+        .expect("native_rotate should accept the rotation request");
+}
+
+#[tokio::test]
+async fn native_rotate_not_found_maps_to_backend_not_found() {
+    use aws_sdk_secretsmanager::operation::rotate_secret::RotateSecretError;
+    use aws_sdk_secretsmanager::types::error::ResourceNotFoundException;
+    use crosstache::backend::error::BackendError;
+    use crosstache::backend::SecretBackend;
+
+    let rule = mock!(Client::rotate_secret).then_error(|| {
+        RotateSecretError::ResourceNotFoundException(
+            ResourceNotFoundException::builder()
+                .message("Secret not found")
+                .build(),
+        )
+    });
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+
+    let result = backend.native_rotate("myproj-kv", "missing-secret").await;
+
+    assert!(
+        matches!(result, Err(BackendError::NotFound { ref name, .. }) if name == "missing-secret"),
+        "expected NotFound error, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn native_rotate_without_lambda_explains_how_to_configure_one() {
+    use aws_sdk_secretsmanager::operation::rotate_secret::RotateSecretError;
+    use aws_sdk_secretsmanager::types::error::InvalidRequestException;
+    use crosstache::backend::error::BackendError;
+    use crosstache::backend::SecretBackend;
+
+    // AWS reports "no rotation Lambda configured" as InvalidRequestException.
+    let rule = mock!(Client::rotate_secret).then_error(|| {
+        RotateSecretError::InvalidRequestException(
+            InvalidRequestException::builder()
+                .message("No Lambda rotation function ARN is associated with this secret")
+                .build(),
+        )
+    });
+
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+
+    let result = backend.native_rotate("myproj-kv", "db-password").await;
+
+    let Err(BackendError::InvalidArgument(msg)) = result else {
+        panic!("expected InvalidArgument error, got: {result:?}");
+    };
+    assert!(
+        msg.contains("aws secretsmanager rotate-secret"),
+        "remediation hint missing: {msg}"
+    );
+    assert!(
+        msg.contains("--secret-id myproj-kv/db-password"),
+        "hint should reference the AWS secret id: {msg}"
+    );
+    assert!(
+        msg.contains("--rotation-lambda-arn"),
+        "hint should mention the rotation Lambda flag: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary
- New `--native` flag on `xv rotate`: on AWS, invokes Secrets Manager RotateSecret (the secret's configured rotation Lambda); output notes rotation is async.
- Clear errors for: no rotation Lambda configured (with setup hint), missing permissions, non-AWS backends (capability message).
- Default (no flag) behavior unchanged on all backends. `has_secret_rotation` true for AWS.
- Also fixes 6 pre-existing clippy 1.95 lints in AWS files to keep -D warnings green.
- (ROADMAP P1 — AWS capability matrix: native rotation)

## Verification
- cargo fmt --check; clippy --all-targets (default AND --features aws) -D warnings; cargo test --all-targets (both feature sets, isolated XDG_CONFIG_HOME) — all green, verified independently of the implementing agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rotation triggers external Lambda-side credential changes and requires correct IAM on `secretsmanager:RotateSecret`; mistakes could cause failed or unintended rotations, though client-side rotate is unchanged.
> 
> **Overview**
> Adds **`xv rotate --native`**, which triggers backend-managed rotation instead of generating a new value locally. On AWS this calls **Secrets Manager `RotateSecret`** (the secret’s rotation Lambda); success only means the request was accepted, and the CLI notes that rotation finishes asynchronously.
> 
> The **`SecretBackend::native_rotate`** hook is introduced (default unsupported); AWS implements it and advertises **`has_secret_rotation: true`**. **`from_rotate`** maps AWS errors to **`NotFound`**, **`PermissionDenied`** for `AccessDeniedException`, and **`InvalidArgument`** with a configure-Lambda CLI hint when the service message indicates no rotation Lambda.
> 
> Non-AWS backends (or missing registry with a non-AWS backend in config) get a clear capability error; **`--native`** conflicts with **`--generator`** and **`--show_value`**. Default `xv rotate` behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df1e4b88f4d197b26c7f31cbefde45d797831ae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->