### PR TITLE
fix: expose Azure audit through backend capability

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,3 +20,19 @@ changes without adding redundant pages.
       implementation state.
 - [x] Verify documentation diffs for accuracy against source and run an
       appropriate docs-only validation command.
+
+## Audit Backend Routing Fix Plan
+
+### Audit Routing Goal
+
+Ensure `xv audit --resource-group ...` only uses the legacy Azure Activity Log
+fallback for Azure, and keeps auditor-backed non-Azure backends on the generic
+`AuditBackend` path.
+
+### Audit Routing Steps
+
+- [x] Confirm the baseline routing bug: the old condition skipped generic audit
+      dispatch for any backend when `--resource-group` was supplied.
+- [x] Add a regression test with an auditor-backed non-Azure backend and a
+      resource-group override.
+- [x] Verify the routing fix with targeted tests and lint diagnostics.

--- a/src/backend/audit.rs
+++ b/src/backend/audit.rs
@@ -6,8 +6,9 @@
 //! [`AuditEvent`] rows in the same table/JSON shapes as the Azure
 //! Activity Log path.
 //!
-//! Azure currently keeps its legacy Activity Log client in
-//! `cli::system_ops` and does not implement this trait.
+//! Azure implements this trait with its Activity Log adapter; the CLI keeps a
+//! small legacy fallback only for explicit Azure `--resource-group` overrides
+//! because this trait is intentionally backend-agnostic.
 
 use async_trait::async_trait;
 

