### PR TITLE
fix: CLI UX issues + route advanced commands through the backend trait

### DIFF
--- a/output.txt
+++ b/output.txt
@@ -1,1 +1,0 @@
-[ok] Secret 'MY_VAR' copied to clipboard (auto-clears in 30s)

--- a/output.txt
+++ b/output.txt
@@ -1,0 +1,1 @@
+[ok] Secret 'MY_VAR' copied to clipboard (auto-clears in 30s)

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -486,7 +486,7 @@ pub enum Commands {
         page_size: Option<usize>,
         /// Use an interactive pager for output. Optional WHEN is auto (default
         /// when the flag is given), always, or never. e.g. `--pager` or `--pager auto`.
-        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "always")]
+        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "auto")]
         pager: Option<PagerWhen>,
         /// Print one name per line, no headers, no ANSI. Pipe-friendly.
         /// Overrides --format and disables auto-format-resolution.
@@ -942,7 +942,7 @@ pub enum VaultCommands {
         page_size: Option<usize>,
         /// Use an interactive pager for output. Optional WHEN is auto (default
         /// when the flag is given), always, or never. e.g. `--pager` or `--pager auto`.
-        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "always")]
+        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "auto")]
         pager: Option<PagerWhen>,
     },
     /// Delete a vault
@@ -1117,7 +1117,7 @@ pub enum VaultShareCommands {
         page_size: Option<usize>,
         /// Use an interactive pager for output. Optional WHEN is auto (default
         /// when the flag is given), always, or never. e.g. `--pager` or `--pager auto`.
-        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "always")]
+        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "auto")]
         pager: Option<PagerWhen>,
     },
 }
@@ -1156,7 +1156,7 @@ pub enum ShareCommands {
         page_size: Option<usize>,
         /// Use an interactive pager for output. Optional WHEN is auto (default
         /// when the flag is given), always, or never. e.g. `--pager` or `--pager auto`.
-        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "always")]
+        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "auto")]
         pager: Option<PagerWhen>,
     },
 }
@@ -1935,7 +1935,7 @@ mod tests {
             } => {
                 assert_eq!(page, Some(2));
                 assert_eq!(page_size, Some(25));
-                assert_eq!(pager, Some(PagerWhen::Always));
+                assert_eq!(pager, Some(PagerWhen::Auto));
             }
             _ => panic!("Expected List command"),
         }
@@ -1982,7 +1982,7 @@ mod tests {
             } => {
                 assert_eq!(page, Some(3));
                 assert_eq!(page_size, Some(50));
-                assert_eq!(pager, Some(PagerWhen::Always));
+                assert_eq!(pager, Some(PagerWhen::Auto));
             }
             _ => panic!("Expected vault list command"),
         }
@@ -2017,7 +2017,7 @@ mod tests {
                 assert_eq!(secret_name, "api-key");
                 assert_eq!(page, Some(2));
                 assert_eq!(page_size, Some(10));
-                assert_eq!(pager, Some(PagerWhen::Always));
+                assert_eq!(pager, Some(PagerWhen::Auto));
             }
             _ => panic!("Expected share list command"),
         }
@@ -2056,7 +2056,7 @@ mod tests {
                 assert_eq!(vault_name, "prod-vault");
                 assert_eq!(page, Some(2));
                 assert_eq!(page_size, Some(10));
-                assert_eq!(pager, Some(PagerWhen::Always));
+                assert_eq!(pager, Some(PagerWhen::Auto));
             }
             _ => panic!("Expected vault share list command"),
         }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -2339,7 +2339,10 @@ mod tests {
         assert!(req.not_before.is_none());
         assert_eq!(req.enabled, Some(true));
         assert_eq!(
-            req.tags.as_ref().and_then(|t| t.get("owner")).map(String::as_str),
+            req.tags
+                .as_ref()
+                .and_then(|t| t.get("owner"))
+                .map(String::as_str),
             Some("team-data")
         );
     }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -861,7 +861,7 @@ pub enum Commands {
         #[arg(default_value = ".", num_args = 1..)]
         paths: Vec<std::path::PathBuf>,
         /// Scan only files staged for commit (`git diff --cached`).
-        #[arg(long)]
+        #[arg(long, conflicts_with = "all")]
         staged: bool,
         /// Scan the full HEAD tree.
         #[arg(long)]
@@ -1939,6 +1939,21 @@ mod tests {
             }
             _ => panic!("Expected List command"),
         }
+    }
+
+    #[test]
+    fn test_scan_staged_and_all_conflict() {
+        // `--staged` and `--all` select different scan sources; passing both
+        // must be a hard clap error rather than silently honoring one.
+        let result = Cli::try_parse_from(["xv", "scan", "--staged", "--all"]);
+        assert!(
+            result.is_err(),
+            "scan --staged --all should be rejected as a conflict"
+        );
+
+        // Each on its own still parses.
+        assert!(Cli::try_parse_from(["xv", "scan", "--staged"]).is_ok());
+        assert!(Cli::try_parse_from(["xv", "scan", "--all"]).is_ok());
     }
 
     #[test]

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -22,6 +22,27 @@ fn get_version() -> &'static str {
     built_info::PKG_VERSION
 }
 
+/// When to route long output through an interactive pager.
+#[derive(Debug, Clone, Copy, clap::ValueEnum, PartialEq, Eq, Default)]
+pub enum PagerWhen {
+    /// Page only when stdout is an interactive terminal (default for `--pager`).
+    #[default]
+    Auto,
+    /// Always attempt to page (still falls back to direct print when not a TTY).
+    Always,
+    /// Never page; print directly.
+    Never,
+}
+
+impl PagerWhen {
+    /// Map to the boolean the pager plumbing expects. `print_output` already
+    /// gates paging on `can_page()`, so Auto and Always both request paging and
+    /// only Never disables it outright.
+    pub fn wants_pager(self) -> bool {
+        !matches!(self, PagerWhen::Never)
+    }
+}
+
 #[derive(Debug, Clone, clap::ValueEnum, PartialEq, Eq, Default)]
 pub enum OnConflict {
     /// Skip secrets that already exist in the target (default)
@@ -292,6 +313,9 @@ pub struct SecretWriteArgs {
     /// Set not-before date (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
     #[arg(long)]
     pub not_before: Option<String>,
+    /// Custom tag in key=value format (repeatable; e.g. `--tag owner=team-data`)
+    #[arg(long = "tag", value_name = "KEY=VALUE", value_parser = parse_key_val::<String, String>)]
+    pub tag: Vec<(String, String)>,
 }
 
 impl SecretWriteArgs {
@@ -303,6 +327,7 @@ impl SecretWriteArgs {
             || self.folder.is_some()
             || self.expires.is_some()
             || self.not_before.is_some()
+            || !self.tag.is_empty()
     }
 
     /// The groups as an `Option<Vec<String>>` matching `SecretRequest.groups`
@@ -335,6 +360,17 @@ impl SecretWriteArgs {
             None => None,
         };
 
+        let tags = if self.tag.is_empty() {
+            None
+        } else {
+            Some(
+                self.tag
+                    .iter()
+                    .cloned()
+                    .collect::<std::collections::HashMap<String, String>>(),
+            )
+        };
+
         Ok(crate::secret::manager::SecretRequest {
             name: name.to_string(),
             value,
@@ -342,7 +378,7 @@ impl SecretWriteArgs {
             enabled: Some(true),
             expires_on,
             not_before: not_before_on,
-            tags: None,
+            tags,
             groups: self.groups_opt(),
             note: self.note.clone(),
             folder: self.folder.clone(),
@@ -365,6 +401,11 @@ pub enum Commands {
         /// Trim leading/trailing whitespace from the value read via --stdin
         #[arg(long, requires = "stdin")]
         trim: bool,
+        /// Inline value for a single secret (avoid: appears in shell history —
+        /// prefer the interactive prompt or --stdin). Only valid with a single
+        /// secret name; mutually exclusive with --stdin.
+        #[arg(long, conflicts_with = "stdin")]
+        value: Option<String>,
         /// Write-time metadata (group/note/folder/expires/not-before)
         #[command(flatten)]
         meta: SecretWriteArgs,
@@ -443,9 +484,10 @@ pub enum Commands {
         /// Number of rows per page
         #[arg(long)]
         page_size: Option<usize>,
-        /// Use an interactive pager for TTY output
-        #[arg(long)]
-        pager: bool,
+        /// Use an interactive pager for output. Optional WHEN is auto (default
+        /// when the flag is given), always, or never. e.g. `--pager` or `--pager auto`.
+        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "always")]
+        pager: Option<PagerWhen>,
         /// Print one name per line, no headers, no ANSI. Pipe-friendly.
         /// Overrides --format and disables auto-format-resolution.
         #[arg(long)]
@@ -532,6 +574,15 @@ pub enum Commands {
         /// Filter secrets by group (can be specified multiple times)
         #[arg(short, long)]
         group: Vec<String>,
+        /// Inject only these secrets by name (repeatable). When given, the set
+        /// of injected secrets is restricted to these names (still subject to
+        /// --group). Names are matched against the original secret name.
+        #[arg(long)]
+        include: Vec<String>,
+        /// Exclude these secrets by name (repeatable). Applied after --group and
+        /// --include. Matched against the original secret name.
+        #[arg(long)]
+        exclude: Vec<String>,
         /// Disable masking of secret values in output
         #[arg(long)]
         no_masking: bool,
@@ -567,8 +618,8 @@ pub enum Commands {
         /// Trim leading/trailing whitespace from the value read via --stdin
         #[arg(long, requires = "stdin")]
         trim: bool,
-        /// Tags for the secret in key=value format
-        #[arg(short, long, value_parser = parse_key_val::<String, String>)]
+        /// Tags for the secret in key=value format (repeatable)
+        #[arg(short, long, visible_alias = "tag", value_parser = parse_key_val::<String, String>)]
         tags: Vec<(String, String)>,
         /// Groups for the secret (can be specified multiple times)
         #[arg(short, long)]
@@ -889,9 +940,10 @@ pub enum VaultCommands {
         /// Number of rows per page
         #[arg(long)]
         page_size: Option<usize>,
-        /// Use an interactive pager for TTY output
-        #[arg(long)]
-        pager: bool,
+        /// Use an interactive pager for output. Optional WHEN is auto (default
+        /// when the flag is given), always, or never. e.g. `--pager` or `--pager auto`.
+        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "always")]
+        pager: Option<PagerWhen>,
     },
     /// Delete a vault
     Delete {
@@ -1063,9 +1115,10 @@ pub enum VaultShareCommands {
         /// Number of rows per page
         #[arg(long)]
         page_size: Option<usize>,
-        /// Use an interactive pager for TTY output
-        #[arg(long)]
-        pager: bool,
+        /// Use an interactive pager for output. Optional WHEN is auto (default
+        /// when the flag is given), always, or never. e.g. `--pager` or `--pager auto`.
+        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "always")]
+        pager: Option<PagerWhen>,
     },
 }
 
@@ -1101,9 +1154,10 @@ pub enum ShareCommands {
         /// Number of rows per page
         #[arg(long)]
         page_size: Option<usize>,
-        /// Use an interactive pager for TTY output
-        #[arg(long)]
-        pager: bool,
+        /// Use an interactive pager for output. Optional WHEN is auto (default
+        /// when the flag is given), always, or never. e.g. `--pager` or `--pager auto`.
+        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "always")]
+        pager: Option<PagerWhen>,
     },
 }
 
