### PR TITLE
fix(ux): context envs shows effective backend (§P2-4) + config naming note (§P2-3)

### DIFF
--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -471,6 +471,13 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
         println!("  env             : XV_ENV > --env flag > .xv.toml default_env");
         println!("  vault           : --vault arg > .xv.toml profile.vault > context > global default_vault");
         println!("  resource_group  : --resource-group > .xv.toml profile.resource_group > global default_resource_group");
+        println!();
+        println!("Naming convention: the global config uses a `default_` prefix (default_vault,");
+        println!("default_resource_group) because those values are fallbacks; a .xv.toml env");
+        println!("profile uses the bare name (vault, resource_group) because it sets a specific");
+        println!(
+            "value that overrides the global default. Same concept, the prefix signals the layer."
+        );
     }
 
     Ok(())
@@ -1187,19 +1194,49 @@ async fn execute_env_list(config: &Config) -> Result<()> {
         .map(|d| format!(", default: {d}"))
         .unwrap_or_default();
     println!("Project envs (from {}{}):", path.display(), default_label);
+    // Global backend (xv.conf / XV_BACKEND / top-level --backend) used as the
+    // fallback when an env profile doesn't pin its own backend.
+    let global_backend = config.effective_backend_name();
     for (name, profile) in &cfg.envs {
         let marker = if active.as_deref() == Some(name.as_str()) {
             "*"
         } else {
             " "
         };
-        let backend = profile.backend.as_deref().unwrap_or("azure");
+        // Show the EFFECTIVE backend each env resolves to, not just the
+        // profile's literal field. A profile with no `backend` inherits the
+        // global backend rather than silently defaulting to "azure" — flag
+        // that case so the displayed value matches what actually runs.
+        let (backend, backend_note) = match profile.backend.as_deref() {
+            Some(b) => (b.to_string(), String::new()),
+            None => (global_backend.to_string(), " (inherited)".to_string()),
+        };
         let vault = profile.vault.as_deref().unwrap_or("(unset)");
         let mut extras = String::new();
         if let Some(rg) = &profile.resource_group {
             extras.push_str(&format!("  resource_group={rg}"));
         }
-        println!("  {marker} {name}  backend={backend}  vault={vault}{extras}");
+        println!("  {marker} {name}  backend={backend}{backend_note}  vault={vault}{extras}");
+    }
+
+    // Summary: what the active env actually resolves to right now, after full
+    // precedence (this is the "effective profile" §P2-4 asks for). Only shown
+    // when an env is active so single-env or no-active-env cases stay terse.
+    if let Some(active_name) = &active {
+        if let Some(profile) = cfg.envs.get(active_name) {
+            let eff_backend = profile.backend.as_deref().unwrap_or(global_backend);
+            let eff_vault = profile
+                .vault
+                .as_deref()
+                .or(if config.default_vault.is_empty() {
+                    None
+                } else {
+                    Some(config.default_vault.as_str())
+                })
+                .unwrap_or("(unset)");
+            println!();
+            println!("Effective ({active_name}): backend={eff_backend}  vault={eff_vault}");
+        }
     }
     Ok(())
 }

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -1215,11 +1215,17 @@ async fn execute_env_list(config: &Config) -> Result<()> {
         // an unset profile backend shows the inherited global value.
         let resolved =
             resolve_effective_backend(cli_backend, profile.backend.as_deref(), global_backend);
-        // "(inherited)" marks the case where the env profile itself set no
-        // backend and no CLI override applied — the value came from the global
-        // layer (or the built-in default).
-        let inherited = profile.backend.is_none() && cli_backend.is_none();
-        let backend_note = if inherited { " (inherited)" } else { "" };
+        // "(inherited)" marks rows whose env profile set no `backend` of its
+        // own — the displayed value came from outside the profile (CLI flag,
+        // XV_BACKEND, global config, or the built-in default). This must key
+        // strictly on the profile field below: the CLI override is populated
+        // from XV_BACKEND even when --backend is absent, so it is not a
+        // reliable signal for "this row has no profile-level backend".
+        let backend_note = if profile.backend.is_none() {
+            " (inherited)"
+        } else {
+            ""
+        };
         let vault = profile.vault.as_deref().unwrap_or("(unset)");
         let mut extras = String::new();
         if let Some(rg) = &profile.resource_group {

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -1194,36 +1194,38 @@ async fn execute_env_list(config: &Config) -> Result<()> {
         .map(|d| format!(", default: {d}"))
         .unwrap_or_default();
     println!("Project envs (from {}{}):", path.display(), default_label);
-    // Backend that envs WITHOUT their own `backend` field fall back to. Use
-    // the pre-profile snapshot (`disk_backend`: global config / XV_BACKEND /
-    // --backend) — NOT `effective_backend_name()`, which has already folded in
-    // the *active* env's profile backend in main.rs and would make inactive
-    // envs appear to inherit the active env's choice.
-    let global_backend = config
-        .disk_backend
-        .as_deref()
-        .or(config.cli_backend.as_deref())
-        .unwrap_or("azure");
+    use crate::config::project::resolve_effective_backend;
+    // Precedence for every row mirrors `resolve_effective_backend`:
+    //   cli_backend (--backend / XV_BACKEND via clap) > profile.backend > global.
+    // `cli_backend` is the raw flag/env snapshot; `disk_backend` is the global
+    // config value taken BEFORE main.rs folded the active env's profile in
+    // (using `effective_backend_name()` here would make inactive envs inherit
+    // the active env's backend). A `None` profile backend falls through to the
+    // global layer rather than silently defaulting to "azure".
+    let cli_backend = config.cli_backend.as_deref();
+    let global_backend = config.disk_backend.as_deref();
     for (name, profile) in &cfg.envs {
         let marker = if active.as_deref() == Some(name.as_str()) {
             "*"
         } else {
             " "
         };
-        // Show the EFFECTIVE backend each env resolves to, not just the
-        // profile's literal field. A profile with no `backend` inherits the
-        // global backend rather than silently defaulting to "azure" — flag
-        // that case so the displayed value matches what actually runs.
-        let (backend, backend_note) = match profile.backend.as_deref() {
-            Some(b) => (b.to_string(), String::new()),
-            None => (global_backend.to_string(), " (inherited)".to_string()),
-        };
+        // Resolve through the canonical precedence helper so a --backend
+        // override is reflected even on rows that pin their own backend, and
+        // an unset profile backend shows the inherited global value.
+        let resolved =
+            resolve_effective_backend(cli_backend, profile.backend.as_deref(), global_backend);
+        // "(inherited)" marks the case where the env profile itself set no
+        // backend and no CLI override applied — the value came from the global
+        // layer (or the built-in default).
+        let inherited = profile.backend.is_none() && cli_backend.is_none();
+        let backend_note = if inherited { " (inherited)" } else { "" };
         let vault = profile.vault.as_deref().unwrap_or("(unset)");
         let mut extras = String::new();
         if let Some(rg) = &profile.resource_group {
             extras.push_str(&format!("  resource_group={rg}"));
         }
-        println!("  {marker} {name}  backend={backend}{backend_note}  vault={vault}{extras}");
+        println!("  {marker} {name}  backend={resolved}{backend_note}  vault={vault}{extras}");
     }
 
     // Summary: what the active env actually resolves to right now, after full
@@ -1231,7 +1233,8 @@ async fn execute_env_list(config: &Config) -> Result<()> {
     // when an env is active so single-env or no-active-env cases stay terse.
     if let Some(active_name) = &active {
         if let Some(profile) = cfg.envs.get(active_name) {
-            let eff_backend = profile.backend.as_deref().unwrap_or(global_backend);
+            let eff_backend =
+                resolve_effective_backend(cli_backend, profile.backend.as_deref(), global_backend);
             // Vault resolution must mirror Config::resolve_vault_name and
             // `config show --resolved`: profile.vault > context vault > global
             // default_vault. Skipping the context layer made the summary

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -1194,9 +1194,16 @@ async fn execute_env_list(config: &Config) -> Result<()> {
         .map(|d| format!(", default: {d}"))
         .unwrap_or_default();
     println!("Project envs (from {}{}):", path.display(), default_label);
-    // Global backend (xv.conf / XV_BACKEND / top-level --backend) used as the
-    // fallback when an env profile doesn't pin its own backend.
-    let global_backend = config.effective_backend_name();
+    // Backend that envs WITHOUT their own `backend` field fall back to. Use
+    // the pre-profile snapshot (`disk_backend`: global config / XV_BACKEND /
+    // --backend) — NOT `effective_backend_name()`, which has already folded in
+    // the *active* env's profile backend in main.rs and would make inactive
+    // envs appear to inherit the active env's choice.
+    let global_backend = config
+        .disk_backend
+        .as_deref()
+        .or(config.cli_backend.as_deref())
+        .unwrap_or("azure");
     for (name, profile) in &cfg.envs {
         let marker = if active.as_deref() == Some(name.as_str()) {
             "*"
@@ -1225,9 +1232,17 @@ async fn execute_env_list(config: &Config) -> Result<()> {
     if let Some(active_name) = &active {
         if let Some(profile) = cfg.envs.get(active_name) {
             let eff_backend = profile.backend.as_deref().unwrap_or(global_backend);
+            // Vault resolution must mirror Config::resolve_vault_name and
+            // `config show --resolved`: profile.vault > context vault > global
+            // default_vault. Skipping the context layer made the summary
+            // disagree with what commands actually use.
+            let context_manager = crate::config::ContextManager::load()
+                .await
+                .unwrap_or_default();
             let eff_vault = profile
                 .vault
                 .as_deref()
+                .or_else(|| context_manager.current_vault())
                 .or(if config.default_vault.is_empty() {
                     None
                 } else {


### PR DESCRIPTION
## Summary
Two related UX-review items from ROADMAP.

### §P2-4 — `context envs` didn't show the effective profile
`xv context envs` listed each env's literal `backend` field, defaulting unset to `azure`. But a profile with no `backend` actually **inherits** the global backend (xv.conf / XV_BACKEND / --backend), so the display lied for the common case. Now:
- Each env shows its **effective** backend; inherited ones are marked `(inherited)`.
- A new `Effective (<env>): backend=.. vault=..` summary line shows what the active env resolves to after full precedence.

Verified on a throwaway `.xv.toml` with `XV_BACKEND=local`:
```
Project envs (from /tmp/.../.xv.toml, default: dev):
  * dev   backend=local (inherited)  vault=myproj-dev
    prod  backend=aws                vault=myproj-prod

Effective (dev): backend=local  vault=myproj-dev
```

### §P2-3 — `.xv.toml` vs `xv.conf` field naming (docs, per agreed approach)
The `default_vault`/`default_resource_group` (global) vs `vault`/`resource_group` (.xv.toml profile) naming is intentional — global sets fallbacks, profiles set overrides. Rather than a schema change with back-compat risk, `xv config show --resolved` now prints a note explaining the `default_` prefix convention.

## Verification
- `cargo fmt --check`, `cargo clippy -- -D warnings` (CI gate): clean
- `cargo test --all-targets --features file-ops`: 26 suites green
- Output empirically confirmed (above).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output and help text only; resolution logic for real commands is unchanged aside from aligning displayed values with existing resolvers.
> 
> **Overview**
> **`xv env list` / `xv context envs`** no longer prints each profile’s raw `backend` (with a misleading `azure` when unset). Rows now use **`resolve_effective_backend`** with `cli_backend` and pre-fold `disk_backend`, mark profiles without a local backend as **`(inherited)`**, and when an env is active add an **`Effective (<env>): backend=… vault=…`** line whose vault chain matches **`Config::resolve_vault_name`** / **`config show --resolved`** (profile → context → global).
> 
> **`xv config show --resolved`** adds a short note that global **`default_*`** keys are fallbacks while **`.xv.toml`** profiles use bare **`vault`** / **`resource_group`** as overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8d9475ae7e1cfea35262b39797dca87cbd8b57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->