### PR TITLE
fix(ux): stop framing crosstache as Azure-only (§P2-1, §P2-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # crosstache
 
-A cross-platform secrets manager for the command line, currently backed by Azure Key Vault. The binary is `xv`.
+A cross-platform secrets manager for the command line. Pluggable backends: Azure Key Vault, AWS Secrets Manager, or local age-encrypted files. The binary is `xv`.
 
 ```bash
 xv set DB_PASSWORD                     # store a secret (prompts for value)

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -49,7 +49,7 @@ use async_trait::async_trait;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum BackendKind {
-    /// Azure Key Vault (the original, and currently only, implementation).
+    /// Azure Key Vault (the original implementation).
     Azure,
     /// Local age-encrypted file backend (Phase 2).
     Local,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -92,7 +92,9 @@ pub struct BuildInfo {
 
 #[derive(Parser)]
 #[command(name = "xv")]
-#[command(about = "A comprehensive tool for managing Azure Key Vault")]
+#[command(
+    about = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"
+)]
 #[command(version = get_version(), author)]
 #[command(help_template = get_help_template())]
 pub struct Cli {

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -62,8 +62,12 @@ pub(crate) fn share_unsupported_error(
              aws secretsmanager put-resource-policy --secret-id <secret-name> --resource-policy file://policy.json\n  \
              aws iam attach-user-policy --user-name <user-name> --policy-arn <policy-arn>"
         )),
+        BackendKind::Azure => CrosstacheError::invalid_argument(format!(
+            "{operation} is not supported on the {backend_name} backend."
+        )),
         _ => CrosstacheError::invalid_argument(format!(
-            "The {backend_name} backend does not support {operation}. Use the azure backend for RBAC."
+            "The {backend_name} backend does not support {operation}. \
+             The azure backend offers RBAC-based sharing."
         )),
     }
 }
@@ -525,14 +529,16 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "Invalid argument: The local backend does not support access sharing. \
-             Use the azure backend for RBAC."
+             The azure backend offers RBAC-based sharing."
         );
 
+        // The azure backend must NOT be told to "use the azure backend" — its
+        // message names the unsupported operation without a self-referential
+        // recommendation.
         let err = share_unsupported_error(BackendKind::Azure, "azure", "vault sharing");
         assert_eq!(
             err.to_string(),
-            "Invalid argument: The azure backend does not support vault sharing. \
-             Use the azure backend for RBAC."
+            "Invalid argument: vault sharing is not supported on the azure backend."
         );
     }
 }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -4334,7 +4334,7 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "Invalid argument: The local backend does not support access sharing. \
-             Use the azure backend for RBAC."
+             The azure backend offers RBAC-based sharing."
         );
     }
 


### PR DESCRIPTION
## Summary
First roadmap item after the v0.12.0 AWS completion. Closes ROADMAP §P2-1 (top-level framing says Azure-only) and the core of §P2-5 (backend-unsupported ops framed in Azure terms). With AWS + local now shipped first-class, the Azure-only language is actively misleading.

## Changes
- **README hero**: "currently backed by Azure Key Vault" → "Pluggable backends: Azure Key Vault, AWS Secrets Manager, or local age-encrypted files".
- **`xv --help` about-text**: "A comprehensive tool for managing Azure Key Vault" → names all three backends.
- **§P2-5 bug fix**: `share_unsupported_error` had a fallback arm that told the **azure** backend "Use the azure backend for RBAC" — a nonsensical self-reference. Now Azure gets a plain "not supported on the azure backend" message; non-RBAC backends (local) get "The azure backend offers RBAC-based sharing" as a suggestion, not an imperative.
- Dropped a stale `BackendKind::Azure` doc comment ("the original, and currently only, implementation").

## Verification
- `cargo fmt --check`, `cargo clippy -- -D warnings` (CI gate, default features): clean
- `cargo test --all-targets --features file-ops`: all suites green
- Updated the two tests that pinned the old share-error wording (`non_aws_share_error_keeps_generic_message`, `local_share_error_message_unchanged`).

Docs + small string/logic change. Remaining §P2-2/§P2-3/§P2-4 UX items are separate, larger changes (flag hiding, config key naming, `context envs` output) — left for follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and user-visible error strings only; no auth, storage, or command behavior changes beyond clearer messaging.
> 
> **Overview**
> Updates user-facing copy so **crosstache is described as supporting Azure, AWS, and local backends**, not Azure-only. The README intro and `xv --help` about line now list all three storage options.
> 
> **`share_unsupported_error`** gains a dedicated **Azure** branch so unsupported share operations no longer tell users to "use the azure backend" when they're already on Azure. **Local** (and similar) backends still get a softer hint that Azure offers RBAC-based sharing instead of the old imperative wording.
> 
> A stale **`BackendKind::Azure`** doc comment is trimmed; tests that assert share-error strings are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65371bbf7bb820950658b40e472853e7327304a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->