--- a/src/backend/azure/audit.rs
+++ b/src/backend/azure/audit.rs
@@ -1,0 +1,202 @@
+//! Azure Activity Log-backed audit implementation.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::auth::provider::AzureAuthProvider;
+use crate::backend::audit::{AuditBackend, AuditEvent};
+use crate::backend::error::BackendError;
+use crate::error::{CrosstacheError, Result};
+
+use super::map_error;
+
+/// Azure Activity Log audit adapter.
+///
+/// The backend trait only accepts a vault name, so Azure stores the default
+/// subscription/resource group from the active config and uses them for trait
+/// dispatch. CLI calls that pass `--resource-group` still use the legacy path
+/// until the trait API grows an explicit resource-group parameter.
+pub struct AzureAuditBackend {
+    auth_provider: Arc<dyn AzureAuthProvider>,
+    subscription_id: String,
+    default_resource_group: String,
+}
+
+impl AzureAuditBackend {
+    pub fn new(
+        auth_provider: Arc<dyn AzureAuthProvider>,
+        subscription_id: String,
+        default_resource_group: String,
+    ) -> Self {
+        Self {
+            auth_provider,
+            subscription_id,
+            default_resource_group,
+        }
+    }
+
+    async fn get_vault_audit_logs(
+        &self,
+        resource_group: &str,
+        vault_name: &str,
+        days: u32,
+    ) -> Result<Vec<AuditEvent>> {
+        let end_time = chrono::Utc::now();
+        let start_time = end_time - chrono::Duration::days(days as i64);
+
+        let start_time_str = start_time.format("%Y-%m-%dT%H:%M:%S.%3fZ");
+        let end_time_str = end_time.format("%Y-%m-%dT%H:%M:%S.%3fZ");
+
+        let activity_url = format!(
+            "https://management.azure.com/subscriptions/{}/providers/microsoft.insights/eventtypes/management/values?api-version=2015-04-01&$filter=eventTimestamp ge '{}' and eventTimestamp le '{}' and resourceUri eq '/subscriptions/{}/resourceGroups/{}/providers/Microsoft.KeyVault/vaults/{}'",
+            self.subscription_id,
+            start_time_str,
+            end_time_str,
+            self.subscription_id,
+            resource_group,
+            vault_name
+        );
+
+        let token = self
+            .auth_provider
+            .get_token(&["https://management.azure.com/.default"])
+            .await?;
+
+        let response = reqwest::Client::new()
+            .get(&activity_url)
+            .header("Authorization", format!("Bearer {}", token.token.secret()))
+            .header("Content-Type", "application/json")
+            .send()
+            .await
+            .map_err(|e| CrosstacheError::network(format!("Failed to fetch activity logs: {e}")))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            return Err(CrosstacheError::azure_api(format!(
+                "Activity Log API returned {status}: {error_text}"
+            )));
+        }
+
+        let activity_response: Value = response.json().await.map_err(|e| {
+            CrosstacheError::serialization(format!("Failed to parse activity logs: {e}"))
+        })?;
+
+        parse_activity_log_response(activity_response)
+    }
+
+    async fn get_secret_audit_logs(
+        &self,
+        resource_group: &str,
+        vault_name: &str,
+        secret_name: &str,
+        days: u32,
+    ) -> Result<Vec<AuditEvent>> {
+        let vault_logs = self
+            .get_vault_audit_logs(resource_group, vault_name, days)
+            .await?;
+
+        Ok(vault_logs
+            .into_iter()
+            .filter(|log| log.resource_name.contains(secret_name))
+            .collect())
+    }
+}
+
+#[async_trait]
+impl AuditBackend for AzureAuditBackend {
+    async fn get_vault_events(
+        &self,
+        vault: &str,
+        days: u32,
+    ) -> std::result::Result<Vec<AuditEvent>, BackendError> {
+        self.get_vault_audit_logs(&self.default_resource_group, vault, days)
+            .await
+            .map_err(map_error)
+    }
+
+    async fn get_secret_events(
+        &self,
+        vault: &str,
+        secret_name: &str,
+        days: u32,
+    ) -> std::result::Result<Vec<AuditEvent>, BackendError> {
+        self.get_secret_audit_logs(&self.default_resource_group, vault, secret_name, days)
+            .await
+            .map_err(map_error)
+    }
+}
+
+fn parse_activity_log_response(response: Value) -> Result<Vec<AuditEvent>> {
+    let mut entries = Vec::new();
+
+    if let Some(value) = response.get("value").and_then(|v| v.as_array()) {
+        for event in value {
+            if let Ok(entry) = parse_activity_log_entry(event) {
+                entries.push(entry);
+            }
+        }
+    }
+
+    entries.sort_by_key(|entry| std::cmp::Reverse(entry.timestamp));
+
+    Ok(entries)
+}
+
+fn parse_activity_log_entry(event: &Value) -> Result<AuditEvent> {
+    let timestamp = event
+        .get("eventTimestamp")
+        .and_then(|v| v.as_str())
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .ok_or_else(|| CrosstacheError::serialization("Invalid timestamp in activity log"))?;
+
+    let operation = event
+        .get("operationName")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let resource_name = event
+        .get("resourceId")
+        .and_then(|v| v.as_str())
+        .and_then(|resource_id| resource_id.split('/').next_back())
+        .unwrap_or("")
+        .to_string();
+
+    let caller = event
+        .get("caller")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let status = event
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or(
+            event
+                .get("subStatus")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown"),
+        )
+        .to_string();
+
+    let event_id = event
+        .get("eventDataId")
+        .or_else(|| event.get("correlationId"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    Ok(AuditEvent {
+        timestamp,
+        operation,
+        resource_name,
+        caller,
+        status,
+        source_ip: None,
+        event_id,
+    })
+}

--- a/src/backend/azure/audit.rs
+++ b/src/backend/azure/audit.rs
@@ -37,12 +37,12 @@ impl AzureAuditBackend {
         }
     }
 
-    async fn get_vault_audit_logs(
+    async fn fetch_raw_events(
         &self,
         resource_group: &str,
         vault_name: &str,
         days: u32,
-    ) -> Result<Vec<AuditEvent>> {
+    ) -> Result<Vec<Value>> {
         let end_time = chrono::Utc::now();
         let start_time = end_time - chrono::Duration::days(days as i64);
 
@@ -84,7 +84,21 @@ impl AzureAuditBackend {
             CrosstacheError::serialization(format!("Failed to parse activity logs: {e}"))
         })?;
 
-        parse_activity_log_response(activity_response)
+        Ok(activity_response
+            .get("value")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    async fn get_vault_audit_logs(
+        &self,
+        resource_group: &str,
+        vault_name: &str,
+        days: u32,
+    ) -> Result<Vec<AuditEvent>> {
+        let raw_events = self.fetch_raw_events(resource_group, vault_name, days).await?;
+        parse_raw_events(raw_events)
     }
 
     async fn get_secret_audit_logs(
@@ -94,14 +108,14 @@ impl AzureAuditBackend {
         secret_name: &str,
         days: u32,
     ) -> Result<Vec<AuditEvent>> {
-        let vault_logs = self
-            .get_vault_audit_logs(resource_group, vault_name, days)
-            .await?;
+        let raw_events = self.fetch_raw_events(resource_group, vault_name, days).await?;
 
-        Ok(vault_logs
+        let filtered: Vec<Value> = raw_events
             .into_iter()
-            .filter(|log| log.resource_name.contains(secret_name))
-            .collect())
+            .filter(|event| event_matches_secret(event, secret_name))
+            .collect();
+
+        parse_raw_events(filtered)
     }
 }
 
@@ -129,14 +143,30 @@ impl AuditBackend for AzureAuditBackend {
     }
 }
 
-fn parse_activity_log_response(response: Value) -> Result<Vec<AuditEvent>> {
+/// Returns true if the raw Activity Log event references the given secret,
+/// either via the `resourceId` path or the `properties.secretName` field.
+fn event_matches_secret(event: &Value, secret_name: &str) -> bool {
+    let resource_id_match = event
+        .get("resourceId")
+        .and_then(|v| v.as_str())
+        .map(|rid| rid.split('/').next_back().unwrap_or(""))
+        .is_some_and(|last_seg| last_seg.contains(secret_name));
+
+    let properties_match = event
+        .get("properties")
+        .and_then(|p| p.get("secretName"))
+        .and_then(|v| v.as_str())
+        .is_some_and(|name| name == secret_name);
+
+    resource_id_match || properties_match
+}
+
+fn parse_raw_events(events: Vec<Value>) -> Result<Vec<AuditEvent>> {
     let mut entries = Vec::new();
 
-    if let Some(value) = response.get("value").and_then(|v| v.as_array()) {
-        for event in value {
-            if let Ok(entry) = parse_activity_log_entry(event) {
-                entries.push(entry);
-            }
+    for event in &events {
+        if let Ok(entry) = parse_activity_log_entry(event) {
+            entries.push(entry);
         }
     }
 

--- a/src/backend/azure/audit.rs
+++ b/src/backend/azure/audit.rs
@@ -108,7 +108,9 @@ impl AzureAuditBackend {
         vault_name: &str,
         days: u32,
     ) -> Result<Vec<AuditEvent>> {
-        let raw_events = self.fetch_raw_events(resource_group, vault_name, days).await?;
+        let raw_events = self
+            .fetch_raw_events(resource_group, vault_name, days)
+            .await?;
         parse_raw_events(raw_events)
     }
 
@@ -119,7 +121,9 @@ impl AzureAuditBackend {
         secret_name: &str,
         days: u32,
     ) -> Result<Vec<AuditEvent>> {
-        let raw_events = self.fetch_raw_events(resource_group, vault_name, days).await?;
+        let raw_events = self
+            .fetch_raw_events(resource_group, vault_name, days)
+            .await?;
 
         let filtered: Vec<Value> = raw_events
             .into_iter()

--- a/src/backend/azure/audit.rs
+++ b/src/backend/azure/audit.rs
@@ -43,6 +43,17 @@ impl AzureAuditBackend {
         vault_name: &str,
         days: u32,
     ) -> Result<Vec<Value>> {
+        if resource_group.is_empty() {
+            return Err(CrosstacheError::config(
+                "No resource group specified. Use --resource-group or 'xv init' to configure",
+            ));
+        }
+        if self.subscription_id.is_empty() {
+            return Err(CrosstacheError::config(
+                "No subscription ID configured. Use 'xv init' to configure",
+            ));
+        }
+
         let end_time = chrono::Utc::now();
         let start_time = end_time - chrono::Duration::days(days as i64);
 

--- a/src/backend/azure/mod.rs
+++ b/src/backend/azure/mod.rs
@@ -7,6 +7,7 @@
 //!
 //! This is a *thin adapter layer* — no business logic is duplicated.
 
+pub mod audit;
 pub mod auth;
 pub mod detect;
 #[allow(clippy::module_inception)]
@@ -22,7 +23,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use super::error::BackendError;
-use super::{Backend, BackendCapabilities, BackendKind, NameCharset, SecretBackend, VaultBackend};
+use super::{
+    AuditBackend, Backend, BackendCapabilities, BackendKind, NameCharset, SecretBackend,
+    VaultBackend,
+};
 use crate::auth::provider::AzureAuthProvider;
 use crate::config::settings::Config;
 use crate::error::CrosstacheError;
@@ -66,6 +70,7 @@ pub fn map_error(err: CrosstacheError) -> BackendError {
     }
 }
 
+use self::audit::AzureAuditBackend;
 use self::secrets::AzureSecretBackend;
 use self::vaults::AzureVaultBackend;
 
@@ -82,6 +87,7 @@ use crate::blob::manager::BlobManager;
 pub struct AzureBackend {
     secret_backend: AzureSecretBackend,
     vault_backend: AzureVaultBackend,
+    audit_backend: AzureAuditBackend,
     #[cfg(feature = "file-ops")]
     file_backend: Option<AzureFileBackend>,
     auth_provider: Arc<dyn AzureAuthProvider>,
@@ -114,6 +120,12 @@ impl AzureBackend {
             config,
         );
 
+        let audit_backend = AzureAuditBackend::new(
+            auth_provider.clone(),
+            config.subscription_id.clone(),
+            config.default_resource_group.clone(),
+        );
+
         // File backend (only when file-ops feature is enabled)
         #[cfg(feature = "file-ops")]
         let file_backend = {
@@ -138,6 +150,7 @@ impl AzureBackend {
         Ok(Self {
             secret_backend,
             vault_backend,
+            audit_backend,
             #[cfg(feature = "file-ops")]
             file_backend,
             auth_provider,
@@ -179,7 +192,7 @@ impl Backend for AzureBackend {
                 }
             },
             has_rbac: true,
-            has_audit: false,
+            has_audit: true,
             has_versioning: true,
             has_soft_delete: true,
             has_secret_rotation: false,
@@ -201,6 +214,10 @@ impl Backend for AzureBackend {
         Some(&self.vault_backend)
     }
 
+    fn audit(&self) -> Option<&dyn AuditBackend> {
+        Some(&self.audit_backend)
+    }
+
     #[cfg(feature = "file-ops")]
     fn files(&self) -> Option<&dyn FileBackend> {
         self.file_backend.as_ref().map(|fb| fb as &dyn FileBackend)
@@ -213,5 +230,46 @@ impl Backend for AzureBackend {
             .await
             .map_err(|e| BackendError::AuthenticationFailed(e.to_string()))?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use azure_core::auth::{AccessToken, TokenCredential};
+    use azure_identity::AzureCliCredential;
+
+    struct StubAzureAuthProvider;
+
+    #[async_trait]
+    impl AzureAuthProvider for StubAzureAuthProvider {
+        async fn get_token(&self, _scopes: &[&str]) -> crate::error::Result<AccessToken> {
+            unreachable!("capability checks must not request Azure tokens")
+        }
+
+        async fn get_tenant_id(&self) -> crate::error::Result<String> {
+            unreachable!("capability checks must not request Azure tenant IDs")
+        }
+
+        async fn get_object_id(&self) -> crate::error::Result<String> {
+            unreachable!("capability checks must not request Azure object IDs")
+        }
+
+        fn get_token_credential(&self) -> Arc<dyn TokenCredential> {
+            Arc::new(AzureCliCredential::new())
+        }
+
+        async fn resolve_user_to_object_id(&self, _user: &str) -> crate::error::Result<String> {
+            unreachable!("capability checks must not resolve Azure users")
+        }
+    }
+
+    #[test]
+    fn azure_backend_declares_and_exposes_audit_backend() {
+        let backend = AzureBackend::new(&Config::default(), Arc::new(StubAzureAuthProvider))
+            .expect("default Azure backend should construct for capability inspection");
+
+        assert!(backend.capabilities().has_audit);
+        assert!(backend.audit().is_some());
     }
 }

--- a/src/cli/system_ops.rs
+++ b/src/cli/system_ops.rs
@@ -273,11 +273,16 @@ pub(crate) async fn execute_audit_command(
                 registry.active().name()
             )));
         }
-        // Backends that implement the audit trait (e.g. AWS via CloudTrail)
-        // are dispatched generically; Azure keeps its legacy Activity Log
-        // path below.
-        if let Some(auditor) = registry.active().audit() {
-            return execute_backend_audit(auditor, name, vault, days, operation, raw, config).await;
+        // Backends that implement the audit trait are dispatched generically.
+        // Azure supports audit through the trait for the configured default
+        // resource group; keep the legacy path only for explicit
+        // `--resource-group` overrides because the trait API has no override
+        // parameter yet.
+        if resource_group_override.is_none() {
+            if let Some(auditor) = registry.active().audit() {
+                return execute_backend_audit(auditor, name, vault, days, operation, raw, config)
+                    .await;
+            }
         }
     }
 

--- a/src/cli/system_ops.rs
+++ b/src/cli/system_ops.rs
@@ -276,9 +276,9 @@ pub(crate) async fn execute_audit_command(
         // Backends that implement the audit trait are dispatched generically.
         // Azure supports audit through the trait for the configured default
         // resource group; keep the legacy path only for explicit
-        // `--resource-group` overrides because the trait API has no override
-        // parameter yet.
-        if resource_group_override.is_none() {
+        // `--resource-group` overrides or when no default resource group is
+        // configured (the legacy path produces a clear ConfigError for that).
+        if resource_group_override.is_none() && !config.default_resource_group.is_empty() {
             if let Some(auditor) = registry.active().audit() {
                 return execute_backend_audit(auditor, name, vault, days, operation, raw, config)
                     .await;

--- a/src/cli/system_ops.rs
+++ b/src/cli/system_ops.rs
@@ -274,11 +274,15 @@ pub(crate) async fn execute_audit_command(
             )));
         }
         // Backends that implement the audit trait are dispatched generically.
-        // Azure supports audit through the trait for the configured default
-        // resource group; keep the legacy path only for explicit
-        // `--resource-group` overrides or when no default resource group is
-        // configured (the legacy path produces a clear ConfigError for that).
-        if resource_group_override.is_none() && !config.default_resource_group.is_empty() {
+        // For Azure specifically, keep the legacy Activity Log path when the
+        // caller passes an explicit `--resource-group` override or when no
+        // default resource group is configured (the legacy path produces a
+        // clear ConfigError for that).  Non-Azure backends always use the
+        // trait path — `--resource-group` is an Azure-only concept.
+        let use_legacy_azure_path = registry.active().kind() == crate::backend::BackendKind::Azure
+            && (resource_group_override.is_some() || config.default_resource_group.is_empty());
+
+        if !use_legacy_azure_path {
             if let Some(auditor) = registry.active().audit() {
                 return execute_backend_audit(auditor, name, vault, days, operation, raw, config)
                     .await;
@@ -1049,4 +1053,186 @@ async fn save_generated_secret(
         .set_secret_safe(&vault_name, name, value, Some(request))
         .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::backend::{
+        AuditBackend, AuditEvent, Backend, BackendCapabilities, BackendError, BackendKind,
+        BackendRegistry, NameCharset, SecretBackend,
+    };
+    use crate::secret::manager::{
+        SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest,
+    };
+
+    struct StubSecretBackend;
+
+    #[async_trait]
+    impl SecretBackend for StubSecretBackend {
+        async fn set_secret(
+            &self,
+            _vault: &str,
+            _request: SecretRequest,
+        ) -> std::result::Result<SecretProperties, BackendError> {
+            unreachable!("audit routing must not call secret operations")
+        }
+
+        async fn get_secret(
+            &self,
+            _vault: &str,
+            _name: &str,
+            _include_value: bool,
+        ) -> std::result::Result<SecretProperties, BackendError> {
+            unreachable!("audit routing must not call secret operations")
+        }
+
+        async fn get_secret_version(
+            &self,
+            _vault: &str,
+            _name: &str,
+            _version: &str,
+            _include_value: bool,
+        ) -> std::result::Result<SecretProperties, BackendError> {
+            unreachable!("audit routing must not call secret operations")
+        }
+
+        async fn list_secrets(
+            &self,
+            _vault: &str,
+            _group_filter: Option<&str>,
+        ) -> std::result::Result<Vec<SecretSummary>, BackendError> {
+            unreachable!("audit routing must not call secret operations")
+        }
+
+        async fn delete_secret(
+            &self,
+            _vault: &str,
+            _name: &str,
+        ) -> std::result::Result<(), BackendError> {
+            unreachable!("audit routing must not call secret operations")
+        }
+
+        async fn update_secret(
+            &self,
+            _vault: &str,
+            _name: &str,
+            _request: SecretUpdateRequest,
+        ) -> std::result::Result<SecretProperties, BackendError> {
+            unreachable!("audit routing must not call secret operations")
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct StubAuditCalls {
+        vault_events: Arc<AtomicUsize>,
+        secret_events: Arc<AtomicUsize>,
+    }
+
+    struct StubAuditBackend {
+        calls: StubAuditCalls,
+    }
+
+    #[async_trait]
+    impl AuditBackend for StubAuditBackend {
+        async fn get_vault_events(
+            &self,
+            vault: &str,
+            days: u32,
+        ) -> std::result::Result<Vec<AuditEvent>, BackendError> {
+            assert_eq!(vault, "test-vault");
+            assert_eq!(days, 7);
+            self.calls.vault_events.fetch_add(1, Ordering::SeqCst);
+            Ok(Vec::new())
+        }
+
+        async fn get_secret_events(
+            &self,
+            _vault: &str,
+            _secret_name: &str,
+            _days: u32,
+        ) -> std::result::Result<Vec<AuditEvent>, BackendError> {
+            self.calls.secret_events.fetch_add(1, Ordering::SeqCst);
+            Ok(Vec::new())
+        }
+    }
+
+    struct StubAuditedBackend {
+        secret_backend: StubSecretBackend,
+        audit_backend: StubAuditBackend,
+    }
+
+    impl StubAuditedBackend {
+        fn new(calls: StubAuditCalls) -> Self {
+            Self {
+                secret_backend: StubSecretBackend,
+                audit_backend: StubAuditBackend { calls },
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Backend for StubAuditedBackend {
+        fn name(&self) -> &'static str {
+            "aws"
+        }
+
+        fn kind(&self) -> BackendKind {
+            BackendKind::Aws
+        }
+
+        fn capabilities(&self) -> BackendCapabilities {
+            BackendCapabilities {
+                has_audit: true,
+                name_charset: NameCharset::AwsRelaxed,
+                ..BackendCapabilities::default()
+            }
+        }
+
+        fn secrets(&self) -> &dyn SecretBackend {
+            &self.secret_backend
+        }
+
+        fn audit(&self) -> Option<&dyn AuditBackend> {
+            Some(&self.audit_backend)
+        }
+
+        async fn health_check(&self) -> std::result::Result<(), BackendError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn non_azure_audit_with_resource_group_uses_backend_trait() {
+        let calls = StubAuditCalls::default();
+        let registry = BackendRegistry::new(Arc::new(StubAuditedBackend::new(calls.clone())));
+        let config = Config {
+            default_vault: "test-vault".to_string(),
+            default_resource_group: "default-rg".to_string(),
+            ..Config::default()
+        };
+
+        execute_audit_command(
+            None,
+            Some("test-vault".to_string()),
+            7,
+            None,
+            Some("ignored-for-non-azure".to_string()),
+            false,
+            config,
+            Some(&registry),
+        )
+        .await
+        .expect("non-Azure auditors must not fall through to Azure Activity Log routing");
+
+        assert_eq!(calls.vault_events.load(Ordering::SeqCst), 1);
+        assert_eq!(calls.secret_events.load(Ordering::SeqCst), 0);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds an Azure Activity Log-backed AuditBackend adapter and wires AzureBackend::audit() to it.
- Flips Azure has_audit to true so capability checks match xv audit behavior.
- Keeps the legacy Azure Activity Log path only when --resource-group is explicitly passed, since the backend-agnostic AuditBackend API has no resource-group override parameter yet.

## Verification
- cargo test azure_backend_declares_and_exposes_audit_backend --lib
- cargo clippy --lib -- -D warnings
- cargo test --lib was attempted in the kanban worktree; it is polluted by the host parent /home/szionic/.hermes/.xv.toml and fails two pre-existing config-sensitive tests unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-backend audit dispatch and introduces a parallel Azure Activity Log implementation; wrong routing could mis-handle AWS/other auditors, though behavior is now covered by a regression test.
> 
> **Overview**
> **Azure audit** is exposed through the shared `AuditBackend` trait via a new Activity Log adapter on `AzureBackend`, with `has_audit` set to true so capability checks match `xv audit` behavior.
> 
> **Routing fix:** `xv audit` no longer skips generic `AuditBackend` dispatch whenever `--resource-group` is present. That flag only steers **Azure** to the legacy Activity Log client when the override is explicit or the default resource group is missing; auditor-backed **non-Azure** backends always use the trait path (the flag is ignored for them).
> 
> Adds regression coverage for non-Azure audit with `--resource-group`, plus a small Azure capability test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ff28dca37f3f3202479db0488fcc4bb179b644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->