### PR TITLE
feat(aws): S3 file storage backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-cloudtrail"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd81ebaf83622705249d1e935a6d37f275e6ab27cf78e595fa94300297abefb9"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.4.1",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.119.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +1694,7 @@ dependencies = [
  "arboard",
  "async-trait",
  "aws-config",
+ "aws-sdk-cloudtrail",
  "aws-sdk-s3",
  "aws-sdk-secretsmanager",
  "aws-smithy-mocks-experimental",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,8 +362,8 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -423,7 +423,8 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -431,7 +432,9 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand 2.4.1",
+ "http 0.2.12",
  "http 1.4.0",
+ "http-body 0.4.6",
  "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
@@ -440,27 +443,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-cloudtrail"
-version = "1.107.0"
+name = "aws-sdk-s3"
+version = "1.119.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd81ebaf83622705249d1e935a6d37f275e6ab27cf78e595fa94300297abefb9"
+checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "aws-smithy-xml",
  "aws-types",
  "bytes",
  "fastrand 2.4.1",
+ "hex",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
+ "http-body 0.4.6",
+ "lru 0.12.5",
+ "percent-encoding",
  "regex-lite",
+ "sha2 0.10.9",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -472,8 +485,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -496,8 +509,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -520,8 +533,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -544,8 +557,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -567,7 +580,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -591,6 +605,59 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.63.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
+dependencies = [
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2 0.10.9",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
 ]
 
 [[package]]
@@ -648,6 +715,15 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tower",
  "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
 ]
 
 [[package]]
