### PR TITLE
fix(version): show Git Ref (tag or branch) instead of 'unknown' on release builds

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -77,8 +77,9 @@ pub fn get_build_info() -> BuildInfo {
     BuildInfo {
         version: built_info::PKG_VERSION,
         git_hash: built_info::GIT_COMMIT_HASH_SHORT.unwrap_or("unknown"),
-        git_branch: built_info::GIT_HEAD_REF
+        git_ref: built_info::GIT_HEAD_REF
             .map(|r| r.strip_prefix("refs/heads/").unwrap_or(r))
+            .or(built_info::GIT_VERSION)
             .unwrap_or("unknown"),
     }
 }
@@ -87,7 +88,7 @@ pub fn get_build_info() -> BuildInfo {
 pub struct BuildInfo {
     pub version: &'static str,
     pub git_hash: &'static str,
-    pub git_branch: &'static str,
+    pub git_ref: &'static str,
 }
 
 #[derive(Parser)]

--- a/src/cli/system_ops.rs
+++ b/src/cli/system_ops.rs
@@ -644,7 +644,7 @@ pub(crate) async fn execute_version_command() -> Result<()> {
     println!("===================");
     println!("Version:      {}", build_info.version);
     println!("Git Hash:     {}", build_info.git_hash);
-    println!("Git Branch:   {}", build_info.git_branch);
+    println!("Git Ref:      {}", build_info.git_ref);
     println!("Backends:     {}", backends.join(", "));
 
     Ok(())

--- a/tests/version_history_tests.rs
+++ b/tests/version_history_tests.rs
@@ -39,10 +39,7 @@ mod version_command_tests {
             stdout.contains("Git Hash:"),
             "Should contain Git Hash field"
         );
-        assert!(
-            stdout.contains("Git Branch:"),
-            "Should contain Git Branch field"
-        );
+        assert!(stdout.contains("Git Ref:"), "Should contain Git Ref field");
     }
 
     /// Test that version string is a valid semver


### PR DESCRIPTION
## Summary
Fixes #227. Released binaries showed `Git Branch: unknown` because the GitHub Actions release workflow checks out tags in detached-HEAD mode, so `built::GIT_HEAD_REF` (which reads `.git/HEAD`) returns `None`.

## Fix (Issue #227, Option A)
Rename the field **Git Branch → Git Ref** and source it from whichever is available:
1. `GIT_HEAD_REF` stripped of `refs/heads/` — dev branch builds → `main`
2. fallback to `GIT_VERSION` (`git describe`) — populated on detached-HEAD/tag release builds (release.yml uses `fetch-depth: 0`) → `v0.13.0`
3. final fallback `unknown`

## Result
| Build | Before | After |
|---|---|---|
| Release (tag) | `Git Branch: unknown` | `Git Ref: v0.13.0` |
| Local dev (branch) | `Git Branch: <branch>` | `Git Ref: <branch>` |

## Verification
- `cargo fmt --check` ✓
- `cargo build --release --features tui,aws` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo test --test version_history_tests` → 22 passed ✓
- `./target/release/xv version` → `Git Ref:` line populated ✓

Files: `src/cli/commands.rs`, `src/cli/system_ops.rs`, `tests/version_history_tests.rs` (+5/-7).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only build metadata and a small test label update; no secrets, auth, or runtime behavior changes.
> 
> **Overview**
> **`xv version`** no longer prints **`Git Branch: unknown`** on release binaries built from a detached tag checkout.
> 
> **Git Branch** is renamed to **Git Ref** in `get_build_info()` and the version output. The value comes from `GIT_HEAD_REF` (branch name, with `refs/heads/` stripped), then **`GIT_VERSION`** (`git describe`) when HEAD ref is missing, then **`unknown`**.
> 
> Version tests now assert the **`Git Ref:`** label instead of **`Git Branch:`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e886dcb89989b53c97bbca5b04edf4a1effc4fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->