### PR TITLE
fix(vault): suggest 'xv cx use' not nonexistent 'xv use' after create

### DIFF
--- a/src/cli/vault_ops.rs
+++ b/src/cli/vault_ops.rs
@@ -352,7 +352,7 @@ async fn execute_vault_create(
     println!("   URI: {}", vault.uri);
 
     output::hint(&format!(
-        "Start using it with 'xv use {}' or 'xv set <name> <value>'",
+        "Start using it with 'xv cx use {}' or 'xv set <name> <value>'",
         vault.name
     ));
 


### PR DESCRIPTION
## Problem
After `xv vault create <name>`, the success output suggested:

```
💡 Start using it with 'xv use <name>' or 'xv set <name> <value>'
```

But there is no `use` subcommand:

```
$ xv use kv-testcreate
error: unrecognized subcommand 'use'
```

## Fix
The vault context-switch command is `xv context use` (alias `xv cx use`). Updated the hint in `src/cli/vault_ops.rs` to suggest `xv cx use <name>`.

Verified `xv cx use <name>` is the correct command via `xv context use --help`. Builds clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing hint text only; no CLI behavior or vault logic changes.
> 
> **Overview**
> After **`xv vault create`**, the success hint told users to run **`xv use <vault>`**, which is not a real subcommand.
> 
> The hint in **`execute_vault_create`** now points to **`xv cx use <vault>`** (alias for **`xv context use`**) so new vaults can be selected correctly; the **`xv set`** part of the message is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2db940068568c668a141a645130805b598e50187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->