@@ -714,7 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -1538,6 +1614,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc-fast"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
+dependencies = [
+ "crc",
+ "digest 0.10.7",
+ "rand 0.9.4",
+ "regex",
+ "rustversion",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,7 +1670,7 @@ dependencies = [
  "arboard",
  "async-trait",
  "aws-config",
- "aws-sdk-cloudtrail",
+ "aws-sdk-s3",
  "aws-sdk-secretsmanager",
  "aws-smithy-mocks-experimental",
  "aws-smithy-runtime-api",
@@ -2576,6 +2665,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3384,6 +3475,15 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
@@ -3435,6 +3535,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4503,7 +4613,7 @@ dependencies = [
  "indoc",
  "itertools",
  "kasuari",
- "lru",
+ "lru 0.16.4",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ azure_mgmt_storage = "0.21"
 # AWS SDK - feature-gated under `aws`
 aws-sdk-secretsmanager = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio", "behavior-version-latest"] }
 aws-sdk-cloudtrail = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio", "behavior-version-latest"] }
+aws-sdk-s3 = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio", "behavior-version-latest"] }
 aws-config = { version = "1", optional = true, features = ["behavior-version-latest"] }
 aws-smithy-runtime-api = { version = "1", optional = true }
 
@@ -106,7 +107,7 @@ zip = "2"
 default = ["file-ops"]
 file-ops = []
 tui = []
-aws = ["dep:aws-sdk-secretsmanager", "dep:aws-sdk-cloudtrail", "dep:aws-config", "dep:aws-smithy-runtime-api"]
+aws = ["dep:aws-sdk-secretsmanager", "dep:aws-sdk-cloudtrail", "dep:aws-config", "dep:aws-smithy-runtime-api", "dep:aws-sdk-s3"]
 
 [build-dependencies]
 built = { version = "0.7", features = ["git2", "chrono"] }

--- a/src/backend/aws/auth.rs
+++ b/src/backend/aws/auth.rs
@@ -6,12 +6,11 @@
 
 use crate::backend::aws::config::AwsConfig;
 use crate::backend::error::BackendError;
-use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 
 /// Load the shared AWS `SdkConfig` from the resolved `AwsConfig` plus
 /// per-invocation overrides (region, profile from CLI flags or env vars).
-/// Service clients (Secrets Manager, CloudTrail) are built from this one
-/// config so they share credentials, region, and endpoint settings.
+/// Service clients (Secrets Manager, CloudTrail, S3) are built from this
+/// one config so they share credentials, region, and endpoint settings.
 pub async fn load_sdk_config(
     aws_cfg: &AwsConfig,
     region_override: Option<String>,
@@ -54,4 +53,25 @@ pub async fn build_client(
 ) -> Result<SecretsManagerClient, BackendError> {
     let sdk_config = load_sdk_config(aws_cfg, region_override, profile_override).await?;
     Ok(SecretsManagerClient::new(&sdk_config))
+}
+
+/// Build an S3 client for `xv file` storage from an already-loaded SDK config.
+///
+/// When an `endpoint_url` override is configured (LocalStack, MinIO, other
+/// S3-compatible APIs), path-style addressing is forced because those
+/// endpoints typically don't resolve virtual-hosted bucket subdomains.
+#[cfg(feature = "file-ops")]
+pub fn build_s3_client(
+    aws_cfg: &AwsConfig,
+    sdk_config: &aws_config::SdkConfig,
+) -> aws_sdk_s3::Client {
+    let mut builder = aws_sdk_s3::config::Builder::from(sdk_config);
+    if aws_cfg
+        .endpoint_url
+        .as_deref()
+        .is_some_and(|e| !e.is_empty())
+    {
+        builder = builder.force_path_style(true);
+    }
+    aws_sdk_s3::Client::from_conf(builder.build())
 }

--- a/src/backend/aws/auth.rs
+++ b/src/backend/aws/auth.rs
@@ -6,6 +6,7 @@
 
 use crate::backend::aws::config::AwsConfig;
 use crate::backend::error::BackendError;
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 
 /// Load the shared AWS `SdkConfig` from the resolved `AwsConfig` plus
 /// per-invocation overrides (region, profile from CLI flags or env vars).

--- a/src/backend/aws/errors.rs
+++ b/src/backend/aws/errors.rs
@@ -361,6 +361,170 @@ pub fn from_lookup_events(e: SdkError<LookupEventsError, Response>) -> BackendEr
     handle_sdk("LookupEvents", e)
 }
 
+// ---------------------------------------------------------------------------
+// S3 (file storage) error mapping
+// ---------------------------------------------------------------------------
+
+/// Classify an S3 service error by its error code.
+///
+/// S3 reports most failures through generic error codes rather than typed
+/// variants, so the mapping is code-based. `key` is the user-facing file
+/// name (used for NotFound); pass `None` for non-object operations (list,
+/// multipart bookkeeping).
+///
+/// Returns `None` when the code isn't recognised, so callers fall through to
+/// the transport-level handling in [`handle_sdk`].
+#[cfg(feature = "file-ops")]
+fn classify_s3_code(op: &str, key: Option<&str>, code: &str) -> Option<BackendError> {
+    match code {
+        "NoSuchKey" | "NotFound" => key.map(|k| BackendError::NotFound {
+            name: k.to_string(),
+            suggestion: None,
+        }),
+        "NoSuchBucket" => Some(BackendError::InvalidArgument(format!(
+            "S3 bucket not found (operation: {op}). Check [aws].s3_bucket / \
+             XV_AWS_S3_BUCKET — the bucket must already exist; xv does not create buckets."
+        ))),
+        "AccessDenied" | "AccessDeniedException" => Some(BackendError::PermissionDenied(format!(
+            "S3 access denied (operation: {op}). Ensure your credentials grant \
+             s3:GetObject, s3:PutObject, s3:DeleteObject, and s3:ListBucket on the \
+             configured bucket."
+        ))),
+        "SlowDown" | "ThrottlingException" | "RequestLimitExceeded" => {
+            Some(BackendError::RateLimited {
+                retry_after_secs: None,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Shared S3 mapping: code-based classification, then transport handling.
+#[cfg(feature = "file-ops")]
+fn handle_s3<E>(op: &str, key: Option<&str>, e: SdkError<E, Response>) -> BackendError
+where
+    E: std::fmt::Display + std::fmt::Debug + aws_sdk_s3::error::ProvideErrorMetadata,
+{
+    if let SdkError::ServiceError(svc) = &e {
+        if let Some(mapped) = classify_s3_code(op, key, svc.err().code().unwrap_or("")) {
+            return mapped;
+        }
+    }
+    handle_sdk(op, e)
+}
+
+#[cfg(feature = "file-ops")]
+pub fn from_s3_head_object(
+    name: &str,
+    e: SdkError<aws_sdk_s3::operation::head_object::HeadObjectError, Response>,
+) -> BackendError {
+    // HEAD responses carry no body, so the SDK can't always parse an error
+    // code — match the typed NotFound variant explicitly.
+    if let SdkError::ServiceError(svc) = &e {
+        if matches!(
+            svc.err(),
+            aws_sdk_s3::operation::head_object::HeadObjectError::NotFound(_)
+        ) {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_s3("HeadObject", Some(name), e)
+}
+
+#[cfg(feature = "file-ops")]
+pub fn from_s3_get_object(
+    name: &str,
+    e: SdkError<aws_sdk_s3::operation::get_object::GetObjectError, Response>,
+) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if matches!(
+            svc.err(),
+            aws_sdk_s3::operation::get_object::GetObjectError::NoSuchKey(_)
+        ) {
+            return BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            };
+        }
+    }
+    handle_s3("GetObject", Some(name), e)
+}
+
+#[cfg(feature = "file-ops")]
+pub fn from_s3_put_object(
+    name: &str,
+    e: SdkError<aws_sdk_s3::operation::put_object::PutObjectError, Response>,
+) -> BackendError {
+    handle_s3("PutObject", Some(name), e)
+}
+
+#[cfg(feature = "file-ops")]
+pub fn from_s3_list_objects(
+    e: SdkError<aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Error, Response>,
+) -> BackendError {
+    if let SdkError::ServiceError(svc) = &e {
+        if matches!(
+            svc.err(),
+            aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Error::NoSuchBucket(_)
+        ) {
+            // Typed variant; route through the same message as the code path.
+            if let Some(mapped) = classify_s3_code("ListObjectsV2", None, "NoSuchBucket") {
+                return mapped;
+            }
+        }
+    }
+    handle_s3("ListObjectsV2", None, e)
+}
+
+#[cfg(feature = "file-ops")]
+pub fn from_s3_delete_object(
+    name: &str,
+    e: SdkError<aws_sdk_s3::operation::delete_object::DeleteObjectError, Response>,
+) -> BackendError {
+    handle_s3("DeleteObject", Some(name), e)
+}
+
+#[cfg(feature = "file-ops")]
+pub fn from_s3_create_multipart(
+    name: &str,
+    e: SdkError<
+        aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadError,
+        Response,
+    >,
+) -> BackendError {
+    handle_s3("CreateMultipartUpload", Some(name), e)
+}
+
+#[cfg(feature = "file-ops")]
+pub fn from_s3_upload_part(
+    name: &str,
+    e: SdkError<aws_sdk_s3::operation::upload_part::UploadPartError, Response>,
+) -> BackendError {
+    handle_s3("UploadPart", Some(name), e)
+}
+
+#[cfg(feature = "file-ops")]
+pub fn from_s3_complete_multipart(
+    name: &str,
+    e: SdkError<
+        aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadError,
+        Response,
+    >,
+) -> BackendError {
+    handle_s3("CompleteMultipartUpload", Some(name), e)
+}
+
+#[cfg(feature = "file-ops")]
+pub fn from_s3_get_object_tagging(
+    name: &str,
+    e: SdkError<aws_sdk_s3::operation::get_object_tagging::GetObjectTaggingError, Response>,
+) -> BackendError {
+    handle_s3("GetObjectTagging", Some(name), e)
+}
+
 #[cfg(all(test, feature = "aws"))]
 mod tests {
     use super::*;
@@ -493,5 +657,57 @@ mod tests {
         assert!(hint.contains("aws secretsmanager rotate-secret"), "{hint}");
         assert!(hint.contains("--secret-id myproj-kv/db-password"), "{hint}");
         assert!(hint.contains("--rotation-lambda-arn"), "{hint}");
+    }
+
+    // ── S3 code classification ───────────────────────────────────────────────
+
+    #[cfg(feature = "file-ops")]
+    #[test]
+    fn s3_no_such_key_maps_to_not_found() {
+        let err = classify_s3_code("GetObject", Some("docs/readme.md"), "NoSuchKey").unwrap();
+        assert!(
+            matches!(err, BackendError::NotFound { ref name, .. } if name == "docs/readme.md"),
+            "got: {err:?}"
+        );
+    }
+
+    #[cfg(feature = "file-ops")]
+    #[test]
+    fn s3_not_found_without_key_falls_through() {
+        assert!(classify_s3_code("ListObjectsV2", None, "NotFound").is_none());
+    }
+
+    #[cfg(feature = "file-ops")]
+    #[test]
+    fn s3_no_such_bucket_maps_to_invalid_argument_with_hint() {
+        let err = classify_s3_code("PutObject", Some("a.txt"), "NoSuchBucket").unwrap();
+        let BackendError::InvalidArgument(msg) = err else {
+            panic!("expected InvalidArgument, got something else");
+        };
+        assert!(msg.contains("s3_bucket"), "hint missing: {msg}");
+        assert!(msg.contains("does not create"), "hint missing: {msg}");
+    }
+
+    #[cfg(feature = "file-ops")]
+    #[test]
+    fn s3_access_denied_maps_to_permission_denied_with_hint() {
+        let err = classify_s3_code("GetObject", Some("a.txt"), "AccessDenied").unwrap();
+        let BackendError::PermissionDenied(msg) = err else {
+            panic!("expected PermissionDenied, got something else");
+        };
+        assert!(msg.contains("s3:GetObject"), "hint missing: {msg}");
+    }
+
+    #[cfg(feature = "file-ops")]
+    #[test]
+    fn s3_slow_down_maps_to_rate_limited() {
+        let err = classify_s3_code("PutObject", Some("a.txt"), "SlowDown").unwrap();
+        assert!(matches!(err, BackendError::RateLimited { .. }));
+    }
+
+    #[cfg(feature = "file-ops")]
+    #[test]
+    fn s3_unknown_code_falls_through() {
+        assert!(classify_s3_code("PutObject", Some("a.txt"), "SomethingElse").is_none());
     }
 }

--- a/src/backend/aws/files.rs
+++ b/src/backend/aws/files.rs
@@ -627,6 +627,7 @@ impl AwsFileBackend {
             .map_err(|e| errors::from_s3_get_object(name, e))?;
 
         let mut body = out.body;
+        let mut written: u64 = 0;
         while let Some(bytes) = body
             .try_next()
             .await
@@ -636,6 +637,7 @@ impl AwsFileBackend {
                 .write_all(&bytes)
                 .await
                 .map_err(|e| BackendError::Internal(format!("write downloaded data: {e}")))?;
+            written += bytes.len() as u64;
             reporter.advance(bytes.len() as u64);
         }
         writer
@@ -644,7 +646,15 @@ impl AwsFileBackend {
             .map_err(|e| BackendError::Internal(format!("flush downloaded data: {e}")))?;
         reporter.finish_clear();
 
-        Ok(content_length)
+        // A truncated body stream (connection drop mid-transfer) must not be
+        // reported as a successful full-size download.
+        if written != content_length {
+            return Err(BackendError::Network(format!(
+                "download of '{name}' truncated: expected {content_length} bytes, wrote {written}"
+            )));
+        }
+
+        Ok(written)
     }
 
     /// Hierarchical listing at one prefix level using S3's delimiter support.

--- a/src/backend/aws/files.rs
+++ b/src/backend/aws/files.rs
@@ -1,0 +1,1160 @@
+//! AWS S3 file/blob backend.
+//!
+//! Files are stored under `<vault>/files/<name>` in a single configured
+//! bucket, so vaults stay isolated (matching the local backend's per-vault
+//! semantics, not Azure's single-container semantics).
+//!
+//! Security invariants (mirroring #223/#243 on the Azure side):
+//! - File names are validated before key construction: no absolute paths,
+//!   no `.`/`..` traversal segments, no backslashes or control characters.
+//! - Downloads are size-guarded (5 GiB cap) via `HeadObject` before the GET
+//!   and streamed to the writer — whole files are never buffered.
+//! - Uploads above the part-size threshold use multipart upload, reading one
+//!   chunk at a time (bounded memory), with abort-on-failure cleanup.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
+use aws_sdk_s3::Client as S3Client;
+use chrono::Utc;
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+
+use crate::backend::error::BackendError;
+use crate::backend::file::FileBackend;
+use crate::blob::manager::format_size;
+use crate::blob::models::{BlobListItem, FileInfo, FileListRequest, FileUploadRequest};
+use crate::config::settings::AwsConfig;
+use crate::utils::progress::{NoopReporter, ProgressReporter};
+
+use super::errors;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum object size accepted for download (mirrors the Azure blob cap).
+pub const MAX_DOWNLOAD_SIZE_BYTES: u64 = 5 * 1024 * 1024 * 1024; // 5 GiB
+
+/// S3 multipart constraint: every part except the last must be >= 5 MiB.
+const MIN_PART_SIZE_BYTES: u64 = 5 * 1024 * 1024;
+
+/// S3 multipart constraint: a single part may not exceed 5 GiB.
+const MAX_PART_SIZE_BYTES: u64 = 5 * 1024 * 1024 * 1024;
+
+/// S3 multipart constraint: at most 10,000 parts per upload.
+const MAX_PARTS: u64 = 10_000;
+
+/// S3 object key length limit (bytes).
+const MAX_KEY_LEN: usize = 1024;
+
+/// Key segment separating the vault prefix from file names.
+const FILES_SEGMENT: &str = "files";
+
+/// Object-metadata key carrying the comma-joined group list (same encoding
+/// as the Azure blob backend).
+const METADATA_KEY_GROUPS: &str = "groups";
+
+/// S3 allows at most 10 tags per object.
+const MAX_OBJECT_TAGS: usize = 10;
+
+// ---------------------------------------------------------------------------
+// Pure helpers (key construction, validation, chunk math)
+// ---------------------------------------------------------------------------
+
+/// Resolve the S3 bucket for file storage: `[aws].s3_bucket` first, then the
+/// `XV_AWS_S3_BUCKET` env var. Errors with a setup hint when neither is set.
+pub fn resolve_bucket(aws_cfg: &AwsConfig) -> Result<String, BackendError> {
+    let env_bucket = std::env::var("XV_AWS_S3_BUCKET").ok();
+    resolve_bucket_from(aws_cfg.s3_bucket.as_deref(), env_bucket.as_deref())
+}
+
+/// Pure bucket resolution (testable without env mutation).
+fn resolve_bucket_from(cfg: Option<&str>, env: Option<&str>) -> Result<String, BackendError> {
+    for candidate in [cfg, env] {
+        if let Some(bucket) = candidate.map(str::trim) {
+            if !bucket.is_empty() {
+                return Ok(bucket.to_string());
+            }
+        }
+    }
+    Err(BackendError::InvalidArgument(
+        "S3 bucket not configured for file storage: set [aws].s3_bucket in your config \
+         (or the XV_AWS_S3_BUCKET env var) to an existing bucket. \
+         xv does not create buckets."
+            .into(),
+    ))
+}
+
+/// Validate a vault name for use as a file key prefix.
+///
+/// The vault must form exactly one key segment — separators or traversal
+/// tokens would break the `<vault>/files/<name>` isolation scheme.
+pub fn validate_vault_for_files(vault: &str) -> Result<(), BackendError> {
+    if vault.trim().is_empty() {
+        return Err(BackendError::InvalidArgument(
+            "vault name cannot be empty for file operations".into(),
+        ));
+    }
+    if vault == "." || vault == ".." {
+        return Err(BackendError::InvalidArgument(format!(
+            "invalid vault name for file operations: '{vault}'"
+        )));
+    }
+    if vault.contains('/') || vault.contains('\\') {
+        return Err(BackendError::InvalidArgument(format!(
+            "vault name '{vault}' cannot contain path separators for file operations"
+        )));
+    }
+    if vault.chars().any(char::is_control) {
+        return Err(BackendError::InvalidArgument(
+            "vault name cannot contain control characters".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate a user-facing file name before it becomes part of an object key.
+///
+/// Rejects empty names, absolute paths, `.`/`..` traversal segments,
+/// backslashes, control characters, and trailing slashes. Forward slashes
+/// are allowed for folder-style names (`docs/readme.md`), matching Azure.
+pub fn validate_file_name(name: &str) -> Result<(), BackendError> {
+    if name.trim().is_empty() {
+        return Err(BackendError::InvalidArgument(
+            "file name cannot be empty".into(),
+        ));
+    }
+    if name.starts_with('/') {
+        return Err(BackendError::InvalidArgument(format!(
+            "file name '{name}' must be relative (no leading '/')"
+        )));
+    }
+    if name.ends_with('/') {
+        return Err(BackendError::InvalidArgument(format!(
+            "file name '{name}' cannot end with '/'"
+        )));
+    }
+    if name.contains('\\') {
+        return Err(BackendError::InvalidArgument(format!(
+            "file name '{name}' cannot contain backslashes (use '/' as separator)"
+        )));
+    }
+    if name.chars().any(char::is_control) {
+        return Err(BackendError::InvalidArgument(
+            "file name cannot contain control characters".into(),
+        ));
+    }
+    if name
+        .split('/')
+        .any(|seg| seg.is_empty() || seg == "." || seg == "..")
+    {
+        return Err(BackendError::InvalidArgument(format!(
+            "file name '{name}' contains path traversal or empty segments"
+        )));
+    }
+    Ok(())
+}
+
+/// The key prefix under which a vault's files live.
+pub fn files_prefix(vault: &str) -> String {
+    format!("{vault}/{FILES_SEGMENT}/")
+}
+
+/// Build the object key for a file (no validation — see [`validated_key`]).
+fn object_key(vault: &str, name: &str) -> String {
+    format!("{vault}/{FILES_SEGMENT}/{name}")
+}
+
+/// Validate vault + name and return the full object key.
+pub fn validated_key(vault: &str, name: &str) -> Result<String, BackendError> {
+    validate_vault_for_files(vault)?;
+    validate_file_name(name)?;
+    let key = object_key(vault, name);
+    if key.len() > MAX_KEY_LEN {
+        return Err(BackendError::InvalidArgument(format!(
+            "object key too long: {} bytes for '{name}' in vault '{vault}' (max {MAX_KEY_LEN})",
+            key.len()
+        )));
+    }
+    Ok(key)
+}
+
+/// Strip the vault's file prefix from an object key, returning the
+/// user-facing file name. `None` if the key is outside the vault's files.
+pub fn strip_file_key(vault: &str, key: &str) -> Option<String> {
+    key.strip_prefix(&files_prefix(vault))
+        .filter(|rest| !rest.is_empty())
+        .map(str::to_string)
+}
+
+/// Compute the multipart part size for a file, honouring the configured
+/// chunk size while satisfying S3 constraints: parts >= 5 MiB, <= 5 GiB,
+/// and at most 10,000 parts per upload.
+pub fn multipart_part_size(file_size: u64, configured_chunk_bytes: u64) -> u64 {
+    let configured = configured_chunk_bytes.clamp(MIN_PART_SIZE_BYTES, MAX_PART_SIZE_BYTES);
+    // Grow the part size if the configured one would exceed the part-count cap.
+    let min_for_count = file_size.div_ceil(MAX_PARTS);
+    configured.max(min_for_count).min(MAX_PART_SIZE_BYTES)
+}
+
+/// Number of parts a multipart upload will produce.
+#[allow(dead_code)] // chunk-math contract; exercised by unit tests
+pub fn part_count(file_size: u64, part_size: u64) -> u64 {
+    file_size.div_ceil(part_size.max(1))
+}
+
+/// Reject downloads whose object size exceeds `max_bytes`.
+fn validate_download_size(content_length: u64, max_bytes: u64) -> Result<(), BackendError> {
+    if content_length > max_bytes {
+        return Err(BackendError::InvalidArgument(format!(
+            "Object size {} exceeds the maximum allowed download size of {}",
+            format_size(content_length),
+            format_size(max_bytes)
+        )));
+    }
+    Ok(())
+}
+
+/// Convert the configured chunk size (MB) into bytes, clamped to >= 1 MB.
+fn chunk_bytes(chunk_size_mb: usize) -> u64 {
+    (chunk_size_mb.max(1) as u64) * 1024 * 1024
+}
+
+/// Encode object tags as an S3 `Tagging` query string. `None` when empty.
+fn encode_tagging(tags: &HashMap<String, String>) -> Result<Option<String>, BackendError> {
+    if tags.is_empty() {
+        return Ok(None);
+    }
+    if tags.len() > MAX_OBJECT_TAGS {
+        return Err(BackendError::InvalidArgument(format!(
+            "Too many tags ({}) — S3 allows a maximum of {MAX_OBJECT_TAGS} tags per object. \
+             Remove {} tag(s).",
+            tags.len(),
+            tags.len() - MAX_OBJECT_TAGS
+        )));
+    }
+    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+    // Sort for deterministic output.
+    let mut pairs: Vec<(&String, &String)> = tags.iter().collect();
+    pairs.sort();
+    for (k, v) in pairs {
+        serializer.append_pair(k, v);
+    }
+    Ok(Some(serializer.finish()))
+}
+
+/// Convert an SDK timestamp to `chrono::DateTime<Utc>`.
+fn to_chrono(dt: Option<&aws_sdk_s3::primitives::DateTime>) -> chrono::DateTime<Utc> {
+    dt.and_then(|d| chrono::DateTime::from_timestamp(d.secs(), d.subsec_nanos()))
+        .unwrap_or_else(Utc::now)
+}
+
+/// Read up to `chunk_size` bytes from `reader` (fewer at EOF, empty when
+/// already at EOF). Same contract as the Azure blob manager's chunker.
+async fn read_chunk<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    chunk_size: usize,
+) -> std::io::Result<Vec<u8>> {
+    use tokio::io::AsyncReadExt;
+    let mut chunk = vec![0u8; chunk_size];
+    let mut bytes_read = 0;
+    while bytes_read < chunk_size {
+        let n = reader.read(&mut chunk[bytes_read..]).await?;
+        if n == 0 {
+            break;
+        }
+        bytes_read += n;
+    }
+    chunk.truncate(bytes_read);
+    Ok(chunk)
+}
+
+/// Sort listing items: directories first, then files (both alphabetically).
+fn sort_list_items(items: &mut [BlobListItem]) {
+    items.sort_by(|a, b| match (a, b) {
+        (BlobListItem::Directory { .. }, BlobListItem::File(_)) => std::cmp::Ordering::Less,
+        (BlobListItem::File(_), BlobListItem::Directory { .. }) => std::cmp::Ordering::Greater,
+        (BlobListItem::Directory { name: n1, .. }, BlobListItem::Directory { name: n2, .. }) => {
+            n1.to_lowercase().cmp(&n2.to_lowercase())
+        }
+        (BlobListItem::File(f1), BlobListItem::File(f2)) => {
+            f1.name.to_lowercase().cmp(&f2.name.to_lowercase())
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Upload spec
+// ---------------------------------------------------------------------------
+
+/// Metadata for a streaming upload (everything in [`FileUploadRequest`]
+/// except the content, which arrives via the reader).
+pub struct FileUploadSpec {
+    pub name: String,
+    pub content_type: Option<String>,
+    pub groups: Vec<String>,
+    pub metadata: HashMap<String, String>,
+    pub tags: HashMap<String, String>,
+}
+
+impl From<&FileUploadRequest> for FileUploadSpec {
+    fn from(request: &FileUploadRequest) -> Self {
+        Self {
+            name: request.name.clone(),
+            content_type: request.content_type.clone(),
+            groups: request.groups.clone(),
+            metadata: request.metadata.clone(),
+            tags: request.tags.clone(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AwsFileBackend
+// ---------------------------------------------------------------------------
+
+/// S3-backed file storage. One instance serves every vault; the target vault
+/// is supplied per call (see [`FileBackend`]).
+pub struct AwsFileBackend {
+    client: S3Client,
+    bucket: String,
+    chunk_size_mb: usize,
+    max_concurrent_uploads: usize,
+}
+
+impl AwsFileBackend {
+    /// Create a backend for an existing bucket with default transfer settings.
+    pub fn new(client: S3Client, bucket: String) -> Self {
+        Self {
+            client,
+            bucket,
+            chunk_size_mb: 8,
+            max_concurrent_uploads: 3,
+        }
+    }
+
+    /// Override chunk size (MB) and upload concurrency (builder style).
+    /// Values are clamped to a minimum of 1; the effective part size is
+    /// additionally clamped to S3's 5 MiB multipart minimum at upload time.
+    pub fn with_transfer_config(mut self, chunk_size_mb: usize, max_concurrent: usize) -> Self {
+        self.chunk_size_mb = chunk_size_mb.max(1);
+        self.max_concurrent_uploads = max_concurrent.max(1);
+        self
+    }
+
+    /// Upload a file from any async reader, streaming chunk-by-chunk.
+    ///
+    /// Files larger than the effective part size go through S3 multipart
+    /// upload (concurrent parts, abort on failure); smaller files use a
+    /// single `PutObject`. At most `max_concurrent_uploads + 1` chunks are
+    /// in memory at any time.
+    pub async fn upload_file_streaming<R: AsyncRead + Unpin>(
+        &self,
+        vault: &str,
+        spec: FileUploadSpec,
+        reader: &mut R,
+        file_size: u64,
+        reporter: &dyn ProgressReporter,
+    ) -> Result<FileInfo, BackendError> {
+        let key = validated_key(vault, &spec.name)?;
+
+        let content_type = spec.content_type.clone().unwrap_or_else(|| {
+            mime_guess::from_path(&spec.name)
+                .first_or_octet_stream()
+                .to_string()
+        });
+
+        // Object metadata, mirroring the Azure blob manager's conventions.
+        let mut metadata = spec.metadata.clone();
+        if !spec.groups.is_empty() {
+            metadata.insert(METADATA_KEY_GROUPS.to_string(), spec.groups.join(","));
+        }
+        metadata.insert("uploaded_by".to_string(), "crosstache".to_string());
+        metadata.insert("uploaded_at".to_string(), Utc::now().to_rfc3339());
+
+        let tagging = encode_tagging(&spec.tags)?;
+
+        reporter.set_total(file_size);
+
+        let part_size = multipart_part_size(file_size, chunk_bytes(self.chunk_size_mb));
+        let etag = if file_size > part_size {
+            self.multipart_upload(
+                &spec.name,
+                &key,
+                reader,
+                part_size,
+                &content_type,
+                &metadata,
+                &tagging,
+                reporter,
+            )
+            .await?
+        } else {
+            // Small file: bounded read (<= part_size) and a single PutObject.
+            let content = read_chunk(reader, file_size as usize)
+                .await
+                .map_err(|e| BackendError::Internal(format!("read file data: {e}")))?;
+            let len = content.len() as u64;
+            let out = self
+                .client
+                .put_object()
+                .bucket(&self.bucket)
+                .key(&key)
+                .content_type(&content_type)
+                .set_metadata(Some(metadata.clone()))
+                .set_tagging(tagging.clone())
+                .body(ByteStream::from(content))
+                .send()
+                .await
+                .map_err(|e| errors::from_s3_put_object(&spec.name, e))?;
+            reporter.advance(len);
+            out.e_tag().unwrap_or_default().to_string()
+        };
+        reporter.finish_clear();
+
+        Ok(FileInfo {
+            name: spec.name,
+            size: file_size,
+            content_type,
+            last_modified: Utc::now(),
+            etag,
+            groups: spec.groups,
+            metadata,
+            tags: spec.tags,
+        })
+    }
+
+    /// Multipart upload: create, upload parts concurrently, complete.
+    /// Aborts the multipart upload (best effort) on any failure so no
+    /// orphaned parts accrue storage charges.
+    #[allow(clippy::too_many_arguments)]
+    async fn multipart_upload<R: AsyncRead + Unpin>(
+        &self,
+        name: &str,
+        key: &str,
+        reader: &mut R,
+        part_size: u64,
+        content_type: &str,
+        metadata: &HashMap<String, String>,
+        tagging: &Option<String>,
+        reporter: &dyn ProgressReporter,
+    ) -> Result<String, BackendError> {
+        let create = self
+            .client
+            .create_multipart_upload()
+            .bucket(&self.bucket)
+            .key(key)
+            .content_type(content_type)
+            .set_metadata(Some(metadata.clone()))
+            .set_tagging(tagging.clone())
+            .send()
+            .await
+            .map_err(|e| errors::from_s3_create_multipart(name, e))?;
+        let upload_id = create
+            .upload_id()
+            .ok_or_else(|| {
+                BackendError::Internal("S3 did not return a multipart upload id".into())
+            })?
+            .to_string();
+
+        let parts = match self
+            .upload_parts(name, key, &upload_id, reader, part_size, reporter)
+            .await
+        {
+            Ok(parts) => parts,
+            Err(e) => {
+                // Best-effort cleanup; the original error is what matters.
+                let _ = self
+                    .client
+                    .abort_multipart_upload()
+                    .bucket(&self.bucket)
+                    .key(key)
+                    .upload_id(&upload_id)
+                    .send()
+                    .await;
+                return Err(e);
+            }
+        };
+
+        let out = self
+            .client
+            .complete_multipart_upload()
+            .bucket(&self.bucket)
+            .key(key)
+            .upload_id(&upload_id)
+            .multipart_upload(
+                CompletedMultipartUpload::builder()
+                    .set_parts(Some(parts))
+                    .build(),
+            )
+            .send()
+            .await
+            .map_err(|e| errors::from_s3_complete_multipart(name, e))?;
+
+        Ok(out.e_tag().unwrap_or_default().to_string())
+    }
+
+    /// Read chunks and upload parts with bounded concurrency.
+    async fn upload_parts<R: AsyncRead + Unpin>(
+        &self,
+        name: &str,
+        key: &str,
+        upload_id: &str,
+        reader: &mut R,
+        part_size: u64,
+        reporter: &dyn ProgressReporter,
+    ) -> Result<Vec<CompletedPart>, BackendError> {
+        use tokio::sync::Semaphore;
+
+        let semaphore = Arc::new(Semaphore::new(self.max_concurrent_uploads));
+        type PartHandle = tokio::task::JoinHandle<Result<CompletedPart, BackendError>>;
+        let mut handles: Vec<(PartHandle, u64)> = Vec::new();
+        let mut part_number: i32 = 0;
+
+        loop {
+            let chunk = read_chunk(reader, part_size as usize)
+                .await
+                .map_err(|e| BackendError::Internal(format!("read file data: {e}")))?;
+            if chunk.is_empty() {
+                break;
+            }
+            part_number += 1;
+            if part_number as u64 > MAX_PARTS {
+                return Err(BackendError::Internal(format!(
+                    "multipart upload would exceed {MAX_PARTS} parts — file larger than declared size?"
+                )));
+            }
+
+            let permit = semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .map_err(|e| BackendError::Internal(format!("semaphore error: {e}")))?;
+            let client = self.client.clone();
+            let bucket = self.bucket.clone();
+            let key = key.to_string();
+            let upload_id = upload_id.to_string();
+            let name = name.to_string();
+            let len = chunk.len() as u64;
+
+            handles.push((
+                tokio::spawn(async move {
+                    let _permit = permit; // held for the duration of the upload
+                    let out = client
+                        .upload_part()
+                        .bucket(bucket)
+                        .key(key)
+                        .upload_id(upload_id)
+                        .part_number(part_number)
+                        .body(ByteStream::from(chunk))
+                        .send()
+                        .await
+                        .map_err(|e| errors::from_s3_upload_part(&name, e))?;
+                    Ok(CompletedPart::builder()
+                        .part_number(part_number)
+                        .set_e_tag(out.e_tag().map(str::to_string))
+                        .build())
+                }),
+                len,
+            ));
+        }
+
+        let mut parts = Vec::with_capacity(handles.len());
+        for (handle, len) in handles {
+            let part = handle
+                .await
+                .map_err(|e| BackendError::Internal(format!("upload task panicked: {e}")))??;
+            parts.push(part);
+            reporter.advance(len);
+        }
+        Ok(parts)
+    }
+
+    /// Stream a file's contents to `writer`, enforcing the 5 GiB download
+    /// cap. At most one body frame is buffered at a time. Returns the
+    /// object's size in bytes.
+    pub async fn download_file_to_writer<W: AsyncWrite + Unpin>(
+        &self,
+        vault: &str,
+        name: &str,
+        writer: &mut W,
+        reporter: &dyn ProgressReporter,
+    ) -> Result<u64, BackendError> {
+        let key = validated_key(vault, name)?;
+
+        let head = self
+            .client
+            .head_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await
+            .map_err(|e| errors::from_s3_head_object(name, e))?;
+        let content_length = head.content_length().unwrap_or(0).max(0) as u64;
+        validate_download_size(content_length, MAX_DOWNLOAD_SIZE_BYTES)?;
+        reporter.set_total(content_length);
+
+        let out = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await
+            .map_err(|e| errors::from_s3_get_object(name, e))?;
+
+        let mut body = out.body;
+        while let Some(bytes) = body
+            .try_next()
+            .await
+            .map_err(|e| BackendError::Network(format!("aws GetObject body stream: {e}")))?
+        {
+            writer
+                .write_all(&bytes)
+                .await
+                .map_err(|e| BackendError::Internal(format!("write downloaded data: {e}")))?;
+            reporter.advance(bytes.len() as u64);
+        }
+        writer
+            .flush()
+            .await
+            .map_err(|e| BackendError::Internal(format!("flush downloaded data: {e}")))?;
+        reporter.finish_clear();
+
+        Ok(content_length)
+    }
+
+    /// Hierarchical listing at one prefix level using S3's delimiter support.
+    /// Common prefixes become [`BlobListItem::Directory`] entries.
+    pub async fn list_files_hierarchical(
+        &self,
+        vault: &str,
+        request: FileListRequest,
+    ) -> Result<Vec<BlobListItem>, BackendError> {
+        validate_vault_for_files(vault)?;
+
+        let base = files_prefix(vault);
+        let user_prefix = normalize_user_prefix(request.prefix.as_deref());
+        let full_prefix = format!("{base}{user_prefix}");
+        let delimiter = request.delimiter.clone().unwrap_or_else(|| "/".to_string());
+
+        let mut items: Vec<BlobListItem> = Vec::new();
+        let mut continuation: Option<String> = None;
+        loop {
+            let page = self
+                .client
+                .list_objects_v2()
+                .bucket(&self.bucket)
+                .prefix(&full_prefix)
+                .delimiter(&delimiter)
+                .set_continuation_token(continuation.take())
+                .send()
+                .await
+                .map_err(errors::from_s3_list_objects)?;
+
+            for cp in page.common_prefixes() {
+                let Some(full_key_prefix) = cp.prefix() else {
+                    continue;
+                };
+                let Some(full_path) = strip_file_key(vault, full_key_prefix) else {
+                    continue;
+                };
+                let dir_name = full_path
+                    .strip_prefix(&user_prefix)
+                    .unwrap_or(&full_path)
+                    .to_string();
+                items.push(BlobListItem::Directory {
+                    name: dir_name,
+                    full_path,
+                });
+            }
+
+            for obj in page.contents() {
+                if let Some(info) = self.object_to_file_info(vault, obj) {
+                    items.push(BlobListItem::File(info));
+                }
+            }
+
+            if page.is_truncated() == Some(true) {
+                continuation = page.next_continuation_token().map(str::to_string);
+                if continuation.is_none() {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        // Group filtering requires per-object metadata (S3 listings carry
+        // none) — resolve via HeadObject only when a filter was requested.
+        if let Some(ref filter_groups) = request.groups {
+            let mut filtered = Vec::with_capacity(items.len());
+            for item in items {
+                match item {
+                    BlobListItem::File(info) => {
+                        let full = self.get_file_info(vault, &info.name).await?;
+                        if filter_groups.iter().any(|fg| full.groups.contains(fg)) {
+                            filtered.push(BlobListItem::File(full));
+                        }
+                    }
+                    dir => filtered.push(dir),
+                }
+            }
+            items = filtered;
+        }
+
+        sort_list_items(&mut items);
+        if let Some(limit) = request.limit {
+            items.truncate(limit);
+        }
+        Ok(items)
+    }
+
+    /// Convert one S3 listing entry to a [`FileInfo`].
+    ///
+    /// S3 listings carry no user metadata or content type, so `content_type`
+    /// is guessed from the name (display only) and `groups`/`metadata` stay
+    /// empty unless resolved separately via `get_file_info`.
+    fn object_to_file_info(
+        &self,
+        vault: &str,
+        obj: &aws_sdk_s3::types::Object,
+    ) -> Option<FileInfo> {
+        let key = obj.key()?;
+        let name = strip_file_key(vault, key)?;
+        Some(FileInfo {
+            content_type: mime_guess::from_path(&name)
+                .first_or_octet_stream()
+                .to_string(),
+            size: obj.size().unwrap_or(0).max(0) as u64,
+            last_modified: to_chrono(obj.last_modified()),
+            etag: obj.e_tag().unwrap_or_default().to_string(),
+            groups: Vec::new(),
+            metadata: HashMap::new(),
+            tags: HashMap::new(),
+            name,
+        })
+    }
+}
+
+/// Normalize the user-supplied list prefix: trim leading slashes; no other
+/// transformation (an exact-name prefix match is intended, like Azure).
+fn normalize_user_prefix(prefix: Option<&str>) -> String {
+    prefix
+        .map(|p| p.trim_start_matches('/').to_string())
+        .unwrap_or_default()
+}
+
+#[async_trait]
+impl FileBackend for AwsFileBackend {
+    async fn upload_file(
+        &self,
+        vault: &str,
+        request: FileUploadRequest,
+        reporter: Option<&dyn ProgressReporter>,
+    ) -> Result<FileInfo, BackendError> {
+        let null = NoopReporter;
+        let reporter = reporter.unwrap_or(&null);
+        let spec = FileUploadSpec::from(&request);
+        let file_size = request.content.len() as u64;
+        let mut reader = std::io::Cursor::new(request.content);
+        self.upload_file_streaming(vault, spec, &mut reader, file_size, reporter)
+            .await
+    }
+
+    async fn download_file(
+        &self,
+        vault: &str,
+        name: &str,
+        reporter: Option<&dyn ProgressReporter>,
+    ) -> Result<Vec<u8>, BackendError> {
+        let null = NoopReporter;
+        let reporter = reporter.unwrap_or(&null);
+        let mut buf: Vec<u8> = Vec::new();
+        self.download_file_to_writer(vault, name, &mut buf, reporter)
+            .await?;
+        Ok(buf)
+    }
+
+    async fn list_files(
+        &self,
+        vault: &str,
+        request: FileListRequest,
+    ) -> Result<Vec<FileInfo>, BackendError> {
+        validate_vault_for_files(vault)?;
+
+        let base = files_prefix(vault);
+        let user_prefix = normalize_user_prefix(request.prefix.as_deref());
+        let full_prefix = format!("{base}{user_prefix}");
+
+        let mut results: Vec<FileInfo> = Vec::new();
+        let mut continuation: Option<String> = None;
+        loop {
+            let page = self
+                .client
+                .list_objects_v2()
+                .bucket(&self.bucket)
+                .prefix(&full_prefix)
+                .set_continuation_token(continuation.take())
+                .send()
+                .await
+                .map_err(errors::from_s3_list_objects)?;
+
+            for obj in page.contents() {
+                if let Some(info) = self.object_to_file_info(vault, obj) {
+                    results.push(info);
+                }
+            }
+
+            if page.is_truncated() == Some(true) {
+                continuation = page.next_continuation_token().map(str::to_string);
+                if continuation.is_none() {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        // Group filtering needs per-object metadata; see hierarchical note.
+        if let Some(ref filter_groups) = request.groups {
+            let mut filtered = Vec::with_capacity(results.len());
+            for info in results {
+                let full = self.get_file_info(vault, &info.name).await?;
+                if filter_groups.iter().any(|fg| full.groups.contains(fg)) {
+                    filtered.push(full);
+                }
+            }
+            results = filtered;
+        }
+
+        results.sort_by(|a, b| a.name.cmp(&b.name));
+        if let Some(limit) = request.limit {
+            results.truncate(limit);
+        }
+        Ok(results)
+    }
+
+    async fn delete_file(&self, vault: &str, name: &str) -> Result<(), BackendError> {
+        let key = validated_key(vault, name)?;
+
+        // S3 DeleteObject succeeds silently for missing keys — head first so
+        // deleting a nonexistent file reports NotFound like other backends.
+        self.client
+            .head_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await
+            .map_err(|e| errors::from_s3_head_object(name, e))?;
+
+        self.client
+            .delete_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await
+            .map_err(|e| errors::from_s3_delete_object(name, e))?;
+        Ok(())
+    }
+
+    async fn get_file_info(&self, vault: &str, name: &str) -> Result<FileInfo, BackendError> {
+        let key = validated_key(vault, name)?;
+
+        let head = self
+            .client
+            .head_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await
+            .map_err(|e| errors::from_s3_head_object(name, e))?;
+
+        let metadata: HashMap<String, String> = head.metadata().cloned().unwrap_or_default();
+        let groups: Vec<String> = metadata
+            .get(METADATA_KEY_GROUPS)
+            .map(|g| g.split(',').map(|s| s.trim().to_string()).collect())
+            .unwrap_or_default();
+
+        // Tags need a separate call; degrade gracefully when the credentials
+        // lack s3:GetObjectTagging (mirrors the Azure 403 fallback).
+        let tags: HashMap<String, String> = match self
+            .client
+            .get_object_tagging()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await
+        {
+            Ok(out) => out
+                .tag_set()
+                .iter()
+                .map(|t| (t.key().to_string(), t.value().to_string()))
+                .collect(),
+            Err(e) => {
+                match errors::from_s3_get_object_tagging(name, e) {
+                    BackendError::PermissionDenied(_) => tracing::debug!(
+                        "Tag read for '{name}' was denied; tags will be empty. \
+                         Grant s3:GetObjectTagging to include them."
+                    ),
+                    other => tracing::warn!("Failed to fetch tags for '{name}': {other}"),
+                }
+                HashMap::new()
+            }
+        };
+
+        Ok(FileInfo {
+            name: name.to_string(),
+            size: head.content_length().unwrap_or(0).max(0) as u64,
+            content_type: head
+                .content_type()
+                .unwrap_or("application/octet-stream")
+                .to_string(),
+            last_modified: to_chrono(head.last_modified()),
+            etag: head.e_tag().unwrap_or_default().to_string(),
+            groups,
+            metadata,
+            tags,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── key construction & vault isolation ──────────────────────────────────
+
+    #[test]
+    fn object_key_is_vault_prefixed() {
+        assert_eq!(
+            validated_key("dev", "docs/readme.md").unwrap(),
+            "dev/files/docs/readme.md"
+        );
+    }
+
+    #[test]
+    fn files_prefix_ends_with_slash() {
+        assert_eq!(files_prefix("prod"), "prod/files/");
+    }
+
+    #[test]
+    fn vaults_with_same_file_name_get_distinct_keys() {
+        let dev = validated_key("dev", "config.txt").unwrap();
+        let prod = validated_key("prod", "config.txt").unwrap();
+        assert_ne!(dev, prod);
+        assert!(dev.starts_with("dev/files/"));
+        assert!(prod.starts_with("prod/files/"));
+    }
+
+    #[test]
+    fn strip_file_key_only_matches_own_vault() {
+        assert_eq!(
+            strip_file_key("dev", "dev/files/config.txt"),
+            Some("config.txt".to_string())
+        );
+        assert_eq!(strip_file_key("dev", "prod/files/config.txt"), None);
+        assert_eq!(strip_file_key("dev", "dev/secrets/config.txt"), None);
+        // The bare prefix itself is not a file.
+        assert_eq!(strip_file_key("dev", "dev/files/"), None);
+    }
+
+    #[test]
+    fn validated_key_rejects_overlong_keys() {
+        // "vault/files/" (12 bytes) + name must stay <= 1024 bytes.
+        let max_name = 1024 - files_prefix("vault").len();
+        assert!(validated_key("vault", &"a".repeat(max_name)).is_ok());
+        let err = validated_key("vault", &"a".repeat(max_name + 1)).unwrap_err();
+        assert!(matches!(err, BackendError::InvalidArgument(_)));
+    }
+
+    // ── file name validation (containment) ──────────────────────────────────
+
+    #[test]
+    fn validate_file_name_accepts_normal_names() {
+        for name in ["a.txt", "docs/readme.md", "configs/app.yaml", "naïve.txt"] {
+            assert!(validate_file_name(name).is_ok(), "should accept: {name}");
+        }
+    }
+
+    #[test]
+    fn validate_file_name_rejects_traversal_and_absolute() {
+        for name in [
+            "",
+            "  ",
+            "/etc/passwd",
+            "../escape.txt",
+            "a/../escape.txt",
+            "a/./b.txt",
+            "..",
+            "a//b.txt",
+            "trailing/",
+            "back\\slash.txt",
+            "ctrl\u{7}.txt",
+        ] {
+            assert!(
+                matches!(
+                    validate_file_name(name),
+                    Err(BackendError::InvalidArgument(_))
+                ),
+                "should reject: {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_vault_rejects_separators_and_traversal() {
+        for vault in ["", "..", ".", "a/b", "a\\b", "v\u{0}lt"] {
+            assert!(
+                matches!(
+                    validate_vault_for_files(vault),
+                    Err(BackendError::InvalidArgument(_))
+                ),
+                "should reject vault: {vault:?}"
+            );
+        }
+        assert!(validate_vault_for_files("myproj-kv").is_ok());
+    }
+
+    // ── multipart chunk math ─────────────────────────────────────────────────
+
+    const MIB: u64 = 1024 * 1024;
+
+    #[test]
+    fn part_size_clamps_small_chunks_to_s3_minimum() {
+        // Default config chunk is 4 MB — below S3's 5 MiB multipart minimum.
+        assert_eq!(multipart_part_size(100 * MIB, 4 * MIB), 5 * MIB);
+        assert_eq!(multipart_part_size(100 * MIB, 0), 5 * MIB);
+    }
+
+    #[test]
+    fn part_size_honours_configured_chunk_when_valid() {
+        assert_eq!(multipart_part_size(100 * MIB, 16 * MIB), 16 * MIB);
+    }
+
+    #[test]
+    fn part_size_grows_to_respect_max_part_count() {
+        // 100,000 MiB at 5 MiB/part would need 20,000 parts (> 10,000 cap).
+        let size = 100_000 * MIB;
+        let part = multipart_part_size(size, 5 * MIB);
+        assert!(part_count(size, part) <= MAX_PARTS, "part size {part}");
+        assert!(part >= size.div_ceil(MAX_PARTS));
+    }
+
+    #[test]
+    fn part_size_never_exceeds_s3_maximum() {
+        assert_eq!(multipart_part_size(u64::MAX, u64::MAX), MAX_PART_SIZE_BYTES);
+    }
+
+    #[test]
+    fn part_count_math() {
+        assert_eq!(part_count(250, 100), 3);
+        assert_eq!(part_count(200, 100), 2);
+        assert_eq!(part_count(0, 100), 0);
+        assert_eq!(part_count(1, 100), 1);
+    }
+
+    // ── download size guard ──────────────────────────────────────────────────
+
+    #[test]
+    fn download_size_guard_allows_under_and_exact() {
+        assert!(validate_download_size(100, 1024).is_ok());
+        assert!(validate_download_size(1024, 1024).is_ok());
+        assert!(validate_download_size(0, 1024).is_ok());
+        assert!(validate_download_size(MAX_DOWNLOAD_SIZE_BYTES, MAX_DOWNLOAD_SIZE_BYTES).is_ok());
+    }
+
+    #[test]
+    fn download_size_guard_rejects_over_limit() {
+        let err = validate_download_size(MAX_DOWNLOAD_SIZE_BYTES + 1, MAX_DOWNLOAD_SIZE_BYTES)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("maximum allowed download size"),
+            "got: {err}"
+        );
+    }
+
+    // ── bucket resolution ────────────────────────────────────────────────────
+
+    #[test]
+    fn bucket_resolution_prefers_config_then_env() {
+        assert_eq!(
+            resolve_bucket_from(Some("cfg-bucket"), Some("env-bucket")).unwrap(),
+            "cfg-bucket"
+        );
+        assert_eq!(
+            resolve_bucket_from(None, Some("env-bucket")).unwrap(),
+            "env-bucket"
+        );
+        assert_eq!(
+            resolve_bucket_from(Some("  "), Some("env-bucket")).unwrap(),
+            "env-bucket"
+        );
+    }
+
+    #[test]
+    fn bucket_resolution_errors_with_setup_hint_when_unset() {
+        let err = resolve_bucket_from(None, None).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("s3_bucket"), "hint missing: {msg}");
+        assert!(msg.contains("XV_AWS_S3_BUCKET"), "hint missing: {msg}");
+        assert!(msg.contains("does not create"), "hint missing: {msg}");
+    }
+
+    // ── tagging ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn tagging_empty_is_none() {
+        assert_eq!(encode_tagging(&HashMap::new()).unwrap(), None);
+    }
+
+    #[test]
+    fn tagging_encodes_url_pairs() {
+        let tags = HashMap::from([("env".to_string(), "prod east".to_string())]);
+        assert_eq!(
+            encode_tagging(&tags).unwrap().unwrap(),
+            "env=prod+east".to_string()
+        );
+    }
+
+    #[test]
+    fn tagging_rejects_more_than_ten_tags() {
+        let tags: HashMap<String, String> = (0..11)
+            .map(|i| (format!("k{i}"), "v".to_string()))
+            .collect();
+        assert!(matches!(
+            encode_tagging(&tags),
+            Err(BackendError::InvalidArgument(_))
+        ));
+    }
+
+    // ── misc helpers ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn user_prefix_normalization_trims_leading_slashes() {
+        assert_eq!(normalize_user_prefix(Some("/docs")), "docs");
+        assert_eq!(normalize_user_prefix(Some("docs/")), "docs/");
+        assert_eq!(normalize_user_prefix(None), "");
+    }
+
+    #[tokio::test]
+    async fn read_chunk_splits_correctly() {
+        let data = (0u8..=249).collect::<Vec<_>>();
+        let mut cursor = std::io::Cursor::new(data.clone());
+        let mut chunks: Vec<Vec<u8>> = Vec::new();
+        loop {
+            let chunk = read_chunk(&mut cursor, 100).await.unwrap();
+            if chunk.is_empty() {
+                break;
+            }
+            chunks.push(chunk);
+        }
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks[0], &data[..100]);
+        assert_eq!(chunks[1], &data[100..200]);
+        assert_eq!(chunks[2], &data[200..]);
+    }
+}

--- a/src/backend/aws/files.rs
+++ b/src/backend/aws/files.rs
@@ -20,7 +20,7 @@ use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
 use aws_sdk_s3::Client as S3Client;
 use chrono::Utc;
-use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::backend::error::BackendError;
 use crate::backend::file::FileBackend;
@@ -380,6 +380,11 @@ impl AwsFileBackend {
         reporter.set_total(file_size);
 
         let part_size = multipart_part_size(file_size, chunk_bytes(self.chunk_size_mb));
+        // Cap reads at the declared size so a stream that keeps growing (e.g.
+        // a file being appended to during upload) cannot make the S3 object
+        // diverge from the size we validated and report in FileInfo.
+        let mut reader = reader.take(file_size);
+        let reader = &mut reader;
         let etag = if file_size > part_size {
             self.multipart_upload(
                 &spec.name,
@@ -479,7 +484,7 @@ impl AwsFileBackend {
             }
         };
 
-        let out = self
+        let out = match self
             .client
             .complete_multipart_upload()
             .bucket(&self.bucket)
@@ -492,7 +497,22 @@ impl AwsFileBackend {
             )
             .send()
             .await
-            .map_err(|e| errors::from_s3_complete_multipart(name, e))?;
+        {
+            Ok(out) => out,
+            Err(e) => {
+                // Abort (best effort) so orphaned parts don't accrue storage
+                // charges; the completion error is what matters.
+                let _ = self
+                    .client
+                    .abort_multipart_upload()
+                    .bucket(&self.bucket)
+                    .key(key)
+                    .upload_id(&upload_id)
+                    .send()
+                    .await;
+                return Err(errors::from_s3_complete_multipart(name, e));
+            }
+        };
 
         Ok(out.e_tag().unwrap_or_default().to_string())
     }
@@ -646,6 +666,11 @@ impl AwsFileBackend {
         // normalize_prefix appends '/' the same way). The flat
         // `list_files` path keeps exact-prefix semantics intentionally.
         let full_prefix = ensure_folder_prefix(full_prefix, &user_prefix, &delimiter);
+        // Directory display names must be stripped with the SAME normalized
+        // folder prefix used for the API call — stripping the raw user
+        // prefix (`docs`) would leave a leading delimiter (`/api/` instead
+        // of `api/`).
+        let strip_base = ensure_folder_prefix(user_prefix.clone(), &user_prefix, &delimiter);
 
         let mut items: Vec<BlobListItem> = Vec::new();
         let mut continuation: Option<String> = None;
@@ -669,7 +694,7 @@ impl AwsFileBackend {
                     continue;
                 };
                 let dir_name = full_path
-                    .strip_prefix(&user_prefix)
+                    .strip_prefix(&strip_base)
                     .unwrap_or(&full_path)
                     .to_string();
                 items.push(BlobListItem::Directory {

--- a/src/backend/aws/files.rs
+++ b/src/backend/aws/files.rs
@@ -640,6 +640,12 @@ impl AwsFileBackend {
         let user_prefix = normalize_user_prefix(request.prefix.as_deref());
         let full_prefix = format!("{base}{user_prefix}");
         let delimiter = request.delimiter.clone().unwrap_or_else(|| "/".to_string());
+        // Hierarchical listing treats the user prefix as a FOLDER: a
+        // non-empty prefix must end with the delimiter, otherwise `docs`
+        // would also match sibling trees like `docs-extra/...` (Azure's
+        // normalize_prefix appends '/' the same way). The flat
+        // `list_files` path keeps exact-prefix semantics intentionally.
+        let full_prefix = ensure_folder_prefix(full_prefix, &user_prefix, &delimiter);
 
         let mut items: Vec<BlobListItem> = Vec::new();
         let mut continuation: Option<String> = None;
@@ -746,6 +752,17 @@ fn normalize_user_prefix(prefix: Option<&str>) -> String {
     prefix
         .map(|p| p.trim_start_matches('/').to_string())
         .unwrap_or_default()
+}
+
+/// For hierarchical (delimiter-based) listing, a non-empty user prefix is a
+/// folder and must end with the delimiter so `docs` cannot also match
+/// sibling trees like `docs-extra/...` (mirrors Azure's normalize_prefix).
+fn ensure_folder_prefix(full_prefix: String, user_prefix: &str, delimiter: &str) -> String {
+    if !user_prefix.is_empty() && !full_prefix.ends_with(delimiter) {
+        format!("{full_prefix}{delimiter}")
+    } else {
+        full_prefix
+    }
 }
 
 #[async_trait]
@@ -1138,6 +1155,25 @@ mod tests {
         assert_eq!(normalize_user_prefix(Some("/docs")), "docs");
         assert_eq!(normalize_user_prefix(Some("docs/")), "docs/");
         assert_eq!(normalize_user_prefix(None), "");
+    }
+
+    #[test]
+    fn folder_prefix_gets_trailing_delimiter_for_hierarchical_list() {
+        // `docs` must not match `docs-extra/...` in hierarchical listing
+        assert_eq!(
+            ensure_folder_prefix("v/files/docs".to_string(), "docs", "/"),
+            "v/files/docs/"
+        );
+        // Already-terminated prefix unchanged
+        assert_eq!(
+            ensure_folder_prefix("v/files/docs/".to_string(), "docs/", "/"),
+            "v/files/docs/"
+        );
+        // Empty user prefix (vault root): exact base prefix, no extra delimiter
+        assert_eq!(
+            ensure_folder_prefix("v/files/".to_string(), "", "/"),
+            "v/files/"
+        );
     }
 
     #[tokio::test]

--- a/src/backend/aws/mod.rs
+++ b/src/backend/aws/mod.rs
@@ -5,6 +5,8 @@ pub mod auth;
 pub mod config;
 pub mod encoding;
 pub mod errors;
+#[cfg(feature = "file-ops")]
+pub mod files;
 pub mod metadata;
 pub mod models;
 pub mod secrets;
@@ -21,10 +23,16 @@ use crate::config::settings::AwsConfig;
 use aws_sdk_cloudtrail::Client as CloudTrailClient;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 
+#[cfg(feature = "file-ops")]
+use crate::backend::FileBackend;
+
 pub struct AwsBackend {
     secrets_impl: Arc<secrets::AwsSecretBackend>,
     vaults_impl: Arc<vaults::AwsVaultBackend>,
     audit_impl: Arc<audit::AwsAuditBackend>,
+    /// S3 file storage — present only when an S3 bucket is configured.
+    #[cfg(feature = "file-ops")]
+    files_impl: Option<Arc<files::AwsFileBackend>>,
 }
 
 impl AwsBackend {
@@ -38,10 +46,21 @@ impl AwsBackend {
         let sdk_config = auth::load_sdk_config(aws_cfg, region_override, profile_override).await?;
         let client = Arc::new(SecretsManagerClient::new(&sdk_config));
         let cloudtrail = Arc::new(CloudTrailClient::new(&sdk_config));
+
+        // File storage is optional: it requires an S3 bucket to be
+        // configured. No bucket -> capability stays off.
+        #[cfg(feature = "file-ops")]
+        let files_impl = files::resolve_bucket(aws_cfg).ok().map(|bucket| {
+            let s3_client = auth::build_s3_client(aws_cfg, &sdk_config);
+            Arc::new(files::AwsFileBackend::new(s3_client, bucket))
+        });
+
         Ok(Self {
             secrets_impl: Arc::new(secrets::AwsSecretBackend::new(client.clone())),
             vaults_impl: Arc::new(vaults::AwsVaultBackend::new(client)),
             audit_impl: Arc::new(audit::AwsAuditBackend::new(cloudtrail)),
+            #[cfg(feature = "file-ops")]
+            files_impl,
         })
     }
 }
@@ -59,7 +78,16 @@ impl Backend for AwsBackend {
     fn capabilities(&self) -> BackendCapabilities {
         BackendCapabilities {
             has_vaults: true,
-            has_file_storage: false,
+            has_file_storage: {
+                #[cfg(feature = "file-ops")]
+                {
+                    self.files_impl.is_some()
+                }
+                #[cfg(not(feature = "file-ops"))]
+                {
+                    false
+                }
+            },
             has_rbac: false,
             has_audit: true,
             has_versioning: true,
@@ -85,6 +113,11 @@ impl Backend for AwsBackend {
 
     fn audit(&self) -> Option<&dyn AuditBackend> {
         Some(self.audit_impl.as_ref())
+    }
+
+    #[cfg(feature = "file-ops")]
+    fn files(&self) -> Option<&dyn FileBackend> {
+        self.files_impl.as_deref().map(|fb| fb as &dyn FileBackend)
     }
 
     async fn health_check(&self) -> Result<(), BackendError> {

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -402,7 +402,7 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
 
     // Backend-specific extras: region/profile for AWS; storage_account for Azure.
     //
-    // Resolution order must match `backend::aws::auth::build_client`:
+    // Resolution order must match `backend::aws::auth::load_sdk_config`:
     //   region:  CLI --region > config aws.region > AWS_REGION > AWS_DEFAULT_REGION
     //   profile: CLI --profile > config aws.profile > AWS_PROFILE (via SDK chain)
     // `--resolved` has no CLI flags in scope, so it reports the remaining order.

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -12,17 +12,23 @@ use crate::utils::pagination::Pagination;
 use crate::utils::progress::{self, MultiProgressContext, NoopReporter};
 use std::path::{Path, PathBuf};
 
-fn progress_threshold_bytes(config: &Config) -> u64 {
+pub(crate) fn progress_threshold_bytes(config: &Config) -> u64 {
     let blob_config = config.get_blob_config();
     (blob_config.progress_threshold_mb as u64) * 1024 * 1024
 }
 
-fn is_tty() -> bool {
+pub(crate) fn is_tty() -> bool {
     use std::io::IsTerminal;
     std::io::stdout().is_terminal()
 }
 
 pub(crate) async fn execute_file_command(command: FileCommands, config: Config) -> Result<()> {
+    // The AWS backend stores files in S3 — route to its own executor.
+    #[cfg(all(feature = "aws", feature = "file-ops"))]
+    if crate::cli::file_ops_aws::is_aws_backend_active(&config) {
+        return crate::cli::file_ops_aws::execute_file_command_aws(command, config).await;
+    }
+
     // Create blob manager
     let blob_manager = create_blob_manager(&config).map_err(|e| {
         if e.to_string().contains("No storage account configured") {
@@ -276,6 +282,11 @@ pub(crate) async fn execute_file_command(command: FileCommands, config: Config) 
 
 /// `xv info` when resource type is file/blob.
 pub(crate) async fn execute_file_info_from_root(file_name: &str, config: &Config) -> Result<()> {
+    #[cfg(all(feature = "aws", feature = "file-ops"))]
+    if crate::cli::file_ops_aws::is_aws_backend_active(config) {
+        return crate::cli::file_ops_aws::execute_file_info_aws(file_name, config).await;
+    }
+
     // Create blob manager
     let blob_manager = create_blob_manager(config).map_err(|e| {
         if e.to_string().contains("No storage account configured") {
@@ -297,6 +308,12 @@ pub(crate) async fn refresh_file_list(
 ) -> Result<()> {
     use crate::blob::models::{BlobListItem, FileListRequest};
     use crate::cache::{CacheKey, CacheManager};
+
+    #[cfg(all(feature = "aws", feature = "file-ops"))]
+    if crate::cli::file_ops_aws::is_aws_backend_active(&config) {
+        return crate::cli::file_ops_aws::refresh_file_list_aws(vault_name, recursive, config)
+            .await;
+    }
 
     let blob_manager = create_blob_manager(&config)?;
     let list_request = FileListRequest {
@@ -486,7 +503,7 @@ async fn execute_file_download_to_path(
     Ok(())
 }
 
-fn resolve_single_download_path(name: &str, output: Option<&str>) -> Result<String> {
+pub(crate) fn resolve_single_download_path(name: &str, output: Option<&str>) -> Result<String> {
     use crate::utils::helpers::safe_join;
 
     // Determine output path with traversal guard.
@@ -507,7 +524,7 @@ fn resolve_single_download_path(name: &str, output: Option<&str>) -> Result<Stri
     }
 }
 
-fn display_file_list_items(
+pub(crate) fn display_file_list_items(
     items: &[crate::blob::models::BlobListItem],
     recursive: bool,
     config: &Config,
@@ -800,7 +817,14 @@ async fn execute_file_delete(
 async fn execute_file_info(blob_manager: &BlobManager, name: &str, config: &Config) -> Result<()> {
     // Get file info
     let file_info = blob_manager.get_file_info(name).await?;
+    display_file_info(&file_info, config)
+}
 
+/// Render a [`FileInfo`] to stdout (shared by the Azure and AWS executors).
+pub(crate) fn display_file_info(
+    file_info: &crate::blob::models::FileInfo,
+    config: &Config,
+) -> Result<()> {
     if config.output_json {
         let json_output = serde_json::to_string_pretty(&file_info).map_err(|e| {
             CrosstacheError::serialization(format!("Failed to serialize file info: {e}"))
@@ -841,13 +865,13 @@ async fn execute_file_info(blob_manager: &BlobManager, name: &str, config: &Conf
 
 /// Information about a file to upload with path tracking
 #[derive(Debug, Clone)]
-struct FileUploadInfo {
+pub(crate) struct FileUploadInfo {
     /// Full local file path
-    local_path: PathBuf,
+    pub(crate) local_path: PathBuf,
     /// Relative path from base directory (for blob name calculation)
     _relative_path: String,
     /// Final blob name (includes prefix and converted path separators)
-    blob_name: String,
+    pub(crate) blob_name: String,
 }
 
 /// Convert a path to blob name format (forward slashes, no leading slash)
@@ -888,7 +912,7 @@ fn path_to_blob_name(path: &Path, prefix: Option<&str>) -> String {
 ///
 /// # Returns
 /// Vector of FileUploadInfo with path mappings for blob storage
-fn collect_files_with_structure(
+pub(crate) fn collect_files_with_structure(
     path: &Path,
     base_path: &Path,
     prefix: Option<&str>,
@@ -1191,7 +1215,7 @@ async fn execute_file_upload_multiple(
 /// Returns an error if `output` names an existing non-directory path (which would
 /// cause every file to clobber the same destination). Creates the directory if it
 /// doesn't exist yet.
-fn resolve_multi_download_dir(output: Option<&str>) -> Result<PathBuf> {
+pub(crate) fn resolve_multi_download_dir(output: Option<&str>) -> Result<PathBuf> {
     use std::fs;
     use std::path::Path;
     match output {
@@ -2288,6 +2312,14 @@ pub(crate) async fn execute_file_upload_quick(
     metadata: Vec<String>,
     config: &Config,
 ) -> Result<()> {
+    #[cfg(all(feature = "aws", feature = "file-ops"))]
+    if crate::cli::file_ops_aws::is_aws_backend_active(config) {
+        return crate::cli::file_ops_aws::execute_file_upload_quick_aws(
+            file_path, name, groups, metadata, config,
+        )
+        .await;
+    }
+
     // Create blob manager
     let blob_manager = create_blob_manager(config).map_err(|e| {
         if e.to_string().contains("No storage account configured") {
@@ -2335,6 +2367,14 @@ pub(crate) async fn execute_file_download_quick(
     open: bool,
     config: &Config,
 ) -> Result<()> {
+    #[cfg(all(feature = "aws", feature = "file-ops"))]
+    if crate::cli::file_ops_aws::is_aws_backend_active(config) {
+        return crate::cli::file_ops_aws::execute_file_download_quick_aws(
+            name, output, open, config,
+        )
+        .await;
+    }
+
     // Create blob manager
     let blob_manager = create_blob_manager(config).map_err(|e| {
         if e.to_string().contains("No storage account configured") {

--- a/src/cli/file_ops_aws.rs
+++ b/src/cli/file_ops_aws.rs
@@ -1,0 +1,1206 @@
+//! `xv file` execution against the AWS backend (S3-backed file storage).
+//!
+//! Mirrors the Azure flow in [`crate::cli::file_ops`] but routes through
+//! [`AwsFileBackend`]: files live under `<vault>/files/<name>` in the
+//! configured bucket, downloads stream to disk behind the 5 GiB guard, and
+//! uploads stream from disk (multipart above the part-size threshold).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::backend::aws::files::{self, AwsFileBackend, FileUploadSpec};
+use crate::backend::file::FileBackend;
+use crate::blob::models::{BlobListItem, FileInfo, FileListRequest};
+use crate::cli::file::FileCommands;
+use crate::cli::file_ops::{
+    collect_files_with_structure, display_file_info, display_file_list_items, is_tty,
+    progress_threshold_bytes, resolve_multi_download_dir, resolve_single_download_path,
+};
+use crate::config::settings::AwsConfig;
+use crate::config::Config;
+use crate::error::{CrosstacheError, Result};
+use crate::utils::helpers::safe_join;
+use crate::utils::output;
+use crate::utils::progress::{self, MultiProgressContext, NoopReporter, ProgressReporter};
+
+// ---------------------------------------------------------------------------
+// Backend detection & construction
+// ---------------------------------------------------------------------------
+
+/// True when the active backend (top-level or named) is AWS.
+pub(crate) fn is_aws_backend_active(config: &Config) -> bool {
+    use crate::backend::BackendKind;
+    use crate::config::settings::NamedBackendEntry;
+
+    let name = config.effective_backend_name();
+    if let Some(entry) = config.named_backends.get(name) {
+        return matches!(entry, NamedBackendEntry::Aws(_));
+    }
+    matches!(name.parse::<BackendKind>(), Ok(BackendKind::Aws))
+}
+
+/// The `AwsConfig` for the active backend (named entry first, then `[aws]`).
+fn aws_config_for(config: &Config) -> Result<&AwsConfig> {
+    use crate::config::settings::NamedBackendEntry;
+
+    let name = config.effective_backend_name();
+    if let Some(NamedBackendEntry::Aws(cfg)) = config.named_backends.get(name) {
+        return Ok(cfg);
+    }
+    config.aws.as_ref().ok_or_else(|| {
+        CrosstacheError::config("[aws] config block is required when backend = \"aws\"")
+    })
+}
+
+/// Build an [`AwsFileBackend`] from config: resolves the bucket (clear setup
+/// hint when unset), loads SDK credentials, and applies the blob transfer
+/// settings (`chunk_size_mb`, `max_concurrent_uploads`).
+async fn create_aws_file_backend(config: &Config) -> Result<AwsFileBackend> {
+    let aws_cfg = aws_config_for(config)?;
+    let bucket = files::resolve_bucket(aws_cfg)?;
+    let sdk_config = crate::backend::aws::auth::load_sdk_config(aws_cfg, None, None).await?;
+    let client = crate::backend::aws::auth::build_s3_client(aws_cfg, &sdk_config);
+    let blob_config = config.get_blob_config();
+    Ok(AwsFileBackend::new(client, bucket).with_transfer_config(
+        blob_config.chunk_size_mb,
+        blob_config.max_concurrent_uploads,
+    ))
+}
+
+/// Resolve the vault whose file prefix is targeted: the usual chain
+/// (context, default_vault), then `[aws].default_vault`.
+async fn resolve_aws_file_vault(config: &Config) -> Result<String> {
+    if let Ok(vault) = config.resolve_vault_name(None).await {
+        return Ok(vault);
+    }
+    if let Ok(aws_cfg) = aws_config_for(config) {
+        if let Some(vault) = aws_cfg.default_vault.as_deref() {
+            if !vault.trim().is_empty() {
+                return Ok(vault.trim().to_string());
+            }
+        }
+    }
+    Err(CrosstacheError::config(
+        "No vault specified for file operations. Set a context with 'xv context use', \
+         configure default_vault, or set [aws].default_vault.",
+    ))
+}
+
+/// Drop the cached file listings for a vault after a mutation.
+fn invalidate_file_cache(config: &Config, vault: &str) {
+    let cache_manager = crate::cache::CacheManager::from_config(config);
+    for recursive in [true, false] {
+        cache_manager.invalidate(&crate::cache::CacheKey::FileList {
+            vault_name: vault.to_string(),
+            recursive,
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Command dispatch
+// ---------------------------------------------------------------------------
+
+pub(crate) async fn execute_file_command_aws(command: FileCommands, config: Config) -> Result<()> {
+    let backend = create_aws_file_backend(&config).await?;
+    let vault = resolve_aws_file_vault(&config).await?;
+
+    match command {
+        FileCommands::Upload {
+            files,
+            name,
+            recursive,
+            flatten,
+            prefix,
+            group,
+            metadata,
+            tag,
+            content_type,
+            continue_on_error,
+        } => {
+            if recursive {
+                if name.is_some() || content_type.is_some() {
+                    return Err(CrosstacheError::invalid_argument(
+                        "--name and --content-type cannot be used with --recursive",
+                    ));
+                }
+                execute_upload_recursive(
+                    &backend,
+                    &vault,
+                    files,
+                    group,
+                    metadata,
+                    tag,
+                    continue_on_error,
+                    flatten,
+                    prefix,
+                    &config,
+                )
+                .await?;
+            } else if files.len() == 1 {
+                execute_upload_single(
+                    &backend,
+                    &vault,
+                    &files[0],
+                    name,
+                    group,
+                    metadata,
+                    tag,
+                    content_type,
+                    &config,
+                )
+                .await?;
+            } else {
+                if name.is_some() || content_type.is_some() {
+                    return Err(CrosstacheError::invalid_argument(
+                        "--name and --content-type can only be used when uploading a single file",
+                    ));
+                }
+                execute_upload_multiple(
+                    &backend,
+                    &vault,
+                    files,
+                    group,
+                    metadata,
+                    tag,
+                    continue_on_error,
+                    &config,
+                )
+                .await?;
+            }
+            invalidate_file_cache(&config, &vault);
+        }
+        FileCommands::Download {
+            files,
+            output,
+            rename,
+            recursive,
+            flatten,
+            force,
+            continue_on_error,
+        } => {
+            if recursive {
+                if rename.is_some() {
+                    return Err(CrosstacheError::invalid_argument(
+                        "--rename cannot be used with --recursive",
+                    ));
+                }
+                execute_download_recursive(
+                    &backend,
+                    &vault,
+                    files,
+                    output,
+                    force,
+                    flatten,
+                    continue_on_error,
+                    &config,
+                )
+                .await?;
+            } else {
+                if rename.is_some() && files.len() > 1 {
+                    return Err(CrosstacheError::invalid_argument(
+                        "--rename can only be used when downloading a single file",
+                    ));
+                }
+                if files.len() == 1 {
+                    let output_path = if let Some(new_name) = rename {
+                        Some(new_name)
+                    } else {
+                        output
+                    };
+                    let resolved = resolve_single_download_path(&files[0], output_path.as_deref())?;
+                    execute_download_to_path(&backend, &vault, &files[0], resolved, force, &config)
+                        .await?;
+                    output::success(&format!("Successfully downloaded file '{}'", files[0]));
+                } else {
+                    execute_download_multiple(
+                        &backend,
+                        &vault,
+                        files,
+                        output,
+                        force,
+                        continue_on_error,
+                        &config,
+                    )
+                    .await?;
+                }
+            }
+        }
+        FileCommands::List {
+            prefix,
+            group,
+            limit,
+            page,
+            page_size,
+            pager,
+            recursive,
+            no_cache,
+        } => {
+            use crate::utils::pagination::Pagination;
+
+            if limit.is_some() && page_size.is_some() {
+                return Err(CrosstacheError::invalid_argument(
+                    "--limit cannot be combined with --page-size; use --page-size instead",
+                ));
+            }
+            if limit.is_some() && page.is_some() {
+                return Err(CrosstacheError::invalid_argument(
+                    "--limit shows the first page only and cannot be combined with --page",
+                ));
+            }
+            let pagination = if limit.is_some() {
+                Pagination::first_page_with_size(limit)?
+            } else {
+                Pagination::from_args(page, page_size)?
+            };
+
+            execute_list(
+                &backend, &vault, prefix, group, pagination, pager, recursive, no_cache, &config,
+            )
+            .await?;
+        }
+        FileCommands::Delete {
+            files,
+            force,
+            continue_on_error,
+        } => {
+            execute_delete(&backend, &vault, files, force, continue_on_error).await?;
+            invalidate_file_cache(&config, &vault);
+        }
+        FileCommands::Info { name } => {
+            let file_info = backend.get_file_info(&vault, &name).await?;
+            display_file_info(&file_info, &config)?;
+        }
+        FileCommands::Sync { .. } => {
+            return Err(CrosstacheError::invalid_argument(
+                "`xv file sync` is not yet supported on the AWS backend. \
+                 upload/download/list/delete/info are available; use \
+                 `xv file upload --recursive` / `xv file download --recursive` meanwhile.",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// `xv info <file>` when the resource is a file.
+pub(crate) async fn execute_file_info_aws(file_name: &str, config: &Config) -> Result<()> {
+    let backend = create_aws_file_backend(config).await?;
+    let vault = resolve_aws_file_vault(config).await?;
+    let file_info = backend.get_file_info(&vault, file_name).await?;
+    display_file_info(&file_info, config)
+}
+
+/// Background cache refresh for file listings.
+pub(crate) async fn refresh_file_list_aws(
+    vault_name: String,
+    recursive: bool,
+    config: Config,
+) -> Result<()> {
+    use crate::cache::{CacheKey, CacheManager};
+
+    let backend = create_aws_file_backend(&config).await?;
+    let list_request = FileListRequest {
+        prefix: None,
+        groups: None,
+        limit: None,
+        delimiter: if recursive {
+            None
+        } else {
+            Some("/".to_string())
+        },
+    };
+
+    let items: Vec<BlobListItem> = if recursive {
+        let files = backend.list_files(&vault_name, list_request).await?;
+        files.into_iter().map(BlobListItem::File).collect()
+    } else {
+        backend
+            .list_files_hierarchical(&vault_name, list_request)
+            .await?
+    };
+
+    let cache_manager = CacheManager::from_config(&config);
+    cache_manager.set(
+        &CacheKey::FileList {
+            vault_name,
+            recursive,
+        },
+        &items,
+    );
+    Ok(())
+}
+
+/// Quick upload (`xv up`).
+pub(crate) async fn execute_file_upload_quick_aws(
+    file_path: &str,
+    name: Option<String>,
+    groups: Option<String>,
+    metadata: Vec<String>,
+    config: &Config,
+) -> Result<()> {
+    let backend = create_aws_file_backend(config).await?;
+    let vault = resolve_aws_file_vault(config).await?;
+
+    let groups_vec: Vec<String> = groups
+        .map(|g| g.split(',').map(|s| s.trim().to_string()).collect())
+        .unwrap_or_default();
+    let metadata_pairs: Vec<(String, String)> = metadata
+        .into_iter()
+        .filter_map(|m| {
+            let parts: Vec<&str> = m.splitn(2, '=').collect();
+            if parts.len() == 2 {
+                Some((parts[0].trim().to_string(), parts[1].trim().to_string()))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    execute_upload_single(
+        &backend,
+        &vault,
+        file_path,
+        name,
+        groups_vec,
+        metadata_pairs,
+        Vec::new(),
+        None,
+        config,
+    )
+    .await?;
+    invalidate_file_cache(config, &vault);
+    Ok(())
+}
+
+/// Quick download (`xv down`).
+pub(crate) async fn execute_file_download_quick_aws(
+    name: &str,
+    output: Option<String>,
+    open: bool,
+    config: &Config,
+) -> Result<()> {
+    let backend = create_aws_file_backend(config).await?;
+    let vault = resolve_aws_file_vault(config).await?;
+
+    let final_output_path = resolve_single_download_path(name, output.as_deref())?;
+    execute_download_to_path(
+        &backend,
+        &vault,
+        name,
+        final_output_path.clone(),
+        false,
+        config,
+    )
+    .await?;
+    output::success(&format!("Successfully downloaded file '{name}'"));
+
+    if open {
+        match std::fs::canonicalize(&final_output_path) {
+            Ok(path) => {
+                if let Err(e) = opener::open(&path) {
+                    eprintln!("Warning: could not open file '{}': {}", path.display(), e);
+                }
+            }
+            Err(e) => {
+                eprintln!(
+                    "Warning: could not resolve path '{}': {}",
+                    final_output_path, e
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Upload
+// ---------------------------------------------------------------------------
+
+/// Stream one local file to S3 (multipart above the part-size threshold).
+#[allow(clippy::too_many_arguments)]
+async fn upload_local_file(
+    backend: &AwsFileBackend,
+    vault: &str,
+    local_path: &Path,
+    remote_name: &str,
+    content_type: Option<String>,
+    groups: Vec<String>,
+    metadata: HashMap<String, String>,
+    tags: HashMap<String, String>,
+    reporter: &dyn ProgressReporter,
+) -> Result<FileInfo> {
+    let meta = tokio::fs::metadata(local_path).await.map_err(|e| {
+        CrosstacheError::config(format!("Failed to read file {}: {e}", local_path.display()))
+    })?;
+    let mut file = tokio::fs::File::open(local_path).await.map_err(|e| {
+        CrosstacheError::config(format!("Failed to read file {}: {e}", local_path.display()))
+    })?;
+    let spec = FileUploadSpec {
+        name: remote_name.to_string(),
+        content_type,
+        groups,
+        metadata,
+        tags,
+    };
+    let info = backend
+        .upload_file_streaming(vault, spec, &mut file, meta.len(), reporter)
+        .await?;
+    Ok(info)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_upload_single(
+    backend: &AwsFileBackend,
+    vault: &str,
+    file_path: &str,
+    name: Option<String>,
+    groups: Vec<String>,
+    metadata: Vec<(String, String)>,
+    tags: Vec<(String, String)>,
+    content_type: Option<String>,
+    config: &Config,
+) -> Result<()> {
+    let path = Path::new(file_path);
+    if !path.exists() {
+        return Err(CrosstacheError::config(format!(
+            "File not found: {file_path}"
+        )));
+    }
+
+    let file_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    if file_size == 0 {
+        output::warn(&format!(
+            "File '{file_path}' is empty (0 bytes). Uploading anyway."
+        ));
+    }
+
+    let remote_name = name.unwrap_or_else(|| {
+        path.file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string()
+    });
+
+    let metadata_map: HashMap<String, String> = metadata.into_iter().collect();
+    let tags_map: HashMap<String, String> = tags.into_iter().collect();
+
+    let threshold = progress_threshold_bytes(config);
+    let tty = is_tty();
+    if !tty {
+        println!("Uploading file '{file_path}' as '{remote_name}'...");
+    }
+    let reporter = progress::create_file_reporter(file_size, threshold, tty);
+    reporter.set_message(format!("Uploading '{remote_name}'..."));
+
+    let file_info = upload_local_file(
+        backend,
+        vault,
+        path,
+        &remote_name,
+        content_type,
+        groups,
+        metadata_map,
+        tags_map,
+        reporter.as_ref(),
+    )
+    .await?;
+
+    output::success(&format!("Successfully uploaded file '{}'", file_info.name));
+    println!("   Size: {} bytes", file_info.size);
+    println!("   Content-Type: {}", file_info.content_type);
+    if !file_info.groups.is_empty() {
+        println!("   Groups: {:?}", file_info.groups);
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_upload_multiple(
+    backend: &AwsFileBackend,
+    vault: &str,
+    files: Vec<String>,
+    groups: Vec<String>,
+    metadata: Vec<(String, String)>,
+    tags: Vec<(String, String)>,
+    continue_on_error: bool,
+    config: &Config,
+) -> Result<()> {
+    println!("Uploading {} file(s)...", files.len());
+
+    let mut success_count = 0;
+    let mut error_count = 0;
+
+    for file_path in files {
+        match execute_upload_single(
+            backend,
+            vault,
+            &file_path,
+            None,
+            groups.clone(),
+            metadata.clone(),
+            tags.clone(),
+            None,
+            config,
+        )
+        .await
+        {
+            Ok(_) => {
+                println!(
+                    "  {}",
+                    output::format_line(
+                        output::Level::Success,
+                        &file_path,
+                        output::should_use_rich_stdout()
+                    )
+                );
+                success_count += 1;
+            }
+            Err(e) => {
+                eprintln!(
+                    "  {}",
+                    output::format_line(
+                        output::Level::Error,
+                        &format!("{file_path}: {e}"),
+                        output::should_use_rich_stderr(),
+                    )
+                );
+                error_count += 1;
+                if !continue_on_error {
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    println!("\nUpload completed: {success_count} succeeded, {error_count} failed");
+    if error_count > 0 && !continue_on_error {
+        return Err(CrosstacheError::unknown(format!(
+            "{error_count} file(s) failed to upload"
+        )));
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_upload_recursive(
+    backend: &AwsFileBackend,
+    vault: &str,
+    paths: Vec<String>,
+    groups: Vec<String>,
+    metadata: Vec<(String, String)>,
+    tags: Vec<(String, String)>,
+    continue_on_error: bool,
+    flatten: bool,
+    prefix: Option<String>,
+    config: &Config,
+) -> Result<()> {
+    let mut all_files = Vec::new();
+    for path_str in &paths {
+        let path = Path::new(path_str);
+        if !path.exists() {
+            if continue_on_error {
+                output::error(&format!("Path not found: {path_str}"));
+                continue;
+            }
+            return Err(CrosstacheError::config(format!(
+                "Path not found: {path_str}"
+            )));
+        }
+        // Use the parent directory as base path so the top-level folder name
+        // is preserved in remote paths (e.g. docs/api/users.md).
+        let base_path = path.parent().unwrap_or(path);
+        all_files.extend(collect_files_with_structure(
+            path,
+            base_path,
+            prefix.as_deref(),
+            flatten,
+        )?);
+    }
+
+    if all_files.is_empty() {
+        output::info("No files found to upload");
+        return Ok(());
+    }
+
+    println!("Found {} file(s) to upload", all_files.len());
+
+    let mut success_count = 0;
+    let mut failure_count = 0;
+    let threshold = progress_threshold_bytes(config);
+    let tty = is_tty();
+    let mp = MultiProgressContext::new(all_files.len() as u64, threshold, tty);
+
+    let metadata_map: HashMap<String, String> = metadata.into_iter().collect();
+    let tags_map: HashMap<String, String> = tags.into_iter().collect();
+
+    for file_info in &all_files {
+        let local_path_str = file_info.local_path.to_string_lossy();
+        if !tty {
+            if !flatten {
+                println!("Uploading: {} → {}", local_path_str, file_info.blob_name);
+            } else {
+                println!("Uploading: {}", local_path_str);
+            }
+        }
+
+        let result = upload_local_file(
+            backend,
+            vault,
+            &file_info.local_path,
+            &file_info.blob_name,
+            None,
+            groups.clone(),
+            metadata_map.clone(),
+            tags_map.clone(),
+            &NoopReporter,
+        )
+        .await;
+
+        match result {
+            Ok(_) => {
+                success_count += 1;
+                mp.log(&format!("Uploaded: {}", file_info.blob_name));
+                mp.advance_overall(&file_info.blob_name);
+            }
+            Err(e) => {
+                output::error(&format!("Failed to upload '{}': {}", local_path_str, e));
+                failure_count += 1;
+                mp.advance_overall(&file_info.blob_name);
+                if !continue_on_error {
+                    return Err(e);
+                }
+            }
+        }
+    }
+    mp.finish();
+
+    println!();
+    output::info("Upload Summary:");
+    println!(
+        "  {}",
+        output::format_line(
+            output::Level::Success,
+            &format!("Successful: {success_count}"),
+            output::should_use_rich_stdout()
+        )
+    );
+    if failure_count > 0 {
+        println!(
+            "  {}",
+            output::format_line(
+                output::Level::Error,
+                &format!("Failed: {failure_count}"),
+                output::should_use_rich_stdout()
+            )
+        );
+        if continue_on_error {
+            return Err(CrosstacheError::unknown(format!(
+                "{failure_count} file(s) failed to upload"
+            )));
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Download
+// ---------------------------------------------------------------------------
+
+/// Stream one file to `output_path`. Downloads into a temporary sibling and
+/// renames on success so a failed transfer never leaves a partial file.
+async fn execute_download_to_path(
+    backend: &AwsFileBackend,
+    vault: &str,
+    name: &str,
+    output_path: String,
+    force: bool,
+    config: &Config,
+) -> Result<()> {
+    if Path::new(&output_path).exists() && !force {
+        return Err(CrosstacheError::config(format!(
+            "File '{output_path}' already exists. Use --force to overwrite."
+        )));
+    }
+
+    // Ensure parent directories exist so names with path segments
+    // (e.g. "docs/readme.md") succeed.
+    if let Some(parent) = Path::new(&output_path).parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                CrosstacheError::config(format!(
+                    "Failed to create parent directories for {output_path}: {e}"
+                ))
+            })?;
+        }
+    }
+
+    let threshold = progress_threshold_bytes(config);
+    let tty = is_tty();
+    if !tty {
+        println!("Downloading file '{name}' to '{output_path}'...");
+    }
+    let file_size = if tty {
+        backend
+            .get_file_info(vault, name)
+            .await
+            .map(|info| info.size)
+            .unwrap_or(0)
+    } else {
+        0
+    };
+    let reporter = progress::create_file_reporter(file_size, threshold, tty);
+    reporter.set_message(format!("Downloading '{name}'..."));
+
+    let tmp_path = format!("{output_path}.xv-partial");
+    let mut file = tokio::fs::File::create(&tmp_path)
+        .await
+        .map_err(|e| CrosstacheError::config(format!("Failed to write file {tmp_path}: {e}")))?;
+
+    match backend
+        .download_file_to_writer(vault, name, &mut file, reporter.as_ref())
+        .await
+    {
+        Ok(_) => {
+            drop(file);
+            tokio::fs::rename(&tmp_path, &output_path)
+                .await
+                .map_err(|e| {
+                    CrosstacheError::config(format!("Failed to write file {output_path}: {e}"))
+                })?;
+            Ok(())
+        }
+        Err(e) => {
+            drop(file);
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            Err(e.into())
+        }
+    }
+}
+
+async fn execute_download_multiple(
+    backend: &AwsFileBackend,
+    vault: &str,
+    files: Vec<String>,
+    output: Option<String>,
+    force: bool,
+    continue_on_error: bool,
+    config: &Config,
+) -> Result<()> {
+    let output_dir = resolve_multi_download_dir(output.as_deref())?;
+
+    println!("Downloading {} file(s)...", files.len());
+
+    let mut success_count = 0;
+    let mut error_count = 0;
+
+    for file_name in files {
+        // Per-file output path with traversal guard.
+        let result = match safe_join(&output_dir, &file_name) {
+            Ok(p) => {
+                execute_download_to_path(
+                    backend,
+                    vault,
+                    &file_name,
+                    p.to_string_lossy().into_owned(),
+                    force,
+                    config,
+                )
+                .await
+            }
+            Err(e) => Err(e),
+        };
+        match result {
+            Ok(_) => {
+                println!(
+                    "  {}",
+                    output::format_line(
+                        output::Level::Success,
+                        &file_name,
+                        output::should_use_rich_stdout()
+                    )
+                );
+                success_count += 1;
+            }
+            Err(e) => {
+                eprintln!(
+                    "  {}",
+                    output::format_line(
+                        output::Level::Error,
+                        &format!("{file_name}: {e}"),
+                        output::should_use_rich_stderr(),
+                    )
+                );
+                error_count += 1;
+                if !continue_on_error {
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    println!("\nDownload completed: {success_count} succeeded, {error_count} failed");
+    if error_count > 0 && !continue_on_error {
+        return Err(CrosstacheError::unknown(format!(
+            "{error_count} file(s) failed to download"
+        )));
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_download_recursive(
+    backend: &AwsFileBackend,
+    vault: &str,
+    prefixes: Vec<String>,
+    output: Option<String>,
+    force: bool,
+    flatten: bool,
+    continue_on_error: bool,
+    config: &Config,
+) -> Result<()> {
+    let output_dir = output.unwrap_or_else(|| ".".to_string());
+    let output_path = Path::new(&output_dir);
+    if !output_path.exists() {
+        std::fs::create_dir_all(output_path).map_err(|e| {
+            CrosstacheError::config(format!(
+                "Failed to create output directory {}: {}",
+                output_dir, e
+            ))
+        })?;
+    }
+    eprintln!(
+        "Downloading to: {}",
+        output_path
+            .canonicalize()
+            .unwrap_or_else(|_| output_path.to_path_buf())
+            .display()
+    );
+
+    let mut all_files: Vec<FileInfo> = Vec::new();
+    for prefix in &prefixes {
+        let files = backend
+            .list_files(
+                vault,
+                FileListRequest {
+                    prefix: Some(prefix.clone()),
+                    groups: None,
+                    limit: None,
+                    delimiter: None,
+                },
+            )
+            .await?;
+        if files.is_empty() {
+            eprintln!(
+                "{}",
+                output::format_line(
+                    output::Level::Warn,
+                    &format!("No files found matching prefix: {}", prefix),
+                    output::should_use_rich_stderr(),
+                )
+            );
+            continue;
+        }
+        all_files.extend(files);
+    }
+
+    if all_files.is_empty() {
+        output::info("No files found to download");
+        return Ok(());
+    }
+
+    println!("Found {} file(s) to download", all_files.len());
+
+    let mut success_count = 0;
+    let mut failure_count = 0;
+    let threshold = progress_threshold_bytes(config);
+    let tty = is_tty();
+    let mp = MultiProgressContext::new(all_files.len() as u64, threshold, tty);
+
+    for file_info in &all_files {
+        let remote_name = &file_info.name;
+
+        // Security: remote names are untrusted; `safe_join` rejects `..`
+        // components and absolute paths before any filesystem call.
+        let joined = if flatten {
+            let filename = Path::new(remote_name)
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned();
+            safe_join(output_path, &filename)
+        } else {
+            safe_join(output_path, remote_name)
+        };
+        let local_path = match joined {
+            Ok(path) => path,
+            Err(e) => {
+                output::warn(&format!("Skipping '{remote_name}': {e}"));
+                failure_count += 1;
+                if continue_on_error {
+                    mp.advance_overall(remote_name);
+                    continue;
+                }
+                return Err(CrosstacheError::config(format!(
+                    "Unsafe file name '{remote_name}': {e}"
+                )));
+            }
+        };
+        let local_path_str = local_path.to_string_lossy().to_string();
+
+        if local_path.exists() && !force {
+            output::warn(&format!(
+                "File already exists: {} (use --force to overwrite)",
+                local_path_str
+            ));
+            failure_count += 1;
+            if !continue_on_error {
+                return Err(CrosstacheError::config(format!(
+                    "File already exists: {}",
+                    local_path_str
+                )));
+            }
+            continue;
+        }
+
+        if !tty {
+            if !flatten {
+                println!("Downloading: {} → {}", remote_name, local_path_str);
+            } else {
+                println!("Downloading: {}", remote_name);
+            }
+        }
+
+        // Force is pre-checked above; pass true to skip the redundant check.
+        let result = execute_download_to_path(
+            backend,
+            vault,
+            remote_name,
+            local_path_str.clone(),
+            true,
+            config,
+        )
+        .await;
+
+        match result {
+            Ok(_) => {
+                success_count += 1;
+                mp.log(&format!("Downloaded: {}", remote_name));
+                mp.advance_overall(remote_name);
+            }
+            Err(e) => {
+                output::error(&format!("Failed to download '{}': {}", remote_name, e));
+                failure_count += 1;
+                mp.advance_overall(remote_name);
+                if !continue_on_error {
+                    return Err(e);
+                }
+            }
+        }
+    }
+    mp.finish();
+
+    println!();
+    output::info("Download Summary:");
+    println!(
+        "  {}",
+        output::format_line(
+            output::Level::Success,
+            &format!("Successful: {}", success_count),
+            output::should_use_rich_stdout()
+        )
+    );
+    if failure_count > 0 {
+        println!(
+            "  {}",
+            output::format_line(
+                output::Level::Error,
+                &format!("Failed: {}", failure_count),
+                output::should_use_rich_stdout()
+            )
+        );
+        if continue_on_error {
+            return Err(CrosstacheError::unknown(format!(
+                "{} file(s) failed to download",
+                failure_count
+            )));
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_list(
+    backend: &AwsFileBackend,
+    vault: &str,
+    prefix: Option<String>,
+    group: Option<String>,
+    pagination: crate::utils::pagination::Pagination,
+    pager: bool,
+    recursive: bool,
+    no_cache: bool,
+    config: &Config,
+) -> Result<()> {
+    use crate::cache::{CacheKey, CacheManager};
+    use crate::utils::pagination::{paginate_slice, pagination_footer_text};
+
+    let cache_manager = CacheManager::from_config(config);
+    let cache_key = CacheKey::FileList {
+        vault_name: vault.to_string(),
+        recursive,
+    };
+    let use_cache = cache_manager.is_enabled() && !no_cache;
+    let is_unfiltered = prefix.is_none() && group.is_none();
+
+    let cached: Option<Vec<BlobListItem>> = if use_cache && is_unfiltered {
+        cache_manager.get::<Vec<BlobListItem>>(&cache_key)
+    } else {
+        None
+    };
+
+    let items = match cached {
+        Some(items) => items,
+        None => {
+            let list_request = FileListRequest {
+                prefix: prefix.clone(),
+                groups: group.map(|g| vec![g]),
+                limit: None,
+                delimiter: if recursive {
+                    None
+                } else {
+                    Some("/".to_string())
+                },
+            };
+            let fetched = if recursive {
+                backend
+                    .list_files(vault, list_request)
+                    .await?
+                    .into_iter()
+                    .map(BlobListItem::File)
+                    .collect::<Vec<_>>()
+            } else {
+                backend.list_files_hierarchical(vault, list_request).await?
+            };
+            if use_cache && is_unfiltered {
+                cache_manager.set(&cache_key, &fetched);
+            }
+            fetched
+        }
+    };
+
+    let page = paginate_slice(&items, pagination);
+    let mut rendered = display_file_list_items(&page.items, recursive, config)?;
+    if !rendered.is_empty() {
+        rendered.push('\n');
+        if let Some(footer) = pagination_footer_text(&page, "item", config.runtime_output_format) {
+            rendered.push_str(&footer);
+        }
+        crate::utils::pager::print_output(&rendered, pager)?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+async fn execute_delete(
+    backend: &AwsFileBackend,
+    vault: &str,
+    files: Vec<String>,
+    force: bool,
+    continue_on_error: bool,
+) -> Result<()> {
+    use crate::utils::interactive::InteractivePrompt;
+
+    if !force {
+        let prompt = InteractivePrompt::new();
+        let confirmed = if files.len() == 1 {
+            prompt.confirm(
+                &format!(
+                    "Are you sure you want to delete file '{}' from S3 storage?",
+                    files[0]
+                ),
+                false,
+            )?
+        } else {
+            println!("You are about to delete {} files:", files.len());
+            for (i, file) in files.iter().enumerate() {
+                if i < 5 {
+                    println!("  - {file}");
+                } else if i == 5 {
+                    println!("  ... and {} more", files.len() - 5);
+                    break;
+                }
+            }
+            prompt.confirm("Are you sure you want to delete these files?", false)?
+        };
+        if !confirmed {
+            println!("Delete operation cancelled.");
+            return Ok(());
+        }
+    }
+
+    let multiple = files.len() > 1;
+    if multiple {
+        println!("Deleting {} file(s)...", files.len());
+    }
+
+    let mut success_count = 0;
+    let mut error_count = 0;
+
+    for file_name in &files {
+        if !multiple {
+            println!("Deleting file '{file_name}'...");
+        }
+        match backend.delete_file(vault, file_name).await {
+            Ok(_) => {
+                if multiple {
+                    println!(
+                        "  {}",
+                        output::format_line(
+                            output::Level::Success,
+                            file_name,
+                            output::should_use_rich_stdout()
+                        )
+                    );
+                } else {
+                    output::success(&format!("Successfully deleted file '{file_name}'"));
+                    output::hint(
+                        "Bucket versioning may allow recovery depending on bucket settings.",
+                    );
+                }
+                success_count += 1;
+            }
+            Err(e) => {
+                let e: CrosstacheError = e.into();
+                eprintln!(
+                    "  {}",
+                    output::format_line(
+                        output::Level::Error,
+                        &format!("{file_name}: {e}"),
+                        output::should_use_rich_stderr(),
+                    )
+                );
+                error_count += 1;
+                if !continue_on_error {
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    if multiple {
+        println!("\nDelete completed: {success_count} succeeded, {error_count} failed");
+    }
+    if error_count > 0 && !continue_on_error {
+        return Err(CrosstacheError::unknown(format!(
+            "{error_count} file(s) failed to delete"
+        )));
+    }
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,6 +9,8 @@ pub(crate) mod config_ops;
 pub mod file;
 #[cfg(feature = "file-ops")]
 pub mod file_ops;
+#[cfg(all(feature = "aws", feature = "file-ops"))]
+pub(crate) mod file_ops_aws;
 pub(crate) mod helpers;
 pub(crate) mod migrate_ops;
 pub(crate) mod scan_ops;

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -287,6 +287,7 @@ impl ConfigInitializer {
                 profile: init_config.aws_profile.clone(),
                 default_vault: init_config.aws_default_vault.clone(),
                 endpoint_url: None,
+                s3_bucket: None,
             }),
             local: None,
             named_backends: std::collections::HashMap::new(),
@@ -1038,6 +1039,7 @@ impl ConfigInitializer {
                 profile: init_config.aws_profile.clone(),
                 default_vault: init_config.aws_default_vault.clone(),
                 endpoint_url: None,
+                s3_bucket: None,
             };
             (Some("aws".to_string()), Some(aws))
         } else {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -54,6 +54,13 @@ pub struct AwsConfig {
     /// Default vault name (= prefix) used when no `--vault` / context is set.
     #[serde(default)]
     pub default_vault: Option<String>,
+
+    /// S3 bucket used for `xv file` storage. Files are stored under
+    /// `<vault>/files/<name>` so vaults stay isolated. Falls through to the
+    /// `XV_AWS_S3_BUCKET` env var. File operations error with a setup hint
+    /// when unset; the bucket is never auto-created.
+    #[serde(default)]
+    pub s3_bucket: Option<String>,
 }
 
 /// A named backend entry in `Config.named_backends`. Each entry is a


### PR DESCRIPTION
## Summary
- Implements `xv file` upload/download/list/delete/info for the AWS backend, backed by S3 with vault-prefixed keys (`<vault>/files/<name>`) for per-vault isolation matching the local backend semantics.
- Streaming both directions: multipart upload above the chunk threshold (reuses `chunk_size_mb`), streamed download with the same 5 GiB guard as #243; containment via the shared safe_join helpers (no traversal/absolute key escapes).
- Bucket from new config field; clear setup hint when unconfigured; no auto-creation. `has_file_storage` true for AWS.
- adds `aws-sdk-s3` as an optional dep under the `aws` feature.
- (ROADMAP P1 — AWS capability matrix: file storage)

## Verification
- cargo fmt --check; clippy --all-targets (default AND --features aws) -D warnings; cargo test --all-targets (both feature sets, isolated XDG_CONFIG_HOME) — all green, verified independently of the implementing agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new surface area (S3 I/O, multipart uploads, path validation) and dependency lockfile churn; mistakes could affect data integrity or local download paths, though patterns mirror existing Azure file ops.
> 
> **Overview**
> Adds **S3-backed `xv file`** for the AWS backend when `[aws].s3_bucket` or `XV_AWS_S3_BUCKET` is set. Objects use vault-scoped keys (`<vault>/files/<name>`); the bucket is never auto-created.
> 
> **Backend:** Optional `aws-sdk-s3` on the `aws` feature; `build_s3_client` forces path-style URLs for custom endpoints. New `AwsFileBackend` implements `FileBackend` with streamed uploads (multipart above chunk threshold, abort on failure), streamed downloads with a **5 GiB** cap, hierarchical listing, and key/path validation aligned with Azure. S3 SDK errors map to `BackendError` with setup and IAM hints. `AwsBackend` exposes file storage only when a bucket resolves; `has_file_storage` reflects that.
> 
> **CLI:** `file_ops_aws` mirrors Azure file commands (upload/download/list/delete/info, quick up/down, cache refresh); `file sync` is explicitly unsupported on AWS. Shared helpers in `file_ops` are reused; Azure paths unchanged when AWS is not active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eb14c679806acd6bf20840527744ec2933e1662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->