### PR TITLE
feat(config): add 'xv config edit' to open config in $EDITOR

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -181,6 +181,7 @@ See [migration.md](migration.md) for the full guide.
 | `xv config show` | Show current config |
 | `xv config set <key> <value>` | Set a config value |
 | `xv config path` | Show config file location |
+| `xv config edit` | Open the config file in `$VISUAL`/`$EDITOR` (or a platform default) |
 
 ### Hierarchy
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1054,6 +1054,14 @@ pub enum ConfigCommands {
     },
     /// Show configuration file path
     Path,
+    /// Open the configuration file in your default editor
+    ///
+    /// Picks the editor from `$VISUAL`, then `$EDITOR`. When neither is
+    /// set, falls back to a sensible platform default (`nano` on
+    /// Linux/macOS, `notepad` on Windows). The config file (and its parent
+    /// directory) is created if it does not yet exist so the editor always
+    /// opens on a real path.
+    Edit,
 }
 
 #[derive(Subcommand)]

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -27,6 +27,9 @@ pub(crate) async fn execute_config_command(command: ConfigCommands, config: Conf
         ConfigCommands::Path => {
             execute_config_path().await?;
         }
+        ConfigCommands::Edit => {
+            execute_config_edit(&config).await?;
+        }
     }
     Ok(())
 }
