### PR TITLE
fix(config): write context files via the private 0600 writer

### DIFF
--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -184,13 +184,18 @@ impl ContextManager {
     /// Save current context
     pub async fn save(&self) -> Result<()> {
         if let Some(ref path) = self.context_file {
-            // Ensure parent directory exists
+            // Ensure parent directory exists with private (0700) permissions —
+            // context files hold the user's active vault/subscription state and
+            // are treated as user-private config.
             if let Some(parent) = path.parent() {
-                tokio::fs::create_dir_all(parent).await?;
+                crate::utils::helpers::create_private_dir(parent)?;
             }
 
             let content = serde_json::to_string_pretty(self)?;
-            tokio::fs::write(path, content).await?;
+            // Route through the sensitive-file writer: atomic 0600 create with
+            // O_NOFOLLOW, so the context file is never group/world-readable and
+            // a symlinked path cannot redirect the write.
+            crate::utils::helpers::write_sensitive_file_async(path, content.as_bytes()).await?;
 
             debug!("Saved context to: {}", path.display());
         }
@@ -337,7 +342,9 @@ impl ContextManager {
     #[allow(dead_code)]
     pub async fn init_local_context() -> Result<PathBuf> {
         let context_dir = std::env::current_dir()?.join(".xv");
-        tokio::fs::create_dir_all(&context_dir).await?;
+        // 0700 dir — the local context lives under the project's .xv/ but holds
+        // the user's active vault state, treated as user-private.
+        crate::utils::helpers::create_private_dir(&context_dir)?;
 
         let context_path = context_dir.join("context");
 
@@ -345,7 +352,9 @@ impl ContextManager {
         if !context_path.exists() {
             let empty_context = ContextManager::default();
             let content = serde_json::to_string_pretty(&empty_context)?;
-            tokio::fs::write(&context_path, content).await?;
+            // 0600, O_NOFOLLOW, atomic — never group/world-readable.
+            crate::utils::helpers::write_sensitive_file_async(&context_path, content.as_bytes())
+                .await?;
         }
 
         Ok(context_path)
@@ -519,5 +528,42 @@ mod tests {
         );
         manager.set_context(context2).await.unwrap();
         assert_eq!(manager.current_storage_container(), Some("my-container"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_saved_context_file_is_private_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let temp_dir = TempDir::new().unwrap();
+        // Nest under a subdir so the private-dir creation path is exercised too.
+        let context_path = temp_dir.path().join("nested").join("context");
+
+        let manager = ContextManager {
+            context_file: Some(context_path.clone()),
+            ..Default::default()
+        };
+        manager.save().await.unwrap();
+
+        let mode = std::fs::metadata(&context_path)
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "context file must be owner-only (0600), got {:03o}",
+            mode & 0o777
+        );
+        // Parent directory must be 0700.
+        let dir_mode = std::fs::metadata(context_path.parent().unwrap())
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(
+            dir_mode & 0o777,
+            0o700,
+            "context dir must be owner-only (0700), got {:03o}",
+            dir_mode & 0o777
+        );
     }
 }

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -31,6 +31,17 @@ pub fn write_private(
     }
     #[cfg(not(unix))]
     {
+        // If the file already exists it may be read-only from a previous
+        // sensitive write; clear the read-only attribute first so the
+        // overwrite does not fail with a permission error (e.g. a second
+        // context `save` after `set_context` on Windows).
+        if let Ok(meta) = std::fs::metadata(path.as_ref()) {
+            let mut perms = meta.permissions();
+            if perms.readonly() {
+                perms.set_readonly(false);
+                std::fs::set_permissions(path.as_ref(), perms)?;
+            }
+        }
         std::fs::write(path.as_ref(), bytes.as_ref())?;
         let mut perms = std::fs::metadata(path.as_ref())?.permissions();
         perms.set_readonly(true);


### PR DESCRIPTION
## Summary
P3 security-hardening: `ContextManager::save` and `init_local_context` (`src/config/context.rs`) wrote context files with `tokio::fs::write` — umask-default perms (typically **0644, group/world-readable**) and symlink-following. Context files hold the user's active vault + subscription state and are user-private config.

## Fix
- Route both write sites through `utils::helpers::write_sensitive_file_async` — atomic **0600** create with **O_NOFOLLOW** (no group/world read, no symlink redirect).
- Create parent dirs via `create_private_dir` (**0700**).

Note: these are *user-private* context files (`~/.config/xv/context`, `.xv/context`), so 0600 is correct here — unlike project-shared `.xv.toml`, which intentionally stays umask-default (PR #211).

## Tests
- `test_saved_context_file_is_private_0600` (unix) — saving through a nested path yields a **0600** file in a **0700** dir.
- Existing 7 context tests still pass.

## Verification
- `cargo fmt` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo test --lib config::context` → 8 passed ✓

No new deps. No shared-file edits (CHANGELOG/ROADMAP deferred to closing docs PR). Built in an isolated worktree.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted filesystem permission and symlink hardening for private context paths, with a small Windows overwrite fix; no auth or shared-config behavior changes.
> 
> **Overview**
> **Security hardening** for user-private vault context files (`~/.config/xv/context`, `.xv/context`), which store active vault and subscription state.
> 
> `ContextManager::save` and `init_local_context` no longer use default `tokio::fs` writes (umask **0644** and symlink-following). They now create parent dirs with **`create_private_dir` (0700)** and persist via **`write_sensitive_file_async`** (**0600**, **O_NOFOLLOW**, atomic).
> 
> On **Windows**, `write_private` clears the read-only flag before overwriting an existing sensitive file so repeated saves (e.g. after `set_context`) do not fail.
> 
> Adds a **unix** test that a nested save produces a **0600** file under a **0700** directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8d19b503b35a79fef56c1c7c74b6c0005c0de07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->