### PR TITLE
docs: record opaque filename follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Opt-in opaque on-disk filenames for the local backend (#276).** Setting `[local].opaque_filenames = true` stores active secrets, version archives, and trash entries under keyed-hash stems instead of reversible secret-name filenames, with an age-encrypted index for name lookup. Existing stores remain unchanged until `xv local migrate` runs; `xv local migrate --dry-run` prints the rename plan first. See [`docs/FEATURES.md`](./docs/FEATURES.md#local-backend-maintenance) and the retained design plan in [`docs/plans/2026-06-19-local-secret-filename-opaquing.md`](./docs/plans/2026-06-19-local-secret-filename-opaquing.md).
+
+### Fixed
+
+- **Vault-create follow-up hint now suggests the real context command (#275).** After creating a vault, the CLI now points users to `xv cx use <name>` instead of the nonexistent `xv use <name>`.
+
 ## v0.14.0 — `gen`/`set` parity, `config edit`, and reliability fixes (2026-06-20)
 
 Makes `xv gen --save` a complete replacement for `xv set`, adds an `xv config edit`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,16 +70,6 @@ longest secret length.
 ### P3 — CSV output manually assembled
 `src/utils/format.rs:174`. Use the `csv` crate.
 
-### P3 — Local secret *names* disclosed via filenames
-`src/backend/local/secrets.rs`. Metadata *content* encryption shipped
-post-v0.12.0 (opt-in `encrypt_metadata` under `[local]` + `xv local
-encrypt-metadata`; see `CHANGELOG.md`), so note/tags/folder/expiry are no
-longer plaintext when enabled. What remains: secret *names* are still visible
-as on-disk filenames (`<percent-encoded-name>.age` / `.meta.json`), leaking
-existence, count, and identity even with metadata encrypted. Closing this
-needs filename opaquing (e.g. hash names, store an encrypted hash→name index),
-which is a larger architectural change — track as its own design.
-
 ### P3 — Missing serialization guards for value-like fields
 `src/error.rs:637`. Extend the existing error-variant guard to cover
 cache entries, scan findings, structured output, logs, tracing.
@@ -137,6 +127,15 @@ Open ground from `2026-04-29-strategic-improvements-phase-1-design.md`:
 - 1Password CLI bridge
 
 Each new backend appends to `docs/superpowers/specs/backend-trait-checklist.md`.
+
+---
+
+## Shipped history
+
+- **Local secret names disclosed via filenames** — closed post-v0.14.0 by
+  opaque local-backend filenames in #276. The retained design plan is
+  [`docs/plans/2026-06-19-local-secret-filename-opaquing.md`](./docs/plans/2026-06-19-local-secret-filename-opaquing.md);
+  release notes live in [`CHANGELOG.md`](./CHANGELOG.md) under `Unreleased`.
 
 ---
 

--- a/docs/plans/2026-06-19-local-secret-filename-opaquing.md
+++ b/docs/plans/2026-06-19-local-secret-filename-opaquing.md
@@ -1,10 +1,10 @@
 # Design: Opaque on-disk filenames for the local secret backend
 
-**Status:** Implemented — Option A (keyed-hash stems + age-encrypted index),
-behind the opt-in `[local].opaque_filenames` flag, with `xv local migrate`
-(+ `--dry-run`) and a one-release back-compat read path. See
+**Status:** Implemented in #276 — Option A (keyed-hash stems + age-encrypted
+index), behind the opt-in `[local].opaque_filenames` flag, with `xv local
+migrate` (+ `--dry-run`) and a one-release back-compat read path. See
 `src/backend/local/opaque.rs` and `src/backend/local/secrets.rs`.
-**ROADMAP item:** P3 — "Local secret NAMES disclosed via filenames"
+**ROADMAP item:** Closed — P3 "Local secret names disclosed via filenames"
 **Author:** Hermes Agent
 **Date:** 2026-06-19
 


### PR DESCRIPTION
## Summary
- Add an `Unreleased` changelog section for PRs #275 and #276.
- Move the local opaque-filename roadmap item out of open P3 work into shipped history.
- Polish the filename-opaquing plan status banner to reference #276.

## Verification
- `git diff --check -- CHANGELOG.md ROADMAP.md docs/plans/2026-06-19-local-secret-filename-opaquing.md`
- `test -f docs/FEATURES.md && grep -n '^### Local backend maintenance$' docs/FEATURES.md && test -f docs/plans/2026-06-19-local-secret-filename-opaquing.md`
- `cargo test --doc`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to changelog, roadmap, and a design plan status banner; no runtime or security behavior changes.
> 
> **Overview**
> Adds an **`Unreleased`** section to **`CHANGELOG.md`** documenting shipped work from **#276** (opt-in `[local].opaque_filenames`, migration/`--dry-run`, links to features and the design plan) and **#275** (post–vault-create hint now suggests `xv cx use` instead of `xv use`).
> 
> **`ROADMAP.md`** drops the open P3 item about local secret names leaking via filenames and records it under a new **Shipped history** entry pointing at #276 and the changelog. The filename-opaquing plan banner is updated to cite **#276** and mark the roadmap item closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936de706ce5a6314ac969c1e4bc528b298b67a06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->