### PR TITLE
fix: wrap long notes in xv ls output

### DIFF
--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -257,6 +257,103 @@ fn secret_count_label(
     }
 }
 
+const SECRET_LIST_NOTE_WRAP_WIDTH: usize = 40;
+
+#[derive(Debug, Clone, serde::Serialize, tabled::Tabled)]
+struct SecretListDisplayRow {
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Note")]
+    note: String,
+    #[tabled(rename = "Folder")]
+    folder: String,
+    #[tabled(rename = "Groups")]
+    groups: String,
+    #[tabled(rename = "Updated")]
+    updated_on: String,
+}
+
+fn format_secret_list_rows_for_human(
+    secrets: &[crate::secret::manager::SecretSummary],
+) -> Vec<SecretListDisplayRow> {
+    secrets
+        .iter()
+        .map(|secret| SecretListDisplayRow {
+            name: secret.name.clone(),
+            note: secret
+                .note
+                .as_deref()
+                .map(|note| wrap_text_to_width(note, SECRET_LIST_NOTE_WRAP_WIDTH))
+                .unwrap_or_default(),
+            folder: secret.folder.clone().unwrap_or_default(),
+            groups: secret.groups.clone().unwrap_or_default(),
+            updated_on: secret.updated_on.clone(),
+        })
+        .collect()
+}
+
+fn wrap_text_to_width(input: &str, width: usize) -> String {
+    if width == 0 || input.is_empty() {
+        return input.to_string();
+    }
+
+    input
+        .split('\n')
+        .map(|paragraph| wrap_paragraph_to_width(paragraph, width))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn wrap_paragraph_to_width(paragraph: &str, width: usize) -> String {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+
+    for word in paragraph.split_whitespace() {
+        push_wrapped_word(word, width, &mut current, &mut lines);
+    }
+
+    if !current.is_empty() {
+        lines.push(current);
+    }
+
+    lines.join("\n")
+}
+
+fn push_wrapped_word(word: &str, width: usize, current: &mut String, lines: &mut Vec<String>) {
+    let word_len = word.chars().count();
+
+    if word_len > width {
+        if !current.is_empty() {
+            lines.push(std::mem::take(current));
+        }
+        let mut chunk = String::new();
+        for ch in word.chars() {
+            chunk.push(ch);
+            if chunk.chars().count() == width {
+                lines.push(std::mem::take(&mut chunk));
+            }
+        }
+        if !chunk.is_empty() {
+            *current = chunk;
+        }
+        return;
+    }
+
+    if current.is_empty() {
+        current.push_str(word);
+        return;
+    }
+
+    let projected_len = current.chars().count() + 1 + word_len;
+    if projected_len <= width {
+        current.push(' ');
+        current.push_str(word);
+    } else {
+        lines.push(std::mem::take(current));
+        current.push_str(word);
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn display_cached_secret_list(
     secrets: Vec<crate::secret::manager::SecretSummary>,
@@ -322,7 +419,8 @@ pub(crate) fn display_cached_secret_list(
         }
 
         let formatter = TableFormatter::new(fmt, config.no_color, config.template.clone());
-        output.push_str(&formatter.format_table(&page.items)?);
+        let display_rows = format_secret_list_rows_for_human(&page.items);
+        output.push_str(&formatter.format_table(&display_rows)?);
         output.push('\n');
         let _ = writeln!(
             output,
@@ -4552,6 +4650,28 @@ mod tests {
             "Showing 10 of 137 secret(s)"
         );
         assert_eq!(secret_count_label(137, 137, None, false), "137 secret(s)");
+    }
+
+    #[test]
+    fn human_secret_list_rows_wrap_long_notes() {
+        let mut secret = summary_named("api-key", Some("prod"), true);
+        secret.note = Some(
+            "This note is intentionally long so the secret list display wraps it across multiple lines"
+                .to_string(),
+        );
+
+        let rows = format_secret_list_rows_for_human(&[secret]);
+
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].note.contains('\n'), "long notes should wrap");
+        assert!(
+            rows[0]
+                .note
+                .lines()
+                .all(|line| line.chars().count() <= SECRET_LIST_NOTE_WRAP_WIDTH),
+            "wrapped note lines should fit the notes column width: {:?}",
+            rows[0].note
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a human-display row for xv ls that wraps long Note values at a fixed notes-column width
- Keeps JSON/YAML/CSV/template output backed by the original SecretSummary values so machine-readable notes remain unmodified
- Covers the wrapping behavior with a unit test

## Verification
- cargo test human_secret_list_rows_wrap_long_notes --lib
- cargo clippy --lib -- -D warnings
- HOME=$tmp/home XDG_CONFIG_HOME=$tmp/config RUSTUP_HOME=/home/szionic/.rustup CARGO_HOME=/home/szionic/.cargo cargo test --lib

Note: a normal cargo test --lib using the host HOME still fails two pre-existing config-contaminated tests because /home/szionic/.hermes/.xv.toml resolves kv-scottzionic instead of the tests' local fixture vault. The isolated HOME run passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display-only change in secret list formatting with structured exports left on the original data path.
> 
> **Overview**
> **xv ls** human table/plain/raw views no longer let long **Note** values stretch the table. The list path builds `SecretListDisplayRow` rows and wraps note text at a fixed 40-character column width (word-aware, with hard breaks for overlong tokens and preserved paragraph newlines).
> 
> JSON, YAML, CSV, and template output still format the original `SecretSummary` records, so machine-readable notes are unchanged. A unit test checks that wrapped note lines stay within the width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e5625d4c922bdf877be5b38208103b20b70c9c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->