### PR TITLE
fix(ux): hide --aws-profile/--region from default help (§P2-2)

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -155,11 +155,11 @@ pub struct Cli {
     pub credential_type: Option<String>,
 
     /// Override the AWS profile for this invocation (only honored when active backend is aws)
-    #[arg(long, global = true)]
+    #[arg(long, global = true, hide = should_hide_options())]
     pub aws_profile: Option<String>,
 
     /// Override the AWS region for this invocation (only honored when active backend is aws)
-    #[arg(long, global = true)]
+    #[arg(long, global = true, hide = should_hide_options())]
     pub region: Option<String>,
 
     /// Show global options in help output


### PR DESCRIPTION
## Summary
ROADMAP §P2-2: `--aws-profile` and `--region` were the only two global flags NOT using `hide = should_hide_options()`, so they appeared in **every** command's `--help` output — including commands and backends (Azure, local) that ignore them entirely. This aligns them with every other global flag.

## Change
One-attribute fix on each of the two flags in `src/cli/commands.rs`: add `hide = should_hide_options()`.

## Behavior (verified on the built binary)
- `xv --help` → AWS flags now hidden (matches `--debug`, `--credential-type`, etc.)
- `xv --show-options --help` → both flags still listed
- The flags themselves are unchanged — still global, still honored when the active backend is AWS.

## Verification
- `cargo fmt --check`, `cargo clippy -- -D warnings` (CI gate): clean
- `cargo test --all-targets --features file-ops`: 26 suites green
- Empirically confirmed hidden-by-default + shown-under-`--show-options`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help-only clap attribute changes; no logic or AWS config wiring was modified.
> 
> **Overview**
> **Default help is quieter:** `--aws-profile` and `--region` now use `hide = should_hide_options()`, like the other advanced global flags (`--debug`, `--credential-type`, `--backend`, etc.). They no longer show up on every subcommand’s `--help` when you’re on Azure or local backends that ignore them.
> 
> **Nothing changes at runtime:** both flags stay global and still feed `config.aws` when set. **`xv --show-options --help`** still lists them for AWS users who need them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9d76a2c25a3271e28f6ccc06ef1f0e5b288081d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->