### PR TITLE
chore: bump version to 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,29 @@
 # Changelog
 
-## Unreleased
+## v0.16.0 — Cross-backend advanced commands, new flags, and UX fixes (2026-06-29)
+
+Advanced commands now work on every backend, the CLI's documented-but-missing
+flags are implemented, and a batch of output/exit-code/confirmation issues are
+fixed. Surfaced by a multi-model UX review and hardened against Cursor Bugbot
+findings (#286).
+
+### Added
+
+- **Advanced commands work on local & AWS backends (#286).** `xv run`, `xv inject`, `xv rotate` (default), `xv scan`, and `xv env pull`/`env push` now route through the active backend trait instead of hardcoding Azure Key Vault, so they no longer fail with Azure auth errors on the local or AWS backends. Azure behavior is unchanged (its trait impl delegates to the same operations).
+- **New flags (#286):** `set --value`, `set --tag`, `run --include`/`--exclude`, `update --tag` (alias of `--tags`), and `--pager [auto|always|never]`.
+- **`xv scan --all` (#286)** performs a full `HEAD`-tree scan (`git ls-tree HEAD` + `git show HEAD:PATH`), honoring `[scan].exclude` and the default exclude globs. `scan --staged --all` is now a clap conflict instead of silently ignoring `--all`.
 
 ### Changed
 
-- `xv config show --resolved`, `xv context show`, and `xv context envs` now surface inline hints for the confusing env-profile vs vault-context vs global-config layers, including notes when active `.xv.toml` env fields override context/global fallbacks or inherit from them.
+- **Log output goes to stderr (#286).** `success`/`warn`/`info`/`hint`/`step` chrome now writes to stderr so stdout stays clean for pipes and redirects (`xv get X > file`, `xv ... | jq`); only data lands on stdout.
+- **`run --include`/`--exclude` name matching (#286)** accepts either the original (user-facing) name shown by `xv list` or the backend name.
+- `xv config show --resolved`, `xv context show`, and `xv context envs` now surface inline hints for the confusing env-profile vs vault-context vs global-config layers, including notes when active `.xv.toml` env fields override context/global fallbacks or inherit from them (#283).
+
+### Fixed
+
+- **`xv run` no longer exits 0 without running the child (#286).** An explicit `--group`/`--include` filter that matches nothing now errors; an empty vault (or `--exclude` removing everything) warns but still runs the command.
+- **Partial failures now exit non-zero (#286)** for bulk `set`, `gen --save`, `vault import`, and `env push`, instead of reporting success; bulk `set` also persists `--tag`, and `vault import` no longer prints an `[ok]` summary on partial failure.
+- **Destructive ops prompt or refuse (#286).** Trait-path `delete`/group-delete/`rollback`/`purge`/vault-delete now prompt on a TTY and refuse with a non-zero exit in non-interactive sessions instead of silently no-opping.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"


### PR DESCRIPTION
Release **v0.16.0**. Bumps `Cargo.toml`/`Cargo.lock` and rolls the changelog.

Headlines (full detail in CHANGELOG.md):
- Advanced commands (`run`/`inject`/`rotate`/`scan`/`env pull|push`) now work on local & AWS backends, not just Azure.
- New flags: `set --value`/`--tag`, `run --include`/`--exclude`, `update --tag`, `--pager [auto|always|never]`, `scan --all`.
- UX fixes: log output to stderr, non-zero exit on partial failure, destructive-op confirmation.

Tag `v0.16.0` will be pushed to the resulting `main` commit to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no runtime code modifications in this diff.
> 
> **Overview**
> Prepares the **v0.16.0** release by bumping `crosstache` from **0.15.0** to **0.16.0** in `Cargo.toml` and `Cargo.lock`, and replacing the **Unreleased** changelog section with a dated **v0.16.0** entry.
> 
> The new changelog text documents what shipped in this release (cross-backend advanced commands, new CLI flags, stderr logging, exit-code/confirmation fixes, config-context hints — mostly **#286** / **#283**), but **this PR diff does not include those implementation changes**; it only updates version metadata and release notes for tagging and the release workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd0da2af45e81f415be7b66326ffb3f078a29776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->