### PR TITLE
chore(release): v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v0.14.0 — `gen`/`set` parity, `config edit`, and reliability fixes (2026-06-20)
+
+Makes `xv gen --save` a complete replacement for `xv set`, adds an `xv config edit`
+convenience command, and lands a batch of reliability/security hardening fixes
+across the secret, cache, scan, auth, and config paths.
+
+### Added
+
+- **`xv gen --save` now carries full write-time metadata, matching `xv set` (#273).** A shared `SecretWriteArgs` clap struct (`--group` (repeatable), `--note`, `--folder`, `--expires`, `--not-before`) is flattened into both `set` and `gen`, so the two commands expose an identical metadata surface and cannot drift. Previously `gen --save` dropped all metadata and routed only through the Azure-only path; it now builds the same `SecretRequest` and goes through the same backend trait path as `set` (local/aws/azure), with a legacy Azure fallback when no backend registry is present. As the symmetric bonus, **`xv set` gains `--group`**, closing the create-time group gap (groups previously required a follow-up `xv update`). `gen` rejects metadata flags passed without `--save`.
+- **`xv config edit` (#272)** — opens the config file in your editor, resolving `$VISUAL` → `$EDITOR` → a platform default (`nano` on Unix, `notepad` on Windows). Editor strings with arguments (e.g. `code --wait`) are supported. A missing config file is seeded with a valid serialized default (never an empty file, which would fail the next load); an existing config is never clobbered.
+
+### Changed
+
+- **`list_secrets` fetches per-secret details with bounded concurrency (#269)** — large vaults list materially faster while keeping a cap on in-flight requests.
+- **`xv version` shows the Git ref (tag or branch) instead of `unknown` on release builds (#263).**
+- **Transitive dependencies refreshed to clear Dependabot alerts (#271).**
+- **Backend capability reference docs refreshed (#262); opaque-on-disk-filename design documented for the local backend (#268).**
+
+### Fixed
+
+- **`xv run` output masking buffer is now bounded (#270)** — the stream-masking buffer can no longer grow without limit on high-volume child output.
+- **Config context files are written via the private 0600 writer (#266)** — context state lands with owner-only permissions, matching the rest of the config writes.
+- **Azure auth hardening (#267)** — the `az` helper subprocess is time-bounded and JWT claim shapes are validated before use.
+- **Scanner memory is bounded and fails loud on unscanned files (#265)** — the secret scanner no longer risks unbounded memory and surfaces files it could not scan instead of silently skipping them.
+- **Cache lock acquisition closes a TOCTOU via atomic `create_new` (#264).**
+
+---
+
 ## v0.13.0 — Local metadata encryption + UX & docs polish (2026-06-15)
 
 Adds opt-in local-backend metadata encryption (ROADMAP P2) and closes the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Crosstache Roadmap
 
-> **Last reviewed:** 2026-06-15 · **Latest released version:** `v0.13.0` · **Branch protection:** `main` (all changes via PR)
+> **Last reviewed:** 2026-06-15 · **Latest released version:** `v0.14.0` · **Branch protection:** `main` (all changes via PR)
 
 Single source of truth for **unimplemented** ideas, deferred work, and known
 limitations worth fixing. Anything already shipped lives in [`CHANGELOG.md`](./CHANGELOG.md).


### PR DESCRIPTION
## Release prep for v0.14.0

Bumps the version and promotes the changelog so the `v0.14.0` tag can be pushed (the `verify-version` release-workflow job requires `Cargo.toml` == tag).

### Version: 0.13.0 -> 0.14.0 (minor)

Two new features have landed since `v0.13.0`, so this is a minor bump:
- `feat(gen/set)`: shared write-time metadata flags -- `gen --save` is now a full `set` replacement, and `set` gains `--group` (#273)
- `feat(config)`: `xv config edit` opens the config in `$EDITOR` (#272)

Plus reliability/security fixes (#263-#270) and a dependency refresh (#271). Full notes in the new `CHANGELOG.md` section.

### Changes in this PR

- `Cargo.toml` + `Cargo.lock`: `0.13.0` -> `0.14.0`
- `CHANGELOG.md`: new `v0.14.0` section (Added / Changed / Fixed)
- `ROADMAP.md`: latest-released-version line -> `v0.14.0`

### Release-binary feature-flag check

Confirmed `.github/workflows/release.yml` builds with `--features tui,aws`, so the shipped binaries include the AWS backend (verified locally: `strings target/release/xv | grep -c secretsmanager` = 40). No feature-flag-trap regression.

### After merge

A chained-trigger cron will push the annotated `v0.14.0` tag once this PR merges (with guardrails that abort if the version on main does not match or the release workflow build line is wrong), which fires the release workflow to build + upload signed binaries for all 4 platforms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and version metadata only; no runtime or application code changes in this diff.
> 
> **Overview**
> Prepares the **v0.14.0** minor release by aligning packaging and docs with what already landed on `main` since **v0.13.0**.
> 
> **`Cargo.toml` / `Cargo.lock`** bump `crosstache` from `0.13.0` → **`0.14.0`** so the `verify-version` release job can match the upcoming `v0.14.0` tag.
> 
> **`CHANGELOG.md`** adds a top-level **v0.14.0** section (dated 2026-06-20) documenting shipped work: `gen --save` / `set` metadata parity, `xv config edit`, bounded `list_secrets` concurrency, version/git ref display, dependency refresh, docs updates, and fixes for run masking, config permissions, Azure auth, scanner bounds, and cache locking.
> 
> **`ROADMAP.md`** updates the “Latest released version” line to **`v0.14.0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b593282dc43fc6ffba192df2d9d971cdb2aa0b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->