@@ -1371,10 +1425,11 @@ impl Cli {
                 args,
                 stdin,
                 trim,
+                value,
                 meta,
             } => {
                 crate::cli::secret_ops::execute_secret_set_direct(
-                    args, stdin, trim, meta, config, registry,
+                    args, stdin, trim, value, meta, config, registry,
                 )
                 .await
             }
@@ -1417,6 +1472,7 @@ impl Cli {
                 names_only,
             } => {
                 let pagination = crate::utils::pagination::Pagination::from_args(page, page_size)?;
+                let pager = pager.map(PagerWhen::wants_pager).unwrap_or(false);
                 crate::cli::secret_ops::execute_secret_list_direct(
                     group, all, expiring, expired, no_cache, pagination, pager, names_only, config,
                     registry,
@@ -1471,12 +1527,16 @@ impl Cli {
             }
             Commands::Run {
                 group,
+                include,
+                exclude,
                 no_masking,
                 inherit_env,
                 command,
             } => {
                 crate::cli::secret_ops::execute_secret_run_direct(
                     group,
+                    include,
+                    exclude,
                     no_masking,
                     inherit_env,
                     command,
@@ -1875,7 +1935,7 @@ mod tests {
             } => {
                 assert_eq!(page, Some(2));
                 assert_eq!(page_size, Some(25));
-                assert!(pager);
+                assert_eq!(pager, Some(PagerWhen::Always));
             }
             _ => panic!("Expected List command"),
         }
@@ -1907,7 +1967,7 @@ mod tests {
             } => {
                 assert_eq!(page, Some(3));
                 assert_eq!(page_size, Some(50));
-                assert!(pager);
+                assert_eq!(pager, Some(PagerWhen::Always));
             }
             _ => panic!("Expected vault list command"),
         }
@@ -1942,7 +2002,7 @@ mod tests {
                 assert_eq!(secret_name, "api-key");
                 assert_eq!(page, Some(2));
                 assert_eq!(page_size, Some(10));
-                assert!(pager);
+                assert_eq!(pager, Some(PagerWhen::Always));
             }
             _ => panic!("Expected share list command"),
         }
@@ -1981,7 +2041,7 @@ mod tests {
                 assert_eq!(vault_name, "prod-vault");
                 assert_eq!(page, Some(2));
                 assert_eq!(page_size, Some(10));
-                assert!(pager);
+                assert_eq!(pager, Some(PagerWhen::Always));
             }
             _ => panic!("Expected vault share list command"),
         }
@@ -2248,6 +2308,7 @@ mod tests {
             folder: Some("f".into()),
             expires: None,
             not_before: None,
+            tag: vec![("owner".into(), "team-data".into())],
         };
         let req = meta
             .to_secret_request("name", zeroize::Zeroizing::new("val".to_string()))
