### PR TITLE
fix(tui): clear clippy --features tui lint debt (§P3-4)

### DIFF
--- a/src/tui/message.rs
+++ b/src/tui/message.rs
@@ -26,5 +26,4 @@ pub enum Message {
     },
     Tick,
     Error(crate::error::CrosstacheError),
-    Quit,
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -122,32 +122,46 @@ async fn handle_command(
     match cmd {
         Command::Quit => {}
         Command::LoadVaults => {
-            let _ = data::spawn_load_vaults(app.config.clone(), tx.clone(), backend.clone());
+            // Detached background task; the JoinHandle is intentionally dropped.
+            drop(data::spawn_load_vaults(
+                app.config.clone(),
+                tx.clone(),
+                backend.clone(),
+            ));
         }
         Command::LoadSecrets { vault } => {
-            let _ =
-                data::spawn_load_secrets(app.config.clone(), vault, tx.clone(), backend.clone());
+            drop(data::spawn_load_secrets(
+                app.config.clone(),
+                vault,
+                tx.clone(),
+                backend.clone(),
+            ));
         }
         Command::LoadValue { vault, name } => {
-            let _ = data::spawn_load_value(
+            drop(data::spawn_load_value(
                 app.config.clone(),
                 vault,
                 name,
                 tx.clone(),
                 backend.clone(),
-            );
+            ));
         }
         Command::LoadHistory { vault, name } => {
-            let _ = data::spawn_load_history(
+            drop(data::spawn_load_history(
                 app.config.clone(),
                 vault,
                 name,
                 tx.clone(),
                 backend.clone(),
-            );
+            ));
         }
         Command::LoadAudit { vault, name } => {
-            let _ = data::spawn_load_audit(app.config.clone(), vault, name, tx.clone());
+            drop(data::spawn_load_audit(
+                app.config.clone(),
+                vault,
+                name,
+                tx.clone(),
+            ));
         }
         Command::CopyToClipboard(s) => {
             if let Err(e) = clipboard::copy_string(&s) {

--- a/src/tui/update.rs
+++ b/src/tui/update.rs
@@ -69,10 +69,6 @@ pub fn update(app: &mut App, msg: Message) -> Vec<Command> {
             app.secrets_loading = false;
             app.value_loading = false;
         }
-        Message::Quit => {
-            app.quit = true;
-            cmds.push(Command::Quit);
-        }
     }
     cmds
 }
@@ -123,11 +119,9 @@ fn handle_key(app: &mut App, key: KeyEvent) -> Vec<Command> {
             cmds.push(Command::Quit);
         }
         KeyCode::Char('?') => app.overlay = Overlay::Help,
-        KeyCode::Char('/') => {
-            if app.pane == crate::tui::app::Pane::Secrets {
-                app.secret_filter_active = true;
-                app.secret_filter.clear();
-            }
+        KeyCode::Char('/') if app.pane == crate::tui::app::Pane::Secrets => {
+            app.secret_filter_active = true;
+            app.secret_filter.clear();
         }
         KeyCode::Char(' ') => app.value_revealed = !app.value_revealed,
         KeyCode::Tab => app.pane = next_pane(app.pane),

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -62,7 +62,7 @@ fn render_vaults(app: &App, frame: &mut Frame, area: Rect) {
                 .border_style(border_for(app, Pane::Vaults)),
         )
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
-    let mut s = app.vault_state.clone();
+    let mut s = app.vault_state;
     frame.render_stateful_widget(list, area, &mut s);
 }
 
@@ -96,7 +96,7 @@ fn render_secrets(app: &App, frame: &mut Frame, area: Rect) {
                 .border_style(border_for(app, Pane::Secrets)),
         )
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
-    let mut s = app.secret_state.clone();
+    let mut s = app.secret_state;
     frame.render_stateful_widget(list, area, &mut s);
 }
 
@@ -156,7 +156,7 @@ fn render_status(app: &App, frame: &mut Frame, area: Rect) {
         parts.push(format!("{} secrets", s.len()));
     }
     if let Some(n) = app.clipboard_countdown {
-        parts.push(format!("clipboard: {}s", (n + 9) / 10));
+        parts.push(format!("clipboard: {}s", n.div_ceil(10)));
     }
     parts.push("?:help q:quit".to_string());
     let p = Paragraph::new(parts.join("  ·  ")).style(Style::default().fg(Color::DarkGray));


### PR DESCRIPTION
## Summary
ROADMAP §P3-4 / the TUI clippy debt tracked since the v0.12.0 release notes. `cargo clippy --features tui -- -D warnings` reported 9 lints + 1 dead-code warning that CI never caught (it runs clippy on default features only; tui is build-and-test-gated, not clippy-gated). This clears them.

## Changes (no behavior change)
- **update.rs**: collapse `if` into outer `match`.
- **view.rs**: drop `.clone()` on `ListState` (it's `Copy`) ×2; use `div_ceil` instead of manual `(a + b - 1) / b`.
- **mod.rs**: 5 detached background tasks used `let _ = spawn_load_*(...)` on a `JoinHandle` (which is a `Future`) → explicit `drop(...)` to signal intentional detach.
- **message.rs / update.rs**: remove the dead `Message::Quit` variant and its unreachable handler arm. Quitting is driven entirely by `Command::Quit` from `handle_key` (q / Esc / Ctrl+C); `Message::Quit` was matched but never constructed.

## Verification
- `cargo clippy --features tui -- -D warnings`: **clean** (was 9 lints + dead-code)
- `cargo clippy -- -D warnings` (default, CI gate): clean
- `cargo fmt --check`: clean
- `cargo test --features tui,file-ops`: 27 suites green

Mechanical lint cleanup — auto-fixable ones via `cargo clippy --fix`, the JoinHandle drops + dead-variant removal by hand.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only refactors in the TUI module with no auth or data-path changes; quit and load behavior should match prior code.
> 
> **Overview**
> Clears **clippy** warnings under `--features tui` with no intended runtime behavior change.
> 
> **Quit path:** Removes unused `Message::Quit` and its `update` arm; exit stays on `Command::Quit` from key handling (q / Esc / Ctrl+C).
> 
> **Background loads:** Replaces `let _ = spawn_load_*()` with explicit `drop(...)` on detached `JoinHandle`s so clippy does not treat the future as accidentally ignored.
> 
> **Small style fixes:** Merges the secrets-pane `/` filter into a single `match` guard; uses `ListState` by copy instead of `.clone()` in vault/secret lists; uses `div_ceil(10)` for clipboard countdown seconds in the status bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e04bbd44fe2b2c639a45cf08acf5c72226a66f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->