### PR TITLE
feat(local): opt-in metadata encryption at rest (ROADMAP P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 Closes the entire UX P2 lane and P3-1..4 from `docs/UX-REVIEW.md`
 (2026-05-16 AWS-backend baseline). Merged to `main`; not yet tagged.
 
+### Added
+
+- **Opt-in local-backend metadata encryption at rest (ROADMAP P2).** A new `encrypt_metadata` key under `[local]` (default `false`, fully backward-compatible) makes the local backend age-encrypt each secret's `.meta.json` — note, tags, folder, expiry, content-type — to the same recipients as the secret value, instead of storing it as plaintext JSON. Reads auto-detect ciphertext vs plaintext via the age header, so stores can mix both formats freely (e.g. mid-migration). A new `xv local encrypt-metadata [--dry-run]` command walks every vault (including archived `.versions/` and `.trash/`) and re-encrypts existing plaintext metadata in place, atomically and idempotently. `xv init` now warns that metadata and secret *names* are plaintext by default and points at the flag + command. **Known limitation:** secret *names* remain visible as on-disk filenames regardless of this setting (filename opaquing is tracked separately).
+
 ### Changed
 
 - **crosstache no longer frames itself as Azure-only (§P2-1, §P2-5, #254)** — the README hero and `xv --help` intro mention AWS and local backends alongside Azure. Backend-unsupported operations are framed in neutral language and surface the active backend in the error instead of assuming Azure.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ backend = "local"
 store_path = "~/.xv/store"
 key_file = "~/.xv/key.txt"
 default_vault = "default"
+# Encrypt secret metadata (notes, tags, folders, expiry) at rest with the
+# same age key as the values. Default false. Secret *names* stay visible as
+# on-disk filenames either way. After enabling on an existing store, run
+# `xv local encrypt-metadata` to convert already-written metadata.
+encrypt_metadata = false
 ```
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,9 +70,15 @@ longest secret length.
 ### P3 — CSV output manually assembled
 `src/utils/format.rs:174`. Use the `csv` crate.
 
-### P3 — Local metadata plaintext disclosure
-`src/backend/local/secrets.rs:146`. Document the limitation in `init`
-and docs; opt-in encrypted metadata index.
+### P3 — Local secret *names* disclosed via filenames
+`src/backend/local/secrets.rs`. Metadata *content* encryption shipped
+post-v0.12.0 (opt-in `encrypt_metadata` under `[local]` + `xv local
+encrypt-metadata`; see `CHANGELOG.md`), so note/tags/folder/expiry are no
+longer plaintext when enabled. What remains: secret *names* are still visible
+as on-disk filenames (`<percent-encoded-name>.age` / `.meta.json`), leaking
+existence, count, and identity even with metadata encrypted. Closing this
+needs filename opaquing (e.g. hash names, store an encrypted hash→name index),
+which is a larger architectural change — track as its own design.
 
 ### P3 — Missing serialization guards for value-like fields
 `src/error.rs:637`. Extend the existing error-variant guard to cover
@@ -123,11 +129,6 @@ Harmless today (the CLI tries the trait first, then falls through to the Azure
 path), but the flag is a lie for Azure. Fix: either migrate Azure audit onto
 the trait and flip `has_audit: true`, or document the flag as "trait-dispatch
 only" so capability introspection isn't misleading.
-
-### P2 — Local backend metadata encryption (opt-in)
-Source: `docs/reviews/2026-05-03-ux-review.md` §3 (since absorbed) and
-code-review P3 item above. Provide an opt-in encrypted index mode or, at
-minimum, a clear warning in `init` + docs.
 
 ### P3 — Additional backends
 Open ground from `2026-04-29-strategic-improvements-phase-1-design.md`:

--- a/src/backend/local/config.rs
+++ b/src/backend/local/config.rs
@@ -18,6 +18,9 @@ pub struct ResolvedLocalConfig {
     pub recipients_file: PathBuf,
     /// Default vault name used when no `--vault` flag is given.
     pub default_vault: String,
+    /// Whether to encrypt secret metadata (`.meta.json`) at rest. Defaults to
+    /// `false` for backward compatibility with existing plaintext stores.
+    pub encrypt_metadata: bool,
 }
 
 impl ResolvedLocalConfig {
@@ -48,11 +51,14 @@ impl ResolvedLocalConfig {
             .unwrap_or("default")
             .to_string();
 
+        let encrypt_metadata = raw.and_then(|c| c.encrypt_metadata).unwrap_or(false);
+
         Self {
             store_path,
             key_file,
             recipients_file,
             default_vault,
+            encrypt_metadata,
         }
     }
 }
@@ -75,10 +81,24 @@ mod tests {
             store_path: Some("/tmp/my-store".into()),
             key_file: Some("/tmp/my-key.txt".into()),
             default_vault: Some("staging".into()),
+            encrypt_metadata: None,
         };
         let cfg = ResolvedLocalConfig::from_raw(Some(&raw));
         assert_eq!(cfg.store_path, PathBuf::from("/tmp/my-store"));
         assert_eq!(cfg.key_file, PathBuf::from("/tmp/my-key.txt"));
         assert_eq!(cfg.default_vault, "staging");
+        assert!(!cfg.encrypt_metadata);
+    }
+
+    #[test]
+    fn encrypt_metadata_opt_in() {
+        let raw = LocalConfig {
+            store_path: None,
+            key_file: None,
+            default_vault: None,
+            encrypt_metadata: Some(true),
+        };
+        let cfg = ResolvedLocalConfig::from_raw(Some(&raw));
+        assert!(cfg.encrypt_metadata);
     }
 }

--- a/src/backend/local/crypto.rs
+++ b/src/backend/local/crypto.rs
@@ -63,6 +63,76 @@ pub fn encrypt_to_file(
     Ok(())
 }
 
+/// The age v1 ASCII-armor / binary header prefix. Used to detect whether a
+/// `.meta.json` file on disk holds age ciphertext (encrypted metadata) or
+/// plaintext JSON, so a store can mix both during/after migration.
+pub const AGE_MAGIC: &[u8] = b"age-encryption.org/";
+
+/// Returns true if `data` begins with the age format header.
+pub fn is_age_encrypted(data: &[u8]) -> bool {
+    data.starts_with(AGE_MAGIC)
+}
+
+/// Encrypt `plaintext` to in-memory age ciphertext bytes for the given
+/// recipients. Used for small payloads (secret metadata) that are held in
+/// memory rather than streamed.
+pub fn encrypt_bytes(
+    plaintext: &[u8],
+    recipients: &[age::x25519::Recipient],
+) -> Result<Vec<u8>, BackendError> {
+    let boxed_recipients: Vec<Box<dyn age::Recipient + Send>> = recipients
+        .iter()
+        .map(|r| Box::new(r.clone()) as Box<dyn age::Recipient + Send>)
+        .collect();
+
+    let encryptor = age::Encryptor::with_recipients(boxed_recipients)
+        .ok_or_else(|| BackendError::Internal("no recipients provided".into()))?;
+
+    let mut out = Vec::new();
+    let mut writer = encryptor
+        .wrap_output(&mut out)
+        .map_err(|e| BackendError::Internal(format!("encrypt init: {e}")))?;
+    writer
+        .write_all(plaintext)
+        .map_err(|e| BackendError::Internal(format!("encrypt write: {e}")))?;
+    writer
+        .finish()
+        .map_err(|e| BackendError::Internal(format!("encrypt finish: {e}")))?;
+
+    Ok(out)
+}
+
+/// Decrypt in-memory age ciphertext `data` with `identity`, returning the
+/// plaintext bytes. The plaintext is wrapped in `Zeroizing` since metadata may
+/// contain sensitive notes/tags.
+pub fn decrypt_bytes(
+    data: &[u8],
+    identity: &age::x25519::Identity,
+) -> Result<Zeroizing<Vec<u8>>, BackendError> {
+    let decryptor = match age::Decryptor::new_buffered(data)
+        .map_err(|e| BackendError::Internal(format!("decrypt header: {e}")))?
+    {
+        age::Decryptor::Recipients(d) => d,
+        _other => {
+            eprintln!("warning: unexpected age decryptor variant (expected Recipients)");
+            return Err(BackendError::Internal(
+                "unexpected passphrase-encrypted data".into(),
+            ));
+        }
+    };
+
+    let mut decrypted = decryptor
+        .decrypt(std::iter::once(identity as &dyn age::Identity))
+        .map_err(|e| BackendError::Internal(format!("decrypt: {e}")))?;
+
+    let mut buf = Zeroizing::new(Vec::new());
+    decrypted
+        .read_to_end(&mut buf)
+        .map_err(|e| BackendError::Internal(format!("read plaintext: {e}")))?;
+
+    Ok(buf)
+}
+
 /// Read and decrypt the age file at `path`, returning the plaintext bytes.
 ///
 /// Used for file/blob storage where the content may not be valid UTF-8.

--- a/src/backend/local/mod.rs
+++ b/src/backend/local/mod.rs
@@ -111,10 +111,11 @@ impl LocalBackend {
             .map_err(|e| BackendError::Internal(format!("write default vault meta: {e}")))?;
         }
 
-        let secret_backend = LocalSecretBackend::new(
+        let secret_backend = LocalSecretBackend::with_options(
             config.store_path.clone(),
             identity.clone(),
             recipients.clone(),
+            config.encrypt_metadata,
         );
         let vault_backend = LocalVaultBackend::new(config.store_path.clone());
 
@@ -128,6 +129,18 @@ impl LocalBackend {
             #[cfg(feature = "file-ops")]
             file_backend,
         })
+    }
+
+    /// Whether this backend was configured to encrypt metadata at rest.
+    pub fn encrypt_metadata_enabled(&self) -> bool {
+        self.config.encrypt_metadata
+    }
+
+    /// Re-encrypt all plaintext secret metadata under the store. See
+    /// [`LocalSecretBackend::reencrypt_all_metadata`]. Returns
+    /// `(converted, skipped)`.
+    pub fn reencrypt_all_metadata(&self, dry_run: bool) -> Result<(usize, usize), BackendError> {
+        self.secret_backend.reencrypt_all_metadata(dry_run)
     }
 
     /// Resolve age identity and recipients from env vars or files.
@@ -247,6 +260,7 @@ mod tests {
             store_path: Some(tmp.path().join("store").to_string_lossy().to_string()),
             key_file: Some(tmp.path().join("key.txt").to_string_lossy().to_string()),
             default_vault: Some("default".into()),
+            encrypt_metadata: None,
         }
     }
 

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -391,15 +391,21 @@ impl LocalSecretBackend {
         }
     }
 
-    /// Re-encrypt every plaintext `.meta.json` under the store as age
-    /// ciphertext, in place. Walks all vaults, including archived versions
-    /// (`.versions/`) and trash (`.trash/`). Already-encrypted metadata is
-    /// skipped, so this is idempotent and safe to re-run.
+    /// Re-encrypt every plaintext secret `.meta.json` under the store as age
+    /// ciphertext, in place. Covers active secrets (`secrets/`), archived
+    /// versions (`secrets/.versions/`), and trashed secrets (`.trash/`).
+    /// Already-encrypted metadata is skipped, so this is idempotent and safe to
+    /// re-run.
     ///
-    /// Each vault's subtree is processed while holding that vault's `.lock`
-    /// (the same lock taken by `set_secret`/`update_secret`/etc.), so a
-    /// concurrent `xv` mutation cannot interleave a write between this
-    /// migration's read and its atomic rename.
+    /// File-storage metadata (`files/*.meta.json`, which holds `FileInfo`, not
+    /// `SecretMeta`) is deliberately left untouched — the file backend reads it
+    /// as plaintext JSON and is not part of the `encrypt_metadata` contract.
+    ///
+    /// Each vault is processed while holding its `.lock` (the same lock taken by
+    /// `set_secret`/`update_secret`/etc.), so a concurrent `xv` mutation cannot
+    /// interleave a write between this migration's read and its atomic rename.
+    /// If a vault's lock cannot be acquired (e.g. another process holds it), the
+    /// migration fails loudly rather than silently leaving that vault plaintext.
     ///
     /// Returns `(converted, skipped)` counts. When `dry_run` is true, nothing
     /// is written and `converted` reflects what *would* be converted.
@@ -411,25 +417,31 @@ impl LocalSecretBackend {
             return Ok((0, 0));
         }
 
-        // Top-level entries under vaults/ are the per-vault directories. Lock
-        // each vault for the duration of its subtree migration.
         let vault_dirs = fs::read_dir(&vaults_root)
             .map_err(|e| BackendError::Internal(format!("read vaults dir: {e}")))?;
         for vault_entry in vault_dirs.flatten() {
             let vault_dir = vault_entry.path();
-            if !vault_dir.is_dir() {
+            // Only directories that look like vaults (have a .vault.json).
+            if !vault_dir.join(".vault.json").exists() {
                 continue;
             }
-            // Serialize against concurrent mutations of this vault. The lock is
-            // held until `_lock` drops at the end of this iteration. Skip
-            // vaults that were removed between read_dir and lock.
-            let _lock = match lock_vault(&vault_dir) {
-                Ok(l) => l,
-                Err(_) => continue,
-            };
+            // Serialize against concurrent mutations of this vault. Fail loudly
+            // on lock errors so the caller never reports success while leaving a
+            // vault's metadata plaintext. The lock is held until `_lock` drops
+            // at the end of this iteration.
+            let _lock = lock_vault(&vault_dir).map_err(|e| {
+                BackendError::Internal(format!(
+                    "could not lock vault {} for metadata migration (another xv process may be \
+                     running): {e}",
+                    vault_dir.display()
+                ))
+            })?;
 
-            // Walk this vault's subtree (secrets/, .versions/, .trash/).
-            let mut stack = vec![vault_dir];
+            // Walk only the secret-metadata subtrees: active + archived secrets
+            // live under secrets/ (which contains .versions/), trashed secrets
+            // under .trash/. files/ is intentionally excluded (FileInfo JSON).
+            let roots = [vault_dir.join("secrets"), vault_dir.join(".trash")];
+            let mut stack: Vec<PathBuf> = roots.into_iter().filter(|p| p.exists()).collect();
             while let Some(dir) = stack.pop() {
                 let entries = match fs::read_dir(&dir) {
                     Ok(e) => e,
@@ -1379,11 +1391,29 @@ mod tests {
             .await
             .unwrap();
 
-        // Every meta file is plaintext right now.
+        // Simulate a file upload: files/<x>.meta.json holds FileInfo JSON, not
+        // SecretMeta. The migration must NOT touch it (the file backend reads
+        // it as plaintext), and must not abort trying to parse it as SecretMeta.
+        let files_dir = tmp.path().join("vaults").join("default").join("files");
+        fs::create_dir_all(&files_dir).unwrap();
+        let file_meta = files_dir.join("upload.meta.json");
+        fs::write(
+            &file_meta,
+            br#"{"name":"upload","size":3,"not_a_secret":true}"#,
+        )
+        .unwrap();
+
+        // Every secret meta file is plaintext right now (under secrets/ + .trash/).
         let metas: Vec<std::path::PathBuf> = {
             let mut v = Vec::new();
-            let mut stack = vec![tmp.path().join("vaults")];
+            let mut stack = vec![
+                tmp.path().join("vaults").join("default").join("secrets"),
+                tmp.path().join("vaults").join("default").join(".trash"),
+            ];
             while let Some(d) = stack.pop() {
+                if !d.exists() {
+                    continue;
+                }
                 for e in fs::read_dir(&d).unwrap().flatten() {
                     let p = e.path();
                     if p.is_dir() {
@@ -1429,6 +1459,18 @@ mod tests {
         assert_eq!(a.value.as_deref().map(|z| z.to_string()), Some("1b".into()));
         let listed = enc.list_secrets("default", None).await.unwrap();
         assert_eq!(listed.len(), 2);
+
+        // The file-storage meta (FileInfo JSON under files/) was left untouched:
+        // still plaintext, still parses, and the migration didn't abort on it.
+        let file_raw = fs::read(&file_meta).unwrap();
+        assert!(
+            !crypto::is_age_encrypted(&file_raw),
+            "files/*.meta.json must not be encrypted by the secret migration"
+        );
+        assert_eq!(
+            file_raw,
+            br#"{"name":"upload","size":3,"not_a_secret":true}"#
+        );
     }
 
     #[tokio::test]

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -204,17 +204,52 @@ fn meta_to_summary(meta: &SecretMeta) -> SecretSummary {
     }
 }
 
-fn read_meta(path: &Path) -> Result<SecretMeta, BackendError> {
-    let data = fs::read_to_string(path)
+/// Read and deserialize secret metadata from `path`.
+///
+/// Auto-detects whether the file holds age ciphertext (encrypted metadata) or
+/// plaintext JSON by inspecting the age magic header, so a store may contain a
+/// mix of both during/after migration. `identity` is only used when the file
+/// is encrypted.
+fn read_meta(path: &Path, identity: &age::x25519::Identity) -> Result<SecretMeta, BackendError> {
+    let raw = fs::read(path)
         .map_err(|e| BackendError::Internal(format!("read meta {}: {e}", path.display())))?;
-    serde_json::from_str(&data)
-        .map_err(|e| BackendError::Internal(format!("parse meta {}: {e}", path.display())))
+
+    if crypto::is_age_encrypted(&raw) {
+        let plaintext = crypto::decrypt_bytes(&raw, identity)
+            .map_err(|e| BackendError::Internal(format!("decrypt meta {}: {e}", path.display())))?;
+        serde_json::from_slice(&plaintext)
+            .map_err(|e| BackendError::Internal(format!("parse meta {}: {e}", path.display())))
+    } else {
+        serde_json::from_slice(&raw)
+            .map_err(|e| BackendError::Internal(format!("parse meta {}: {e}", path.display())))
+    }
 }
 
-fn write_meta(path: &Path, meta: &SecretMeta) -> Result<(), BackendError> {
-    let json = serde_json::to_string_pretty(meta)
+/// How metadata should be written: which recipients to encrypt to, and whether
+/// to encrypt at all. Bundled so write paths don't sprout extra positional args.
+#[derive(Clone, Copy)]
+struct MetaCrypto<'a> {
+    recipients: &'a [age::x25519::Recipient],
+    encrypt: bool,
+}
+
+/// Serialize and write secret metadata to `path`.
+///
+/// When `crypto_opts.encrypt` is true, the JSON is age-encrypted to the given
+/// recipients before being written; otherwise it is written as plaintext JSON.
+/// Either way the file is created with private (0600) permissions.
+fn write_meta(path: &Path, meta: &SecretMeta, crypto_opts: MetaCrypto) -> Result<(), BackendError> {
+    let json = serde_json::to_vec_pretty(meta)
         .map_err(|e| BackendError::Internal(format!("serialize meta: {e}")))?;
-    write_private(path, json.as_bytes())
+
+    let bytes = if crypto_opts.encrypt {
+        crypto::encrypt_bytes(&json, crypto_opts.recipients)
+            .map_err(|e| BackendError::Internal(format!("encrypt meta: {e}")))?
+    } else {
+        json
+    };
+
+    write_private(path, &bytes)
         .map_err(|e| BackendError::Internal(format!("write meta {}: {e}", path.display())))
 }
 
@@ -238,6 +273,7 @@ fn archive_snapshot(
     version: &str,
     age_bytes: &[u8],
     meta: &SecretMeta,
+    crypto_opts: MetaCrypto,
 ) -> Result<(), BackendError> {
     let vdir = versions_dir(store_path, vault, name)?;
     fs::create_dir_all(&vdir)
@@ -248,7 +284,7 @@ fn archive_snapshot(
 
     write_private(&age_dest, age_bytes)
         .map_err(|e| BackendError::Internal(format!("archive age: {e}")))?;
-    write_meta(&meta_dest, meta)
+    write_meta(&meta_dest, meta, crypto_opts)
         .map_err(|e| BackendError::Internal(format!("archive meta: {e}")))?;
 
     Ok(())
@@ -336,19 +372,96 @@ pub struct LocalSecretBackend {
     store_path: PathBuf,
     identity: age::x25519::Identity,
     recipients: Vec<age::x25519::Recipient>,
+    encrypt_metadata: bool,
 }
 
 impl LocalSecretBackend {
-    pub fn new(
+    /// Construct a backend, choosing whether new metadata writes are encrypted.
+    pub fn with_options(
         store_path: PathBuf,
         identity: age::x25519::Identity,
         recipients: Vec<age::x25519::Recipient>,
+        encrypt_metadata: bool,
     ) -> Self {
         Self {
             store_path,
             identity,
             recipients,
+            encrypt_metadata,
         }
+    }
+
+    /// Re-encrypt every plaintext `.meta.json` under the store as age
+    /// ciphertext, in place. Walks all vaults, including archived versions
+    /// (`.versions/`) and trash (`.trash/`). Already-encrypted metadata is
+    /// skipped, so this is idempotent and safe to re-run.
+    ///
+    /// Returns `(converted, skipped)` counts. When `dry_run` is true, nothing
+    /// is written and `converted` reflects what *would* be converted.
+    pub fn reencrypt_all_metadata(&self, dry_run: bool) -> Result<(usize, usize), BackendError> {
+        let vaults_root = paths::vaults_dir(&self.store_path);
+        let mut converted = 0usize;
+        let mut skipped = 0usize;
+        if !vaults_root.exists() {
+            return Ok((0, 0));
+        }
+
+        // Collect every *.meta.json file anywhere under vaults/.
+        let mut stack = vec![vaults_root];
+        while let Some(dir) = stack.pop() {
+            let entries = match fs::read_dir(&dir) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                let is_meta = path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .map(|n| n.ends_with(".meta.json"))
+                    .unwrap_or(false);
+                if !is_meta {
+                    continue;
+                }
+                // Skip symlinks defensively.
+                if fs::symlink_metadata(&path)
+                    .map(|m| m.is_symlink())
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+                let raw = fs::read(&path).map_err(|e| {
+                    BackendError::Internal(format!("read meta {}: {e}", path.display()))
+                })?;
+                if crypto::is_age_encrypted(&raw) {
+                    skipped += 1;
+                    continue;
+                }
+                // Validate it parses before rewriting, so we never clobber a
+                // genuinely corrupt file silently.
+                let _meta: SecretMeta = serde_json::from_slice(&raw).map_err(|e| {
+                    BackendError::Internal(format!("parse meta {}: {e}", path.display()))
+                })?;
+                converted += 1;
+                if dry_run {
+                    continue;
+                }
+                let ciphertext = crypto::encrypt_bytes(&raw, &self.recipients)?;
+                // Write via a temp file + rename for atomicity.
+                let tmp = temp_path_for(&path)?;
+                write_private(&tmp, &ciphertext).map_err(|e| {
+                    BackendError::Internal(format!("write temp meta {}: {e}", tmp.display()))
+                })?;
+                fs::rename(&tmp, &path).map_err(|e| {
+                    BackendError::Internal(format!("activate meta {}: {e}", path.display()))
+                })?;
+            }
+        }
+        Ok((converted, skipped))
     }
 
     /// Soft-delete `name` into a trash entry stamped with `deleted_at_millis`.
@@ -455,7 +568,7 @@ impl SecretBackend for LocalSecretBackend {
 
         // Snapshot old state for transactional replace+archive.
         let old_snapshot = if mp.exists() {
-            let old_meta = read_meta(&mp)?;
+            let old_meta = read_meta(&mp, &self.identity)?;
             let old_age = fs::read(&ap).map_err(|e| {
                 BackendError::Internal(format!("read existing age {}: {e}", ap.display()))
             })?;
@@ -498,7 +611,14 @@ impl SecretBackend for LocalSecretBackend {
         let mp_tmp = temp_path_for(&mp)?;
 
         crypto::encrypt_to_file(&ap_tmp, request.value.as_bytes(), &recipients)?;
-        write_meta(&mp_tmp, &meta)?;
+        write_meta(
+            &mp_tmp,
+            &meta,
+            MetaCrypto {
+                recipients: &recipients,
+                encrypt: self.encrypt_metadata,
+            },
+        )?;
 
         fs::rename(&ap_tmp, &ap)
             .map_err(|e| BackendError::Internal(format!("activate age {}: {e}", ap.display())))?;
@@ -507,7 +627,18 @@ impl SecretBackend for LocalSecretBackend {
 
         // Archive old version only after replacement is durable.
         if let Some((old_meta, old_age)) = old_snapshot {
-            archive_snapshot(&store, vault, &name, &old_meta.version, &old_age, &old_meta)?;
+            archive_snapshot(
+                &store,
+                vault,
+                &name,
+                &old_meta.version,
+                &old_age,
+                &old_meta,
+                MetaCrypto {
+                    recipients: &recipients,
+                    encrypt: self.encrypt_metadata,
+                },
+            )?;
         }
 
         Ok(meta_to_properties(&meta, None))
@@ -539,7 +670,7 @@ impl SecretBackend for LocalSecretBackend {
             )));
         }
 
-        let meta = read_meta(&mp)?;
+        let meta = read_meta(&mp, &self.identity)?;
 
         let value = if include_value {
             let ap = age_path(&self.store_path, vault, name)?;
@@ -572,7 +703,7 @@ impl SecretBackend for LocalSecretBackend {
         // First check if this is the current version.
         let mp = meta_path(&self.store_path, vault, name)?;
         if mp.exists() {
-            let meta = read_meta(&mp)?;
+            let meta = read_meta(&mp, &self.identity)?;
             if meta.version == version {
                 return self.get_secret(vault, name, include_value).await;
             }
@@ -598,7 +729,7 @@ impl SecretBackend for LocalSecretBackend {
             )));
         }
 
-        let meta = read_meta(&meta_file)?;
+        let meta = read_meta(&meta_file, &self.identity)?;
 
         let value = if include_value {
             let age_file = vdir.join(format!("{version}.age"));
@@ -641,7 +772,7 @@ impl SecretBackend for LocalSecretBackend {
                 continue;
             }
 
-            let meta = match read_meta(&entry.path()) {
+            let meta = match read_meta(&entry.path(), &self.identity) {
                 Ok(m) => m,
                 Err(e) => {
                     eprintln!(
@@ -693,7 +824,7 @@ impl SecretBackend for LocalSecretBackend {
             });
         }
 
-        let mut meta = read_meta(&mp)?;
+        let mut meta = read_meta(&mp, &self.identity)?;
         let now = Utc::now();
 
         // If value is being updated, replace active first, then archive prior snapshot.
@@ -724,6 +855,10 @@ impl SecretBackend for LocalSecretBackend {
                 &old_meta.version,
                 &old_age,
                 &old_meta,
+                MetaCrypto {
+                    recipients: &self.recipients,
+                    encrypt: self.encrypt_metadata,
+                },
             )?;
         }
 
@@ -763,7 +898,14 @@ impl SecretBackend for LocalSecretBackend {
         meta.folder = request.folder.apply(meta.folder.take());
 
         meta.updated_at = now;
-        write_meta(&mp, &meta)?;
+        write_meta(
+            &mp,
+            &meta,
+            MetaCrypto {
+                recipients: &self.recipients,
+                encrypt: self.encrypt_metadata,
+            },
+        )?;
 
         Ok(meta_to_properties(&meta, None))
     }
@@ -786,7 +928,7 @@ impl SecretBackend for LocalSecretBackend {
                 for entry in entries.flatten() {
                     let fname = entry.file_name().to_string_lossy().to_string();
                     if fname.ends_with(".meta.json") {
-                        if let Ok(meta) = read_meta(&entry.path()) {
+                        if let Ok(meta) = read_meta(&entry.path(), &self.identity) {
                             versions.push(meta_to_properties(&meta, None));
                         }
                     }
@@ -797,7 +939,7 @@ impl SecretBackend for LocalSecretBackend {
         // Add current version
         let mp = meta_path(&self.store_path, vault, name)?;
         if mp.exists() {
-            let meta = read_meta(&mp)?;
+            let meta = read_meta(&mp, &self.identity)?;
             versions.push(meta_to_properties(&meta, None));
         }
 
@@ -849,11 +991,18 @@ impl SecretBackend for LocalSecretBackend {
             .map_err(|e| BackendError::Internal(format!("restore meta: {e}")))?;
 
         // Update the version label to the next version number
-        let mut meta = read_meta(&mp)?;
+        let mut meta = read_meta(&mp, &self.identity)?;
         let next_ver = next_version(&self.store_path, vault, name)?;
         meta.version = format!("v{next_ver}");
         meta.updated_at = Utc::now();
-        write_meta(&mp, &meta)?;
+        write_meta(
+            &mp,
+            &meta,
+            MetaCrypto {
+                recipients: &self.recipients,
+                encrypt: self.encrypt_metadata,
+            },
+        )?;
 
         Ok(meta_to_properties(&meta, None))
     }
@@ -922,14 +1071,21 @@ impl SecretBackend for LocalSecretBackend {
         fs::remove_dir_all(&tdir)
             .map_err(|e| BackendError::Internal(format!("remove trash dir: {e}")))?;
 
-        let mut meta = read_meta(&mp)?;
+        let mut meta = read_meta(&mp, &self.identity)?;
         if had_active {
             // Relabel so the restored secret doesn't reuse a version label
             // already taken by the archived active secret.
             let next_ver = next_version(&self.store_path, vault, name)?;
             meta.version = format!("v{next_ver}");
             meta.updated_at = Utc::now();
-            write_meta(&mp, &meta)?;
+            write_meta(
+                &mp,
+                &meta,
+                MetaCrypto {
+                    recipients: &self.recipients,
+                    encrypt: self.encrypt_metadata,
+                },
+            )?;
         }
         Ok(meta_to_properties(&meta, None))
     }
@@ -981,7 +1137,7 @@ impl SecretBackend for LocalSecretBackend {
                 for inner in inner_entries.flatten() {
                     let fname = inner.file_name().to_string_lossy().to_string();
                     if fname.ends_with(".meta.json") {
-                        if let Ok(meta) = read_meta(&inner.path()) {
+                        if let Ok(meta) = read_meta(&inner.path(), &self.identity) {
                             results.push(meta_to_summary(&meta));
                         }
                     }
@@ -1002,7 +1158,13 @@ mod tests {
     use tempfile::TempDir;
 
     /// Create a test backend with a temp dir and return it along with the temp dir.
+    /// Metadata encryption is off (matches the default).
     fn test_backend() -> (LocalSecretBackend, TempDir) {
+        test_backend_opts(false)
+    }
+
+    /// Like [`test_backend`] but lets the caller opt into metadata encryption.
+    fn test_backend_opts(encrypt_metadata: bool) -> (LocalSecretBackend, TempDir) {
         let tmp = TempDir::new().unwrap();
         let store = tmp.path().to_path_buf();
         let key_path = tmp.path().join("key.txt");
@@ -1024,8 +1186,21 @@ mod tests {
         )
         .unwrap();
 
-        let backend = LocalSecretBackend::new(store, identity, recipients);
+        let backend =
+            LocalSecretBackend::with_options(store, identity, recipients, encrypt_metadata);
         (backend, tmp)
+    }
+
+    /// Re-open an existing store (created by [`test_backend_opts`]) reusing its
+    /// key files, optionally toggling metadata encryption. Used to simulate a
+    /// user flipping `encrypt_metadata` on and re-running against the same data.
+    fn test_backend_reopen(tmp: &TempDir, encrypt_metadata: bool) -> LocalSecretBackend {
+        let store = tmp.path().to_path_buf();
+        let key_path = tmp.path().join("key.txt");
+        let recipients_path = tmp.path().join("recipients.txt");
+        let identity = crypto::load_identity(&key_path).unwrap();
+        let recipients = crypto::load_recipients(&recipients_path).unwrap();
+        LocalSecretBackend::with_options(store, identity, recipients, encrypt_metadata)
     }
 
     fn make_request(name: &str, value: &str) -> SecretRequest {
@@ -1041,6 +1216,196 @@ mod tests {
             note: Some("test note".into()),
             folder: Some("infra".into()),
         }
+    }
+
+    /// Path to the active `.meta.json` for a secret in the default vault.
+    fn meta_file_path(tmp: &TempDir, name: &str) -> std::path::PathBuf {
+        let enc = encode_name(name);
+        tmp.path()
+            .join("vaults")
+            .join("default")
+            .join("secrets")
+            .join(format!("{enc}.meta.json"))
+    }
+
+    #[tokio::test]
+    async fn encrypted_metadata_roundtrips_and_is_age_on_disk() {
+        let (backend, tmp) = test_backend_opts(true);
+
+        let props = backend
+            .set_secret("default", make_request("api-key", "s3cr3t"))
+            .await
+            .unwrap();
+        assert_eq!(props.name, "api-key");
+        assert_eq!(
+            props.tags.get("note").map(String::as_str),
+            Some("test note")
+        );
+
+        // On disk, the meta file must be age ciphertext, not readable JSON.
+        let raw = fs::read(meta_file_path(&tmp, "api-key")).unwrap();
+        assert!(
+            crypto::is_age_encrypted(&raw),
+            "meta file should be age-encrypted"
+        );
+        assert!(
+            serde_json::from_slice::<SecretMeta>(&raw).is_err(),
+            "encrypted meta must not parse as plaintext JSON"
+        );
+        // The sensitive note must not appear in cleartext anywhere in the file.
+        assert!(
+            !raw.windows(9).any(|w| w == b"test note"),
+            "note leaked in cleartext"
+        );
+
+        // Reading it back through the backend transparently decrypts.
+        let got = backend
+            .get_secret("default", "api-key", true)
+            .await
+            .unwrap();
+        assert_eq!(
+            got.value.as_deref().map(|z| z.to_string()),
+            Some("s3cr3t".into())
+        );
+        assert_eq!(got.tags.get("note").map(String::as_str), Some("test note"));
+    }
+
+    #[tokio::test]
+    async fn plaintext_metadata_is_json_on_disk_by_default() {
+        let (backend, tmp) = test_backend_opts(false);
+
+        backend
+            .set_secret("default", make_request("api-key", "s3cr3t"))
+            .await
+            .unwrap();
+
+        let raw = fs::read(meta_file_path(&tmp, "api-key")).unwrap();
+        assert!(!crypto::is_age_encrypted(&raw));
+        // Plaintext mode must parse straight back as JSON.
+        let meta: SecretMeta = serde_json::from_slice(&raw).unwrap();
+        assert_eq!(meta.name, "api-key");
+    }
+
+    #[tokio::test]
+    async fn mixed_mode_store_reads_both_plaintext_and_encrypted() {
+        // Write one secret in plaintext mode, then reopen the SAME store with
+        // encryption on and confirm the old plaintext secret is still readable
+        // and that a newly written secret is encrypted.
+        let tmp = TempDir::new().unwrap();
+        let store = tmp.path().to_path_buf();
+        let key_path = tmp.path().join("key.txt");
+        let recipients_path = tmp.path().join("recipients.txt");
+        let (identity, recipients) = generate_keypair(&key_path, &recipients_path).unwrap();
+
+        let vault_dir = store.join("vaults").join("default");
+        fs::create_dir_all(vault_dir.join("secrets")).unwrap();
+        fs::write(
+            vault_dir.join(".vault.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "name": "default", "created_at": Utc::now().to_rfc3339(), "tags": {}
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let plain = LocalSecretBackend::with_options(
+            store.clone(),
+            identity.clone(),
+            recipients.clone(),
+            false,
+        );
+        plain
+            .set_secret("default", make_request("old-plain", "v1"))
+            .await
+            .unwrap();
+
+        let enc = LocalSecretBackend::with_options(store.clone(), identity, recipients, true);
+        enc.set_secret("default", make_request("new-enc", "v2"))
+            .await
+            .unwrap();
+
+        // Both readable through the encryption-on backend.
+        let a = enc.get_secret("default", "old-plain", true).await.unwrap();
+        let b = enc.get_secret("default", "new-enc", true).await.unwrap();
+        assert_eq!(a.value.as_deref().map(|z| z.to_string()), Some("v1".into()));
+        assert_eq!(b.value.as_deref().map(|z| z.to_string()), Some("v2".into()));
+
+        // list_secrets sees both regardless of meta encoding.
+        let listed = enc.list_secrets("default", None).await.unwrap();
+        let names: Vec<&str> = listed.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"old-plain") && names.contains(&"new-enc"));
+    }
+
+    #[tokio::test]
+    async fn reencrypt_all_metadata_migrates_plaintext_and_is_idempotent() {
+        // Seed a plaintext store with two secrets (one updated, so it has an
+        // archived version), then migrate with the same key and verify every
+        // meta file becomes age ciphertext while values still decrypt.
+        let (plain, tmp) = test_backend_opts(false);
+        plain
+            .set_secret("default", make_request("a", "1"))
+            .await
+            .unwrap();
+        plain
+            .set_secret("default", make_request("b", "2"))
+            .await
+            .unwrap();
+        // Second write to "a" archives v1 under .versions/.
+        plain
+            .set_secret("default", make_request("a", "1b"))
+            .await
+            .unwrap();
+
+        // Every meta file is plaintext right now.
+        let metas: Vec<std::path::PathBuf> = {
+            let mut v = Vec::new();
+            let mut stack = vec![tmp.path().join("vaults")];
+            while let Some(d) = stack.pop() {
+                for e in fs::read_dir(&d).unwrap().flatten() {
+                    let p = e.path();
+                    if p.is_dir() {
+                        stack.push(p);
+                    } else if p.to_string_lossy().ends_with(".meta.json") {
+                        v.push(p);
+                    }
+                }
+            }
+            v
+        };
+        assert!(metas.len() >= 3, "expected active + archived meta files");
+        for m in &metas {
+            assert!(!crypto::is_age_encrypted(&fs::read(m).unwrap()));
+        }
+
+        // Re-open with encryption enabled and run the migration.
+        let enc = test_backend_reopen(&tmp, true);
+
+        // Dry run reports work but changes nothing.
+        let (would, already0) = enc.reencrypt_all_metadata(true).unwrap();
+        assert_eq!(would, metas.len());
+        assert_eq!(already0, 0);
+        for m in &metas {
+            assert!(!crypto::is_age_encrypted(&fs::read(m).unwrap()));
+        }
+
+        // Real run converts everything.
+        let (converted, already1) = enc.reencrypt_all_metadata(false).unwrap();
+        assert_eq!(converted, metas.len());
+        assert_eq!(already1, 0);
+        for m in &metas {
+            assert!(crypto::is_age_encrypted(&fs::read(m).unwrap()));
+        }
+
+        // Idempotent: a second run converts nothing and skips all.
+        let (converted2, already2) = enc.reencrypt_all_metadata(false).unwrap();
+        assert_eq!(converted2, 0);
+        assert_eq!(already2, metas.len());
+
+        // Values and metadata still resolve correctly post-migration.
+        let a = enc.get_secret("default", "a", true).await.unwrap();
+        assert_eq!(a.value.as_deref().map(|z| z.to_string()), Some("1b".into()));
+        let listed = enc.list_secrets("default", None).await.unwrap();
+        assert_eq!(listed.len(), 2);
     }
 
     #[tokio::test]

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -396,6 +396,11 @@ impl LocalSecretBackend {
     /// (`.versions/`) and trash (`.trash/`). Already-encrypted metadata is
     /// skipped, so this is idempotent and safe to re-run.
     ///
+    /// Each vault's subtree is processed while holding that vault's `.lock`
+    /// (the same lock taken by `set_secret`/`update_secret`/etc.), so a
+    /// concurrent `xv` mutation cannot interleave a write between this
+    /// migration's read and its atomic rename.
+    ///
     /// Returns `(converted, skipped)` counts. When `dry_run` is true, nothing
     /// is written and `converted` reflects what *would* be converted.
     pub fn reencrypt_all_metadata(&self, dry_run: bool) -> Result<(usize, usize), BackendError> {
@@ -406,59 +411,77 @@ impl LocalSecretBackend {
             return Ok((0, 0));
         }
 
-        // Collect every *.meta.json file anywhere under vaults/.
-        let mut stack = vec![vaults_root];
-        while let Some(dir) = stack.pop() {
-            let entries = match fs::read_dir(&dir) {
-                Ok(e) => e,
+        // Top-level entries under vaults/ are the per-vault directories. Lock
+        // each vault for the duration of its subtree migration.
+        let vault_dirs = fs::read_dir(&vaults_root)
+            .map_err(|e| BackendError::Internal(format!("read vaults dir: {e}")))?;
+        for vault_entry in vault_dirs.flatten() {
+            let vault_dir = vault_entry.path();
+            if !vault_dir.is_dir() {
+                continue;
+            }
+            // Serialize against concurrent mutations of this vault. The lock is
+            // held until `_lock` drops at the end of this iteration. Skip
+            // vaults that were removed between read_dir and lock.
+            let _lock = match lock_vault(&vault_dir) {
+                Ok(l) => l,
                 Err(_) => continue,
             };
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir() {
-                    stack.push(path);
-                    continue;
+
+            // Walk this vault's subtree (secrets/, .versions/, .trash/).
+            let mut stack = vec![vault_dir];
+            while let Some(dir) = stack.pop() {
+                let entries = match fs::read_dir(&dir) {
+                    Ok(e) => e,
+                    Err(_) => continue,
+                };
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.is_dir() {
+                        stack.push(path);
+                        continue;
+                    }
+                    let is_meta = path
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .map(|n| n.ends_with(".meta.json"))
+                        .unwrap_or(false);
+                    if !is_meta {
+                        continue;
+                    }
+                    // Skip symlinks defensively.
+                    if fs::symlink_metadata(&path)
+                        .map(|m| m.is_symlink())
+                        .unwrap_or(false)
+                    {
+                        continue;
+                    }
+                    let raw = fs::read(&path).map_err(|e| {
+                        BackendError::Internal(format!("read meta {}: {e}", path.display()))
+                    })?;
+                    if crypto::is_age_encrypted(&raw) {
+                        skipped += 1;
+                        continue;
+                    }
+                    // Validate it parses before rewriting, so we never clobber a
+                    // genuinely corrupt file silently.
+                    let _meta: SecretMeta = serde_json::from_slice(&raw).map_err(|e| {
+                        BackendError::Internal(format!("parse meta {}: {e}", path.display()))
+                    })?;
+                    converted += 1;
+                    if dry_run {
+                        continue;
+                    }
+                    let ciphertext = crypto::encrypt_bytes(&raw, &self.recipients)?;
+                    // Write via a temp file + rename for atomicity.
+                    let tmp = temp_path_for(&path)?;
+                    write_private(&tmp, &ciphertext).map_err(|e| {
+                        BackendError::Internal(format!("write temp meta {}: {e}", tmp.display()))
+                    })?;
+                    fs::rename(&tmp, &path).map_err(|e| {
+                        BackendError::Internal(format!("activate meta {}: {e}", path.display()))
+                    })?;
                 }
-                let is_meta = path
-                    .file_name()
-                    .and_then(|s| s.to_str())
-                    .map(|n| n.ends_with(".meta.json"))
-                    .unwrap_or(false);
-                if !is_meta {
-                    continue;
-                }
-                // Skip symlinks defensively.
-                if fs::symlink_metadata(&path)
-                    .map(|m| m.is_symlink())
-                    .unwrap_or(false)
-                {
-                    continue;
-                }
-                let raw = fs::read(&path).map_err(|e| {
-                    BackendError::Internal(format!("read meta {}: {e}", path.display()))
-                })?;
-                if crypto::is_age_encrypted(&raw) {
-                    skipped += 1;
-                    continue;
-                }
-                // Validate it parses before rewriting, so we never clobber a
-                // genuinely corrupt file silently.
-                let _meta: SecretMeta = serde_json::from_slice(&raw).map_err(|e| {
-                    BackendError::Internal(format!("parse meta {}: {e}", path.display()))
-                })?;
-                converted += 1;
-                if dry_run {
-                    continue;
-                }
-                let ciphertext = crypto::encrypt_bytes(&raw, &self.recipients)?;
-                // Write via a temp file + rename for atomicity.
-                let tmp = temp_path_for(&path)?;
-                write_private(&tmp, &ciphertext).map_err(|e| {
-                    BackendError::Internal(format!("write temp meta {}: {e}", tmp.display()))
-                })?;
-                fs::rename(&tmp, &path).map_err(|e| {
-                    BackendError::Internal(format!("activate meta {}: {e}", path.display()))
-                })?;
             }
         }
         Ok((converted, skipped))

--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -239,6 +239,7 @@ mod tests {
                 store_path: Some(tmp.path().join("store").to_string_lossy().to_string()),
                 key_file: Some(tmp.path().join("key.txt").to_string_lossy().to_string()),
                 default_vault: Some("default".into()),
+                encrypt_metadata: None,
             }),
             ..Default::default()
         };

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -693,6 +693,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: CacheCommands,
     },
+    /// Local backend maintenance commands (only relevant for `backend = "local"`)
+    Local {
+        #[command(subcommand)]
+        command: LocalCommands,
+    },
     /// Quick file upload (alias for file upload)
     #[cfg(feature = "file-ops")]
     #[command(alias = "up")]
@@ -1064,6 +1069,22 @@ pub enum CacheCommands {
     Refresh {
         #[arg(long)]
         key: String,
+    },
+}
+
+/// Maintenance subcommands for the local age-encrypted backend.
+#[derive(Subcommand)]
+pub enum LocalCommands {
+    /// Re-encrypt existing plaintext secret metadata at rest.
+    ///
+    /// Requires `encrypt_metadata = true` under `[local]` in your config.
+    /// Walks every vault and rewrites any plaintext `.meta.json` (including
+    /// archived versions and trash) as age ciphertext. Already-encrypted
+    /// metadata is left untouched, so the command is safe to re-run.
+    EncryptMetadata {
+        /// Show what would be re-encrypted without modifying anything.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -1548,6 +1569,9 @@ impl Cli {
             }
             Commands::Cache { command } => {
                 crate::cli::config_ops::execute_cache_command(command, config).await
+            }
+            Commands::Local { command } => {
+                crate::cli::local_ops::execute_local_command(command, config).await
             }
             #[cfg(feature = "file-ops")]
             Commands::Upload {

--- a/src/cli/local_ops.rs
+++ b/src/cli/local_ops.rs
@@ -1,0 +1,68 @@
+//! Local backend maintenance command handlers (`xv local ...`).
+
+use crate::backend::local::LocalBackend;
+use crate::cli::commands::LocalCommands;
+use crate::config::Config;
+use crate::error::{CrosstacheError, Result};
+use crate::utils::output;
+
+pub(crate) async fn execute_local_command(command: LocalCommands, config: Config) -> Result<()> {
+    match command {
+        LocalCommands::EncryptMetadata { dry_run } => {
+            execute_encrypt_metadata(dry_run, config).await
+        }
+    }
+}
+
+async fn execute_encrypt_metadata(dry_run: bool, config: Config) -> Result<()> {
+    // This command only makes sense for the local backend.
+    if config.effective_backend_name() != "local" {
+        return Err(CrosstacheError::config(format!(
+            "`xv local encrypt-metadata` only applies to the local backend, but the active \
+             backend is '{}'. Set backend = \"local\" (or pass --backend local) to use it.",
+            config.effective_backend_name()
+        )));
+    }
+
+    let backend = LocalBackend::new(config.local.as_ref())
+        .map_err(|e| CrosstacheError::config(format!("failed to open local backend: {e}")))?;
+
+    if !backend.encrypt_metadata_enabled() {
+        output::warn(
+            "Metadata encryption is not enabled. New writes will still store metadata as \
+             plaintext.\n  Set `encrypt_metadata = true` under [local] in your config first, \
+             then re-run this command\n  so existing secrets and all future writes are \
+             encrypted consistently.",
+        );
+        return Err(CrosstacheError::config(
+            "encrypt_metadata is false under [local]; enable it before migrating".to_string(),
+        ));
+    }
+
+    if dry_run {
+        let (would_convert, already) = backend
+            .reencrypt_all_metadata(true)
+            .map_err(|e| CrosstacheError::config(format!("scan failed: {e}")))?;
+        output::info(&format!(
+            "Dry run: {would_convert} plaintext metadata file(s) would be encrypted; \
+             {already} already encrypted (left as-is)."
+        ));
+        return Ok(());
+    }
+
+    let (converted, already) = backend
+        .reencrypt_all_metadata(false)
+        .map_err(|e| CrosstacheError::config(format!("re-encryption failed: {e}")))?;
+
+    if converted == 0 {
+        output::success(&format!(
+            "Nothing to do: all {already} metadata file(s) are already encrypted."
+        ));
+    } else {
+        output::success(&format!(
+            "Encrypted {converted} metadata file(s) at rest ({already} already encrypted). \
+             Secret names remain visible as on-disk filenames."
+        ));
+    }
+    Ok(())
+}

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -639,6 +639,7 @@ mod tests {
                     .to_string(),
             ),
             default_vault: Some("default".into()),
+            encrypt_metadata: None,
         };
         let target_config = LocalConfig {
             store_path: Some(
@@ -656,6 +657,7 @@ mod tests {
                     .to_string(),
             ),
             default_vault: Some("default".into()),
+            encrypt_metadata: None,
         };
 
         // Create source backend and seed it with secrets

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,6 +12,7 @@ pub mod file_ops;
 #[cfg(all(feature = "aws", feature = "file-ops"))]
 pub(crate) mod file_ops_aws;
 pub(crate) mod helpers;
+pub(crate) mod local_ops;
 pub(crate) mod migrate_ops;
 pub(crate) mod scan_ops;
 pub(crate) mod secret_ops;

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -4240,6 +4240,7 @@ mod tests {
                 store_path: None,
                 key_file: None,
                 default_vault: Some("local-vault".to_string()),
+                encrypt_metadata: None,
             }),
             ..Default::default()
         };

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -193,6 +193,7 @@ impl ConfigInitializer {
             store_path: Some(store_path.clone()),
             key_file: Some(key_file.clone()),
             default_vault: Some(default_vault.clone()),
+            encrypt_metadata: None,
         };
 
         let progress = ProgressIndicator::new("Setting up local backend...");
@@ -251,6 +252,15 @@ impl ConfigInitializer {
         if !public_key.is_empty() {
             println!("  Public key:    {public_key}");
         }
+
+        println!();
+        output::warn(
+            "Secret values are encrypted, but metadata (notes, tags, folders) and secret \
+             NAMES are stored in plaintext on disk by default.\n  To encrypt metadata at rest, \
+             set `encrypt_metadata = true` under [local] in your config, then run \
+             `xv local encrypt-metadata`.\n  (Secret names remain visible as filenames \
+             regardless.)",
+        );
 
         Ok(config)
     }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -32,6 +32,15 @@ pub struct LocalConfig {
     /// Default vault name used when no `--vault` / context is set.
     #[serde(default)]
     pub default_vault: Option<String>,
+
+    /// Encrypt secret metadata (`.meta.json`) at rest using the same age
+    /// recipients as secret values. When `false` (the default, for backward
+    /// compatibility), metadata — note, tags, folder, expiry, content-type —
+    /// is stored as plaintext JSON. Secret *names* remain visible as on-disk
+    /// filenames regardless of this setting. After enabling, run
+    /// `xv local encrypt-metadata` to convert existing plaintext metadata.
+    #[serde(default)]
+    pub encrypt_metadata: Option<bool>,
 }
 
 /// Configuration for the AWS Secrets Manager backend.

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,7 @@ Rebuild with `cargo build --features aws` or install an AWS-enabled binary.",
             | crate::cli::Commands::Completion { .. }
             | crate::cli::Commands::Parse { .. }
             | crate::cli::Commands::Cache { .. }
+            | crate::cli::Commands::Local { .. }
             | crate::cli::Commands::Context { .. }
             | crate::cli::Commands::Env { .. }
             | crate::cli::Commands::Migrate { .. }

--- a/tests/local_backend_integration.rs
+++ b/tests/local_backend_integration.rs
@@ -24,6 +24,7 @@ fn make_backend(tmp: &TempDir) -> crosstache::backend::local::LocalBackend {
         store_path: Some(tmp.path().join("store").to_string_lossy().to_string()),
         key_file: Some(tmp.path().join("key.txt").to_string_lossy().to_string()),
         default_vault: Some("default".into()),
+        encrypt_metadata: None,
     };
     crosstache::backend::local::LocalBackend::new(Some(&cfg)).expect("create backend")
 }

--- a/tests/migration_round_trip_tests.rs
+++ b/tests/migration_round_trip_tests.rs
@@ -47,6 +47,7 @@ async fn local_to_aws_round_trip() {
         store_path: Some(tmp.path().join("store").to_string_lossy().to_string()),
         key_file: Some(tmp.path().join("key.txt").to_string_lossy().to_string()),
         default_vault: Some("test-vault".into()),
+        encrypt_metadata: None,
     };
     let local = LocalBackend::new(Some(&local_cfg)).unwrap();
 


### PR DESCRIPTION
## What

Closes the highest open severity item on `ROADMAP.md` (§P2 — Local backend metadata encryption).

The local backend already age-encrypts secret **values**, but each secret's `.meta.json` (note, tags, folder, expiry, content-type) was written as **plaintext JSON** on disk. This adds an **opt-in** `encrypt_metadata` flag under `[local]` (default `false`, fully backward-compatible) that age-encrypts metadata to the same recipients as the value.

## How

- **Auto-detection on read** via the age magic header (`age-encryption.org/`), so a store can freely mix plaintext and encrypted `.meta.json` (e.g. during migration). Filenames are unchanged, so all list/version/trash path logic is untouched — the seam is entirely in `read_meta`/`write_meta`.
- New crypto helpers: `is_age_encrypted`, `encrypt_bytes`, `decrypt_bytes` (in-memory, `Zeroizing` plaintext).
- Write params bundled into a small `MetaCrypto` struct (keeps `archive_snapshot` clippy-clean).
- **Eager migration:** `xv local encrypt-metadata [--dry-run]` walks every vault (including archived `.versions/` and `.trash/`), re-encrypts plaintext metadata in place — atomic (temp+rename), idempotent (skips already-encrypted), validates JSON before rewriting.
- `xv init` now warns that metadata and secret **names** are plaintext by default, pointing at the flag + command. README `[local]` config block documents the option.

## Tests

New unit tests (all green): encrypted-on-disk roundtrip (asserts ciphertext + note not leaked), plaintext-by-default, mixed-mode store reads both, and a migration test covering dry-run + real + idempotent re-run + archived-version coverage. Full suite passes hermetically (`XDG_CONFIG_HOME=$(mktemp -d)`); the 2 pre-existing non-hermetic vault tests pass in isolation.

## Verification

- `cargo build` ✅, `cargo clippy -- -D warnings` ✅ (default features — CI gate)
- `cargo build --features tui,aws` ✅, `cargo clippy --features tui,aws -- -D warnings` ✅
- `cargo test` hermetic: **0 failures**

## Known limitation (tracked in ROADMAP)

Secret **names** remain visible as on-disk filenames regardless of this setting. Filename opaquing (hash + encrypted index) is a larger architectural change, now scoped as its own Security-P3 item.

## Docs

CHANGELOG `Unreleased` (Added), ROADMAP (removed shipped §P2; narrowed Security-P3 to the names-via-filenames gap), README config block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk format and migration behavior for local stores holding sensitive metadata; default off preserves compatibility, but misconfiguration or partial migration could confuse operators until `encrypt-metadata` completes.
> 
> **Overview**
> Adds **opt-in local metadata encryption** via `[local] encrypt_metadata` (default `false`). When enabled, secret `.meta.json` files (notes, tags, folders, expiry, etc.) are age-encrypted like values; reads detect plaintext vs ciphertext by the age header so mixed stores work during migration.
> 
> **`xv local encrypt-metadata [--dry-run]`** migrates existing plaintext metadata across active secrets, `.versions/`, and `.trash/` (vault-locked, atomic rewrites, idempotent). **`xv init`** and README document the option and the limitation that **secret names stay visible as filenames**.
> 
> New in-memory crypto helpers (`encrypt_bytes` / `decrypt_bytes` / `is_age_encrypted`) and wiring through `LocalSecretBackend::with_options`. ROADMAP/CHANGELOG updated; shipped P2 metadata item removed, remaining gap scoped to filename opaquing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb08fb6819590a4bc2df21d139596e3ac9f3ca3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->