@@ -2260,6 +2321,19 @@ mod tests {
         assert!(req.expires_on.is_none());
         assert!(req.not_before.is_none());
         assert_eq!(req.enabled, Some(true));
+        assert_eq!(
+            req.tags.as_ref().and_then(|t| t.get("owner")).map(String::as_str),
+            Some("team-data")
+        );
+    }
+
+    #[test]
+    fn test_has_any_detects_tag() {
+        let with_tag = SecretWriteArgs {
+            tag: vec![("k".into(), "v".into())],
+            ..Default::default()
+        };
+        assert!(with_tag.has_any());
     }
 
     #[test]

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1672,7 +1672,7 @@ impl Cli {
                 crate::cli::config_ops::execute_context_command(command, config).await
             }
             Commands::Env { command } => {
-                crate::cli::config_ops::execute_env_command(command, config).await
+                crate::cli::config_ops::execute_env_command(command, config, registry).await
             }
             Commands::Audit {
                 name,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -576,11 +576,13 @@ pub enum Commands {
         group: Vec<String>,
         /// Inject only these secrets by name (repeatable). When given, the set
         /// of injected secrets is restricted to these names (still subject to
-        /// --group). Names are matched against the original secret name.
+        /// --group). Names match either the original (user-facing) name shown by
+        /// `xv list` or the backend name.
         #[arg(long)]
         include: Vec<String>,
         /// Exclude these secrets by name (repeatable). Applied after --group and
-        /// --include. Matched against the original secret name.
+        /// --include. Names match either the original (user-facing) name shown by
+        /// `xv list` or the backend name.
         #[arg(long)]
         exclude: Vec<String>,
         /// Disable masking of secret values in output

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -1284,7 +1284,11 @@ async fn execute_context_init(
 
 // ── Env Commands ─────────────────────────────────────────────────────────────
 
-pub(crate) async fn execute_env_command(command: EnvCommands, config: Config) -> Result<()> {
+pub(crate) async fn execute_env_command(
+    command: EnvCommands,
+    config: Config,
+    registry: Option<&crate::backend::BackendRegistry>,
+) -> Result<()> {
     match command {
         EnvCommands::List => execute_env_list(&config).await,
         EnvCommands::Use { name } => execute_env_use(&name, &config).await,
@@ -1317,8 +1321,10 @@ pub(crate) async fn execute_env_command(command: EnvCommands, config: Config) ->
             format,
             group,
             output,
-        } => execute_env_pull(&format, group, output, &config).await,
-        EnvCommands::Push { file, overwrite } => execute_env_push(file, overwrite, &config).await,
+        } => execute_env_pull(&format, group, output, &config, registry).await,
+        EnvCommands::Push { file, overwrite } => {
+            execute_env_push(file, overwrite, &config, registry).await
+        }
     }
 }
 
@@ -1604,22 +1610,18 @@ async fn execute_env_pull(
     groups: Vec<String>,
     output: Option<String>,
     config: &Config,
+    registry: Option<&crate::backend::BackendRegistry>,
 ) -> Result<()> {
-    use crate::auth::provider::DefaultAzureCredentialProvider;
-    use crate::secret::manager::SecretManager;
     use crate::utils::format::OutputFormat;
-    use std::sync::Arc;
 
-    // Create authentication provider and secret manager
-    let auth_provider = Arc::new(
-        DefaultAzureCredentialProvider::with_credential_priority(
-            config.azure_credential_priority.clone(),
+    // Route through the active backend trait so `xv env pull` works on every
+    // backend (azure/local/aws), not just Azure.
+    let reg = registry.ok_or_else(|| {
+        CrosstacheError::config(
+            "No backend registry available. Run 'xv config show' to check your configuration.",
         )
-        .map_err(|e| {
-            CrosstacheError::authentication(format!("Failed to create auth provider: {e}"))
-        })?,
-    );
-    let secret_manager = SecretManager::new(auth_provider, config.no_color);
+    })?;
+    let secrets_backend = reg.active().secrets();
 
     // Determine vault name
     let vault_name = config.resolve_vault_name(None).await?;
@@ -1630,18 +1632,13 @@ async fn execute_env_pull(
     let mut all_secrets = Vec::new();
     if groups.is_empty() {
         // Get all secrets
-        let secrets = secret_manager
-            .list_secrets_formatted(
-                &vault_name,
-                None,
-                crate::utils::format::OutputFormat::Json, // We don't use the output, just need the list
-                false,
-                true,
-            )
-            .await?;
+        let secrets = secrets_backend
+            .list_secrets(&vault_name, None)
+            .await
+            .map_err(CrosstacheError::from)?;
         for secret_summary in secrets {
-            match secret_manager
-                .get_secret_safe(&vault_name, &secret_summary.name, true, true)
+            match secrets_backend
+                .get_secret(&vault_name, &secret_summary.name, true)
                 .await
             {
                 Ok(secret) => all_secrets.push(secret),
@@ -1654,18 +1651,13 @@ async fn execute_env_pull(
     } else {
         // Get secrets filtered by groups
         for group in &groups {
-            let secrets = secret_manager
-                .list_secrets_formatted(
-                    &vault_name,
-                    Some(group),
-                    crate::utils::format::OutputFormat::Json, // We don't use the output, just need the list
-                    false,
-                    true,
-                )
-                .await?;
+            let secrets = secrets_backend
+                .list_secrets(&vault_name, Some(group))
+                .await
+                .map_err(CrosstacheError::from)?;
             for secret_summary in secrets {
-                match secret_manager
-                    .get_secret_safe(&vault_name, &secret_summary.name, true, true)
+                match secrets_backend
+                    .get_secret(&vault_name, &secret_summary.name, true)
                     .await
                 {
                     Ok(secret) => all_secrets.push(secret),
@@ -1762,24 +1754,24 @@ async fn execute_env_pull(
     Ok(())
 }
 
-async fn execute_env_push(file: Option<String>, overwrite: bool, config: &Config) -> Result<()> {
-    use crate::auth::provider::DefaultAzureCredentialProvider;
-    use crate::secret::manager::SecretManager;
+async fn execute_env_push(
+    file: Option<String>,
+    overwrite: bool,
+    config: &Config,
+    registry: Option<&crate::backend::BackendRegistry>,
+) -> Result<()> {
     use crate::secret::manager::SecretRequest;
     use std::collections::HashMap;
     use std::io::Read;
-    use std::sync::Arc;
 
-    // Create authentication provider and secret manager
-    let auth_provider = Arc::new(
-        DefaultAzureCredentialProvider::with_credential_priority(
-            config.azure_credential_priority.clone(),
+    // Route through the active backend trait so `xv env push` works on every
+    // backend (azure/local/aws), not just Azure.
+    let reg = registry.ok_or_else(|| {
+        CrosstacheError::config(
+            "No backend registry available. Run 'xv config show' to check your configuration.",
         )
-        .map_err(|e| {
-            CrosstacheError::authentication(format!("Failed to create auth provider: {e}"))
-        })?,
-    );
-    let secret_manager = SecretManager::new(auth_provider, config.no_color);
+    })?;
+    let secrets_backend = reg.active().secrets();
 
     // Determine vault name
     let vault_name = config.resolve_vault_name(None).await?;
@@ -1853,8 +1845,8 @@ async fn execute_env_push(file: Option<String>, overwrite: bool, config: &Config
     if !overwrite {
         let mut existing_secrets = Vec::new();
         for key in secrets.keys() {
-            if secret_manager
-                .get_secret_safe(&vault_name, key, false, false)
+            if secrets_backend
+                .get_secret(&vault_name, key, false)
                 .await
                 .is_ok()
             {
@@ -1892,8 +1884,8 @@ async fn execute_env_push(file: Option<String>, overwrite: bool, config: &Config
             folder: None,
         };
 
-        match secret_manager
-            .set_secret_safe(&vault_name, &key, &value, Some(secret_request))
+        match secrets_backend
+            .set_secret(&vault_name, secret_request)
             .await
         {
             Ok(_) => {

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -1915,16 +1915,17 @@ async fn execute_env_push(file: Option<String>, overwrite: bool, config: &Config
     }
 
     if error_count > 0 {
-        println!(
-            "Completed with {} successful and {} failed operations",
-            success_count, error_count
-        );
-    } else {
-        output::success(&format!(
-            "Successfully pushed {} secret(s) to vault '{}'",
-            success_count, vault_name
-        ));
+        // Surface partial failures as a non-zero exit so CI/scripts don't treat
+        // a half-finished push as success.
+        return Err(CrosstacheError::unknown(format!(
+            "env push: {error_count} of {} secret(s) failed to set in vault '{vault_name}'",
+            success_count + error_count
+        )));
     }
+    output::success(&format!(
+        "Successfully pushed {} secret(s) to vault '{}'",
+        success_count, vault_name
+    ));
 
     Ok(())
 }

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -101,6 +101,32 @@ pub(crate) async fn resolve_vault_for_trait(
     Ok("default".to_string())
 }
 
+/// Decide whether a destructive operation may proceed, prompting when possible.
+///
+/// Behaviour, matching the Azure legacy delete/purge paths so confirmation is
+/// uniform across every backend:
+/// * `force == true` → proceed unconditionally (`Ok(true)`).
+/// * interactive stdin (a TTY) → prompt `y/N` (default no); return the answer.
+/// * non-interactive (pipe/CI, no TTY) → refuse with a non-zero
+///   [`CrosstacheError::InvalidArgument`] (exit code 2) telling the user to
+///   pass `--force`, instead of silently no-opping.
+///
+/// `prompt` is the full confirmation question (e.g. `"Delete secret 'X'?"`).
+pub(crate) fn confirm_destructive(force: bool, prompt: &str) -> Result<bool> {
+    use std::io::IsTerminal;
+
+    if force {
+        return Ok(true);
+    }
+    if !std::io::stdin().is_terminal() {
+        return Err(CrosstacheError::invalid_argument(format!(
+            "Refusing to proceed without confirmation in a non-interactive session ({prompt}). \
+             Re-run with --force to confirm."
+        )));
+    }
+    crate::utils::interactive::InteractivePrompt::new().confirm(prompt, false)
+}
+
 /// Obtain the Azure auth provider, preferring the one from the
 /// [`BackendRegistry`] (which was built once at startup) and falling back
 /// to creating a fresh provider from the config when the registry is absent.

--- a/src/cli/scan_ops.rs
+++ b/src/cli/scan_ops.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 pub(crate) async fn execute_scan_command(
     paths: Vec<PathBuf>,
     staged: bool,
-    _all: bool,
+    all: bool,
     hook: bool,
     all_vaults: bool,
     command: Option<ScanCommands>,
@@ -30,6 +30,9 @@ pub(crate) async fn execute_scan_command(
     }
     if staged {
         return execute_scan_staged(hook, all_vaults, format, &config, registry).await;
+    }
+    if all {
+        return execute_scan_head(hook, all_vaults, format, &config, registry).await;
     }
     execute_scan_paths(paths, hook, all_vaults, format, &config, registry).await
 }
@@ -145,6 +148,48 @@ async fn execute_scan_staged(
     let patterns = builtin_patterns();
     let engine = MatchEngine::new(&secrets, &patterns);
     let findings = scan_staged(&engine)?;
+
+    render_findings(&findings, hook, format)
+}
+
+async fn execute_scan_head(
+    hook: bool,
+    all_vaults: bool,
+    format: crate::utils::format::OutputFormat,
+    config: &Config,
+    registry: Option<&crate::backend::BackendRegistry>,
+) -> Result<()> {
+    use crate::scan::staged::scan_head;
+    use crate::secret::manager::SecretManager;
+
+    let auth_provider = crate::cli::helpers::get_azure_auth_provider(registry, config)?;
+    let secret_manager = SecretManager::new(auth_provider, config.no_color);
+
+    let vault_names: Vec<String> = if all_vaults {
+        let auth = crate::cli::helpers::get_azure_auth_provider(registry, config)?;
+        let vault_manager = crate::vault::manager::VaultManager::new(
+            auth,
+            config.subscription_id.clone(),
+            config.no_color,
+        )?;
+        vault_manager
+            .vault_ops()
+            .list_vaults(Some(&config.subscription_id), None)
+            .await?
+            .into_iter()
+            .map(|v| v.name)
+            .collect()
+    } else {
+        vec![config.resolve_vault_name(None).await?]
+    };
+
+    let progress = crate::utils::interactive::ProgressIndicator::new("Fetching secret values...");
+    let secrets = fetch_secret_values(&secret_manager, &vault_names, 10).await?;
+    progress.finish_clear();
+
+    let patterns = builtin_patterns();
+    let engine = MatchEngine::new(&secrets, &patterns);
+    let findings = scan_head(&engine)?;
 
     render_findings(&findings, hook, format)
 }

--- a/src/cli/scan_ops.rs
+++ b/src/cli/scan_ops.rs
@@ -159,9 +159,22 @@ async fn execute_scan_head(
 
     let secrets = fetch_scan_secrets(all_vaults, config, registry).await?;
 
+    // Apply the same [scan].exclude + default globs the filesystem walk uses,
+    // so `scan --all` doesn't scan target/, node_modules/, or user-excluded
+    // committed paths that `scan .` would skip.
+    let mut extra_excludes: Vec<String> = Vec::new();
+    if let Ok(Some((_, project))) =
+        crate::config::project::find_project_config(&std::env::current_dir()?).await
+    {
+        if let Some(scan) = &project.scan {
+            extra_excludes = scan.exclude.clone();
+        }
+    }
+    let excludes = crate::scan::walker::build_exclude_set(&extra_excludes)?;
+
     let patterns = builtin_patterns();
     let engine = MatchEngine::new(&secrets, &patterns);
-    let findings = scan_head(&engine)?;
+    let findings = scan_head(&engine, &excludes)?;
 
     render_findings(&findings, hook, format)
 }

--- a/src/cli/scan_ops.rs
+++ b/src/cli/scan_ops.rs
@@ -37,6 +37,52 @@ pub(crate) async fn execute_scan_command(
     execute_scan_paths(paths, hook, all_vaults, format, &config, registry).await
 }
 
+/// Resolve the active backend and the set of vaults to scan, then fetch every
+/// secret value across them through the backend trait.
+///
+/// Works on any backend (azure/local/aws). `--all-vaults` requires a backend
+/// that can enumerate vaults (`Backend::vaults()`); backends without that
+/// capability return a clear capability error instead of silently scanning a
+/// single vault.
+async fn fetch_scan_secrets(
+    all_vaults: bool,
+    config: &Config,
+    registry: Option<&crate::backend::BackendRegistry>,
+) -> Result<Vec<crate::scan::engine::SecretRef>> {
+    let reg = registry.ok_or_else(|| {
+        CrosstacheError::config(
+            "No backend registry available. Run 'xv config show' to check your configuration.",
+        )
+    })?;
+    let backend = reg.active_arc();
+
+    let vault_names: Vec<String> = if all_vaults {
+        match backend.vaults() {
+            Some(vaults) => vaults
+                .list_vaults()
+                .await
+                .map_err(CrosstacheError::from)?
+                .into_iter()
+                .map(|v| v.name)
+                .collect(),
+            None => {
+                return Err(CrosstacheError::invalid_argument(format!(
+                    "--all-vaults is not supported on the {} backend (it cannot enumerate \
+                     vaults). Scan a single vault instead.",
+                    backend.name()
+                )))
+            }
+        }
+    } else {
+        vec![config.resolve_vault_name(None).await?]
+    };
+
+    let progress = crate::utils::interactive::ProgressIndicator::new("Fetching secret values...");
+    let secrets = fetch_secret_values(backend, &vault_names, 10).await?;
+    progress.finish_clear();
+    Ok(secrets)
+}
+
 async fn execute_scan_paths(
     paths: Vec<PathBuf>,
     hook: bool,
@@ -45,33 +91,7 @@ async fn execute_scan_paths(
     config: &Config,
     registry: Option<&crate::backend::BackendRegistry>,
 ) -> Result<()> {
-    use crate::secret::manager::SecretManager;
-
-    let auth_provider = crate::cli::helpers::get_azure_auth_provider(registry, config)?;
-    let secret_manager = SecretManager::new(auth_provider, config.no_color);
-
-    // Pick which vaults to fetch from.
-    let vault_names: Vec<String> = if all_vaults {
-        let auth = crate::cli::helpers::get_azure_auth_provider(registry, config)?;
-        let vault_manager = crate::vault::manager::VaultManager::new(
-            auth,
-            config.subscription_id.clone(),
-            config.no_color,
-        )?;
-        vault_manager
-            .vault_ops()
-            .list_vaults(Some(&config.subscription_id), None)
-            .await?
-            .into_iter()
-            .map(|v| v.name)
-            .collect()
-    } else {
-        vec![config.resolve_vault_name(None).await?]
-    };
-
-    let progress = crate::utils::interactive::ProgressIndicator::new("Fetching secret values...");
-    let secrets = fetch_secret_values(&secret_manager, &vault_names, 10).await?;
-    progress.finish_clear();
+    let secrets = fetch_scan_secrets(all_vaults, config, registry).await?;
 
     let patterns = builtin_patterns();
     let engine = MatchEngine::new(&secrets, &patterns);
@@ -118,32 +138,8 @@ async fn execute_scan_staged(
     registry: Option<&crate::backend::BackendRegistry>,
 ) -> Result<()> {
     use crate::scan::staged::scan_staged;
-    use crate::secret::manager::SecretManager;
 
-    let auth_provider = crate::cli::helpers::get_azure_auth_provider(registry, config)?;
-    let secret_manager = SecretManager::new(auth_provider, config.no_color);
-
-    let vault_names: Vec<String> = if all_vaults {
-        let auth = crate::cli::helpers::get_azure_auth_provider(registry, config)?;
-        let vault_manager = crate::vault::manager::VaultManager::new(
-            auth,
-            config.subscription_id.clone(),
-            config.no_color,
-        )?;
-        vault_manager
-            .vault_ops()
-            .list_vaults(Some(&config.subscription_id), None)
-            .await?
-            .into_iter()
-            .map(|v| v.name)
-            .collect()
-    } else {
-        vec![config.resolve_vault_name(None).await?]
-    };
-
-    let progress = crate::utils::interactive::ProgressIndicator::new("Fetching secret values...");
-    let secrets = fetch_secret_values(&secret_manager, &vault_names, 10).await?;
-    progress.finish_clear();
+    let secrets = fetch_scan_secrets(all_vaults, config, registry).await?;
 
     let patterns = builtin_patterns();
     let engine = MatchEngine::new(&secrets, &patterns);
@@ -160,32 +156,8 @@ async fn execute_scan_head(
     registry: Option<&crate::backend::BackendRegistry>,
 ) -> Result<()> {
     use crate::scan::staged::scan_head;
-    use crate::secret::manager::SecretManager;
 
-    let auth_provider = crate::cli::helpers::get_azure_auth_provider(registry, config)?;
-    let secret_manager = SecretManager::new(auth_provider, config.no_color);
-
-    let vault_names: Vec<String> = if all_vaults {
-        let auth = crate::cli::helpers::get_azure_auth_provider(registry, config)?;
-        let vault_manager = crate::vault::manager::VaultManager::new(
-            auth,
-            config.subscription_id.clone(),
-            config.no_color,
-        )?;
-        vault_manager
-            .vault_ops()
-            .list_vaults(Some(&config.subscription_id), None)
-            .await?
-            .into_iter()
-            .map(|v| v.name)
-            .collect()
-    } else {
-        vec![config.resolve_vault_name(None).await?]
-    };
-
-    let progress = crate::utils::interactive::ProgressIndicator::new("Fetching secret values...");
-    let secrets = fetch_secret_values(&secret_manager, &vault_names, 10).await?;
-    progress.finish_clear();
+    let secrets = fetch_scan_secrets(all_vaults, config, registry).await?;
 
     let patterns = builtin_patterns();
     let engine = MatchEngine::new(&secrets, &patterns);

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -34,7 +34,6 @@ fn read_secret_value_from_stdin(trim: bool) -> Result<String> {
 }
 
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_secret_set_direct(
     args: Vec<String>,
     stdin: bool,

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -43,14 +43,14 @@ pub(crate) async fn execute_secret_set_direct(
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
+    // Only `--expires` / `--not-before` are inspected directly here (to reject
+    // them for bulk set); all other write-time metadata is applied uniformly via
+    // `meta.to_secret_request`.
     let SecretWriteArgs {
-        note,
-        folder,
         expires,
         not_before,
         ..
     } = meta.clone();
-    let groups = meta.groups_opt();
 
     // `--value` is only meaningful for a single secret; reject it alongside
     // bulk KEY=value arguments so the inline value can't be silently dropped.
@@ -115,18 +115,11 @@ pub(crate) async fn execute_secret_set_direct(
             let mut success_count = 0usize;
             let mut error_count = 0usize;
             for (key, value) in pairs {
-                let request = crate::secret::manager::SecretRequest {
-                    name: key.clone(),
-                    value: Zeroizing::new(value),
-                    content_type: None,
-                    enabled: Some(true),
-                    expires_on: None,
-                    not_before: None,
-                    tags: None,
-                    groups: groups.clone(),
-                    note: note.clone(),
-                    folder: folder.clone(),
-                };
+                // Build each request via the shared helper so bulk set applies
+                // the same write-time metadata (--group/--note/--folder/--tag)
+                // as the single-secret path. (--expires/--not-before are rejected
+                // for bulk above, so they're always None here.)
+                let request = meta.to_secret_request(&key, Zeroizing::new(value))?;
                 match reg
                     .active()
                     .secrets()

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -926,13 +926,17 @@ pub(crate) async fn execute_secret_run_direct(
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
-    let auth_provider = get_azure_auth_provider(registry, &config)?;
-
-    // Create secret manager
-    let secret_manager = SecretManager::new(auth_provider, config.no_color);
+    // Route through the active backend trait so `xv run` works on every backend
+    // (azure/local/aws). The Azure trait impl delegates to the same secret ops
+    // the legacy path used, so Azure behaviour is unchanged.
+    let reg = registry.ok_or_else(|| {
+        CrosstacheError::config(
+            "No backend registry available. Run 'xv config show' to check your configuration.",
+        )
+    })?;
 
     execute_secret_run(
-        &secret_manager,
+        reg,
         None,
         group,
         include,
@@ -952,12 +956,15 @@ pub(crate) async fn execute_secret_inject_direct(
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
-    let auth_provider = get_azure_auth_provider(registry, &config)?;
+    // Route through the active backend trait so `xv inject` works on every
+    // backend (azure/local/aws), not just Azure.
+    let reg = registry.ok_or_else(|| {
+        CrosstacheError::config(
+            "No backend registry available. Run 'xv config show' to check your configuration.",
+        )
+    })?;
 
-    // Create secret manager
-    let secret_manager = SecretManager::new(auth_provider, config.no_color);
-
-    execute_secret_inject(&secret_manager, None, template, out, group, &config).await
+    execute_secret_inject(reg, None, template, out, group, &config).await
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2311,7 +2318,7 @@ async fn execute_secret_rotate(
 async fn resolve_uri_secret(
     backend_ref: &BackendRef,
     secret_name: &str,
-    secret_manager: &crate::secret::manager::SecretManager,
+    active_secrets: &dyn crate::backend::SecretBackend,
     config: &Config,
     active_kind: BackendKind,
     cross_backends: &mut std::collections::HashMap<BackendKind, Arc<dyn crate::backend::Backend>>,
@@ -2333,15 +2340,15 @@ async fn resolve_uri_secret(
                 .map_err(CrosstacheError::from);
         }
     }
-    secret_manager
-        .secret_ops()
+    active_secrets
         .get_secret(&backend_ref.vault, secret_name, true)
         .await
+        .map_err(CrosstacheError::from)
 }
 
 #[allow(clippy::too_many_arguments)]
 async fn execute_secret_run(
-    secret_manager: &crate::secret::manager::SecretManager,
+    reg: &BackendRegistry,
     vault: Option<String>,
     groups: Vec<String>,
     include: Vec<String>,
@@ -2393,14 +2400,12 @@ async fn execute_secret_run(
         }
     }
 
-    // Get all secrets from the vault
+    // Get all secrets from the active backend (trait path — works for azure,
+    // local, and aws alike).
     let progress = crate::utils::interactive::ProgressIndicator::new("Loading secrets...");
-    let secrets = secret_manager
-        .secret_ops()
-        .list_secrets(&vault_name, None)
-        .await;
+    let secrets = reg.active().secrets().list_secrets(&vault_name, None).await;
     progress.finish_clear();
-    let secrets = secrets?;
+    let secrets = secrets.map_err(CrosstacheError::from)?;
 
     // Filter secrets by groups if specified
     let filtered_secrets = if !groups.is_empty() {
@@ -2466,8 +2471,9 @@ async fn execute_secret_run(
     // Fetch secrets from current vault (group-filtered)
     for secret in filtered_secrets {
         // Get the secret value
-        match secret_manager
-            .secret_ops()
+        match reg
+            .active()
+            .secrets()
             .get_secret(&vault_name, &secret.name, true)
             .await
         {
@@ -2498,10 +2504,7 @@ async fn execute_secret_run(
             uri_refs.len()
         ));
 
-        let active_kind: BackendKind = config
-            .effective_backend_name()
-            .parse()
-            .unwrap_or(BackendKind::Azure);
+        let active_kind: BackendKind = reg.active().kind();
 
         // Cache backends by kind — avoids re-initialising the SDK per URI
         let mut cross_backends: std::collections::HashMap<
@@ -2521,7 +2524,7 @@ async fn execute_secret_run(
             let fetch_result = resolve_uri_secret(
                 backend_ref,
                 &secret_name,
-                secret_manager,
+                reg.active().secrets(),
                 config,
                 active_kind,
                 &mut cross_backends,
@@ -2777,7 +2780,7 @@ fn clean_split(window: &[u8], secrets: &[Zeroizing<String>], mut split: usize) -
 }
 
 async fn execute_secret_inject(
-    secret_manager: &crate::secret::manager::SecretManager,
+    reg: &BackendRegistry,
     vault: Option<String>,
     template_file: Option<String>,
     output_file: Option<String>,
@@ -2890,14 +2893,12 @@ async fn execute_secret_inject(
         );
     }
 
-    // Get all secrets from the vault
+    // Get all secrets from the active backend (trait path — works for azure,
+    // local, and aws alike).
     let progress = crate::utils::interactive::ProgressIndicator::new("Loading secrets...");
-    let secrets = secret_manager
-        .secret_ops()
-        .list_secrets(&vault_name, None)
-        .await;
+    let secrets = reg.active().secrets().list_secrets(&vault_name, None).await;
     progress.finish_clear();
-    let secrets = secrets?;
+    let secrets = secrets.map_err(CrosstacheError::from)?;
 
     // Filter secrets by groups if specified
     let available_secrets = if !groups.is_empty() {
@@ -2929,8 +2930,9 @@ async fn execute_secret_inject(
         // Check if the secret exists in the available secrets
         if let Some(secret_summary) = available_secrets.iter().find(|s| s.name == *secret_name) {
             // Get the secret value
-            match secret_manager
-                .secret_ops()
+            match reg
+                .active()
+                .secrets()
                 .get_secret(&vault_name, &secret_summary.name, true)
                 .await
             {
@@ -2956,10 +2958,7 @@ async fn execute_secret_inject(
 
     // Fetch URI-referenced secrets (supports optional backend prefix)
     {
-        let active_kind: BackendKind = config
-            .effective_backend_name()
-            .parse()
-            .unwrap_or(BackendKind::Azure);
+        let active_kind: BackendKind = reg.active().kind();
 
         // Cache backends by kind — avoids re-initialising the SDK per URI
         let mut cross_backends: std::collections::HashMap<
@@ -2980,7 +2979,7 @@ async fn execute_secret_inject(
             let fetch_result = resolve_uri_secret(
                 backend_ref,
                 &secret_name,
-                secret_manager,
+                reg.active().secrets(),
                 config,
                 active_kind,
                 &mut cross_backends,

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -802,15 +802,7 @@ pub(crate) async fn execute_secret_rotate_direct(
     })?;
 
     execute_secret_rotate(
-        reg,
-        name,
-        None,
-        length,
-        charset,
-        generator,
-        show_value,
-        force,
-        &config,
+        reg, name, None, length, charset, generator, show_value, force, &config,
     )
     .await?;
 

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2428,14 +2428,22 @@ async fn execute_secret_run(
 
     // Apply name-based --include / --exclude on top of the group filter.
     // --include restricts to the named secrets; --exclude removes them.
-    // Both match against the secret's name (the canonical key).
+    //
+    // Match against EITHER the user-facing original name (what `xv list` prints
+    // and what the flag help documents) OR the backend name, so a name copied
+    // from list output always resolves — `original_name` falls back to `name`
+    // when unset, mirroring the list display logic.
+    let name_matches = |secret: &crate::secret::manager::SecretSummary, n: &str| -> bool {
+        n == secret.name || (!secret.original_name.is_empty() && n == secret.original_name)
+    };
+
     // Positive selection first: --group (already applied above) plus --include.
     // If a positive selector was given but matched nothing, that's almost always
     // a mistake (typo'd group/name, wrong vault); silently running the child with
     // no secrets — and exiting 0 — is dangerous in scripts/CI, so fail loud.
     let selected: Vec<_> = filtered_secrets
         .into_iter()
-        .filter(|secret| include.is_empty() || include.iter().any(|n| n == &secret.name))
+        .filter(|secret| include.is_empty() || include.iter().any(|n| name_matches(secret, n)))
         .collect();
     let positive_selector = !groups.is_empty() || !include.is_empty();
     if selected.is_empty() && positive_selector {
@@ -2451,7 +2459,7 @@ async fn execute_secret_run(
     // so it behaves like an empty vault: warn, but still run the command.
     let filtered_secrets: Vec<_> = selected
         .into_iter()
-        .filter(|secret| !exclude.iter().any(|n| n == &secret.name))
+        .filter(|secret| !exclude.iter().any(|n| name_matches(secret, n)))
         .collect();
 
     if filtered_secrets.is_empty() {

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -801,13 +801,16 @@ pub(crate) async fn execute_secret_rotate_direct(
         return execute_secret_rotate_native(name, force, config, registry).await;
     }
 
-    let auth_provider = get_azure_auth_provider(registry, &config)?;
-
-    // Create secret manager
-    let secret_manager = SecretManager::new(auth_provider, config.no_color);
+    // Route through the active backend trait so default (client-side) rotation
+    // works on every backend; the Azure trait impl delegates to the same ops.
+    let reg = registry.ok_or_else(|| {
+        CrosstacheError::config(
+            "No backend registry available. Run 'xv config show' to check your configuration.",
+        )
+    })?;
 
     execute_secret_rotate(
-        &secret_manager,
+        reg,
         name,
         None,
         length,
@@ -2204,7 +2207,7 @@ async fn execute_secret_rollback(
 
 #[allow(clippy::too_many_arguments)]
 async fn execute_secret_rotate(
-    secret_manager: &crate::secret::manager::SecretManager,
+    reg: &BackendRegistry,
     name: &str,
     vault: Option<String>,
     length: usize,
@@ -2226,8 +2229,9 @@ async fn execute_secret_rotate(
     let _ = context_manager.update_usage(&vault_name).await;
 
     // Check if the secret exists first
-    let existing_secret = secret_manager
-        .secret_ops()
+    let existing_secret = reg
+        .active()
+        .secrets()
         .get_secret(&vault_name, name, true)
         .await
         .map_err(|e| {
@@ -2290,10 +2294,12 @@ async fn execute_secret_rotate(
     };
 
     // Set the rotated secret
-    let result = secret_manager
-        .secret_ops()
-        .set_secret(&vault_name, &set_request)
-        .await?;
+    let result = reg
+        .active()
+        .secrets()
+        .set_secret(&vault_name, set_request)
+        .await
+        .map_err(CrosstacheError::from)?;
 
     output::success(&format!("Successfully rotated secret '{}'", name));
     println!("New version: {}", result.version);

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2429,30 +2429,34 @@ async fn execute_secret_run(
     // Apply name-based --include / --exclude on top of the group filter.
     // --include restricts to the named secrets; --exclude removes them.
     // Both match against the secret's name (the canonical key).
-    let filtered_secrets: Vec<_> = filtered_secrets
+    // Positive selection first: --group (already applied above) plus --include.
+    // If a positive selector was given but matched nothing, that's almost always
+    // a mistake (typo'd group/name, wrong vault); silently running the child with
+    // no secrets — and exiting 0 — is dangerous in scripts/CI, so fail loud.
+    let selected: Vec<_> = filtered_secrets
         .into_iter()
         .filter(|secret| include.is_empty() || include.iter().any(|n| n == &secret.name))
+        .collect();
+    let positive_selector = !groups.is_empty() || !include.is_empty();
+    if selected.is_empty() && positive_selector {
+        return Err(CrosstacheError::invalid_argument(format!(
+            "No secrets matched the requested selection in vault '{vault_name}' \
+             (group={groups:?}, include={include:?}). \
+             Refusing to run the command with nothing injected — check the values."
+        )));
+    }
+
+    // Negative filter: --exclude. Excluding every selected secret (leaving
+    // nothing to inject) is a legitimate "run without these secrets" workflow,
+    // so it behaves like an empty vault: warn, but still run the command.
+    let filtered_secrets: Vec<_> = selected
+        .into_iter()
         .filter(|secret| !exclude.iter().any(|n| n == &secret.name))
         .collect();
 
-    // An explicit `--group` filter that matches nothing is almost always a
-    // mistake (typo'd group, wrong vault). Silently running the child command
-    // with no secrets injected — and exiting 0 — is dangerous in scripts/CI, so
-    // fail loud instead. When no filter was given, an empty vault is a legitimate
-    // state: warn, but still run the requested command (with no injected vars).
     if filtered_secrets.is_empty() {
-        let has_explicit_filter =
-            !groups.is_empty() || !include.is_empty() || !exclude.is_empty();
-        if has_explicit_filter {
-            return Err(CrosstacheError::invalid_argument(format!(
-                "No secrets matched the requested filters in vault '{vault_name}' \
-                 (group={groups:?}, include={include:?}, exclude={exclude:?}). \
-                 Refusing to run the command with nothing injected — \
-                 check the filter values."
-            )));
-        }
         output::warn(&format!(
-            "No secrets found in vault '{vault_name}'; running command with no injected secrets."
+            "No secrets to inject in vault '{vault_name}'; running command with no injected secrets."
         ));
     } else {
         output::step(&format!(

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -3,8 +3,9 @@
 use crate::backend::{BackendKind, BackendRef, BackendRegistry};
 use crate::cli::commands::{CharsetType, SecretWriteArgs, ShareCommands};
 use crate::cli::helpers::{
-    copy_to_clipboard, generate_random_value, get_azure_auth_provider, mask_secrets,
-    resolve_vault_for_trait, schedule_clipboard_clear, share_unsupported_error, use_trait_path,
+    confirm_destructive, copy_to_clipboard, generate_random_value, get_azure_auth_provider,
+    mask_secrets, resolve_vault_for_trait, schedule_clipboard_clear, share_unsupported_error,
+    use_trait_path,
 };
 use crate::config::Config;
 use crate::error::{CrosstacheError, Result};
@@ -33,10 +34,12 @@ fn read_secret_value_from_stdin(trim: bool) -> Result<String> {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_secret_set_direct(
     args: Vec<String>,
     stdin: bool,
     trim: bool,
+    value: Option<String>,
     meta: SecretWriteArgs,
     config: Config,
     registry: Option<&BackendRegistry>,
@@ -50,6 +53,15 @@ pub(crate) async fn execute_secret_set_direct(
     } = meta.clone();
     let groups = meta.groups_opt();
 
+    // `--value` is only meaningful for a single secret; reject it alongside
+    // bulk KEY=value arguments so the inline value can't be silently dropped.
+    let is_bulk = args.len() > 1 || args.iter().any(|a| a.contains('='));
+    if value.is_some() && is_bulk {
+        return Err(CrosstacheError::invalid_argument(
+            "--value can only be used when setting a single secret (not with KEY=value bulk args)",
+        ));
+    }
+
     // ── Trait-based path (non-Azure backends) ──────────────────────────
     if use_trait_path(registry) {
         let reg = registry.expect("use_trait_path guarantees Some");
@@ -58,17 +70,19 @@ pub(crate) async fn execute_secret_set_direct(
         if args.len() == 1 && !args[0].contains('=') {
             // Single secret set
             let name = &args[0];
-            let value = if stdin {
+            let secret_value = if let Some(v) = value.clone() {
+                v
+            } else if stdin {
                 read_secret_value_from_stdin(trim)?
             } else {
                 rpassword::prompt_password(format!("Enter value for secret '{name}': "))?
             };
-            if value.is_empty() {
+            if secret_value.is_empty() {
                 return Err(CrosstacheError::config("Secret value cannot be empty"));
             }
             // Build the request via the shared helper so `set` and `gen --save`
             // construct identical requests from the same metadata flags.
-            let request = meta.to_secret_request(name, Zeroizing::new(value))?;
+            let request = meta.to_secret_request(name, Zeroizing::new(secret_value))?;
             let props = reg
                 .active()
                 .secrets()
@@ -130,7 +144,18 @@ pub(crate) async fn execute_secret_set_direct(
                     }
                 }
             }
-            println!();
+            if error_count > 0 {
+                output::warn(&format!(
+                    "Bulk set complete: {success_count} succeeded, {error_count} failed"
+                ));
+                // Any failed write must surface as a non-zero exit so scripts
+                // and CI don't treat a partial failure as success.
+                invalidate_trait_secret_cache(&config, &vault_name);
+                return Err(CrosstacheError::unknown(format!(
+                    "{error_count} of {} secret(s) failed to set",
+                    success_count + error_count
+                )));
+            }
             output::success(&format!(
                 "Bulk set complete: {success_count} succeeded, {error_count} failed"
             ));
@@ -597,11 +622,14 @@ pub(crate) async fn execute_secret_delete_direct(
                 output::info(&format!("No secrets found in group '{group_name}'"));
                 return Ok(());
             }
-            if !force {
-                output::warn(&format!(
-                    "About to delete {} secret(s) in group '{group_name}'. Use --force to confirm.",
+            if !confirm_destructive(
+                force,
+                &format!(
+                    "Delete {} secret(s) in group '{group_name}'?",
                     secrets.len()
-                ));
+                ),
+            )? {
+                output::info("Aborted; no secrets deleted.");
                 return Ok(());
             }
             for s in &secrets {
@@ -612,10 +640,8 @@ pub(crate) async fn execute_secret_delete_direct(
                 output::success(&format!("Deleted '{}'", s.name));
             }
         } else if let Some(secret_name) = name {
-            if !force {
-                output::warn(&format!(
-                    "About to delete secret '{secret_name}'. Use --force to confirm."
-                ));
+            if !confirm_destructive(force, &format!("Delete secret '{secret_name}'?"))? {
+                output::info("Aborted; secret not deleted.");
                 return Ok(());
             }
             reg.active()
@@ -710,10 +736,11 @@ pub(crate) async fn execute_secret_rollback_direct(
             return execute_secret_rollback_legacy(name, version, force, config, registry).await;
         }
         let vault_name = resolve_vault_for_trait(&config, registry).await?;
-        if !force {
-            output::warn(&format!(
-                "About to roll back secret '{name}' to version {version}. Use --force to confirm."
-            ));
+        if !confirm_destructive(
+            force,
+            &format!("Roll back secret '{name}' to version {version}?"),
+        )? {
+            output::info("Aborted; no rollback performed.");
             return Ok(());
         }
         let props = reg
@@ -888,8 +915,11 @@ async fn execute_secret_rotate_native(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_secret_run_direct(
     group: Vec<String>,
+    include: Vec<String>,
+    exclude: Vec<String>,
     no_masking: bool,
     inherit_env: bool,
     command: Vec<String>,
@@ -905,6 +935,8 @@ pub(crate) async fn execute_secret_run_direct(
         &secret_manager,
         None,
         group,
+        include,
+        exclude,
         no_masking,
         inherit_env,
         command,
@@ -1095,10 +1127,11 @@ pub(crate) async fn execute_secret_purge_direct(
             return execute_secret_purge_legacy(name, force, config, registry).await;
         }
         let vault_name = resolve_vault_for_trait(&config, registry).await?;
-        if !force {
-            output::warn(&format!(
-                "About to PERMANENTLY DELETE secret '{name}'. This cannot be undone. Use --force to confirm."
-            ));
+        if !confirm_destructive(
+            force,
+            &format!("PERMANENTLY DELETE secret '{name}'? This cannot be undone."),
+        )? {
+            output::info("Aborted; secret not purged.");
             return Ok(());
         }
         reg.active()
@@ -2306,10 +2339,13 @@ async fn resolve_uri_secret(
         .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn execute_secret_run(
     secret_manager: &crate::secret::manager::SecretManager,
     vault: Option<String>,
     groups: Vec<String>,
+    include: Vec<String>,
+    exclude: Vec<String>,
     no_masking: bool,
     inherit_env: bool,
     command: Vec<String>,
@@ -2387,15 +2423,40 @@ async fn execute_secret_run(
         secrets
     };
 
-    if filtered_secrets.is_empty() {
-        output::info("No secrets found to inject");
-        return Ok(());
-    }
+    // Apply name-based --include / --exclude on top of the group filter.
+    // --include restricts to the named secrets; --exclude removes them.
+    // Both match against the secret's name (the canonical key).
+    let filtered_secrets: Vec<_> = filtered_secrets
+        .into_iter()
+        .filter(|secret| include.is_empty() || include.iter().any(|n| n == &secret.name))
+        .filter(|secret| !exclude.iter().any(|n| n == &secret.name))
+        .collect();
 
-    output::step(&format!(
-        "Injecting {} secret(s) as environment variables...",
-        filtered_secrets.len()
-    ));
+    // An explicit `--group` filter that matches nothing is almost always a
+    // mistake (typo'd group, wrong vault). Silently running the child command
+    // with no secrets injected — and exiting 0 — is dangerous in scripts/CI, so
+    // fail loud instead. When no filter was given, an empty vault is a legitimate
+    // state: warn, but still run the requested command (with no injected vars).
+    if filtered_secrets.is_empty() {
+        let has_explicit_filter =
+            !groups.is_empty() || !include.is_empty() || !exclude.is_empty();
+        if has_explicit_filter {
+            return Err(CrosstacheError::invalid_argument(format!(
+                "No secrets matched the requested filters in vault '{vault_name}' \
+                 (group={groups:?}, include={include:?}, exclude={exclude:?}). \
+                 Refusing to run the command with nothing injected — \
+                 check the filter values."
+            )));
+        }
+        output::warn(&format!(
+            "No secrets found in vault '{vault_name}'; running command with no injected secrets."
+        ));
+    } else {
+        output::step(&format!(
+            "Injecting {} secret(s) as environment variables...",
+            filtered_secrets.len()
+        ));
+    }
 
     // Fetch secret values and build environment map
     let mut env_vars: HashMap<String, Zeroizing<String>> = HashMap::new();
@@ -3784,6 +3845,9 @@ async fn execute_secret_share(
             use crate::utils::pagination::{paginate_slice, pagination_footer_text, Pagination};
             use std::fmt::Write as _;
 
+            let pager = pager
+                .map(crate::cli::commands::PagerWhen::wants_pager)
+                .unwrap_or(false);
             let mut roles = vault_manager
                 .list_secret_access(&vault_name, &resource_group, &secret_name)
                 .await?;
@@ -4468,7 +4532,7 @@ mod tests {
                 all: false,
                 page: None,
                 page_size: None,
-                pager: false,
+                pager: None,
             },
             config,
             Some(&registry),

--- a/src/cli/system_ops.rs
+++ b/src/cli/system_ops.rs
@@ -973,6 +973,12 @@ pub(crate) async fn execute_gen_command(
                     output::warn("Generated password (save this now):");
                     println!("{}", password.as_str());
                 }
+                // `gen --save` was asked to persist the secret; the save failed,
+                // so exit non-zero (after printing the value for recovery) rather
+                // than reporting success.
+                return Err(CrosstacheError::unknown(format!(
+                    "failed to save generated secret '{name}': {e}"
+                )));
             }
         }
         return Ok(());

--- a/src/cli/vault_ops.rs
+++ b/src/cli/vault_ops.rs
@@ -74,6 +74,9 @@ pub(crate) async fn execute_vault_command(
                     paginate_slice, pagination_footer_text, Pagination,
                 };
 
+                let pager = pager
+                    .map(crate::cli::commands::PagerWhen::wants_pager)
+                    .unwrap_or(false);
                 let vaults = vaults_backend.list_vaults().await?;
                 let output_format = format.resolve_for_stdout();
                 let pagination = Pagination::from_args(page, page_size)?;
@@ -97,10 +100,11 @@ pub(crate) async fn execute_vault_command(
                 }
             }
             VaultCommands::Delete { name, force, .. } => {
-                if !force {
-                    output::warn(&format!(
-                        "About to delete vault '{name}'. Use --force to confirm."
-                    ));
+                if !crate::cli::helpers::confirm_destructive(
+                    force,
+                    &format!("Delete vault '{name}'?"),
+                )? {
+                    output::info("Aborted; vault not deleted.");
                     return Ok(());
                 }
                 vaults_backend.delete_vault(&name).await?;
@@ -176,7 +180,8 @@ pub(crate) async fn execute_vault_command(
                 no_cache,
                 page,
                 page_size,
-                pager,
+                pager.map(crate::cli::commands::PagerWhen::wants_pager)
+                    .unwrap_or(false),
                 &config,
             )
             .await?;
@@ -968,6 +973,7 @@ async fn execute_vault_import(
 
     let mut imported_count = 0;
     let mut skipped_count = 0;
+    let mut failed_count = 0;
 
     for secret_request in secrets_to_import {
         let secret_name = secret_request.name.clone();
@@ -1000,12 +1006,13 @@ async fn execute_vault_import(
             }
             Err(e) => {
                 output::error(&format!("Failed to import secret '{secret_name}': {e}"));
+                failed_count += 1;
             }
         }
     }
 
     output::success(&format!(
-        "Import completed: {imported_count} imported, {skipped_count} skipped"
+        "Import completed: {imported_count} imported, {skipped_count} skipped, {failed_count} failed"
     ));
 
     // Invalidate the secrets list cache for the target vault
@@ -1014,6 +1021,14 @@ async fn execute_vault_import(
         cache_manager.invalidate(&crate::cache::CacheKey::SecretsList {
             vault_name: name.to_string(),
         });
+    }
+
+    // Any failed secret import must surface as a non-zero exit so scripted
+    // imports don't silently drop secrets.
+    if failed_count > 0 {
+        return Err(CrosstacheError::unknown(format!(
+            "vault import: {failed_count} secret(s) failed to import into vault '{name}'"
+        )));
     }
 
     Ok(())
@@ -1159,6 +1174,9 @@ async fn execute_vault_share(
             use crate::utils::pagination::{paginate_slice, pagination_footer_text, Pagination};
             use std::fmt::Write as _;
 
+            let pager = pager
+                .map(crate::cli::commands::PagerWhen::wants_pager)
+                .unwrap_or(false);
             let resource_group =
                 resource_group.unwrap_or_else(|| config.default_resource_group.clone());
 

--- a/src/cli/vault_ops.rs
+++ b/src/cli/vault_ops.rs
@@ -1012,9 +1012,16 @@ async fn execute_vault_import(
         }
     }
 
-    output::success(&format!(
-        "Import completed: {imported_count} imported, {skipped_count} skipped, {failed_count} failed"
-    ));
+    // Don't dress a partial failure up as success: use a warning summary when
+    // any secret failed (the non-zero exit is returned below), and reserve the
+    // `[ok]` success line for a fully clean import.
+    let summary =
+        format!("Import completed: {imported_count} imported, {skipped_count} skipped, {failed_count} failed");
+    if failed_count > 0 {
+        output::warn(&summary);
+    } else {
+        output::success(&summary);
+    }
 
     // Invalidate the secrets list cache for the target vault
     if imported_count > 0 {

--- a/src/cli/vault_ops.rs
+++ b/src/cli/vault_ops.rs
@@ -180,7 +180,8 @@ pub(crate) async fn execute_vault_command(
                 no_cache,
                 page,
                 page_size,
-                pager.map(crate::cli::commands::PagerWhen::wants_pager)
+                pager
+                    .map(crate::cli::commands::PagerWhen::wants_pager)
                     .unwrap_or(false),
                 &config,
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,16 @@ Rebuild with `cargo build --features aws` or install an AWS-enabled binary.",
             | crate::cli::Commands::Cache { .. }
             | crate::cli::Commands::Local { .. }
             | crate::cli::Commands::Context { .. }
-            | crate::cli::Commands::Env { .. }
+            // Env subcommands that only read/write `.xv.toml` need no backend.
+            // `env pull` / `env push` DO talk to the active backend, so they are
+            // intentionally excluded here and get a registry built below.
+            | crate::cli::Commands::Env {
+                command: crate::cli::commands::EnvCommands::List
+                    | crate::cli::commands::EnvCommands::Use { .. }
+                    | crate::cli::commands::EnvCommands::Create { .. }
+                    | crate::cli::commands::EnvCommands::Delete { .. }
+                    | crate::cli::commands::EnvCommands::Show,
+            }
             | crate::cli::Commands::Migrate { .. }
             | crate::cli::Commands::Scan {
                 command: Some(crate::cli::commands::ScanCommands::Install { .. }),

--- a/src/scan/orchestrator.rs
+++ b/src/scan/orchestrator.rs
@@ -99,7 +99,7 @@ pub fn skipped_files_error(outcome: &ScanOutcome) -> CrosstacheError {
 /// semaphore. Failures for individual vaults / secrets degrade
 /// silently with a debug log.
 pub async fn fetch_secret_values(
-    secret_manager: &crate::secret::manager::SecretManager,
+    backend: std::sync::Arc<dyn crate::backend::Backend>,
     vault_names: &[String],
     concurrency: usize,
 ) -> Result<Vec<SecretRef>> {
@@ -107,8 +107,8 @@ pub async fn fetch_secret_values(
     let sem = std::sync::Arc::new(Semaphore::new(concurrency.max(1)));
     let mut handles = Vec::new();
     for vault in vault_names {
-        // List secrets for this vault.
-        let summaries = match secret_manager.secret_ops().list_secrets(vault, None).await {
+        // List secrets for this vault via the active backend trait.
+        let summaries = match backend.secrets().list_secrets(vault, None).await {
             Ok(s) => s,
             Err(e) => {
                 tracing::debug!("list_secrets failed for vault {vault}: {e}");
@@ -124,10 +124,10 @@ pub async fn fetch_secret_values(
                 s.original_name.clone()
             };
             let backend_name = s.name.clone();
-            let ops = secret_manager.secret_ops().clone();
+            let backend = backend.clone();
             let handle = tokio::spawn(async move {
                 let _permit = sem.acquire_owned().await.ok()?;
-                match ops.get_secret(&vault, &backend_name, true).await {
+                match backend.secrets().get_secret(&vault, &backend_name, true).await {
                     Ok(props) => props.value.map(|v| SecretRef {
                         name: secret_name,
                         vault,

--- a/src/scan/orchestrator.rs
+++ b/src/scan/orchestrator.rs
@@ -127,7 +127,11 @@ pub async fn fetch_secret_values(
             let backend = backend.clone();
             let handle = tokio::spawn(async move {
                 let _permit = sem.acquire_owned().await.ok()?;
-                match backend.secrets().get_secret(&vault, &backend_name, true).await {
+                match backend
+                    .secrets()
+                    .get_secret(&vault, &backend_name, true)
+                    .await
+                {
                     Ok(props) => props.value.map(|v| SecretRef {
                         name: secret_name,
                         vault,

--- a/src/scan/staged.rs
+++ b/src/scan/staged.rs
@@ -111,7 +111,7 @@ where
 /// will be committed.
 pub fn scan_staged(engine: &MatchEngine) -> Result<Vec<Finding>> {
     let files = list_staged_files()?;
-    Ok(scan_git_paths(&files, |p| read_staged_file(p), engine))
+    Ok(scan_git_paths(&files, read_staged_file, engine))
 }
 
 /// Scan every file tracked at `HEAD` (`xv scan --all`). Content comes from the
@@ -119,5 +119,5 @@ pub fn scan_staged(engine: &MatchEngine) -> Result<Vec<Finding>> {
 /// committed rather than the working tree or index.
 pub fn scan_head(engine: &MatchEngine) -> Result<Vec<Finding>> {
     let files = list_head_files()?;
-    Ok(scan_git_paths(&files, |p| read_head_file(p), engine))
+    Ok(scan_git_paths(&files, read_head_file, engine))
 }

--- a/src/scan/staged.rs
+++ b/src/scan/staged.rs
@@ -41,27 +41,83 @@ fn read_staged_file(path: &str) -> Result<String> {
     Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }
 
+/// Enumerate every file tracked at `HEAD` via `git ls-tree -r --name-only -z HEAD`.
+fn list_head_files() -> Result<Vec<String>> {
+    let out = Command::new("git")
+        .args(["ls-tree", "-r", "--name-only", "-z", "HEAD"])
+        .output()
+        .map_err(|e| CrosstacheError::config(format!("failed to run git: {e}")))?;
+    if !out.status.success() {
+        return Err(CrosstacheError::config(format!(
+            "git ls-tree HEAD failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        )));
+    }
+    Ok(out
+        .stdout
+        .split(|&b| b == 0)
+        .filter(|s| !s.is_empty())
+        .map(|s| String::from_utf8_lossy(s).into_owned())
+        .collect())
+}
+
+/// Read a file's content at `HEAD` (the last commit, not the index or worktree).
+fn read_head_file(path: &str) -> Result<String> {
+    let out = Command::new("git")
+        .args(["show", &format!("HEAD:{path}")])
+        .output()
+        .map_err(|e| CrosstacheError::config(format!("failed to run git show: {e}")))?;
+    if !out.status.success() {
+        return Err(CrosstacheError::config(format!(
+            "git show HEAD:{path} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Heuristically skip binary-looking paths by extension; git object reads
+/// don't expose raw bytes for a content-sniff here.
+fn looks_binary(path: &str) -> bool {
+    const BIN_EXT: &[&str] = &[
+        ".png", ".jpg", ".jpeg", ".gif", ".pdf", ".zip", ".gz", ".tar",
+    ];
+    let lower = path.to_lowercase();
+    BIN_EXT.iter().any(|e| lower.ends_with(e))
+}
+
+/// Scan a set of git-tracked paths, reading each one's content via `reader`
+/// (the index for staged scans, `HEAD` for full-tree scans).
+fn scan_git_paths<F>(files: &[String], reader: F, engine: &MatchEngine) -> Vec<Finding>
+where
+    F: Fn(&str) -> Result<String>,
+{
+    let mut findings: Vec<Finding> = Vec::new();
+    for f in files {
+        if looks_binary(f) {
+            continue;
+        }
+        let content = match reader(f) {
+            Ok(c) => c,
+            Err(_) => continue, // file might be deleted in this revision
+        };
+        findings.extend(engine.scan_text(Path::new(f), &content));
+    }
+    findings
+}
+
 /// Scan all staged files. Each file's content comes from `git show :PATH`
 /// (the index, not the working tree) so the scan reflects exactly what
 /// will be committed.
 pub fn scan_staged(engine: &MatchEngine) -> Result<Vec<Finding>> {
     let files = list_staged_files()?;
-    let mut findings: Vec<Finding> = Vec::new();
-    for f in &files {
-        // Skip binary-looking paths heuristically by extension; the
-        // index doesn't expose the raw bytes here.
-        let lower = f.to_lowercase();
-        const BIN_EXT: &[&str] = &[
-            ".png", ".jpg", ".jpeg", ".gif", ".pdf", ".zip", ".gz", ".tar",
-        ];
-        if BIN_EXT.iter().any(|e| lower.ends_with(e)) {
-            continue;
-        }
-        let content = match read_staged_file(f) {
-            Ok(c) => c,
-            Err(_) => continue, // file might be deleted in this commit
-        };
-        findings.extend(engine.scan_text(Path::new(f), &content));
-    }
-    Ok(findings)
+    Ok(scan_git_paths(&files, |p| read_staged_file(p), engine))
+}
+
+/// Scan every file tracked at `HEAD` (`xv scan --all`). Content comes from the
+/// committed tree via `git show HEAD:PATH`, so this reflects what is already
+/// committed rather than the working tree or index.
+pub fn scan_head(engine: &MatchEngine) -> Result<Vec<Finding>> {
+    let files = list_head_files()?;
+    Ok(scan_git_paths(&files, |p| read_head_file(p), engine))
 }

--- a/src/scan/staged.rs
+++ b/src/scan/staged.rs
@@ -117,7 +117,14 @@ pub fn scan_staged(engine: &MatchEngine) -> Result<Vec<Finding>> {
 /// Scan every file tracked at `HEAD` (`xv scan --all`). Content comes from the
 /// committed tree via `git show HEAD:PATH`, so this reflects what is already
 /// committed rather than the working tree or index.
-pub fn scan_head(engine: &MatchEngine) -> Result<Vec<Finding>> {
-    let files = list_head_files()?;
+///
+/// `excludes` carries the same default + `[scan].exclude` globs the filesystem
+/// walker applies (see `walker::build_exclude_set`), so `--all` does not scan
+/// `target/`, `node_modules/`, or user-excluded paths that `scan .` skips.
+pub fn scan_head(engine: &MatchEngine, excludes: &globset::GlobSet) -> Result<Vec<Finding>> {
+    let files: Vec<String> = list_head_files()?
+        .into_iter()
+        .filter(|f| !excludes.is_match(f))
+        .collect();
     Ok(scan_git_paths(&files, read_head_file, engine))
 }

--- a/src/scan/walker.rs
+++ b/src/scan/walker.rs
@@ -29,25 +29,33 @@ pub struct WalkConfig {
     pub extra_excludes: Vec<String>,
 }
 
-/// Walk one or more roots and return the paths to scan, with all the
-/// exclusion rules applied (gitignore, xvignore, defaults, custom,
-/// binary skip).
-pub fn walk(roots: &[&Path], cfg: &WalkConfig) -> Result<Vec<PathBuf>> {
-    // Build the exclude globset.
+/// Build the scanner's exclude globset: [`DEFAULT_EXCLUDES`] plus any extra
+/// globs (e.g. `[scan].exclude` from `.xv.toml`).
+///
+/// Shared by the filesystem walker and the git-tree scans (`scan --all`) so
+/// every scan source applies the same exclusion rules. Match paths against it
+/// relative to the scan root / repo root.
+pub fn build_exclude_set(extra_excludes: &[String]) -> Result<globset::GlobSet> {
     let mut gs = GlobSetBuilder::new();
     for g in DEFAULT_EXCLUDES
         .iter()
         .copied()
-        .chain(cfg.extra_excludes.iter().map(|s| s.as_str()))
+        .chain(extra_excludes.iter().map(|s| s.as_str()))
     {
         let glob = Glob::new(g).map_err(|e| {
             CrosstacheError::config(format!("invalid scan exclude glob '{g}': {e}"))
         })?;
         gs.add(glob);
     }
-    let excludes = gs
-        .build()
-        .map_err(|e| CrosstacheError::config(format!("scan glob build failed: {e}")))?;
+    gs.build()
+        .map_err(|e| CrosstacheError::config(format!("scan glob build failed: {e}")))
+}
+
+/// Walk one or more roots and return the paths to scan, with all the
+/// exclusion rules applied (gitignore, xvignore, defaults, custom,
+/// binary skip).
+pub fn walk(roots: &[&Path], cfg: &WalkConfig) -> Result<Vec<PathBuf>> {
+    let excludes = build_exclude_set(&cfg.extra_excludes)?;
 
     let mut out: Vec<PathBuf> = Vec::new();
     for root in roots {
@@ -152,6 +160,20 @@ mod tests {
         .unwrap();
         let lines = read_xvignore(temp.path());
         assert_eq!(lines, vec!["target/", "*.bak"]);
+    }
+
+    #[test]
+    fn build_exclude_set_matches_defaults_and_custom() {
+        let set = build_exclude_set(&["secrets/**".to_string()]).unwrap();
+        // Defaults
+        assert!(set.is_match("target/debug/app"));
+        assert!(set.is_match("node_modules/pkg/index.js"));
+        assert!(set.is_match("Cargo.lock"));
+        assert!(set.is_match(".git/config"));
+        // Custom [scan].exclude glob
+        assert!(set.is_match("secrets/prod.env"));
+        // Normal source is not excluded
+        assert!(!set.is_match("src/main.rs"));
     }
 
     #[test]

--- a/src/utils/output.rs
+++ b/src/utils/output.rs
@@ -73,11 +73,17 @@ pub fn format_line(level: Level, msg: &str, rich: bool) -> String {
     }
 }
 
-/// Print a success message to stdout
+// NOTE: All decorative log helpers below write to STDERR, never stdout.
+// stdout is reserved for machine-consumable data (secret values, JSON/YAML/
+// CSV/table payloads) so that `xv get X > file` or `xv ... | jq` is never
+// polluted by `[ok]`/`::`/`[info]` chrome. Only `error` previously went to
+// stderr; `success`/`warn`/`info`/`hint`/`step` were moved here to match.
+
+/// Print a success message to stderr
 pub fn success(msg: &str) {
-    println!(
+    eprintln!(
         "{}",
-        format_line(Level::Success, msg, should_use_rich(is_tty()))
+        format_line(Level::Success, msg, should_use_rich(is_tty_stderr()))
     );
 }
 
@@ -89,35 +95,35 @@ pub fn error(msg: &str) {
     );
 }
 
-/// Print a warning message to stdout
+/// Print a warning message to stderr
 pub fn warn(msg: &str) {
-    println!(
+    eprintln!(
         "{}",
-        format_line(Level::Warn, msg, should_use_rich(is_tty()))
+        format_line(Level::Warn, msg, should_use_rich(is_tty_stderr()))
     );
 }
 
-/// Print an info message to stdout
+/// Print an info message to stderr
 pub fn info(msg: &str) {
-    println!(
+    eprintln!(
         "{}",
-        format_line(Level::Info, msg, should_use_rich(is_tty()))
+        format_line(Level::Info, msg, should_use_rich(is_tty_stderr()))
     );
 }
 
-/// Print a hint message to stdout
+/// Print a hint message to stderr
 pub fn hint(msg: &str) {
-    println!(
+    eprintln!(
         "{}",
-        format_line(Level::Hint, msg, should_use_rich(is_tty()))
+        format_line(Level::Hint, msg, should_use_rich(is_tty_stderr()))
     );
 }
 
-/// Print a step/action message to stdout (e.g., "Rotating secret...")
+/// Print a step/action message to stderr (e.g., "Rotating secret...")
 pub fn step(msg: &str) {
-    println!(
+    eprintln!(
         "{}",
-        format_line(Level::Step, msg, should_use_rich(is_tty()))
+        format_line(Level::Step, msg, should_use_rich(is_tty_stderr()))
     );
 }
 

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -233,9 +233,12 @@ fn context_envs_lists_envs() {
         stdout.contains("* dev"),
         "active env should be starred: {stdout}"
     );
+    // The explanatory hint is informational chrome and goes to stderr (so the
+    // env list on stdout stays pipe-clean).
+    let stderr = stderr_str(&out);
     assert!(
-        stdout.contains("not the vault context") && stdout.contains("config show --resolved"),
-        "context envs should explain env-vs-context and point to resolved config: {stdout}"
+        stderr.contains("not the vault context") && stderr.contains("config show --resolved"),
+        "context envs should explain env-vs-context and point to resolved config: {stderr}"
     );
 }
 

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -543,22 +543,24 @@ fn set_with_metadata() {
 }
 
 // ===========================================================================
-// Delete without --force should NOT delete (prompt guard)
+// Delete without --force in a non-interactive session should REFUSE (exit
+// non-zero) and not delete — never silently no-op.
 // ===========================================================================
 
 #[test]
-fn delete_without_force_is_noop() {
+fn delete_without_force_refuses_noninteractive() {
     let env = TestEnv::new();
     env.set_secret("SAFE_SECRET", "safe-value");
 
-    // Delete WITHOUT --force should succeed (prints warning) but not delete
-    let output = env.xv_ok(&["delete", "SAFE_SECRET"]);
+    // Delete WITHOUT --force in a non-TTY (test harness) must fail loudly and
+    // point at --force, instead of silently no-opping with exit 0.
+    let (_stdout, stderr) = env.xv_fail(&["delete", "SAFE_SECRET"]);
     assert!(
-        output.contains("--force") || output.contains("force"),
-        "should mention --force requirement"
+        stderr.contains("--force") || stderr.contains("force"),
+        "should mention --force requirement, got stderr:\n{stderr}"
     );
 
-    // Secret should still be there
+    // Secret must still be there (refusal must not delete).
     let value = env.get_raw("SAFE_SECRET");
     assert_eq!(value, "safe-value");
 }

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -872,3 +872,45 @@ fn vault_info() {
         output,
     );
 }
+
+// ===========================================================================
+// env pull / env push — must route through the active backend on local.
+// Regression guard: these once required a registry the CLI never built for
+// Env commands, so they always failed with "No backend registry available".
+// ===========================================================================
+
+#[test]
+fn env_pull_exports_secrets_dotenv() {
+    let env = TestEnv::new();
+    env.set_secret("ALPHA", "one");
+    env.set_secret("BETA", "two");
+
+    // Default format is dotenv (plain); values go to stdout.
+    let out = env.xv_ok(&["env", "pull"]);
+    assert!(
+        out.contains("ALPHA=one"),
+        "env pull should export ALPHA, got:\n{out}"
+    );
+    assert!(
+        out.contains("BETA=two"),
+        "env pull should export BETA, got:\n{out}"
+    );
+}
+
+#[test]
+fn env_push_imports_secrets() {
+    let env = TestEnv::new();
+    let dotenv = "GAMMA=three\nDELTA=four\n";
+    let output = env.xv_with_stdin(&["env", "push"], dotenv);
+    assert!(
+        output.status.success(),
+        "env push failed (exit {:?}):\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // Both secrets must now be retrievable from the local backend.
+    assert_eq!(env.get_raw("GAMMA"), "three");
+    assert_eq!(env.get_raw("DELTA"), "four");
+}


### PR DESCRIPTION
## Summary

Addresses UX issues surfaced by a tri-model review (Codex for CLI architecture/correctness, Antigravity for human-facing UX), with every severe finding verified against source before fixing. The headline defect — advanced commands hardcoding Azure and breaking on local/AWS backends — is fully resolved, alongside a batch of correctness and ergonomics fixes.

## What changed

**Backend routing (the #1 finding).** `run`, `inject`, `rotate` (default), `scan` (paths/staged/`--all`), and `env pull`/`env push` instantiated the Azure `SecretManager` / `DefaultAzureCredentialProvider` directly, so they failed with Azure auth errors on `local` and `aws` backends. All now fetch through `registry.active().secrets()`. The Azure backend's trait impls delegate to the same underlying operations, so **Azure behavior is unchanged** while local/AWS now work.
- `scan`: `fetch_secret_values` now takes `Arc<dyn Backend>`; `--all-vaults` uses `Backend::vaults()` and returns a clear capability error on backends that can't enumerate vaults.

**Correctness / exit codes.**
- `xv run` no longer exits 0 without running the child: an explicit `--group/--include/--exclude` that matches nothing now errors; an empty vault warns but still runs.
- Partial failures in bulk `set`, `gen --save`, `vault import`, and `env push` now return non-zero instead of reporting success.

**Destructive-op confirmation.** Trait-path `delete`/group-delete/`rollback`/`purge`/vault-delete now prompt on a TTY and **refuse with a non-zero exit** in non-interactive sessions, instead of silently no-opping with "Use --force". Shared `confirm_destructive` helper.

**Output streams.** `success/warn/info/hint/step` now write to stderr so stdout stays clean for pipes/redirects (only data lands on stdout).

**Flags (README ↔ CLI).** Added documented-but-missing flags so README workflows parse: `set --value`, `set --tag`, `run --include/--exclude`, `update --tag` (alias of `--tags`), and `--pager [auto|always|never]`.

**`scan --all`.** Implemented the previously-ignored flag as a full HEAD-tree scan (`git ls-tree` + `git show HEAD:PATH`).

## Testing

- `cargo clippy --all-targets` — clean.
- Full test suite green, including local-backend e2e (`e2e_local_backend`, `local_backend_integration`, `scan_tests`), which exercises the routing changes against a real non-Azure backend.
- Two tests updated to match new contracts: `context envs` hint now asserted on stderr; delete-without-force now asserts non-interactive refusal + secret survival.

## Notes
- No AWS credentials available in the dev env, so AWS paths are covered by unit/compile checks rather than live e2e; local backend is covered end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide behavior changes across secret injection, scan, env sync, and destructive confirmations affect CI/scripts and non-Azure backends; Azure paths largely delegate to existing impls but exit codes and stderr routing are breaking for some pipelines.
> 
> **Overview**
> Routes **`run`**, **`inject`**, **`rotate`**, **`scan`**, and **`env pull`/`push`** through `registry.active().secrets()` (and scan through `Arc<dyn Backend>`) so local/AWS backends work instead of hardcoded Azure `SecretManager`. **`main`** now builds a backend registry for `env pull`/`push` only; other `env` subcommands stay registry-free.
> 
> **CLI flags:** `PagerWhen` (`--pager [auto|always|never]`), `set --value` / `--tag`, `run --include` / `--exclude`, `update --tag` alias; **`scan --all`** scans the committed HEAD tree with shared exclude globs; **`--staged`** and **`--all`** conflict at parse time.
> 
> **Safety / scripts:** Shared **`confirm_destructive`** prompts on a TTY and errors in CI without `--force` for trait-path deletes, rollback, purge, and vault delete. Partial failures in bulk **`set`**, **`gen --save`**, **`vault import`**, and **`env push`** exit non-zero. **`xv run`** errors when `--group`/`--include`/`--exclude` match nothing; empty vault still runs with a warning.
> 
> **Output:** `success`/`warn`/`info`/`hint`/`step` move to **stderr** so stdout stays pipe-clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e2bee130ce01b9fd5ea9dd1417ae6f977864d19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->