### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## Unreleased — UX & docs polish (post-v0.12.0)
+## v0.13.0 — Local metadata encryption + UX & docs polish (2026-06-15)
 
-Closes the entire UX P2 lane and P3-1..4 from `docs/UX-REVIEW.md`
-(2026-05-16 AWS-backend baseline). Merged to `main`; not yet tagged.
+Adds opt-in local-backend metadata encryption (ROADMAP P2) and closes the
+entire UX P2 lane and P3-1..4 from `docs/UX-REVIEW.md` (2026-05-16
+AWS-backend baseline).
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,7 +1686,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Crosstache Roadmap
 
-> **Last reviewed:** 2026-06-14 · **Latest released version:** `v0.12.0` · **Branch protection:** `main` (all changes via PR)
+> **Last reviewed:** 2026-06-15 · **Latest released version:** `v0.13.0` · **Branch protection:** `main` (all changes via PR)
 
 Single source of truth for **unimplemented** ideas, deferred work, and known
 limitations worth fixing. Anything already shipped lives in [`CHANGELOG.md`](./CHANGELOG.md).


### PR DESCRIPTION
Release prep for **v0.13.0** (minor bump).

## Why minor
The post-v0.12.0 `Unreleased` work includes a **new feature** — opt-in local-backend metadata encryption (`encrypt_metadata` config key + new `xv local encrypt-metadata` command, #260) — plus the UX/docs P2/P3 polish. New feature → minor bump per semver.

## Changes
- `Cargo.toml` / `Cargo.lock`: `0.12.0` → `0.13.0`
- `CHANGELOG.md`: promote `Unreleased` → `v0.13.0 (2026-06-15)`
- `ROADMAP.md`: latest released version → `v0.13.0`

## Release mechanics
Once merged, pushing tag `v0.13.0` triggers `.github/workflows/release.yml`: `verify-version` (Cargo.toml must equal tag — satisfied), GitHub release with autogenerated notes, and signed cross-platform `xv` binaries built with `--features tui,aws`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog/roadmap updates only; no runtime code paths change in this PR.
> 
> **Overview**
> **Release bookkeeping** for **v0.13.0**: bumps `crosstache` from `0.12.0` to `0.13.0` in `Cargo.toml` and `Cargo.lock`, and aligns project docs with the new tag.
> 
> `CHANGELOG.md` promotes the former **Unreleased** section to **v0.13.0 (2026-06-15)** — notably opt-in local metadata encryption (`encrypt_metadata`, `xv local encrypt-metadata`) plus the UX/docs P2/P3 items already described there. `ROADMAP.md` updates **last reviewed** and **latest released version** to `v0.13.0`.
> 
> No application source changes in this diff; tagging `v0.13.0` after merge should satisfy `verify-version` in the release workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55f7cc500cb8532b32b5ea91af9515793c38e206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->