### PR TITLE
docs: surface env context resolution hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- `xv config show --resolved`, `xv context show`, and `xv context envs` now surface inline hints for the confusing env-profile vs vault-context vs global-config layers, including notes when active `.xv.toml` env fields override context/global fallbacks or inherit from them.
+
+---
+
 ## v0.15.0 — Opaque local filenames (2026-06-22)
 
 Adds opt-in opaque on-disk filenames for the local backend and includes a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,11 +117,13 @@ From `docs/UX-REVIEW.md` (2026-05-16 AWS-backend baseline).
 
 The full P2 lane and P3-1..4 shipped post-v0.12.0 (#254 §P2-1/§P2-5,
 #255 §P2-2, #256 §P2-3/§P2-4, #257 §P3-4, #258 §P3-1..3). They are
-recorded in [`CHANGELOG.md`](./CHANGELOG.md) under `v0.13.0`. One
-substantive UX item remains open:
+recorded in [`CHANGELOG.md`](./CHANGELOG.md) under `v0.13.0`. §P3-5 is
+also addressed in unreleased CLI output by inline hints on
+`config show --resolved`, `context show`, and `context envs` that explain
+env profile vs vault context vs global config precedence where users see the
+resolved values.
 
-### P3
-- **§P3-5 The CLI doesn't surface the env-vs-profile-vs-context distinction at the moment of confusion** — only docs do. Add inline hints at the point a user is likely to confuse env profiles, the active context, and global config (e.g. when `context envs` / `config show --resolved` disagree, or a vault/backend resolves from an unexpected layer).
+No substantive UX review items remain open.
 
 ---
 

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -347,6 +347,8 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
         .and_then(|p| p.backend.as_deref().map(String::from));
     let effective_backend = config.effective_backend_name().to_string();
 
+    let mut resolution_notes: Vec<String> = Vec::new();
+
     let backend_source = if config.cli_backend_was_arg && config.cli_backend.is_some() {
         // --backend was explicitly passed; it wins over everything below.
         "--backend CLI flag".to_string()
@@ -380,6 +382,15 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
         "built-in default".to_string()
     };
 
+    if active_profile
+        .as_ref()
+        .is_some_and(|profile| profile.backend.is_none())
+    {
+        resolution_notes.push(
+            "active env has no backend, so backend falls through to --backend/XV_BACKEND/global config/built-in default".to_string(),
+        );
+    }
+
     // --- Vault & resource_group resolution ---
     // Bugbot finding #4 on PR #216: if .xv.toml exists but resolve_env
     // failed (unknown XV_ENV / --env), real commands error out via
@@ -396,6 +407,12 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
             format!("env resolution failed: {err}"),
         )
     } else if let Some(v) = active_profile.as_ref().and_then(|p| p.vault.as_deref()) {
+        if context_manager.current_vault().is_some() || !config.default_vault.is_empty() {
+            resolution_notes.push(format!(
+                "active env `{}` supplies vault `{v}`, so vault context/global default are ignored",
+                active_env_name.as_deref().unwrap_or("?")
+            ));
+        }
         (
             v.to_string(),
             format!(
@@ -404,11 +421,22 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
             ),
         )
     } else if let Some(v) = context_manager.current_vault() {
+        if active_env_name.is_some() {
+            resolution_notes.push(
+                "active env has no vault, so vault falls through to the current context"
+                    .to_string(),
+            );
+        }
         (
             v.to_string(),
             context_manager.scope_description().to_string(),
         )
     } else if !config.default_vault.is_empty() {
+        if active_env_name.is_some() {
+            resolution_notes.push(
+                "active env has no vault and no context is set, so vault falls through to global config".to_string(),
+            );
+        }
         (
             config.default_vault.clone(),
             "global config `default_vault`".to_string(),
@@ -429,6 +457,14 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
         .as_ref()
         .and_then(|p| p.resource_group.as_deref())
     {
+        if context_manager.current_resource_group().is_some()
+            || !config.default_resource_group.is_empty()
+        {
+            resolution_notes.push(format!(
+                "active env `{}` supplies resource_group `{rg}`, so context/global resource_group are ignored",
+                active_env_name.as_deref().unwrap_or("?")
+            ));
+        }
         (
             rg.to_string(),
             format!(
@@ -437,11 +473,21 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
             ),
         )
     } else if let Some(rg) = context_manager.current_resource_group() {
+        if active_env_name.is_some() {
+            resolution_notes.push(
+                "active env has no resource_group, so resource_group falls through to the current context".to_string(),
+            );
+        }
         (
             rg.to_string(),
             context_manager.scope_description().to_string(),
         )
     } else if !config.default_resource_group.is_empty() {
+        if active_env_name.is_some() {
+            resolution_notes.push(
+                "active env has no resource_group and no context is set, so resource_group falls through to global config".to_string(),
+            );
+        }
         (
             config.default_resource_group.clone(),
             "global config `default_resource_group`".to_string(),
@@ -562,7 +608,7 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
         println!("  backend         : --backend flag > .xv.toml profile > XV_BACKEND / global config > built-in (azure)");
         println!("  env             : XV_ENV > --env flag > .xv.toml default_env");
         println!("  vault           : --vault arg > .xv.toml profile.vault > context > global default_vault");
-        println!("  resource_group  : --resource-group > .xv.toml profile.resource_group > global default_resource_group");
+        println!("  resource_group  : --resource-group > .xv.toml profile.resource_group > context > global default_resource_group");
         println!();
         println!("Naming convention: the global config uses a `default_` prefix (default_vault,");
         println!("default_resource_group) because those values are fallbacks; a .xv.toml env");
@@ -570,6 +616,15 @@ async fn execute_config_show_resolved(config: &Config) -> Result<()> {
         println!(
             "value that overrides the global default. Same concept, the prefix signals the layer."
         );
+        if !resolution_notes.is_empty() {
+            println!();
+            println!("Layer notes:");
+            resolution_notes.sort();
+            resolution_notes.dedup();
+            for note in resolution_notes {
+                println!("  - {note}");
+            }
+        }
     }
 
     Ok(())
@@ -926,6 +981,9 @@ async fn execute_context_show(config: &Config) -> Result<()> {
                 if let Some(f) = &profile.folder {
                     println!("  folder: {f}");
                 }
+                println!(
+                    "  hint: env profiles override context/global defaults when a field is set; missing env fields fall back to the vault context, then global config."
+                );
             }
             Err(e) => {
                 println!();
@@ -1354,6 +1412,9 @@ async fn execute_env_list(config: &Config) -> Result<()> {
             println!("Effective ({active_name}): backend={eff_backend}  vault={eff_vault}");
         }
     }
+    output::hint(
+        "`context envs` lists .xv.toml env profiles, not the vault context; run `xv config show --resolved` to see the effective backend/vault after env → context → global fallbacks.",
+    );
     Ok(())
 }
 

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -233,6 +233,43 @@ fn context_envs_lists_envs() {
         stdout.contains("* dev"),
         "active env should be starred: {stdout}"
     );
+    assert!(
+        stdout.contains("not the vault context") && stdout.contains("config show --resolved"),
+        "context envs should explain env-vs-context and point to resolved config: {stdout}"
+    );
+}
+
+#[test]
+fn config_show_resolved_notes_env_fallback_layers() {
+    let (mut cmd, temp) = xv_isolated();
+    write_local_global_config(temp.path());
+    std::fs::write(
+        temp.path().join(".xv.toml"),
+        r#"default_env = "dev"
+
+[env.dev]
+"#,
+    )
+    .expect("write .xv.toml");
+
+    let out = cmd
+        .args(["--format", "table", "config", "show", "--resolved"])
+        .output()
+        .expect("spawn");
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr_str(&out));
+    let stdout = stdout_str(&out);
+    assert!(
+        stdout.contains("resource_group  : --resource-group > .xv.toml profile.resource_group > context > global default_resource_group"),
+        "resolved config should document the context fallback for resource_group: {stdout}"
+    );
+    assert!(
+        stdout.contains("active env has no backend"),
+        "resolved config should explain inherited backend: {stdout}"
+    );
+    assert!(
+        stdout.contains("active env has no vault") && stdout.contains("global config"),
+        "resolved config should explain vault fallback to global config: {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add inline layer notes to `xv config show --resolved` when env profiles override or inherit from context/global config
- add env-vs-context hints to `xv context show` and `xv context envs`
- update ROADMAP/CHANGELOG to record §P3-5 as addressed

## Verification
- `cargo fmt --check`
- `cargo test --test context_tests`
- `cargo clippy --all-targets -- -D warnings`

Note: a plain `cargo test` from the worktree failed because unit tests picked up the developer-level `/home/szionic/.hermes/.xv.toml` via walk-up config discovery; the targeted context suite and clippy pass in the worktree.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing help text and precedence documentation only; no changes to how backend, vault, or resource_group are actually resolved at runtime.
> 
> **Overview**
> Addresses UX review **§P3-5** by adding **inline CLI guidance** where users often mix up `.xv.toml` env profiles, the vault context, and global config.
> 
> **`xv config show --resolved`** now prints a **Layer notes** section when the active env overrides or inherits backend, vault, and `resource_group`, and the printed precedence line for `resource_group` includes the **context** step (aligned with real resolution).
> 
> **`xv context show`** adds a short hint when an active env profile is shown: set env fields win; unset fields fall back to context then global config.
> 
> **`xv context envs`** ends with a hint that it lists project env profiles, not the vault context, and points to **`xv config show --resolved`** for effective values.
> 
> **CHANGELOG** (Unreleased) and **ROADMAP** record §P3-5 as done; **context_tests** cover the new output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c3792195e0427e77026a15bb6c4a060039929d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->