### PR TITLE
feat(gen/set): share write-time metadata flags so `gen --save` is a full `set` replacement

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -23,7 +23,8 @@
 
 | Command | Description |
 |---------|-------------|
-| `xv set <name>` | Create a secret (interactive prompt, `--stdin`, or bulk `K1=v1 K2=v2`) |
+| `xv set <name>` | Create a secret (interactive prompt, `--stdin`, or bulk `K1=v1 K2=v2`); write-time metadata via `--group` (repeatable), `--note`, `--folder`, `--expires`, `--not-before` |
+| `xv gen` | Generate a random password to the clipboard (`--length`, `--charset`, `--raw`); `--save <name>` stores it as a secret with the same write-time metadata flags as `set` (`--group`, `--note`, `--folder`, `--expires`, `--not-before`, `--vault`) |
 | `xv get <name>` | Retrieve a secret (clipboard by default; `--raw` for stdout) |
 | `xv list` | List secrets (`--group`, `--all`, `--expiring <period>`, `--expired`, `--page-size`, `--page`) |
 | `xv delete <name>` | Soft-delete a secret (`--force` to skip confirmation) |

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -268,6 +268,88 @@ impl std::str::FromStr for CharsetType {
     }
 }
 
+/// Write-time metadata flags shared by the secret-creating commands
+/// (`set` and `gen --save`).
+///
+/// Flattened into both commands with `#[command(flatten)]` so they expose an
+/// identical metadata surface and can never drift apart. Both build a single
+/// [`crate::secret::manager::SecretRequest`] from these fields through the same
+/// backend trait path.
+#[derive(Debug, Clone, Default, clap::Args)]
+pub struct SecretWriteArgs {
+    /// Group to assign the secret to (repeatable; e.g. `-g db -g prod`)
+    #[arg(short, long)]
+    pub group: Vec<String>,
+    /// Note to attach to the secret
+    #[arg(long)]
+    pub note: Option<String>,
+    /// Folder path for the secret (e.g., 'app/database', 'config/dev')
+    #[arg(long)]
+    pub folder: Option<String>,
+    /// Set expiration date (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
+    #[arg(long)]
+    pub expires: Option<String>,
+    /// Set not-before date (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
+    #[arg(long)]
+    pub not_before: Option<String>,
+}
+
+impl SecretWriteArgs {
+    /// True when the user supplied at least one metadata flag. Used by `gen`
+    /// to reject metadata passed without `--save` (nothing to attach it to).
+    pub fn has_any(&self) -> bool {
+        !self.group.is_empty()
+            || self.note.is_some()
+            || self.folder.is_some()
+            || self.expires.is_some()
+            || self.not_before.is_some()
+    }
+
+    /// The groups as an `Option<Vec<String>>` matching `SecretRequest.groups`
+    /// (None when no `--group` was given, so existing groups are untouched).
+    pub fn groups_opt(&self) -> Option<Vec<String>> {
+        if self.group.is_empty() {
+            None
+        } else {
+            Some(self.group.clone())
+        }
+    }
+
+    /// Build a [`crate::secret::manager::SecretRequest`] for a single secret
+    /// from these write-time flags, parsing the `--expires` / `--not-before`
+    /// date strings. Shared by `set` (single-secret path) and `gen --save`
+    /// so both produce byte-identical requests from the same flags.
+    pub fn to_secret_request(
+        &self,
+        name: &str,
+        value: zeroize::Zeroizing<String>,
+    ) -> Result<crate::secret::manager::SecretRequest> {
+        use crate::utils::datetime::parse_datetime_or_duration;
+
+        let expires_on = match self.expires.as_deref() {
+            Some(s) => Some(parse_datetime_or_duration(s)?),
+            None => None,
+        };
+        let not_before_on = match self.not_before.as_deref() {
+            Some(s) => Some(parse_datetime_or_duration(s)?),
+            None => None,
+        };
+
+        Ok(crate::secret::manager::SecretRequest {
+            name: name.to_string(),
+            value,
+            content_type: None,
+            enabled: Some(true),
+            expires_on,
+            not_before: not_before_on,
+            tags: None,
+            groups: self.groups_opt(),
+            note: self.note.clone(),
+            folder: self.folder.clone(),
+        })
+    }
+}
+
 #[derive(Subcommand)]
 pub enum Commands {
     /// Set a secret in the current vault context
@@ -283,18 +365,9 @@ pub enum Commands {
         /// Trim leading/trailing whitespace from the value read via --stdin
         #[arg(long, requires = "stdin")]
         trim: bool,
-        /// Note to attach to the secret(s)
-        #[arg(long)]
-        note: Option<String>,
-        /// Folder path for the secret(s) (e.g., 'app/database', 'config/dev')
-        #[arg(long)]
-        folder: Option<String>,
-        /// Set expiration date (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
-        #[arg(long)]
-        expires: Option<String>,
-        /// Set not-before date (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
-        #[arg(long)]
-        not_before: Option<String>,
+        /// Write-time metadata (group/note/folder/expires/not-before)
+        #[command(flatten)]
+        meta: SecretWriteArgs,
     },
     /// Get a secret from the current vault context
     Get {
@@ -450,6 +523,9 @@ pub enum Commands {
         /// Print to stdout instead of copying to clipboard
         #[arg(long)]
         raw: bool,
+        /// Write-time metadata for --save (group/note/folder/expires/not-before)
+        #[command(flatten)]
+        meta: SecretWriteArgs,
     },
     /// Run a command with secrets injected as environment variables
     Run {
@@ -1283,13 +1359,10 @@ impl Cli {
                 args,
                 stdin,
                 trim,
-                note,
-                folder,
-                expires,
-                not_before,
+                meta,
             } => {
                 crate::cli::secret_ops::execute_secret_set_direct(
-                    args, stdin, trim, note, folder, expires, not_before, config, registry,
+                    args, stdin, trim, meta, config, registry,
                 )
                 .await
             }
@@ -1377,9 +1450,10 @@ impl Cli {
                 save,
                 vault,
                 raw,
+                meta,
             } => {
                 crate::cli::system_ops::execute_gen_command(
-                    length, charset, save, vault, raw, config, registry,
+                    length, charset, save, vault, raw, meta, config, registry,
                 )
                 .await
             }
@@ -2075,5 +2149,114 @@ mod tests {
                 "Unexpected char '{ch}' in base64 output"
             );
         }
+    }
+
+    // ── shared SecretWriteArgs (set / gen --save parity) ─────────────────────
+
+    #[test]
+    fn test_gen_accepts_group_and_metadata_flags() {
+        // gen --save must now accept the same metadata surface as set.
+        let cli = Cli::try_parse_from([
+            "xv",
+            "gen",
+            "--save",
+            "db-pass",
+            "-g",
+            "db",
+            "-g",
+            "prod",
+            "--note",
+            "n",
+            "--folder",
+            "app/db",
+            "--expires",
+            "2030-01-01",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Gen { save, meta, .. } => {
+                assert_eq!(save.as_deref(), Some("db-pass"));
+                assert_eq!(meta.group, vec!["db".to_string(), "prod".to_string()]);
+                assert_eq!(meta.note.as_deref(), Some("n"));
+                assert_eq!(meta.folder.as_deref(), Some("app/db"));
+                assert_eq!(meta.expires.as_deref(), Some("2030-01-01"));
+                assert!(meta.has_any());
+            }
+            _ => panic!("Expected Gen command"),
+        }
+    }
+
+    #[test]
+    fn test_set_accepts_group_flag() {
+        // set gained --group as the symmetric bonus of the shared struct.
+        let cli =
+            Cli::try_parse_from(["xv", "set", "api-key", "-g", "web", "--folder", "svc"]).unwrap();
+        match cli.command {
+            Commands::Set { args, meta, .. } => {
+                assert_eq!(args, vec!["api-key".to_string()]);
+                assert_eq!(meta.group, vec!["web".to_string()]);
+                assert_eq!(meta.folder.as_deref(), Some("svc"));
+            }
+            _ => panic!("Expected Set command"),
+        }
+    }
+
+    #[test]
+    fn test_secret_write_args_has_any() {
+        assert!(!SecretWriteArgs::default().has_any());
+
+        let with_group = SecretWriteArgs {
+            group: vec!["x".into()],
+            ..Default::default()
+        };
+        assert!(with_group.has_any());
+
+        let with_note = SecretWriteArgs {
+            note: Some("hi".into()),
+            ..Default::default()
+        };
+        assert!(with_note.has_any());
+    }
+
+    #[test]
+    fn test_secret_write_args_groups_opt() {
+        assert_eq!(SecretWriteArgs::default().groups_opt(), None);
+        let a = SecretWriteArgs {
+            group: vec!["a".into(), "b".into()],
+            ..Default::default()
+        };
+        assert_eq!(a.groups_opt(), Some(vec!["a".into(), "b".into()]));
+    }
+
+    #[test]
+    fn test_to_secret_request_populates_metadata() {
+        let meta = SecretWriteArgs {
+            group: vec!["db".into()],
+            note: Some("note".into()),
+            folder: Some("f".into()),
+            expires: None,
+            not_before: None,
+        };
+        let req = meta
+            .to_secret_request("name", zeroize::Zeroizing::new("val".to_string()))
+            .unwrap();
+        assert_eq!(req.name, "name");
+        assert_eq!(req.value.as_str(), "val");
+        assert_eq!(req.groups, Some(vec!["db".to_string()]));
+        assert_eq!(req.note.as_deref(), Some("note"));
+        assert_eq!(req.folder.as_deref(), Some("f"));
+        assert!(req.expires_on.is_none());
+        assert!(req.not_before.is_none());
+        assert_eq!(req.enabled, Some(true));
+    }
+
+    #[test]
+    fn test_to_secret_request_rejects_bad_date() {
+        let meta = SecretWriteArgs {
+            expires: Some("not-a-date".into()),
+            ..Default::default()
+        };
+        let res = meta.to_secret_request("n", zeroize::Zeroizing::new("v".to_string()));
+        assert!(res.is_err(), "invalid --expires should be rejected");
     }
 }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -1,7 +1,7 @@
 //! Secret command execution handlers.
 
 use crate::backend::{BackendKind, BackendRef, BackendRegistry};
-use crate::cli::commands::{CharsetType, ShareCommands};
+use crate::cli::commands::{CharsetType, SecretWriteArgs, ShareCommands};
 use crate::cli::helpers::{
     copy_to_clipboard, generate_random_value, get_azure_auth_provider, mask_secrets,
     resolve_vault_for_trait, schedule_clipboard_clear, share_unsupported_error, use_trait_path,
@@ -37,31 +37,23 @@ pub(crate) async fn execute_secret_set_direct(
     args: Vec<String>,
     stdin: bool,
     trim: bool,
-    note: Option<String>,
-    folder: Option<String>,
-    expires: Option<String>,
-    not_before: Option<String>,
+    meta: SecretWriteArgs,
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
+    let SecretWriteArgs {
+        note,
+        folder,
+        expires,
+        not_before,
+        ..
+    } = meta.clone();
+    let groups = meta.groups_opt();
+
     // ── Trait-based path (non-Azure backends) ──────────────────────────
     if use_trait_path(registry) {
         let reg = registry.expect("use_trait_path guarantees Some");
         let vault_name = resolve_vault_for_trait(&config, registry).await?;
-
-        // Parse expiry dates if provided
-        let expires_on = if let Some(expires_str) = expires.as_deref() {
-            use crate::utils::datetime::parse_datetime_or_duration;
-            Some(parse_datetime_or_duration(expires_str)?)
-        } else {
-            None
-        };
-        let not_before_on = if let Some(not_before_str) = not_before.as_deref() {
-            use crate::utils::datetime::parse_datetime_or_duration;
-            Some(parse_datetime_or_duration(not_before_str)?)
-        } else {
-            None
-        };
 
         if args.len() == 1 && !args[0].contains('=') {
             // Single secret set
@@ -74,18 +66,9 @@ pub(crate) async fn execute_secret_set_direct(
             if value.is_empty() {
                 return Err(CrosstacheError::config("Secret value cannot be empty"));
             }
-            let request = crate::secret::manager::SecretRequest {
-                name: name.to_string(),
-                value: Zeroizing::new(value),
-                content_type: None,
-                enabled: Some(true),
-                expires_on,
-                not_before: not_before_on,
-                tags: None,
-                groups: None,
-                note,
-                folder,
-            };
+            // Build the request via the shared helper so `set` and `gen --save`
+            // construct identical requests from the same metadata flags.
+            let request = meta.to_secret_request(name, Zeroizing::new(value))?;
             let props = reg
                 .active()
                 .secrets()
@@ -127,7 +110,7 @@ pub(crate) async fn execute_secret_set_direct(
                     expires_on: None,
                     not_before: None,
                     tags: None,
-                    groups: None,
+                    groups: groups.clone(),
                     note: note.clone(),
                     folder: folder.clone(),
                 };
@@ -237,7 +220,7 @@ fn trait_secret_cache_key(vault_name: &str) -> crate::cache::CacheKey {
     }
 }
 
-fn invalidate_trait_secret_cache(config: &Config, vault_name: &str) {
+pub(crate) fn invalidate_trait_secret_cache(config: &Config, vault_name: &str) {
     let cache_manager = crate::cache::CacheManager::from_config(config);
     cache_manager.invalidate(&trait_secret_cache_key(vault_name));
 }

--- a/src/cli/system_ops.rs
+++ b/src/cli/system_ops.rs
@@ -880,12 +880,14 @@ async fn get_current_subscription_details(token: &str) -> Result<(String, String
     Err(CrosstacheError::azure_api("No subscriptions found"))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_gen_command(
     length: usize,
     charset: Option<CharsetType>,
     save: Option<String>,
     vault: Option<String>,
     raw: bool,
+    meta: crate::cli::commands::SecretWriteArgs,
     config: Config,
     registry: Option<&crate::backend::BackendRegistry>,
 ) -> Result<()> {
@@ -893,6 +895,16 @@ pub(crate) async fn execute_gen_command(
     if !(6..=100).contains(&length) {
         return Err(CrosstacheError::invalid_argument(
             "Length must be between 6 and 100",
+        ));
+    }
+
+    // Metadata flags only make sense when saving — there is nothing to attach
+    // them to otherwise. Reject early with a clear message instead of silently
+    // ignoring them.
+    if save.is_none() && meta.has_any() {
+        return Err(CrosstacheError::invalid_argument(
+            "--group/--note/--folder/--expires/--not-before require --save (there is no \
+             secret to attach metadata to without it)",
         ));
     }
 
@@ -914,25 +926,17 @@ pub(crate) async fn execute_gen_command(
 
     // Handle --save
     if let Some(ref name) = save {
-        use crate::secret::manager::SecretManager;
-
-        let auth_provider = crate::cli::helpers::get_azure_auth_provider(registry, &config)?;
-        let secret_manager = SecretManager::new(auth_provider, config.no_color);
-        let vault_name = config.resolve_vault_name(vault).await?;
-
-        // Print raw password first so it appears before set_secret_safe's info messages
+        // Print raw password first so it appears before any info messages
         if raw {
             println!("{}", password.as_str());
         }
 
-        match secret_manager
-            .set_secret_safe(&vault_name, name, password.as_str(), None)
-            .await
-        {
-            Ok(_) => {
-                if raw {
-                    // Password already printed above
-                } else {
+        let save_result =
+            save_generated_secret(name, password.as_str(), vault, &meta, &config, registry).await;
+
+        match save_result {
+            Ok(()) => {
+                if !raw {
                     match copy_to_clipboard(password.as_str()) {
                         Ok(()) => {
                             let timeout = config.clipboard_timeout;
@@ -956,8 +960,10 @@ pub(crate) async fn execute_gen_command(
             }
             Err(e) => {
                 output::warn(&format!("Failed to save secret '{name}': {e}"));
-                output::warn("Generated password (save this now):");
-                println!("{}", password.as_str());
+                if !raw {
+                    output::warn("Generated password (save this now):");
+                    println!("{}", password.as_str());
+                }
             }
         }
         return Ok(());
@@ -987,5 +993,55 @@ pub(crate) async fn execute_gen_command(
         }
     }
 
+    Ok(())
+}
+
+/// Persist a generated secret with full write-time metadata, routing through
+/// the same code paths `xv set` uses:
+///   - trait backend (local/aws and Azure-via-registry) → `set_secret`
+///   - legacy Azure fallback (no registry) → `set_secret_safe` with options
+///
+/// This is what makes `gen --save` a true superset of `set`: groups, note,
+/// folder, expires, and not-before are all carried through, instead of the
+/// old behavior that dropped every piece of metadata.
+async fn save_generated_secret(
+    name: &str,
+    value: &str,
+    vault: Option<String>,
+    meta: &crate::cli::commands::SecretWriteArgs,
+    config: &Config,
+    registry: Option<&crate::backend::BackendRegistry>,
+) -> Result<()> {
+    use crate::cli::helpers::{resolve_vault_for_trait, use_trait_path};
+
+    let request = meta.to_secret_request(name, zeroize::Zeroizing::new(value.to_string()))?;
+
+    // Trait path: any backend exposed through the registry (local, aws, and
+    // Azure once it has a registry). A --vault flag overrides the resolved
+    // context/config vault.
+    if use_trait_path(registry) {
+        let reg = registry.expect("use_trait_path guarantees Some");
+        let vault_name = match vault {
+            Some(v) => v,
+            None => resolve_vault_for_trait(config, registry).await?,
+        };
+        reg.active()
+            .secrets()
+            .set_secret(&vault_name, request)
+            .await?;
+        crate::cli::secret_ops::invalidate_trait_secret_cache(config, &vault_name);
+        return Ok(());
+    }
+
+    // Legacy Azure fallback (registry construction failed / skipped): create
+    // an auth provider on demand and use set_secret_safe with the metadata
+    // options so groups/note/folder/expiry still apply.
+    use crate::secret::manager::SecretManager;
+    let auth_provider = crate::cli::helpers::get_azure_auth_provider(registry, config)?;
+    let secret_manager = SecretManager::new(auth_provider, config.no_color);
+    let vault_name = config.resolve_vault_name(vault).await?;
+    secret_manager
+        .set_secret_safe(&vault_name, name, value, Some(request))
+        .await?;
     Ok(())
 }


### PR DESCRIPTION
## Problem

`xv gen --save <name>` was an incomplete substitute for `xv set`:

- It called `set_secret_safe(.., None)` — dropping **all** metadata. No `--group`, `--note`, `--folder`, `--expires`, or `--not-before` could be attached to a generated secret.
- It routed only through the Azure-only `SecretManager` path, so `--save` was at best untested on the `local`/`aws` backends.

Separately, `xv set` itself had no `--group` flag — groups were only assignable after creation via `xv update`.

## Fix (idiomatic clap: `#[command(flatten)]`)

A single shared `SecretWriteArgs` struct (`group` / `note` / `folder` / `expires` / `not-before`) is flattened into **both** `Set` and `Gen`, so the two commands expose an identical metadata surface and can never drift again. Both build one `SecretRequest` via the shared `SecretWriteArgs::to_secret_request`.

- **`gen --save` now carries full metadata** and routes through the same backend trait path as `set` (works on local/aws/azure), with a legacy Azure `set_secret_safe(Some(request))` fallback when no registry is present.
- **`set` gains `--group`** as the symmetric bonus, closing the create-time group gap.
- **`gen` rejects metadata flags passed without `--save`** (nothing to attach them to) with a clear error.

## Tests

6 new unit tests: flag parsing for both commands, `has_any`, `groups_opt`, `to_secret_request` population, and bad-`--expires` rejection. Full lib suite green under an isolated `XDG_CONFIG_HOME`.

Manually verified on the local backend: `gen --length 20 --save db-pass -g db -g prod --note primary --folder app/db --raw` stores `groups: "db, prod"`, `note: primary`, `folder: app/db`; `set api-key --group web --folder svc` succeeds; bare `gen --group db` errors.

`cargo fmt --check`, `cargo clippy`, and `cargo test` all pass.

## Backward compatibility

All added flags are optional; existing `set`/`gen` invocations are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret creation paths for `set`, bulk set, and `gen --save` across backends; behavior is additive (optional flags) but metadata and routing differ from prior `gen --save`.
> 
> **Overview**
> Introduces **`SecretWriteArgs`**, flattened into **`xv set`** and **`xv gen`** via clap so both commands expose the same write-time flags: repeatable **`--group`**, **`--note`**, **`--folder`**, **`--expires`**, and **`--not-before`**. A shared **`to_secret_request`** helper builds **`SecretRequest`** values so single-secret **`set`** and **`gen --save`** stay aligned.
> 
> **`xv set`** now accepts **`--group`** at create time (including bulk **`KEY=value`** sets, which also pick up note/folder/groups from the shared struct). **`xv gen --save`** persists through the registry **`set_secret`** path (local/aws/Azure) with trait cache invalidation, with a legacy Azure **`set_secret_safe(Some(request))`** fallback when no registry exists—replacing the old path that dropped all metadata and was Azure-only. **`gen`** errors if metadata flags are used without **`--save`**.
> 
> Docs in **`FEATURES.md`** are updated for **`set`** and **`gen`**. Six unit tests cover parsing, **`has_any`**, **`groups_opt`**, request building, and invalid dates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66cde361ede7233984fa8e3420b61057543a9980. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->