### PR TITLE
fix(cache): close TOCTOU in lock acquisition with atomic create_new

### DIFF
--- a/src/cache/refresh.rs
+++ b/src/cache/refresh.rs
@@ -3,6 +3,7 @@
 //! Provides helpers for spawning background refresh processes and managing
 //! lock files to prevent concurrent refreshes of the same cache entry.
 
+use std::io::Write;
 use std::path::Path;
 use std::time::{Duration, SystemTime};
 use tracing::debug;
@@ -74,11 +75,17 @@ pub fn is_locked(lock_path: &Path) -> bool {
 ///
 /// Returns `true` if the lock was successfully acquired, `false` if the
 /// entry is already locked (or an error occurred creating the file).
+///
+/// Acquisition is atomic: the lock file is created with
+/// `OpenOptions::create_new(true)`, which fails if the file already exists.
+/// This closes the check-then-create (TOCTOU) window that a separate
+/// `is_locked()` test followed by `File::create()` would leave open — two
+/// racing processes can no longer both observe "no lock" and then both create
+/// it. If creation fails with `AlreadyExists`, the existing lock is examined:
+/// a fresh lock means another refresh holds it (return `false`); a stale lock
+/// is removed and acquisition is retried exactly once. The lock body records
+/// the owning PID and a creation timestamp for stale-lock diagnostics.
 pub fn acquire_lock(lock_path: &Path) -> bool {
-    if is_locked(lock_path) {
-        return false;
-    }
-
     // Create parent directories if needed.
     if let Some(parent) = lock_path.parent() {
         if let Err(e) = std::fs::create_dir_all(parent) {
@@ -87,16 +94,52 @@ pub fn acquire_lock(lock_path: &Path) -> bool {
         }
     }
 
-    match std::fs::File::create(lock_path) {
-        Ok(_) => {
-            debug!("Lock acquired: {}", lock_path.display());
-            true
-        }
-        Err(e) => {
-            debug!("acquire_lock: could not create lock file: {e}");
-            false
+    // Try once, then — only if the failure was a pre-existing *stale* lock —
+    // remove it and try a second time. Capped at one retry so a live
+    // contender can never spin.
+    for attempt in 0..2 {
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(lock_path)
+        {
+            Ok(mut file) => {
+                // Best-effort metadata for diagnosing stale locks; failure to
+                // write the body does not invalidate the (already-held) lock.
+                let now = SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                let _ = writeln!(file, "pid={} created_at={}", std::process::id(), now);
+                debug!("Lock acquired: {}", lock_path.display());
+                return true;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                // Something already holds the lock. If it's fresh, yield;
+                // if it's stale, `is_locked` removes it so the next attempt
+                // can win the create race.
+                if is_locked(lock_path) {
+                    debug!("acquire_lock: lock held and fresh: {}", lock_path.display());
+                    return false;
+                }
+                if attempt == 1 {
+                    // Removed a stale lock but still lost the re-create race to
+                    // another contender — treat as locked rather than spin.
+                    debug!(
+                        "acquire_lock: lost re-create race after clearing stale lock: {}",
+                        lock_path.display()
+                    );
+                    return false;
+                }
+                // Loop to retry the atomic create now that the stale lock is gone.
+            }
+            Err(e) => {
+                debug!("acquire_lock: could not create lock file: {e}");
+                return false;
+            }
         }
     }
+    false
 }
 
 /// Remove the lock file at `lock_path` (errors silently ignored).
@@ -145,6 +188,48 @@ mod tests {
         // Release and confirm the lock can be re-acquired.
         release_lock(&lock_path);
         assert!(acquire_lock(&lock_path));
+        release_lock(&lock_path);
+    }
+
+    #[test]
+    fn test_stale_lock_is_reclaimed() {
+        let dir = tempdir().unwrap();
+        let lock_path = dir.path().join("stale.lock");
+
+        // Create a lock file and backdate its mtime well past the staleness
+        // threshold so it looks abandoned.
+        {
+            let mut f = std::fs::File::create(&lock_path).unwrap();
+            f.write_all(b"pid=999999 created_at=0\n").unwrap();
+            let stale = SystemTime::now() - Duration::from_secs(LOCK_MAX_AGE_SECS + 30);
+            f.set_modified(stale).unwrap();
+        }
+
+        // A stale lock must be reclaimed atomically, not block acquisition.
+        assert!(
+            acquire_lock(&lock_path),
+            "stale lock should be reclaimed atomically"
+        );
+        // The new lock records our PID, not the stale 999999.
+        let body = std::fs::read_to_string(&lock_path).unwrap();
+        assert!(
+            body.contains(&format!("pid={}", std::process::id())),
+            "lock body should record acquiring PID, got: {body}"
+        );
+        release_lock(&lock_path);
+    }
+
+    #[test]
+    fn test_lock_body_records_pid() {
+        let dir = tempdir().unwrap();
+        let lock_path = dir.path().join("meta.lock");
+        assert!(acquire_lock(&lock_path));
+        let body = std::fs::read_to_string(&lock_path).unwrap();
+        assert!(body.contains("pid="), "lock body missing pid: {body}");
+        assert!(
+            body.contains("created_at="),
+            "lock body missing created_at: {body}"
+        );
         release_lock(&lock_path);
     }
 }

--- a/src/cache/refresh.rs
+++ b/src/cache/refresh.rs
@@ -13,6 +13,17 @@ use crate::cache::models::CacheKey;
 /// Age threshold for lock file staleness (60 seconds).
 const LOCK_MAX_AGE_SECS: u64 = 60;
 
+#[cfg(test)]
+static STALE_LOCK_CLEARED_HOOK: std::sync::Mutex<Option<fn(&Path)>> = std::sync::Mutex::new(None);
+
+#[cfg(test)]
+fn notify_stale_lock_cleared(lock_path: &Path) {
+    let hook = *STALE_LOCK_CLEARED_HOOK.lock().unwrap();
+    if let Some(hook) = hook {
+        hook(lock_path);
+    }
+}
+
 /// Spawn a detached `xv cache refresh --key <key>` child process.
 ///
 /// The child runs independently; any error spawning it is logged at debug
@@ -94,10 +105,12 @@ pub fn acquire_lock(lock_path: &Path) -> bool {
         }
     }
 
-    // Try once, then — only if the failure was a pre-existing *stale* lock —
-    // remove it and try a second time. Capped at one retry so a live
-    // contender can never spin.
-    for attempt in 0..2 {
+    // Try once, then retry after clearing stale locks. Capped so a sequence of
+    // abandoned locks cannot spin forever, while still allowing a create after
+    // a stale lock is cleared on the retry path.
+    const MAX_STALE_RECLAIMS: usize = 2;
+    let mut stale_reclaims = 0;
+    loop {
         match std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -122,7 +135,10 @@ pub fn acquire_lock(lock_path: &Path) -> bool {
                     debug!("acquire_lock: lock held and fresh: {}", lock_path.display());
                     return false;
                 }
-                if attempt == 1 {
+                #[cfg(test)]
+                notify_stale_lock_cleared(lock_path);
+                stale_reclaims += 1;
+                if stale_reclaims > MAX_STALE_RECLAIMS {
                     // Removed a stale lock but still lost the re-create race to
                     // another contender — treat as locked rather than spin.
                     debug!(
@@ -139,7 +155,6 @@ pub fn acquire_lock(lock_path: &Path) -> bool {
             }
         }
     }
-    false
 }
 
 /// Remove the lock file at `lock_path` (errors silently ignored).
@@ -153,7 +168,32 @@ pub fn release_lock(lock_path: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use tempfile::tempdir;
+
+    static RECREATED_STALE_LOCK: AtomicBool = AtomicBool::new(false);
+
+    struct StaleLockClearedHookGuard;
+
+    impl Drop for StaleLockClearedHookGuard {
+        fn drop(&mut self) {
+            *STALE_LOCK_CLEARED_HOOK.lock().unwrap() = None;
+        }
+    }
+
+    fn recreate_stale_lock_once(lock_path: &Path) {
+        if lock_path.file_name().and_then(|name| name.to_str()) != Some("retry-stale.lock") {
+            return;
+        }
+        if RECREATED_STALE_LOCK.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        let mut f = std::fs::File::create(lock_path).unwrap();
+        f.write_all(b"pid=888888 created_at=0\n").unwrap();
+        let stale = SystemTime::now() - Duration::from_secs(LOCK_MAX_AGE_SECS + 30);
+        f.set_modified(stale).unwrap();
+    }
 
     #[test]
     fn test_lock_acquire_and_release() {
@@ -211,6 +251,35 @@ mod tests {
             "stale lock should be reclaimed atomically"
         );
         // The new lock records our PID, not the stale 999999.
+        let body = std::fs::read_to_string(&lock_path).unwrap();
+        assert!(
+            body.contains(&format!("pid={}", std::process::id())),
+            "lock body should record acquiring PID, got: {body}"
+        );
+        release_lock(&lock_path);
+    }
+
+    #[test]
+    fn test_stale_lock_recreated_during_retry_is_reclaimed() {
+        let dir = tempdir().unwrap();
+        let lock_path = dir.path().join("retry-stale.lock");
+
+        {
+            let mut f = std::fs::File::create(&lock_path).unwrap();
+            f.write_all(b"pid=999999 created_at=0\n").unwrap();
+            let stale = SystemTime::now() - Duration::from_secs(LOCK_MAX_AGE_SECS + 30);
+            f.set_modified(stale).unwrap();
+        }
+
+        RECREATED_STALE_LOCK.store(false, Ordering::SeqCst);
+        *STALE_LOCK_CLEARED_HOOK.lock().unwrap() = Some(recreate_stale_lock_once);
+        let _hook_guard = StaleLockClearedHookGuard;
+
+        assert!(
+            acquire_lock(&lock_path),
+            "second stale lock should be reclaimed and followed by another create attempt"
+        );
+
         let body = std::fs::read_to_string(&lock_path).unwrap();
         assert!(
             body.contains(&format!("pid={}", std::process::id())),


### PR DESCRIPTION
## Summary
P3 security-hardening: closes the cache-lock TOCTOU (`src/cache/refresh.rs`).

`acquire_lock()` did `is_locked()` **then** `File::create()` — a check-then-create window where two racing processes could both see no lock and both create it (the second silently truncating the first).

## Fix
- Atomic acquisition via `OpenOptions::create_new(true)` — fails with `AlreadyExists` if a lock exists, so there is no longer a gap between check and create.
- On `AlreadyExists`: a **fresh** lock yields (`false`); a **stale** lock is removed and acquisition retried **exactly once** (capped — a live contender can never spin).
- Lock body now records `pid=<n> created_at=<epoch>` for stale-lock diagnostics.

## Tests
- `test_stale_lock_is_reclaimed` — backdated lock (std `File::set_modified`, no new deps) is atomically reclaimed; new lock records our PID.
- `test_lock_body_records_pid` — lock body carries pid + created_at.
- Existing acquire/release + double-acquire tests still pass.

## Verification
- `cargo fmt` ✓
- `cargo test --lib cache::refresh` → 4 passed ✓
- `cargo clippy --all-targets -- -D warnings` ✓

No new dependencies; no shared-file edits (CHANGELOG/ROADMAP deferred to closing docs PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency-sensitive cache refresh locking used when triggering background refreshes; behavior change is intentional hardening but races and stale-lock edge cases warrant careful review.
> 
> **Overview**
> Hardens cache refresh lock acquisition so concurrent processes cannot both win the same lock through a check-then-create race.
> 
> **`acquire_lock`** no longer calls `is_locked()` before creating the file. It uses **`OpenOptions::create_new(true)`** so only one process can create the lock. On `AlreadyExists`, a fresh lock returns `false`; a stale lock is cleared via `is_locked` and creation is retried with a **bounded** reclaim loop (losing a post-clear race returns `false` instead of spinning). Successful locks now write **`pid=`** and **`created_at=`** in the file body for debugging abandoned locks.
> 
> Tests cover stale reclaim, a hook-simulated second stale lock during retry, and lock body metadata; existing acquire/release behavior is unchanged for callers such as **`cache::manager`** stale-while-revalidate refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5a0fdf5d01e2db2cf90b44a42329ee389753c34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->