### PR TITLE
chore: bump version to 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Unreleased
+## v0.15.0 — Opaque local filenames (2026-06-22)
+
+Adds opt-in opaque on-disk filenames for the local backend and includes a
+small vault-create UX fix.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Crosstache Roadmap
 
-> **Last reviewed:** 2026-06-15 · **Latest released version:** `v0.14.0` · **Branch protection:** `main` (all changes via PR)
+> **Last reviewed:** 2026-06-15 · **Latest released version:** `v0.15.0` · **Branch protection:** `main` (all changes via PR)
 
 Single source of truth for **unimplemented** ideas, deferred work, and known
 limitations worth fixing. Anything already shipped lives in [`CHANGELOG.md`](./CHANGELOG.md).
@@ -17,9 +17,8 @@ Severity legend (mirrors the UX/code reviews):
 
 ## In flight
 
-No active release-soak lane. Implemented-but-unreleased fixes are tracked in
-[`CHANGELOG.md`](./CHANGELOG.md) under `Unreleased`; this roadmap only tracks
-open work.
+No active release-soak lane. Implemented work is tracked in
+[`CHANGELOG.md`](./CHANGELOG.md); this roadmap only tracks open work.
 
 ---
 
@@ -132,10 +131,10 @@ Each new backend appends to `docs/superpowers/specs/backend-trait-checklist.md`.
 
 ## Shipped history
 
-- **Local secret names disclosed via filenames** — closed post-v0.14.0 by
+- **Local secret names disclosed via filenames** — closed in v0.15.0 by
   opaque local-backend filenames in #276. The retained design plan is
   [`docs/plans/2026-06-19-local-secret-filename-opaquing.md`](./docs/plans/2026-06-19-local-secret-filename-opaquing.md);
-  release notes live in [`CHANGELOG.md`](./CHANGELOG.md) under `Unreleased`.
+  release notes live in [`CHANGELOG.md`](./CHANGELOG.md) under `v0.15.0`.
 
 ---
 
@@ -145,7 +144,7 @@ From `docs/UX-REVIEW.md` (2026-05-16 AWS-backend baseline).
 
 The full P2 lane and P3-1..4 shipped post-v0.12.0 (#254 §P2-1/§P2-5,
 #255 §P2-2, #256 §P2-3/§P2-4, #257 §P3-4, #258 §P3-1..3). They are
-recorded in [`CHANGELOG.md`](./CHANGELOG.md) under `Unreleased`. One
+recorded in [`CHANGELOG.md`](./CHANGELOG.md) under `v0.13.0`. One
 substantive UX item remains open:
 
 ### P3

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -3212,8 +3212,14 @@ mod tests {
         );
 
         let report = opaque_backend.migrate_all(false).unwrap();
-        assert_eq!(report.migrated, 1, "must migrate the opaque-looking legacy stem");
-        assert_eq!(report.recovered, 0, "index entry comes from Pass A, not recovery");
+        assert_eq!(
+            report.migrated, 1,
+            "must migrate the opaque-looking legacy stem"
+        );
+        assert_eq!(
+            report.recovered, 0,
+            "index entry comes from Pass A, not recovery"
+        );
 
         assert!(
             !sdir.join(format!("{legacy_name}.meta.json")).exists(),
@@ -3692,7 +3698,10 @@ mod tests {
         fs::rename(&trash_dir, tbase.join(&bad_name)).unwrap();
         // Force decode_name fallback by corrupting inner metadata.
         write_private(
-            tbase.join(&bad_name).join(format!("{enc}.meta.json")).as_path(),
+            tbase
+                .join(&bad_name)
+                .join(format!("{enc}.meta.json"))
+                .as_path(),
             b"not-valid-meta",
         )
         .unwrap();
@@ -3702,9 +3711,10 @@ mod tests {
         let report = opaque_backend.migrate_all(false).unwrap();
         assert_eq!(report.trash_migrated, 1);
         assert!(
-            report.plan.iter().any(|line| {
-                line.contains(&expected_stem) && line.contains("\"trash-at\"")
-            }),
+            report
+                .plan
+                .iter()
+                .any(|line| { line.contains(&expected_stem) && line.contains("\"trash-at\"") }),
             "plan must migrate using the stem before @, not the full dir name: {:?}",
             report.plan
         );


### PR DESCRIPTION
## Summary
- Bump crosstache from `0.14.0` to `0.15.0` in `Cargo.toml` and `Cargo.lock`.
- Promote the current changelog `Unreleased` section to `v0.15.0`.
- Update `ROADMAP.md` release metadata and shipped-history references.
- Apply `cargo fmt` to existing local-backend test code so the release branch is format-clean.

## Verification
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`
- `cargo test --doc`
- `cargo test`
- `git diff --check`

## Release notes
This release adds opt-in opaque on-disk filenames for the local backend (`[local].opaque_filenames` + `xv local migrate`) and fixes the vault-create follow-up hint to use `xv cx use <name>`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping and formatting only; no application logic or dependency changes beyond the package version string.
> 
> **Overview**
> Cuts the **v0.15.0** release by bumping `crosstache` from `0.14.0` to `0.15.0` in `Cargo.toml` and `Cargo.lock`.
> 
> **`CHANGELOG.md`** promotes the former `Unreleased` section into **v0.15.0 — Opaque local filenames (2026-06-22)**, documenting shipped work (opaque local-backend filenames #276, vault-create hint fix #275) rather than adding new code in this PR.
> 
> **`ROADMAP.md`** updates release metadata to `v0.15.0`, simplifies the “in flight” note, and points shipped-history and UX polish entries at the correct changelog versions.
> 
> **`src/backend/local/secrets.rs`** only receives `cargo fmt` line breaks in opaque-migration tests; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9228b19a81b209bbc1d743b471abb6ab4f6ae56f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->