### PR TITLE
chore: release v0.12.0 — AWS capability matrix completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.12.0 — AWS capability matrix completion (2026-06-12)
+
+Closes all four P1 AWS capability gaps deferred since v0.10.0 (#248–#251).
+AWS is an opt-in Cargo feature (`aws`); these paths are absent from the
+default build.
+
+### Added
+
+- **`xv audit` on AWS via CloudTrail (#249)** — reads recent Secrets Manager events through CloudTrail `LookupEvents` (event-source filter + vault-prefix match), mirroring the Azure Activity Log output shapes (table/json, time-range/limit flags). `CreateSecret` events are resolved from `requestParameters.name` as well as `secretId`. Missing `cloudtrail:LookupEvents` permission yields an actionable error. AWS backend now reports `has_audit: true`. Adds optional dep `aws-sdk-cloudtrail`.
+- **Native rotation on AWS (#250)** — new `xv rotate --native` flag invokes Secrets Manager `RotateSecret` (the secret's configured rotation Lambda); rotation is asynchronous and the command says so. Clear errors for no-Lambda-configured (with `aws secretsmanager rotate-secret` setup hint), missing permissions, and non-AWS backends (capability message, including when the backend registry failed to initialize). Without `--native`, behavior is unchanged on all backends. AWS backend now reports `has_secret_rotation: true`.
+- **S3 file storage on AWS (#251)** — `xv file` upload/download/list/delete/info now work on the AWS backend, backed by S3 with vault-prefixed keys (`<vault>/files/<name>`) for per-vault isolation matching the local backend. Streaming both directions: multipart upload above the chunk threshold (reuses `chunk_size_mb`), streamed download with the same 5 GiB guard as the Azure path; containment via shared `safe_join` (no traversal/absolute-key escapes). Bucket comes from a new `aws_s3_bucket` config field / `--bucket` flag; unconfigured → clear setup hint; no bucket auto-creation. Truncated download bodies are rejected rather than reported as a full-size success. AWS backend now reports `has_file_storage: true`. Adds optional dep `aws-sdk-s3`.
+
+### Changed
+
+- **`xv share` on AWS returns a capability-aware hint (#248)** — share/grant/revoke/list operations on the AWS backend now exit 2 with a message naming the backend and giving a copyable `aws secretsmanager put-resource-policy` example, instead of failing opaquely. The hint is returned even when the AWS backend registry failed to initialize. Local secret-share messages are byte-identical; the vault-share message was unified to the share-specific text.
+
+### Known limitations
+
+- The `has_audit` capability flag is `false` for Azure even though `xv audit` works there, because Azure audit uses a legacy Activity Log path that bypasses the capability trait (AWS dispatches through the trait correctly). Tracked in `ROADMAP.md` (P3). Harmless — the CLI tries the trait first, then falls through.
+- `rustls-webpki 0.101.7` (RUSTSEC DoS via malformed CRL panic, GHSA high) remains pinned transitively by `rustls 0.21` inside `aws-smithy-http-client`. It enters the tree only under the opt-in `aws` feature, is **not** present in the released binaries (built `--features tui`, no `aws`), and is unreachable in practice (the AWS SDK only contacts trusted AWS TLS endpoints, never processing attacker-controlled CRLs). Will clear when the AWS SDK drops rustls 0.21 upstream — same posture as the documented `rand 0.7.3` pin.
+
+---
+
 ## v0.11.2 — P2 security-hardening completion (2026-06-11)
 
 Closes out all four remaining P2 items from the 2026-05-09 GPT-5.5 code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,7 +1686,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.11.2"
+version = "0.12.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Crosstache Roadmap
 
-> **Last reviewed:** 2026-06-11 · **Latest released version:** `v0.11.2` · **Branch protection:** `main` (all changes via PR)
+> **Last reviewed:** 2026-06-12 · **Latest released version:** `v0.12.0` · **Branch protection:** `main` (all changes via PR)
 
 Single source of truth for **unimplemented** ideas, deferred work, and known
 limitations worth fixing. Anything already shipped lives in [`CHANGELOG.md`](./CHANGELOG.md).
@@ -103,17 +103,39 @@ low-confidence (`src/scan/patterns.rs:62`).
 ### P1 — AWS capability matrix gaps (deferred from v0.10.0)
 Source: `CHANGELOG.md` § AWS capabilities matrix.
 
-| Feature           | AWS status today                                       | Next step                                                                    |
+All four gaps shipped in **v0.12.0** (2026-06-12, #248–#251). Retained here
+as history; current AWS capability state lives in `CHANGELOG.md`.
+
+| Feature           | AWS status                                             | Shipped                                                                       |
 | ----------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| `xv share` (RBAC) | ❌ Use AWS IAM directly                                | Add capability-aware hint with `aws iam` example; longer term, wrapper UX.   |
-| `xv audit`        | ❌ Use AWS CloudTrail                                  | Read recent CloudTrail events for the vault; mirror Azure Activity Log UX.   |
-| Native rotation   | ❌ `xv rotate` writes new versions                     | Optional integration with Secrets Manager rotation Lambdas.                  |
-| File storage (S3) | ❌ Deferred                                            | Mirror Azure Blob backend; same containment fixes as local file backend.    |
+| `xv share` (RBAC) | ✅ Capability-aware hint with `aws secretsmanager put-resource-policy` example | v0.12.0 (#248) |
+| `xv audit`        | ✅ Reads CloudTrail `LookupEvents`, mirrors Azure Activity Log UX | v0.12.0 (#249) |
+| Native rotation   | ✅ `xv rotate --native` invokes Secrets Manager `RotateSecret` (Lambda) | v0.12.0 (#250) |
+| File storage (S3) | ✅ `xv file` on S3, vault-prefixed, streaming + containment | v0.12.0 (#251) |
+
+### P3 — `has_audit` capability flag is inconsistent across audit backends
+Surfaced during the v0.12.0 audit work (#249). AWS audit dispatches through
+the `AuditBackend` trait (`registry.active().audit()`), so AWS correctly sets
+`has_audit: true`. Azure audit still uses a **legacy Activity Log path** in
+`src/cli/system_ops.rs` that bypasses the capability system entirely, so
+`xv audit` works on Azure while the Azure backend reports `has_audit: false`.
+Harmless today (the CLI tries the trait first, then falls through to the Azure
+path), but the flag is a lie for Azure. Fix: either migrate Azure audit onto
+the trait and flip `has_audit: true`, or document the flag as "trait-dispatch
+only" so capability introspection isn't misleading.
 
 ### P2 — Local backend metadata encryption (opt-in)
 Source: `docs/reviews/2026-05-03-ux-review.md` §3 (since absorbed) and
 code-review P3 item above. Provide an opt-in encrypted index mode or, at
 minimum, a clear warning in `init` + docs.
+
+### P3 — TUI clippy lint debt
+`cargo clippy --features tui -- -D warnings` reports ~9 lints in `src/tui/`
+(collapsible-if, `.clone()` on `Copy` `ListState`, manual `div_ceil`,
+non-binding `let` on futures). Pre-existing and NOT gated by CI (which runs
+clippy on default features only; the tui feature is build-and-test-gated, not
+clippy-gated), so they don't block releases — but worth a sweep. Newer clippy
+versions surface them; same class as the AWS-files lints cleaned up in #250.
 
 ### P3 — Additional backends
 Open ground from `2026-04-29-strategic-improvements-phase-1-design.md`:


### PR DESCRIPTION
## Summary
Version bump + docs for the v0.12.0 release. Closes the four P1 AWS capability gaps shipped in #248–#251.

- **Cargo.toml/lock**: 0.11.2 → 0.12.0 (minor bump — these are features).
- **CHANGELOG**: new v0.12.0 section (Added: audit/rotation/S3; Changed: share hints; Known limitations).
- **ROADMAP**: AWS P1 capability matrix flipped to ✅ shipped with PR refs; version banner → v0.12.0; two new P3 entries (has_audit flag inconsistency surfaced by the audit lane; pre-existing TUI clippy debt).

## Dependabot triage (rustls-webpki HIGH)
Not release-blocking, documented in CHANGELOG Known limitations:
- Patched 0.103.13 is already in-tree; the vulnerable 0.101.7 is a second copy pinned by `rustls 0.21` inside `aws-smithy-http-client` — not bumpable without the AWS SDK dropping rustls 0.21 upstream.
- Enters the tree only under the opt-in `aws` feature (0 occurrences in default build).
- Release binaries build `--features tui` (no `aws`) — not in shipped artifacts.
- Unreachable in practice (AWS SDK only contacts trusted AWS TLS endpoints).

## Verification
- `cargo clippy -- -D warnings` (default features, the CI gate): clean
- `cargo build --features tui` (the release gate): clean
- `cargo test --all-targets --features file-ops`: all suites green
- (The ~9 `clippy --features tui` lints are pre-existing on main and not gated by CI; tracked in ROADMAP P3.)

Docs+version only — no code changes. Pre-approved release-branch auto-merge class once CI green + Bugbot clean. Tag v0.12.0 pushed after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no runtime or security behavior changes in this PR.
> 
> **Overview**
> **Release packaging only:** bumps `crosstache` from **0.11.2 → 0.12.0** in `Cargo.toml` / `Cargo.lock` with no application code in this diff.
> 
> Adds a **v0.12.0** `CHANGELOG.md` section that documents AWS work already merged in #248–#251 (CloudTrail audit, `xv rotate --native`, S3 `xv file`, share capability hints) plus known limitations (`has_audit` on Azure, `rustls-webpki` under the opt-in `aws` feature).
> 
> Updates **`ROADMAP.md`**: banner to v0.12.0, marks the four P1 AWS matrix gaps as shipped, and adds P3 follow-ups for Azure `has_audit` inconsistency and TUI clippy debt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aec29f4326e8086f33f39a3d478865247edbb36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->