### PR TITLE
fix(scan): bound scanner memory and fail loud on unscanned files

### DIFF
--- a/src/cli/scan_ops.rs
+++ b/src/cli/scan_ops.rs
@@ -84,9 +84,27 @@ async fn execute_scan_paths(
     }
     let path_refs: Vec<&std::path::Path> = paths.iter().map(|p| p.as_path()).collect();
     let walked = walk(&path_refs, &walk_cfg)?;
-    let findings = scan_paths(&walked, &engine)?;
+    let outcome = scan_paths(&walked, &engine)?;
 
-    render_findings(&findings, hook, format)
+    // Fail loud in hook/CI mode if any file could not be scanned — an
+    // unscanned file could conceal a leak, so silence is unacceptable there.
+    if outcome.skipped_count() > 0 {
+        if hook {
+            return Err(crate::scan::orchestrator::skipped_files_error(&outcome));
+        }
+        for (p, sz) in &outcome.skipped_too_large {
+            eprintln!(
+                "xv scan: skipped {} (too large: {sz} bytes, cap {})",
+                p.display(),
+                crate::scan::orchestrator::MAX_SCAN_FILE_SIZE
+            );
+        }
+        for p in &outcome.skipped_unreadable {
+            eprintln!("xv scan: skipped {} (unreadable)", p.display());
+        }
+    }
+
+    render_findings(&outcome.findings, hook, format)
 }
 
 async fn execute_scan_staged(

--- a/src/scan/orchestrator.rs
+++ b/src/scan/orchestrator.rs
@@ -6,23 +6,93 @@
 //! `tests/scan_tests.rs`; this module only carries pure-orchestration
 //! tests that don't need a real backend.
 
-use crate::error::Result;
+use crate::error::{CrosstacheError, Result};
 use crate::scan::engine::{MatchEngine, SecretRef};
 use crate::scan::finding::Finding;
 use std::path::PathBuf;
 
+/// Maximum size (bytes) of a file the scanner will read into memory.
+///
+/// Files larger than this are skipped rather than read whole into RAM,
+/// bounding the scanner's memory use regardless of input. 10 MiB comfortably
+/// covers source, config, and env files while refusing to slurp multi-GB blobs
+/// (build artifacts, archives, media) that a naive `read_to_string` would.
+pub const MAX_SCAN_FILE_SIZE: u64 = 10 * 1024 * 1024;
+
+/// Outcome of scanning a set of paths: the findings plus any files that were
+/// skipped (too large or unreadable) so the caller can decide whether to
+/// fail loud (CI/hook mode) or merely warn (interactive mode).
+#[derive(Debug, Default)]
+pub struct ScanOutcome {
+    pub findings: Vec<Finding>,
+    /// Files skipped because they exceeded [`MAX_SCAN_FILE_SIZE`], with size.
+    pub skipped_too_large: Vec<(PathBuf, u64)>,
+    /// Files skipped because they could not be read (non-UTF8, perms, gone).
+    pub skipped_unreadable: Vec<PathBuf>,
+}
+
+impl ScanOutcome {
+    /// Total number of files that were not scanned for any reason.
+    pub fn skipped_count(&self) -> usize {
+        self.skipped_too_large.len() + self.skipped_unreadable.len()
+    }
+}
+
 /// Scan an already-walked list of paths against an already-built engine.
-/// Pure I/O at the file level; no Azure calls.
-pub fn scan_paths(paths: &[PathBuf], engine: &MatchEngine) -> Result<Vec<Finding>> {
-    let mut findings: Vec<Finding> = Vec::new();
+///
+/// Memory is bounded: each file's size is checked before reading, and files
+/// larger than [`MAX_SCAN_FILE_SIZE`] are skipped (recorded in the returned
+/// [`ScanOutcome`]) rather than read whole into RAM. Unreadable files are
+/// likewise recorded instead of silently dropped, so a caller in CI/hook mode
+/// can fail loud rather than let an unscanned file hide a leak.
+pub fn scan_paths(paths: &[PathBuf], engine: &MatchEngine) -> Result<ScanOutcome> {
+    let mut outcome = ScanOutcome::default();
     for path in paths {
+        // Stat first so an oversized file is never read into memory.
+        match std::fs::metadata(path) {
+            Ok(meta) if meta.len() > MAX_SCAN_FILE_SIZE => {
+                tracing::debug!(
+                    "skipping oversized file ({} bytes > {} cap): {}",
+                    meta.len(),
+                    MAX_SCAN_FILE_SIZE,
+                    path.display()
+                );
+                outcome.skipped_too_large.push((path.clone(), meta.len()));
+                continue;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::debug!("skipping unstattable file {}: {e}", path.display());
+                outcome.skipped_unreadable.push(path.clone());
+                continue;
+            }
+        }
+
         let Ok(content) = std::fs::read_to_string(path) else {
             tracing::debug!("skipping unreadable file: {}", path.display());
+            outcome.skipped_unreadable.push(path.clone());
             continue;
         };
-        findings.extend(engine.scan_text(path, &content));
+        outcome.findings.extend(engine.scan_text(path, &content));
     }
-    Ok(findings)
+    Ok(outcome)
+}
+
+/// Build a fail-loud error describing files that were skipped during a scan.
+/// Intended for CI/hook mode, where an unscanned file could conceal a leak.
+pub fn skipped_files_error(outcome: &ScanOutcome) -> CrosstacheError {
+    let mut parts: Vec<String> = Vec::new();
+    for (p, sz) in &outcome.skipped_too_large {
+        parts.push(format!("{} (too large: {sz} bytes)", p.display()));
+    }
+    for p in &outcome.skipped_unreadable {
+        parts.push(format!("{} (unreadable)", p.display()));
+    }
+    CrosstacheError::InvalidArgument(format!(
+        "scan could not read {} file(s); refusing to pass in hook/CI mode: {}",
+        outcome.skipped_count(),
+        parts.join(", ")
+    ))
 }
 
 /// Fetch values for every secret in `vault_names` via a bounded
@@ -104,8 +174,50 @@ mod tests {
         let patterns = builtin_patterns();
         let engine = MatchEngine::new(&secrets, &patterns);
         let paths = walk(&[temp.path()], &WalkConfig::default()).unwrap();
-        let findings = scan_paths(&paths, &engine).unwrap();
-        assert_eq!(findings.len(), 1);
-        assert_eq!(findings[0].secret_name.as_deref(), Some("DB_PW"));
+        let outcome = scan_paths(&paths, &engine).unwrap();
+        assert_eq!(outcome.findings.len(), 1);
+        assert_eq!(outcome.findings[0].secret_name.as_deref(), Some("DB_PW"));
+        assert_eq!(outcome.skipped_count(), 0);
+    }
+
+    #[test]
+    fn oversized_file_is_skipped_not_read() {
+        // A file larger than the cap must be recorded as skipped, never read
+        // into memory, and must not produce findings.
+        let temp = tempdir().unwrap();
+        let big = temp.path().join("big.bin");
+        // Write just over the cap. Content is the secret repeated so that a
+        // naive read-whole scan WOULD match — proving we skipped, not matched.
+        let secret = "hunter2-very-long-password";
+        let mut f = std::fs::File::create(&big).unwrap();
+        {
+            use std::io::Write;
+            let chunk = secret.repeat(1024); // ~26 KiB
+            let iters = (MAX_SCAN_FILE_SIZE as usize / chunk.len()) + 2;
+            for _ in 0..iters {
+                f.write_all(chunk.as_bytes()).unwrap();
+            }
+        }
+        assert!(std::fs::metadata(&big).unwrap().len() > MAX_SCAN_FILE_SIZE);
+
+        let secrets = vec![SecretRef {
+            name: "DB_PW".to_string(),
+            vault: "v".to_string(),
+            value: Zeroizing::new(secret.to_string()),
+        }];
+        let patterns = builtin_patterns();
+        let engine = MatchEngine::new(&secrets, &patterns);
+        let outcome = scan_paths(std::slice::from_ref(&big), &engine).unwrap();
+        assert!(
+            outcome.findings.is_empty(),
+            "oversized file must not be scanned"
+        );
+        assert_eq!(outcome.skipped_too_large.len(), 1);
+        assert_eq!(outcome.skipped_count(), 1);
+        let err = skipped_files_error(&outcome).to_string();
+        assert!(
+            err.contains("too large"),
+            "fail-loud error should explain why: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
P3 security-hardening: `scan_paths` (`src/scan/orchestrator.rs`) read every file with `read_to_string` — unbounded RAM — and **silently** skipped unreadable files with only a debug log, so an oversized/unreadable file could slip through a scan that should have flagged it.

## Fix
- **Bounded memory**: stat each file first; skip files over `MAX_SCAN_FILE_SIZE` (10 MiB) — an oversized file is *never* read into memory.
- **No silent skips**: return a `ScanOutcome { findings, skipped_too_large, skipped_unreadable }` instead of dropping skips.
- **Fail loud in hook/CI mode**: if any file was skipped, hook mode returns an error (an unscanned file can hide a leak); interactive mode warns per-file and continues.

## Tests
- `oversized_file_is_skipped_not_read` — a >cap file whose content *would* match is recorded as skipped, produces **no** findings, and yields a fail-loud error mentioning "too large".
- Existing inline-engine scan test updated for the new return type; asserts `skipped_count() == 0` on the happy path.

## Verification
- `cargo fmt` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo test --lib scan::orchestrator` → 2 passed ✓

No new dependencies. No shared-file edits (CHANGELOG/ROADMAP deferred to closing docs PR). Built in an isolated worktree to avoid colliding with concurrent auto-fix workers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret-scan safety behavior in CI/hooks (new failures on skipped files) and caps what gets scanned, which could block large legitimate files unless users adjust workflow.
> 
> **Overview**
> **Path scanning** no longer reads every file unbounded into RAM or drops skip failures quietly. `scan_paths` now stats each file first, skips anything over **`MAX_SCAN_FILE_SIZE` (10 MiB)** without reading it, and returns a **`ScanOutcome`** with findings plus lists of oversized and unreadable paths instead of only a finding vector.
> 
> **`xv scan` (non-staged)** uses that outcome: **hook/CI mode** errors via `skipped_files_error` when any file was not scanned; **interactive mode** prints per-file warnings and still renders findings. A unit test asserts oversized secret-bearing files are skipped and produce no matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aec79fc9552052a95c6ab60330749f93a99ade4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->