### PR TITLE
fix: use csv crate for formatter output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ dependencies = [
  "clap_complete",
  "config",
  "crossterm 0.27.0",
+ "csv",
  "data-encoding",
  "dialoguer",
  "dirs",
@@ -1846,6 +1847,27 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ strsim = "0.11"
 flate2 = "1"
 tar = "0.4"
 opener = "0.7"
+csv = "1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 zip = "2"

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -203,20 +203,35 @@ impl TableFormatter {
 
     /// Format data as CSV
     fn format_as_csv<T: Tabled>(&self, data: &[T]) -> Result<String> {
-        let mut output = String::new();
-        // Header row from Tabled trait
+        let mut writer = csv::WriterBuilder::new()
+            .terminator(csv::Terminator::Any(b'\n'))
+            .from_writer(Vec::new());
+
         let headers = T::headers();
-        let header_row: Vec<String> = headers.iter().map(|h| csv_escape(h.as_ref())).collect();
-        output.push_str(&header_row.join(","));
-        output.push('\n');
-        // Data rows
+        writer
+            .write_record(headers.iter().map(|header| header.as_ref()))
+            .map_err(|err| {
+                crate::error::CrosstacheError::SerializationError(format!("CSV error: {err}"))
+            })?;
+
         for item in data {
             let fields = item.fields();
-            let row: Vec<String> = fields.iter().map(|f| csv_escape(f.as_ref())).collect();
-            output.push_str(&row.join(","));
-            output.push('\n');
+            writer
+                .write_record(fields.iter().map(|field| field.as_ref()))
+                .map_err(|err| {
+                    crate::error::CrosstacheError::SerializationError(format!("CSV error: {err}"))
+                })?;
         }
-        Ok(output)
+
+        let bytes = writer.into_inner().map_err(|err| {
+            crate::error::CrosstacheError::SerializationError(format!("CSV error: {}", err.error()))
+        })?;
+
+        String::from_utf8(bytes).map_err(|err| {
+            crate::error::CrosstacheError::SerializationError(format!(
+                "CSV output was not UTF-8: {err}"
+            ))
+        })
     }
 
     /// Format data as plain text
@@ -277,15 +292,6 @@ impl TableFormatter {
         let mut table = Table::new(data);
         table.with(Style::empty());
         Ok(table.to_string())
-    }
-}
-
-/// Escape a value for CSV output (RFC 4180)
-fn csv_escape(value: &str) -> String {
-    if value.contains(',') || value.contains('"') || value.contains('\n') {
-        format!("\"{}\"", value.replace('"', "\"\""))
-    } else {
-        value.to_string()
     }
 }
 
@@ -488,6 +494,29 @@ mod tests {
         let formatter = TableFormatter::new(OutputFormat::Json, true, None);
         let out = formatter.format_table(&data).expect("format");
         assert_eq!(out.trim(), "[]");
+    }
+
+    #[test]
+    fn csv_output_uses_rfc4180_escaping() {
+        let data = vec![
+            TestData {
+                name: "plain".to_string(),
+                value: "contains,comma".to_string(),
+                status: "active".to_string(),
+            },
+            TestData {
+                name: "quoted".to_string(),
+                value: "has \"quotes\"".to_string(),
+                status: "line\nbreak".to_string(),
+            },
+        ];
+        let formatter = TableFormatter::new(OutputFormat::Csv, true, None);
+        let out = formatter.format_table(&data).expect("format");
+
+        assert_eq!(
+            out,
+            "Name,Value,Status\nplain,\"contains,comma\",active\nquoted,\"has \"\"quotes\"\"\",\"line\nbreak\"\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace hand-assembled CSV rows in TableFormatter with the csv crate writer
- Keep LF terminators to preserve existing output shape
- Add a regression test for comma, quote, and newline escaping

## Verification
- cargo fmt
- cargo test utils::format::tests::csv_output_uses_rfc4180_escaping
- cargo check
- cargo clippy --all-targets -- -D warnings
- HOME=$(mktemp -d) CARGO_HOME=/home/szionic/.cargo RUSTUP_HOME=/home/szionic/.rustup cargo test --lib (still fails 2 existing config-contaminated vault-resolution tests reading /home/szionic/.hermes/.xv.toml; unrelated to CSV change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to display serialization in `TableFormatter`; behavior is covered by a new escaping test and does not touch auth, vault I/O, or data persistence.
> 
> **Overview**
> **TableFormatter** CSV output no longer builds rows by hand or uses a local `csv_escape` helper; it writes through the **`csv`** crate with an explicit **LF** line terminator so piped output shape stays the same.
> 
> A unit test locks in **RFC 4180** behavior for commas, doubled quotes, and embedded newlines. The **`csv`** dependency is added in **`Cargo.toml`** / lockfile only for this path—other CLI CSV branches (e.g. config/file ops) are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90840a62290ede0f84fbd4922ba102edada7068d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->