@@ -176,6 +179,95 @@ async fn execute_config_path() -> Result<()> {
     let config_path = Config::get_config_path()?;
     println!("{}", config_path.display());
     Ok(())
+}
+
+/// `xv config edit` — open the config file in the user's editor.
+///
+/// Editor resolution, highest priority first:
+///   1. `$VISUAL`
+///   2. `$EDITOR`
+///   3. platform default (`nano` on Unix, `notepad` on Windows)
+///
+/// When the config file does not yet exist it is seeded with a valid,
+/// serialized default configuration (NOT an empty file — an empty file
+/// fails to parse on the next load with "missing field `debug`"). The
+/// parent directory is created as needed so the editor always opens on a
+/// real, writable path. `$VISUAL`/`$EDITOR` may contain arguments (e.g.
+/// `code --wait`), so the value is split on whitespace: the first token is
+/// the program and the rest are passed as leading arguments.
+async fn execute_config_edit(config: &Config) -> Result<()> {
+    use std::process::Command;
+
+    let config_path = Config::get_config_path()?;
+
+    // Seed a missing config file with a VALID default so the editor opens on
+    // a real path and the next `xv` invocation can still parse it. We never
+    // clobber an existing file. `save_config` handles parent-dir creation
+    // and the 0600 sensitive-file write.
+    if !config_path.exists() {
+        crate::config::settings::save_config(config)
+            .await
+            .map_err(|e| {
+                CrosstacheError::config(format!(
+                    "Failed to create config file {}: {e}",
+                    config_path.display()
+                ))
+            })?;
+    }
+
+    let editor = resolve_editor();
+    // Split so `$EDITOR` values like `code --wait` or `emacs -nw` work.
+    let mut parts = editor.split_whitespace();
+    let program = parts
+        .next()
+        .ok_or_else(|| CrosstacheError::config("Resolved editor command was empty".to_string()))?;
+
+    let status = Command::new(program)
+        .args(parts)
+        .arg(&config_path)
+        .status()
+        .map_err(|e| {
+            CrosstacheError::config(format!(
+                "Failed to launch editor '{program}': {e}. \
+                 Set $EDITOR or $VISUAL to a valid editor command."
+            ))
+        })?;
+
+    if !status.success() {
+        return Err(CrosstacheError::config(format!(
+            "Editor '{program}' exited with a non-zero status: {status}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Resolve the editor command from `$VISUAL`, then `$EDITOR`, then a
+/// platform default. Empty/whitespace-only env values are ignored.
+fn resolve_editor() -> String {
+    resolve_editor_from(std::env::var("VISUAL").ok(), std::env::var("EDITOR").ok())
+}
+
+/// Pure resolution logic for [`resolve_editor`], split out so it can be
+/// unit-tested without mutating process-global environment variables.
+///
+/// Precedence: `visual` (`$VISUAL`) > `editor` (`$EDITOR`) > platform
+/// default. Empty or whitespace-only values are treated as unset.
+fn resolve_editor_from(visual: Option<String>, editor: Option<String>) -> String {
+    for candidate in [visual, editor].into_iter().flatten() {
+        if !candidate.trim().is_empty() {
+            return candidate;
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        "notepad".to_string()
+    }
+    #[cfg(not(windows))]
+    {
+        "nano".to_string()
+    }
 }
 
 /// `xv config show --resolved` — prints the effective active backend,
@@ -1774,4 +1866,53 @@ async fn execute_env_push(file: Option<String>, overwrite: bool, config: &Config
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_editor_from;
+
+    #[cfg(not(windows))]
+    const DEFAULT_EDITOR: &str = "nano";
+    #[cfg(windows)]
+    const DEFAULT_EDITOR: &str = "notepad";
+
+    #[test]
+    fn visual_takes_precedence_over_editor() {
+        let got = resolve_editor_from(Some("vim".into()), Some("emacs".into()));
+        assert_eq!(got, "vim");
+    }
+
+    #[test]
+    fn falls_back_to_editor_when_visual_unset() {
+        let got = resolve_editor_from(None, Some("emacs".into()));
+        assert_eq!(got, "emacs");
+    }
+
+    #[test]
+    fn empty_or_whitespace_values_are_ignored() {
+        // Empty VISUAL and whitespace-only EDITOR -> platform default.
+        let got = resolve_editor_from(Some(String::new()), Some("   ".into()));
+        assert_eq!(got, DEFAULT_EDITOR);
+    }
+
+    #[test]
+    fn empty_visual_falls_through_to_editor() {
+        let got = resolve_editor_from(Some("  ".into()), Some("micro".into()));
+        assert_eq!(got, "micro");
+    }
+
+    #[test]
+    fn platform_default_when_both_unset() {
+        let got = resolve_editor_from(None, None);
+        assert_eq!(got, DEFAULT_EDITOR);
+    }
+
+    #[test]
+    fn editor_with_arguments_is_preserved_verbatim() {
+        // The command-with-args string is returned intact; argument splitting
+        // happens at the call site in execute_config_edit.
+        let got = resolve_editor_from(Some("code --wait".into()), None);
+        assert_eq!(got, "code --wait");
+    }
 }


### PR DESCRIPTION
## Summary

Adds a new `xv config edit` subcommand that opens the xv config file (`$XDG_CONFIG_HOME/xv/xv.conf`) in the user's editor.

## Behavior

- **Editor resolution** (highest priority first): `$VISUAL` -> `$EDITOR` -> platform default (`nano` on Unix, `notepad` on Windows). Empty/whitespace-only env values are ignored.
- **Editor args supported**: the editor string is whitespace-split, so `EDITOR='code --wait'` or `emacs -nw` work -- first token is the program, the rest are leading args before the config path.
- **Missing config is seeded with a valid default**, not an empty file. An empty file would fail the *next* config load with ``missing field `debug` ``; we serialize the in-memory default config instead (via `save_config`, which also handles 0600 perms + parent-dir creation).
- **Never clobbers an existing config.**
- A non-zero editor exit (or a failed spawn) surfaces an actionable error pointing at `$EDITOR`/`$VISUAL`.

## Tests

Six unit tests cover the resolution precedence. The pure logic is split into `resolve_editor_from(visual, editor)` so tests don't mutate process-global env vars (avoids flakiness/races under parallel test execution).

Manually verified end-to-end with a fake editor: seeding+open, VISUAL precedence, default fallback, bad-editor error (exit 3), and no-clobber of an existing file.

`cargo fmt --check`, `cargo clippy`, and `cargo test` all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local CLI workflow only: spawns the user’s editor and may create the config file; no changes to auth, secrets, or backend behavior.
> 
> **Overview**
> Adds **`xv config edit`**, which opens the user config file (`xv.conf`) in an external editor instead of requiring manual path lookup or `config set` for bulk edits.
> 
> Editor choice follows **`$VISUAL` → `$EDITOR` → platform default** (`nano` / `notepad`). Values with extra args (e.g. `code --wait`) are whitespace-split so the program and flags are passed correctly before the config path.
> 
> If the config file is missing, the command **writes a parseable default** via `save_config` (parent dir + `0600`) and **does not overwrite** an existing file. Failed spawn or non-zero editor exit returns a clear config error. **`resolve_editor_from`** is unit-tested for precedence and empty env handling; **FEATURES.md** documents the new command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a333fe7af9c3b2b9976601b431714be0b3736803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->