### PR TITLE
docs: move shipped UX P2/P3 items to CHANGELOG Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased — UX & docs polish (post-v0.12.0)
+
+Closes the entire UX P2 lane and P3-1..4 from `docs/UX-REVIEW.md`
+(2026-05-16 AWS-backend baseline). Merged to `main`; not yet tagged.
+
+### Changed
+
+- **crosstache no longer frames itself as Azure-only (§P2-1, §P2-5, #254)** — the README hero and `xv --help` intro mention AWS and local backends alongside Azure. Backend-unsupported operations are framed in neutral language and surface the active backend in the error instead of assuming Azure.
+- **AWS-inherited flags hidden where they do nothing (§P2-2, #255)** — `--aws-profile` and `--region` are hidden from the default help of commands that ignore them, so they no longer appear on Azure/local-only operations.
+- **`context envs` shows the effective profile (§P2-4) + config naming note (§P2-3, #256)** — the listing now displays the resolved backend (with an `(inherited)` marker for envs that set no `backend` of their own) and an `Effective (<env>): backend=… vault=…` summary that mirrors full `resolve_effective_backend` / vault-resolution precedence. A note disambiguates the overlapping `.xv.toml` vs `xv.conf` backend fields.
+
+### Fixed
+
+- **TUI clippy lint debt cleared (§P3-4, #257)** — `cargo clippy --features tui -- -D warnings` is clean (collapsible-if, `.clone()` on `Copy` `ListState`, manual `div_ceil`, non-binding `let` on futures).
+- **`xv env create --group` disambiguated (§P3-1..4, #258)** — help text now explains that `--group` (secret-group filter) and `--resource-group` (Azure resource group) are distinct concepts; the minimal help template advertises `--show-options` for discoverability of hidden globals.
+
+---
+
 ## v0.12.0 — AWS capability matrix completion (2026-06-12)
 
 Closes all four P1 AWS capability gaps deferred since v0.10.0 (#248–#251).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Crosstache Roadmap
 
-> **Last reviewed:** 2026-06-12 · **Latest released version:** `v0.12.0` · **Branch protection:** `main` (all changes via PR)
+> **Last reviewed:** 2026-06-14 · **Latest released version:** `v0.12.0` · **Branch protection:** `main` (all changes via PR)
 
 Single source of truth for **unimplemented** ideas, deferred work, and known
 limitations worth fixing. Anything already shipped lives in [`CHANGELOG.md`](./CHANGELOG.md).
@@ -129,14 +129,6 @@ Source: `docs/reviews/2026-05-03-ux-review.md` §3 (since absorbed) and
 code-review P3 item above. Provide an opt-in encrypted index mode or, at
 minimum, a clear warning in `init` + docs.
 
-### P3 — TUI clippy lint debt
-`cargo clippy --features tui -- -D warnings` reports ~9 lints in `src/tui/`
-(collapsible-if, `.clone()` on `Copy` `ListState`, manual `div_ceil`,
-non-binding `let` on futures). Pre-existing and NOT gated by CI (which runs
-clippy on default features only; the tui feature is build-and-test-gated, not
-clippy-gated), so they don't block releases — but worth a sweep. Newer clippy
-versions surface them; same class as the AWS-files lints cleaned up in #250.
-
 ### P3 — Additional backends
 Open ground from `2026-04-29-strategic-improvements-phase-1-design.md`:
 - GCP Secret Manager
@@ -149,21 +141,15 @@ Each new backend appends to `docs/superpowers/specs/backend-trait-checklist.md`.
 
 ## UX & docs polish
 
-From `docs/UX-REVIEW.md` (2026-05-16 AWS-backend baseline):
+From `docs/UX-REVIEW.md` (2026-05-16 AWS-backend baseline).
 
-### P2
-- **§P2-1 Top-level framing still says Azure-only.** README hero + `xv --help` intro need an AWS mention.
-- **§P2-2 AWS flags appear on commands where they do nothing.** Hide `--aws-profile` / `--region` from commands that ignore them.
-- **§P2-3 `.xv.toml` and `xv.conf` overlapping backend fields** have inconsistent naming. Pick one canonical key per concept.
-- **§P2-4 `context envs` does not show the effective profile.** Include resolved backend + vault.
-- **§P2-5 Backend-unsupported operations framed in Azure terms.** Use neutral language; surface the active backend in the error.
+The full P2 lane and P3-1..4 shipped post-v0.12.0 (#254 §P2-1/§P2-5,
+#255 §P2-2, #256 §P2-3/§P2-4, #257 §P3-4, #258 §P3-1..3). They are
+recorded in [`CHANGELOG.md`](./CHANGELOG.md) under `Unreleased`. One
+substantive UX item remains open:
 
 ### P3
-- **§P3-1 Help hides global options by default.** ✅ Resolved — the minimal help template advertises `--show-options` (twice: in the `-h` line and a trailing hint), so hidden globals are discoverable.
-- **§P3-2 `xv env create --group` reads ambiguously next to `--resource-group`.** ✅ Resolved (v0.12.x) — they are distinct concepts (secret-group filter vs Azure resource group); help text now says so explicitly. Not a rename.
-- **§P3-3 Generic AWS inherited flags visually louder in `--help`.** ✅ Obsoleted by §P2-2 — `--aws-profile`/`--region` are now hidden from default help entirely.
-- **§P3-4 Build warnings / clippy debt.** ✅ Resolved (v0.12.x) — `cargo clippy --features tui -- -D warnings` is clean; periodic sweeps still encouraged.
-- **§P3-5 The CLI doesn't surface the env-vs-profile-vs-context distinction at the moment of confusion** — only docs do. Add inline hints. *(Open — the remaining substantive UX item.)*
+- **§P3-5 The CLI doesn't surface the env-vs-profile-vs-context distinction at the moment of confusion** — only docs do. Add inline hints at the point a user is likely to confuse env profiles, the active context, and global config (e.g. when `context envs` / `config show --resolved` disagree, or a vault/backend resolves from an unexpected layer).
 
 ---
 


### PR DESCRIPTION
## What

The UX & docs polish lane from `docs/UX-REVIEW.md` shipped post-v0.12.0 across #254–#258, but `ROADMAP.md` still listed every item as open — and even claimed TUI clippy debt that #257 already cleared. This syncs the docs to reality.

## Changes

- **CHANGELOG.md** — new `Unreleased — UX & docs polish (post-v0.12.0)` section documenting #254 (§P2-1/§P2-5), #255 (§P2-2), #256 (§P2-3/§P2-4), #257 (§P3-4), #258 (§P3-1..3).
- **ROADMAP.md**
  - Collapsed "UX & docs polish" to the single genuinely-open item: §P3-5 (inline env/profile/context hints).
  - Removed the "P3 — TUI clippy lint debt" entry (cleared by #257).
  - Refreshed `Last reviewed` to 2026-06-14.

## Notes

Docs-only; no code touched. Follows the roadmap's own convention: shipped-but-unreleased work lives in CHANGELOG under `Unreleased`, the roadmap tracks only open work.

After this, the highest open severity is **P2 — Local backend metadata encryption (opt-in)**; the remaining substantive UX item is **§P3-5**.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation updates with no runtime or security impact.
> 
> **Overview**
> **Docs-only** sync so shipped UX work is recorded in the changelog and the roadmap no longer lists it as open.
> 
> **`CHANGELOG.md`** adds an **`Unreleased — UX & docs polish (post-v0.12.0)`** section for merged work from #254–#258: multi-backend framing in README/help, hiding irrelevant AWS flags, richer `context envs` effective profile output, TUI clippy cleanup, and clearer `xv env create --group` help.
> 
> **`ROADMAP.md`** collapses the UX & docs polish lane to the single remaining item (**§P3-5** inline env/profile/context hints), removes the obsolete **P3 — TUI clippy lint debt** entry (#257), and updates **Last reviewed** to 2026-06-14.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28a4bf5afe220a9688b46b87a58e518489b80eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->