### PR TITLE
feat: list-command surface consistency (flags, empty-states, counts, --no-color)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,19 @@
 
 ### Added
 
+- **Global `--no-color` flag** (complements the `NO_COLOR` env var and config key).
+- **`--names-only` on `vault list` and `file list`** (one name per line, pipe-friendly; `file list --names-only` lists recursively).
+- **`file list --pager [auto|always|never]`** matching every other list command (bare `--pager` unchanged).
 - **`xv ls` is folder-aware and ls-styled.** The default TTY output is now a multi-column name grid with folders listed first (`prod/`), derived from each secret's `folder` tag. `xv ls prod` lists inside a folder, `xv ls -l` is a borderless long listing (name, updated date, groups, note), `xv ls -r` flattens recursively, and the previous rounded table remains available via explicit `--format table`. Piped/machine output (`--format json|yaml|csv`, `--names-only`) keeps the flat schema unchanged, scoped to the requested subtree. Machine output rows are now sorted by display name (previously backend order).
+
+### Changed
+
+- **List empty-states now go to stderr** for human formats across all list commands (including `xv ls`, whose empty message previously landed on stdout — `xv ls > file` on an empty scope now writes an empty file), and empty-state/count wording is standardized via shared helpers. `xv history`'s count line moved from stderr to stdout (human formats only).
+- **`vault share list -f/--fmt` is deprecated**: use the global `--format`. `--fmt` still works with a warning for one release; `-f` is removed. `vault list`'s redundant local `--format` was removed (the identical global flag takes over transparently).
 
 ### Fixed
 
+- **Empty machine-format output is now valid-empty** (`[]` for JSON) on stdout for `vault list`, `vault share list`, and `file list`, instead of a stderr-only message that broke `| jq` on empty results.
 - **`xv ls` table rendering.** Columns whose cells are all empty are no longer rendered as blank zero-width headers, narrow terminals now shrink the widest column first instead of chopping every column (no more `UT`/`C` timestamp wrapping), and the `Updated` column shows the date only (`2026-05-17`). Machine formats (JSON/YAML/CSV) are unchanged.
 - **`xv share list` honors the global `--format`** (json/yaml/csv/…) like `xv vault share list` already did; its empty-state message now goes to stderr, and machine formats emit valid empty output (`[]`) for pipes.
 - **`NO_COLOR` now disables color for all table output.** The environment variable was previously honored only by status messages; it now also sets the config's `no_color`, and `xv context list` no longer hard-codes colored output.

--- a/README.md
+++ b/README.md
@@ -1153,6 +1153,7 @@ These work with any command:
 | `--format <FORMAT>` | `table` / `json` / `yaml` / `csv` / `plain` / `raw` / `template` (default: `auto` — table on TTY, json for pipes) |
 | `--credential-type <TYPE>` | Azure credential type (`cli`, `managed_identity`, `environment`, `default`) |
 | `--template <TEMPLATE>` | Custom template string for template format |
+| `--no-color` | Disable colored output (same effect as the `NO_COLOR` env var) |
 | `--env <NAME>` | Active env from `.xv.toml` (overridden by `XV_ENV`) |
 | `--debug` | Enable debug logging |
 | `--show-options` | Show global options in `--help` output |

--- a/README.md
+++ b/README.md
@@ -710,6 +710,7 @@ xv vault create my-vault --resource-group my-rg --location eastus
 xv vault list                                  # all vaults you can see
 xv vault list --resource-group my-rg
 xv vault list --page-size 25 --page 2          # pagination
+xv vault list --names-only      # one vault name per line
 xv vault info my-vault                         # detail
 xv vault info my-vault --format json
 xv vault delete my-vault                       # soft-delete
@@ -817,6 +818,8 @@ xv file list
 xv file list --prefix backup/
 xv file list --page-size 100 --page 3
 xv file list --limit 100                         # legacy alias for first-page page-size 100
+xv file list --names-only       # one file name per line (recursive)
+xv file list --pager never       # never page output
 ```
 
 ### Sync

--- a/docs/superpowers/plans/2026-07-01-list-p2-surface.md
+++ b/docs/superpowers/plans/2026-07-01-list-p2-surface.md
@@ -1,0 +1,750 @@
+# List Command P2 Surface-Consistency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Phase A of the P2 spec (`docs/superpowers/specs/2026-07-01-list-p2-surface-design.md`): unify list-command flags (`--format`/`--fmt`/`--pager`/`--names-only`), add a global `--no-color`, and standardize empty-states and counts through a new `src/utils/list_output.rs` helper module.
+
+**Architecture:** Small pure conventions module + per-command mechanical edits. No renderer restructuring, no machine-output schema changes except the bug-fix class: empty machine output becomes valid-empty (`[]`) on stdout instead of a stderr-only message.
+
+**Tech Stack:** Rust, `clap` derive, existing `TableFormatter`/`Pagination`/`output` helpers. No new dependencies.
+
+## Global Constraints
+
+- Branch: `list-p2-surface` (exists, spec committed).
+- Machine output shapes are byte-identical after this phase EXCEPT: empty machine-format output for `vault list`, `vault share list`, and `file list` becomes valid-empty (`[]`/format-appropriate) on stdout (bug fix per spec).
+- Human empty-states go to stderr via `crate::utils::output::info`; counts appear on stdout for human formats only; machine formats never carry counts or info messages on stdout.
+- `--fmt` on `vault export/import`, `env pull`, `parse` is untouched (file formats, not output rendering).
+- Every commit: `cargo fmt` first; messages `feat:`/`fix:`/`docs:` ending with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Line numbers cited below may drift a few lines — locate anchors by symbol/string, not absolute position.
+
+---
+
+### Task 1: `src/utils/list_output.rs` conventions module
+
+**Files:**
+- Create: `src/utils/list_output.rs`
+- Modify: `src/utils/mod.rs` (register `pub mod list_output;` alongside the other modules)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces (all later tasks rely on these exact signatures):
+  - `pub fn empty_state_message(noun_plural: &str, scope: Option<&str>) -> String` — `("vaults", None)` → `"No vaults found."`; `("secrets", Some("folder 'prod'"))` → `"No secrets found in folder 'prod'."`
+  - `pub fn count_label(displayed: usize, total: usize, noun: &str, scope: Option<&str>, paginated: bool) -> String` — `(3, 3, "vault", None, false)` → `"3 vault(s)"`; `(10, 42, "secret", Some("vault 'kv'"), true)` → `"Showing 10 of 42 secret(s) in vault 'kv'"`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/utils/list_output.rs`:
+
+```rust
+//! Shared wording for list-command empty-states and count lines.
+//!
+//! Every list-style command routes its human empty-state and count text
+//! through these helpers so the wording cannot drift per-command again.
+//! Streams are the caller's job: empty-states go to stderr via
+//! `output::info`, counts go to stdout on human formats only.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_state_without_scope() {
+        assert_eq!(empty_state_message("vaults", None), "No vaults found.");
+    }
+
+    #[test]
+    fn empty_state_with_scope() {
+        assert_eq!(
+            empty_state_message("secrets", Some("folder 'prod'")),
+            "No secrets found in folder 'prod'."
+        );
+    }
+
+    #[test]
+    fn count_unpaginated_unscoped() {
+        assert_eq!(count_label(3, 3, "vault", None, false), "3 vault(s)");
+    }
+
+    #[test]
+    fn count_unpaginated_scoped() {
+        assert_eq!(
+            count_label(65, 65, "secret", Some("vault 'kv'"), false),
+            "65 secret(s) in vault 'kv'"
+        );
+    }
+
+    #[test]
+    fn count_paginated() {
+        assert_eq!(
+            count_label(10, 42, "secret", Some("vault 'kv'"), true),
+            "Showing 10 of 42 secret(s) in vault 'kv'"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib utils::list_output`
+Expected: compile error — `empty_state_message` / `count_label` not found.
+
+- [ ] **Step 3: Implement**
+
+Add above the tests module:
+
+```rust
+/// "No <nouns> found[ in <scope>]." — scope is pre-formatted, e.g. "vault 'kv'".
+pub fn empty_state_message(noun_plural: &str, scope: Option<&str>) -> String {
+    match scope {
+        Some(scope) => format!("No {noun_plural} found in {scope}."),
+        None => format!("No {noun_plural} found."),
+    }
+}
+
+/// "N <noun>(s)[ in <scope>]", or "Showing X of Y <noun>(s)[ in <scope>]"
+/// when paginated. Matches the pre-existing "(s)" pluralization style.
+pub fn count_label(
+    displayed: usize,
+    total: usize,
+    noun: &str,
+    scope: Option<&str>,
+    paginated: bool,
+) -> String {
+    let base = if paginated {
+        format!("Showing {displayed} of {total} {noun}(s)")
+    } else {
+        format!("{displayed} {noun}(s)")
+    };
+    match scope {
+        Some(scope) => format!("{base} in {scope}"),
+        None => base,
+    }
+}
+```
+
+Register in `src/utils/mod.rs`: add `pub mod list_output;` in alphabetical position among the existing `pub mod` lines.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib utils::list_output`
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt && git add src/utils/list_output.rs src/utils/mod.rs && git commit -m "feat: add shared list empty-state and count wording helpers
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Global `--no-color` flag
+
+**Files:**
+- Modify: `src/cli/commands.rs` — `Cli` struct (global args block, near the `format`/`template` fields ~line 122-190) and the dispatch resolution block (search for `config.format_explicit =`, ~line 1385)
+- Modify: `README.md` — global-options table (the one listing `--format`, `--credential-type`, `--template`, `--env`)
+
+**Interfaces:**
+- Consumes: `Config.no_color` (exists; env `NO_COLOR` already sets it in `load_from_env`).
+- Produces: `xv --no-color <any command>` forces `config.no_color = true` (highest priority in the CLI > env > file hierarchy).
+
+- [ ] **Step 1: Add the flag**
+
+In the `Cli` struct, after the `template` field:
+
+```rust
+    /// Disable colored output (same effect as the NO_COLOR env var)
+    #[arg(long, global = true, hide = should_hide_options())]
+    pub no_color: bool,
+```
+
+In the dispatch resolution block (where `config.runtime_output_format` and `config.format_explicit` are assigned), add:
+
+```rust
+        if self.no_color {
+            config.no_color = true;
+        }
+```
+
+- [ ] **Step 2: README**
+
+Add a row to the global-options table (next to `--format`):
+
+```markdown
+| `--no-color` | Disable colored output (same effect as the `NO_COLOR` env var) |
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo check`
+Expected: clean.
+Run: `cargo run --quiet -- --no-color context list 2>/dev/null | grep -c $'\x1b'; true`
+Expected: `0`.
+Run: `cargo run --quiet -- --format table ls 2>/dev/null | grep -c $'\x1b'; true` (no `--no-color`)
+Expected: non-zero (color still on by default) — confirms the flag defaults off.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cargo fmt && git add src/cli/commands.rs README.md && git commit -m "feat: add global --no-color flag
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `xv vault list` — drop local `--format`, add `--names-only`, conventions
+
+**Files:**
+- Modify: `src/cli/commands.rs` — `VaultCommands::List` variant (~line 936: the `format: OutputFormat` field)
+- Modify: `src/cli/vault_ops.rs` — the `VaultCommands::List` dispatch arm (~line 168) and `execute_vault_list` (~line 369; it has a cached branch and a fresh branch, each with its own empty-check and table rendering)
+
+**Interfaces:**
+- Consumes: Task 1's `empty_state_message` / `count_label`; global `config.runtime_output_format` (already TTY-resolved at dispatch).
+- Produces: `xv vault list` honoring only the global `--format`; `--names-only` printing one vault name per line.
+
+- [ ] **Step 1: Variant changes**
+
+Delete from the `VaultCommands::List` variant:
+
+```rust
+        /// Output format (default: auto = table on TTY, json for pipes/redirects)
+        #[arg(long, value_enum, default_value = "auto")]
+        format: OutputFormat,
+```
+
+Add (after `resource_group`):
+
+```rust
+        /// Print one name per line, no headers, no ANSI. Pipe-friendly.
+        /// Overrides --format and disables auto-format-resolution.
+        #[arg(long)]
+        names_only: bool,
+```
+
+- [ ] **Step 2: Rework `execute_vault_list`**
+
+Update the dispatch arm to stop passing `format` and pass `names_only`. Change `execute_vault_list`'s signature: remove `format: OutputFormat`, add `names_only: bool`. Inside:
+
+- Replace `let output_format = format.resolve_for_stdout();` with `let output_format = config.runtime_output_format;`.
+- In BOTH the cached and fresh branches, apply this shared rendering (extract a local helper inside `vault_ops.rs` to avoid duplicating it):
+
+```rust
+fn render_vault_list(
+    vaults: &[crate::vault::models::VaultSummary],
+    output_format: crate::utils::format::OutputFormat,
+    pagination: crate::utils::pagination::Pagination,
+    pager: bool,
+    names_only: bool,
+    config: &Config,
+) -> Result<()> {
+    use crate::utils::format::{OutputFormat, TableFormatter};
+    use crate::utils::list_output::{count_label, empty_state_message};
+    use crate::utils::pagination::{paginate_slice, pagination_footer_text};
+
+    if names_only {
+        for v in vaults {
+            println!("{}", v.name);
+        }
+        return Ok(());
+    }
+
+    let human_table_like = matches!(
+        output_format,
+        OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+    );
+    let formatter = TableFormatter::new(output_format, config.no_color, config.template.clone());
+
+    if vaults.is_empty() {
+        if human_table_like {
+            crate::utils::output::info(&empty_state_message("vaults", None));
+        } else {
+            println!("{}", formatter.format_table(vaults)?);
+        }
+        return Ok(());
+    }
+
+    let page = paginate_slice(vaults, pagination);
+    let mut output = formatter.format_table(&page.items)?;
+    if human_table_like {
+        output.push('\n');
+        output.push_str(&count_label(
+            page.items.len(),
+            page.total_items,
+            "vault",
+            None,
+            page.page_size.is_some(),
+        ));
+    }
+    if let Some(footer) = pagination_footer_text(&page, "vault", output_format) {
+        output.push('\n');
+        output.push_str(&footer);
+    }
+    crate::utils::pager::print_output(&output, pager)?;
+    Ok(())
+}
+```
+
+Both branches then reduce to fetching `Vec<VaultSummary>` (cached or fresh, with the existing cache-store behavior kept) and calling `render_vault_list(&vaults, output_format, pagination, pager, names_only, config)`. Check `VaultSummary`'s name field is `name` (see `src/vault/models.rs:235` region) — if the field differs (e.g. `vault_name`), use the actual field.
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo test --lib` — green.
+Run: `cargo run --quiet -- vault list --names-only 2>/dev/null | head -3` — one name per line.
+Run: `cargo run --quiet -- vault list --format json 2>/dev/null | python3 -c 'import json,sys; print(type(json.load(sys.stdin)).__name__)'` — `list` (global format flag now serves vault list).
+Run: `cargo run --quiet -- vault list 2>&1 >/dev/null | head -1` with a resource group that has no vaults if available; otherwise skip and note — empty-state to stderr.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cargo fmt && git add src/cli/commands.rs src/cli/vault_ops.rs && git commit -m "feat: unify vault list format flag, add --names-only and standard count
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `xv vault share list` — deprecate `--fmt`, fix machine empty-state, add count
+
+**Files:**
+- Modify: `src/cli/commands.rs` — `VaultShareCommands::List` variant (~line 1104: the `-f/--fmt` field)
+- Modify: `src/cli/vault_ops.rs` — the `VaultShareCommands::List` arm (~line 1173-1226)
+
+**Interfaces:**
+- Consumes: Task 1 helpers; `config.runtime_output_format`.
+- Produces: global `--format` drives output; hidden `--fmt` warns for one release.
+
+- [ ] **Step 1: Variant change**
+
+Replace:
+
+```rust
+        /// Output format
+        #[arg(
+            short = 'f',
+            long = "fmt",
+            default_value = "auto",
+            id = "share_list_format"
+        )]
+        format: crate::utils::format::OutputFormat,
+```
+
+with:
+
+```rust
+        /// Deprecated: use the global --format
+        #[arg(long = "fmt", hide = true, id = "share_list_format")]
+        format: Option<crate::utils::format::OutputFormat>,
+```
+
+(The `-f` short is removed outright; `--fmt json` keeps working with a warning.)
+
+- [ ] **Step 2: Rework the arm**
+
+At the top of the `VaultShareCommands::List` arm body, resolve the format:
+
+```rust
+            let fmt = match format {
+                Some(f) => {
+                    crate::utils::output::warn("--fmt is deprecated; use the global --format");
+                    f.resolve_for_stdout()
+                }
+                None => config.runtime_output_format,
+            };
+            let human_table_like = matches!(
+                fmt,
+                crate::utils::format::OutputFormat::Table
+                    | crate::utils::format::OutputFormat::Plain
+                    | crate::utils::format::OutputFormat::Raw
+            );
+```
+
+Then replace the body's rendering half (from `if roles.is_empty()` to the end of the arm) with:
+
+```rust
+            let formatter = crate::utils::format::TableFormatter::new(
+                fmt,
+                config.no_color,
+                config.template.clone(),
+            );
+
+            if roles.is_empty() {
+                if human_table_like {
+                    output::info(&format!(
+                        "No access assignments found for vault '{vault_name}'"
+                    ));
+                } else {
+                    println!("{}", formatter.format_table(&paged.items)?);
+                }
+            } else {
+                let table_output = formatter.format_table(&paged.items)?;
+                let mut output = String::new();
+                if human_table_like {
+                    let _ = writeln!(output, "Access assignments for vault '{vault_name}':");
+                }
+                output.push_str(&table_output);
+                if human_table_like {
+                    output.push('\n');
+                    output.push_str(&crate::utils::list_output::count_label(
+                        paged.items.len(),
+                        paged.total_items,
+                        "assignment",
+                        None,
+                        paged.page_size.is_some(),
+                    ));
+                }
+                if let Some(footer) = pagination_footer_text(&paged, "assignment", fmt) {
+                    output.push('\n');
+                    output.push_str(&footer);
+                }
+                crate::utils::pager::print_output(&output, pager)?;
+            }
+```
+
+(Header gating widens from `== Table` to all human table-like formats, matching `xv share list`. The existing pre-rendering half of the arm — role fetch, `resolve_and_filter_roles`, pagination — stays as-is.)
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo test --lib` — green.
+Run: `cargo run --quiet -- vault share list <vault> --format json 2>/dev/null | python3 -c 'import json,sys; json.load(sys.stdin); print("valid")'` — `valid` (use the configured default vault name from `xv context show`).
+Run: `cargo run --quiet -- vault share list <vault> --fmt json 2>&1 >/dev/null | head -1` — deprecation warning on stderr.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cargo fmt && git add src/cli/commands.rs src/cli/vault_ops.rs && git commit -m "fix: deprecate vault share list --fmt, emit valid-empty machine output, add count
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `xv file list` — `--pager [WHEN]`, `--names-only`, conventions
+
+**Files:**
+- Modify: `src/cli/file.rs` — `FileCommands::List` variant (~line 66-98)
+- Modify: `src/cli/file_ops.rs` — the `FileCommands::List` dispatch arm (~line 184), the empty-state (`output::info("No files found")`, ~line 540), and the count block (`Total files:` / `Total: {} directories, {} files`, ~line 662-675)
+
+**Interfaces:**
+- Consumes: Task 1 helpers; `crate::cli::commands::PagerWhen`.
+- Produces: `--pager [auto|always|never]` matching every other list command; `--names-only` printing one file name per line (recursive semantics).
+
+- [ ] **Step 1: Variant changes**
+
+Replace:
+
+```rust
+        /// Use an interactive pager for TTY output
+        #[arg(long)]
+        pager: bool,
+```
+
+with:
+
+```rust
+        /// Use an interactive pager for output. Optional WHEN is auto (default
+        /// when the flag is given), always, or never. e.g. `--pager` or `--pager auto`.
+        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "auto")]
+        pager: Option<crate::cli::commands::PagerWhen>,
+```
+
+Add after `recursive`:
+
+```rust
+        /// Print one file name per line, no headers, no ANSI. Pipe-friendly.
+        /// Lists recursively; directory entries are omitted.
+        #[arg(long)]
+        names_only: bool,
+```
+
+- [ ] **Step 2: Dispatch + execution changes** (`src/cli/file_ops.rs`)
+
+In the `FileCommands::List` arm, convert the pager at the boundary and thread `names_only`:
+
+```rust
+            let pager = pager
+                .map(crate::cli::commands::PagerWhen::wants_pager)
+                .unwrap_or(false);
+```
+
+Thread `names_only: bool` into `execute_file_list` (add parameter). Inside `execute_file_list`:
+
+- Where the listing call chooses hierarchical vs recursive (the existing `recursive` argument to the blob listing), pass `recursive || names_only` so names-only always lists the full subtree.
+- Immediately after items are fetched (before any display/formatting), add:
+
+```rust
+    if names_only {
+        for item in &items {
+            if let BlobListItem::File(file) = item {
+                println!("{}", file.name);
+            }
+        }
+        return Ok(());
+    }
+```
+
+(Adapt the exact iteration to the local variable/type names; the enum is `BlobListItem::{File, Directory}` as used in `display_file_list_items`.)
+
+- [ ] **Step 3: Conventions** (`src/cli/file_ops.rs`)
+
+Empty-state (~line 540): the current `output::info("No files found")` short-circuits for every format. Gate it:
+
+```rust
+    let human_table_like = matches!(
+        fmt,
+        OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+    );
+    if items.is_empty() {
+        if human_table_like {
+            output::info(&crate::utils::list_output::empty_state_message("files", None));
+        } else {
+            // fall through to the format match, which serializes the empty
+            // items list as valid-empty machine output ([] for JSON)
+        }
+    }
+```
+
+Adapt to the function's actual control flow: the goal is human-empty → stderr info and return; machine-empty → continue into the existing `match fmt` so JSON/YAML/CSV serialize the empty list. (If `fmt` is resolved later in the function, hoist the resolution above the empty check.)
+
+Count block (~line 662-675): replace the three-way `Total files:` / `Total: X directories, Y files` writeln block with:
+
+```rust
+            output.push('\n');
+            let mut count_line = crate::utils::list_output::count_label(
+                file_count,
+                file_count,
+                "file",
+                None,
+                false,
+            );
+            if !recursive && dir_count > 0 {
+                let _ = write!(count_line, ", {} directory(ies)", dir_count);
+            }
+            let _ = writeln!(output, "{}", count_line);
+```
+
+(`file_count`/`dir_count` already exist at that point; keep them.)
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo test --lib` and `cargo test --test file_commands_tests` (file integration tests exist) — green; report honestly if the integration suite needs storage config not present.
+Run: `cargo run --quiet -- file list --pager never 2>&1 | head -3` — parses, lists.
+Run: `cargo run --quiet -- file list --names-only 2>/dev/null | head -3` — bare names.
+Run: `cargo run --quiet -- file list --prefix xv-definitely-nonexistent --format json 2>/dev/null` — `[]`.
+(If no storage account is configured on this machine, record the commands as blocked-by-environment in the report rather than skipping silently.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt && git add src/cli/file.rs src/cli/file_ops.rs && git commit -m "feat: standard --pager and --names-only for file list, conventions wording
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Adopt conventions in `ls`, `history`, `audit`, `find`, `context list`
+
+**Files:**
+- Modify: `src/cli/secret_ops.rs` — `display_cached_secret_list` empty branch (~line 432-447) and count line (~line 500-512); history count (`"{} version(s) of '{name}'"`, ~line 765); find empty messages (~line 2046-2057)
+- Modify: `src/cli/system_ops.rs` — audit count lines (~line 367 and ~line 475) and audit empty messages (search `"No audit log entries found"`)
+- Modify: `src/cli/config_ops.rs` — context list empty (~line 1071-1072)
+
+**Interfaces:**
+- Consumes: Task 1 helpers.
+- Produces: standardized wording; `xv ls` empty message moves to stderr (spec-mandated behavior change).
+
+- [ ] **Step 1: `xv ls` empty-state to stderr** (`display_cached_secret_list`)
+
+Replace the current empty branch (which pushes the message into the stdout `output` buffer):
+
+```rust
+    if scoped.subtree.is_empty() {
+        let scope_desc = if !path.is_empty() {
+            format!("folder '{path}'")
+        } else {
+            format!("vault '{vault_name}'")
+        };
+        let msg = if all {
+            crate::utils::list_output::empty_state_message("secrets", Some(&scope_desc))
+        } else {
+            format!(
+                "{} Use --all to show disabled secrets.",
+                crate::utils::list_output::empty_state_message("enabled secrets", Some(&scope_desc))
+            )
+        };
+        crate::utils::output::info(&msg);
+        return Ok(());
+    }
+```
+
+Notes: this branch no longer prints the `Vault:` header or anything to stdout — `xv ls > file` on an empty scope produces an empty file. Delete the now-dead `output.push_str(&output::format_line(...))` block. Move this empty check ABOVE the header-composition block (the `let mut output = String::new(); ... writeln!(output, "Vault: ...")` section) so no stdout bytes are emitted first. The wording produced: `No enabled secrets found in folder 'p'. Use --all to show disabled secrets.` — same as today except scope wording for the root case changes from "in vault." to "in vault '<name>'." (richer; changelog-noted).
+
+- [ ] **Step 2: `xv ls` count via helper**
+
+In the grid/long footer block, replace the `secret_count_label(...)` + `" in vault '{}'"` composition with:
+
+```rust
+    let mut count_line = crate::utils::list_output::count_label(
+        page.items
+            .iter()
+            .filter(|e| matches!(e, LsEntry::Secret(_)))
+            .count(),
+        secret_count,
+        "secret",
+        None,
+        page.page_size.is_some(),
+    );
+    if folder_count > 0 {
+        let _ = write!(count_line, ", {} folder(s)", folder_count);
+    }
+    let _ = writeln!(output, "{} in vault '{}'", count_line, vault_name);
+```
+
+And in the legacy-table branch, replace `secret_count_label(...)` similarly with `count_label(page.items.len(), page.total_items, "secret", None, page.page_size.is_some())` inside the existing `"{} in vault '{}'"` writeln. Then delete the now-unused `secret_count_label` function and its tests if nothing else references it (grep first; `filter_secret_summaries_for_display` tests may share the module).
+
+- [ ] **Step 3: history count to stdout, human-gated** (`secret_ops.rs` ~line 765)
+
+The current line prints to stderr unconditionally:
+
+```rust
+            output::info(&format!("{} version(s) of '{name}'", versions.len()));
+```
+
+Replace with (only in the human path — check the surrounding code: if the function prints the table for all formats, gate on the resolved format):
+
+```rust
+            let fmt = config.runtime_output_format;
+            if matches!(
+                fmt,
+                OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+            ) {
+                println!(
+                    "{} of '{name}'",
+                    crate::utils::list_output::count_label(
+                        versions.len(),
+                        versions.len(),
+                        "version",
+                        None,
+                        false
+                    )
+                );
+            }
+```
+
+(Yields `N version(s) of 'name'` on stdout for humans; machine formats stay clean.)
+
+- [ ] **Step 4: audit wording** (`system_ops.rs`)
+
+Both count sites (`~367`, `~475`):
+
+```rust
+    output::info(&format!(
+        "{}:\n",
+        crate::utils::list_output::count_label(logs.len(), logs.len(), "audit log entry", None, false)
+    ));
+```
+
+(second site uses `events.len()`). Both empty sites: replace the literal with `crate::utils::list_output::empty_state_message("audit log entries", None)` — note the criteria phrase is dropped by design (spec: wording normalized).
+
+- [ ] **Step 5: find + context list wording polish**
+
+- `secret_ops.rs` find empties (~2046-2057): keep the "match" wording (it's search-specific) but add terminal periods so all four variants end with `.` — e.g. `"No secrets match '{p}' in vault '{vault_name}'."` and `"No secrets found across all vaults."` (this one can use `empty_state_message("secrets", Some("any vault"))`? No — keep literal `"No secrets found across all vaults."`; the helper's "in" phrasing doesn't fit "across").
+- `config_ops.rs` context list (~1071-1072): change `output::info("No vault contexts found")` to `output::info(&crate::utils::list_output::empty_state_message("vault contexts", None))` and change the following stdout `println!("Hint: ...")` to `output::hint("Use 'xv context use <vault-name>' to create a context")` so the hint also lands on stderr.
+- `env list` (`config_ops.rs` ~1337): intentionally UNCHANGED — its "No .xv.toml found from {path}. Create one with: xv context init" message is a config-missing diagnostic (with an actionable path), not a list-empty; it already goes to stderr. Note this in the task report so the spec's adopters table is accounted for.
+
+- [ ] **Step 6: Verify**
+
+Run: `cargo test --lib` — green (fix any tests asserting the old wording; update expectations to the new strings, do not weaken assertions).
+Run: `cargo run --quiet -- ls xv-no-such-folder --no-cache --format table > /tmp/p2-ls-empty.out 2>/tmp/p2-ls-empty.err; wc -c < /tmp/p2-ls-empty.out; cat /tmp/p2-ls-empty.err | head -1`
+Expected: `0` bytes on stdout; stderr shows `No enabled secrets found in folder 'xv-no-such-folder'. Use --all to show disabled secrets.`
+Run: `cargo run --quiet -- history <existing-secret> --format json 2>/dev/null | python3 -c 'import json,sys; json.load(sys.stdin); print("clean json")'` — `clean json` (no count line contaminating stdout).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt && git add src/cli/secret_ops.rs src/cli/system_ops.rs src/cli/config_ops.rs && git commit -m "feat: standardize list empty-states and counts via list_output helpers
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: CHANGELOG, README, gates, e2e
+
+**Files:**
+- Modify: `CHANGELOG.md` (extend `## Unreleased`)
+- Modify: `README.md` (only if Task 2's row and existing flag docs need reconciliation — check the `vault list` / `file list` sections for stale `--format`/`--pager` descriptions)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-6.
+- Produces: release notes + verified branch.
+
+- [ ] **Step 1: CHANGELOG**
+
+Under `## Unreleased` add:
+
+```markdown
+### Added
+
+- **Global `--no-color` flag** (complements the `NO_COLOR` env var and config key).
+- **`--names-only` on `vault list` and `file list`** (one name per line, pipe-friendly; `file list --names-only` lists recursively).
+- **`file list --pager [auto|always|never]`** matching every other list command (bare `--pager` unchanged).
+
+### Changed
+
+- **List empty-states now go to stderr** for human formats across all list commands (including `xv ls`, whose empty message previously landed on stdout — `xv ls > file` on an empty scope now writes an empty file), and empty-state/count wording is standardized via shared helpers. `xv history`'s count line moved from stderr to stdout (human formats only).
+- **`vault share list -f/--fmt` is deprecated**: use the global `--format`. `--fmt` still works with a warning for one release; `-f` is removed. `vault list`'s redundant local `--format` was removed (the identical global flag takes over transparently).
+
+### Fixed
+
+- **Empty machine-format output is now valid-empty** (`[]` for JSON) on stdout for `vault list`, `vault share list`, and `file list`, instead of a stderr-only message that broke `| jq` on empty results.
+```
+
+- [ ] **Step 2: Gates**
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets
+cargo test --lib
+cargo test
+```
+Expected: all clean/green (full suite needs the Azure creds on this machine; report failures honestly).
+
+- [ ] **Step 3: E2E (read-only against the real vault)**
+
+```bash
+cargo run --quiet -- vault list --names-only | head -3
+cargo run --quiet -- vault list --format yaml | head -3
+cargo run --quiet -- vault share list "$(cargo run --quiet -- context show 2>/dev/null | grep -o 'kv-[a-z]*' | head -1)" --format json | python3 -m json.tool | head -3
+cargo run --quiet -- ls xv-no-such-folder > /tmp/e2e-empty.out 2>/tmp/e2e-empty.err; echo "stdout_bytes=$(wc -c < /tmp/e2e-empty.out)"; head -1 /tmp/e2e-empty.err
+cargo run --quiet -- --no-color --format table ls | grep -c $'\x1b'; true
+cargo run --quiet -- history azure-client-id | tail -1
+```
+
+Capture actual outputs. `xv ls xv-no-such-folder` piped → machine format → expect `[]` on stdout (not zero bytes) — the zero-byte stdout check applies to `--format table` (Task 6 verified it); adjust expectations accordingly and record both.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cargo fmt && git add CHANGELOG.md README.md && git commit -m "docs: changelog for list-command surface consistency pass
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Spec coverage map
+
+| Spec section | Task |
+|---|---|
+| §1 vault list local `--format` removal + `--names-only` | Task 3 |
+| §1 vault share list `--fmt` deprecation | Task 4 |
+| §1 file list `--pager [WHEN]` + `--names-only` | Task 5 |
+| §1 global `--no-color` | Task 2 |
+| §2 conventions module | Task 1 |
+| §2 adopters table (ls/vault/file/share/history/audit/find/context) | Tasks 3-6 |
+| §2 machine valid-empty (vault list, vault share list, file list) | Tasks 3, 4, 5 |
+| §2 `ls` stderr change | Task 6 |
+| Testing + gates | per-task steps + Task 7 |

--- a/docs/superpowers/specs/2026-07-01-list-p2-surface-design.md
+++ b/docs/superpowers/specs/2026-07-01-list-p2-surface-design.md
@@ -57,7 +57,7 @@ Adopters and their conventions after this change (human formats):
 | `history` | existing wording | count moves from stderr to stdout, `N version(s) of 'name'` |
 | `audit`, `find`, `context list`, `env list` | wording normalized to the pattern; streams already stderr | unchanged (audit keeps its `Found N…` header position but reworded via helper) |
 
-Machine formats: every adopter prints its format's valid-empty output on stdout (`[]` for JSON — via `TableFormatter` where used, via the command's own serializer for `find`) and never the info message — this fixes the `vault share list` defect. Counts never appear in machine output.
+Machine formats: adopters with machine-format support this phase (`ls`, `vault list`, `vault share list`, `share list`, `file list`) print their format's valid-empty output on stdout (`[]` for JSON — via `TableFormatter` where used) and never the info message — this fixes the `vault share list` defect. Counts never appear in machine output.
 
 **`ls` stream change called out:** its human empty message moves from the stdout buffer to stderr `output::info`, aligning with the v0.16.0 stdout-purity rule. `xv ls > file` on an empty vault now produces an empty file. The P1 spec's §2 note about "existing stdout convention" is superseded by this spec.
 
@@ -66,6 +66,7 @@ Machine formats: every adopter prints its format's valid-empty output on stdout 
 - Routing `audit`/`find`/`config show`/`context list`/`env list`/`file list` rendering through `TableFormatter`; adding JSON/YAML/CSV to commands that lack them; any change to `find`'s JSON envelope or `file list`'s CSV header casing.
 - `--columns` column selection (returns with the shared renderer).
 - `find --folder`, TUI folder tree, folder completion (P1 deferrals, unchanged).
+- Machine-format valid-empty output for `history`, `find`, and `audit` (their machine paths are untouched this phase; Phase B).
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-01-list-p2-surface-design.md
+++ b/docs/superpowers/specs/2026-07-01-list-p2-surface-design.md
@@ -1,0 +1,78 @@
+# List Command P2 Surface-Consistency Design
+
+> **Status:** 📋 Approved design — not yet implemented. | **Date:** 2026-07-01 | **Author:** Claude + Scott
+> Phase A of the P2 tier of the 2026-07-01 list-command UX review (P0 = PR #289, P1 = PR #290). Phase B (renderer unification through `TableFormatter`, `--columns`, machine formats for the bespoke renderers) is a separate future spec.
+
+---
+
+## Problem
+
+The list commands drifted apart because each one hand-rolled its own surface. Concretely, today:
+
+1. **Format selection is inconsistent.** `xv vault list` declares a local `--format` that shadows the identical global flag (`src/cli/commands.rs:933` region); `xv vault share list` uses `-f/--fmt`; everything else uses the global `--format`.
+2. **Pager flags differ.** `xv file list` takes a bare `--pager` boolean (`src/cli/file.rs:90`), while `ls`, `vault list`, `share list`, and `vault share list` take `--pager [auto|always|never]` (`PagerWhen`).
+3. **`--names-only` exists only on `ls` and `find`** — the most pipe-friendly flag is missing from `vault list` and `file list`.
+4. **Empty-states and counts are five different conventions.** Wording, punctuation, and stream (stdout vs stderr) vary per command; `xv vault share list` with no assignments prints stderr info even for machine formats, leaving stdout empty and breaking `| jq` (defect flagged in the P1 final review). Counts range from `"N secret(s) in vault 'X'"` to `"Total files: N"` to nothing at all.
+5. **No `--no-color` flag exists** — color is controlled only by the config `no_color` key and the `NO_COLOR` env var (added in P0).
+
+## Decisions
+
+Settled in-session (user AFK at the option prompts; recommended options adopted, overridable at spec review):
+
+- **P2 is split.** This spec is the mechanical surface pass (Phase A). Renderer unification and `--columns` are Phase B, later.
+- **Convention is enforced by small shared helpers** (`src/utils/list_output.rs`), not a full rendering abstraction and not tests alone.
+- **Human empty-states go to stderr; machine formats emit valid-empty stdout.** This changes `xv ls`, whose empty message currently lands in the stdout buffer — changelog-noted.
+- **`--fmt` on `vault export/import`, `env pull`, and `parse` is untouched** — there it selects file formats, not output rendering.
+
+## Design
+
+### 1. Flag unification
+
+- **`xv vault list`:** delete the local `--format` field and its plumbing; the global `--format` takes over transparently (same name, same values, same default `auto`). No user-visible change. Add `--names-only`.
+- **`xv vault share list`:** replace `-f/--fmt` with reliance on the global `--format`. Keep `--fmt` as a **hidden** local `Option<OutputFormat>` (`hide = true`, no `-f` short) for one release: when supplied it wins and prints `output::warn("--fmt is deprecated; use the global --format")`. Remove entirely in the release after.
+- **`xv file list`:** change `--pager: bool` to `--pager [WHEN]` (`Option<PagerWhen>`, `num_args 0..=1`, `default_missing_value = "auto"`) exactly matching the other list commands. Bare `--pager` behaves as before. Add `--names-only` (one blob name per line, files only, no directory entries, recursive listing semantics like `ls --names-only` uses the subtree).
+- **Global `--no-color`:** new global bool flag on the `Cli` struct; when set, `config.no_color = true` at dispatch (highest priority, consistent with CLI > env > file hierarchy). Documented alongside `NO_COLOR` in README.
+
+### 2. Shared conventions module (`src/utils/list_output.rs`)
+
+Pure helpers; no I/O:
+
+```rust
+/// "No <nouns> found[ in <scope>]." — human empty-state wording.
+pub fn empty_state_message(noun_plural: &str, scope: Option<&str>) -> String
+/// Optional follow-up hint line, e.g. "Use --all to show disabled secrets."
+/// Callers pass it separately so wording stays caller-owned but placement uniform.
+/// "N <noun>(s) in <scope>" or "Showing X of Y <noun>(s) in <scope>".
+pub fn count_label(displayed: usize, total: usize, noun: &str, scope: Option<&str>, paginated: bool) -> String
+```
+
+Adopters and their conventions after this change (human formats):
+
+| Command | Empty-state (stderr `output::info`) | Count (stdout, after listing) |
+|---|---|---|
+| `ls` (grid/long/table) | `No secrets found in folder 'p'.` / `No secrets found in vault 'v'.` + `--all` hint when filtered | existing `N secret(s)[, M folder(s)] in vault 'v'` reworded via `count_label` |
+| `vault list` | `No vaults found.` | **new** `N vault(s)` |
+| `file list` | `No files found.` | `N file(s), M directory(ies)` replacing `Total files:`/`Total:` wording |
+| `share list` / `vault share list` | `No access assignments found for …` (existing wording kept, stream already stderr) | **new** `N assignment(s)` |
+| `history` | existing wording | count moves from stderr to stdout, `N version(s) of 'name'` |
+| `audit`, `find`, `context list`, `env list` | wording normalized to the pattern; streams already stderr | unchanged (audit keeps its `Found N…` header position but reworded via helper) |
+
+Machine formats: every adopter prints its format's valid-empty output on stdout (`[]` for JSON — via `TableFormatter` where used, via the command's own serializer for `find`) and never the info message — this fixes the `vault share list` defect. Counts never appear in machine output.
+
+**`ls` stream change called out:** its human empty message moves from the stdout buffer to stderr `output::info`, aligning with the v0.16.0 stdout-purity rule. `xv ls > file` on an empty vault now produces an empty file. The P1 spec's §2 note about "existing stdout convention" is superseded by this spec.
+
+### 3. Explicitly out of scope (Phase B or later)
+
+- Routing `audit`/`find`/`config show`/`context list`/`env list`/`file list` rendering through `TableFormatter`; adding JSON/YAML/CSV to commands that lack them; any change to `find`'s JSON envelope or `file list`'s CSV header casing.
+- `--columns` column selection (returns with the shared renderer).
+- `find --folder`, TUI folder tree, folder completion (P1 deferrals, unchanged).
+
+## Testing
+
+- Unit tests for `list_output.rs` helpers (scoped/unscoped wording, paginated wording, singular/plural form left as `(s)` style matching current output).
+- Behavioral checks per adopter: empty vault/folder/prefix cases send info to stderr and keep stdout clean (or valid-empty for machine formats); `xv vault share list --format json` with zero assignments emits `[]`; `xv file list --pager never` parses; `--fmt` on `vault share list` warns but works; `xv --no-color ls` emits no ANSI.
+- Gates: `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test --lib`, full `cargo test`.
+
+## Out of scope
+
+Everything in §3 above, plus any renderer or schema change. Machine output shapes are byte-identical after this phase except: empty `vault share list` machine output (bug fix: `[]` instead of nothing).

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1395,6 +1395,7 @@ impl Cli {
         // Disable colors if --no-color flag is set
         if self.no_color {
             config.no_color = true;
+            crate::utils::output::disable_color();
         }
 
         // Warn if --template given without --format template

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -941,9 +941,10 @@ pub enum VaultCommands {
         /// Resource group
         #[arg(short, long)]
         resource_group: Option<String>,
-        /// Output format (default: auto = table on TTY, json for pipes/redirects)
-        #[arg(long, value_enum, default_value = "auto")]
-        format: OutputFormat,
+        /// Print one name per line, no headers, no ANSI. Pipe-friendly.
+        /// Overrides --format and disables auto-format-resolution.
+        #[arg(long)]
+        names_only: bool,
         /// Bypass the local cache and fetch fresh data
         #[arg(long)]
         no_cache: bool,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1112,14 +1112,9 @@ pub enum VaultShareCommands {
         /// Resource group
         #[arg(short, long)]
         resource_group: Option<String>,
-        /// Output format
-        #[arg(
-            short = 'f',
-            long = "fmt",
-            default_value = "auto",
-            id = "share_list_format"
-        )]
-        format: crate::utils::format::OutputFormat,
+        /// Deprecated: use the global --format
+        #[arg(long = "fmt", hide = true, id = "share_list_format")]
+        format: Option<crate::utils::format::OutputFormat>,
         /// Include service accounts in output
         #[arg(long)]
         all: bool,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -161,6 +161,10 @@ pub struct Cli {
     #[arg(long, global = true, hide = should_hide_options())]
     pub template: Option<String>,
 
+    /// Disable colored output (same effect as the NO_COLOR env var)
+    #[arg(long, global = true, hide = should_hide_options())]
+    pub no_color: bool,
+
     /// Azure credential type to use first (cli, managed_identity, environment, default)
     #[arg(
         long,
@@ -1391,6 +1395,11 @@ impl Cli {
 
         // Wire template string
         config.template = self.template.clone();
+
+        // Disable colors if --no-color flag is set
+        if self.no_color {
+            config.no_color = true;
+        }
 
         // Warn if --template given without --format template
         if config.template.is_some() && resolved != OutputFormat::Template {

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -1068,8 +1068,11 @@ async fn execute_context_list(config: &Config) -> Result<()> {
     let context_manager = ContextManager::load().await.unwrap_or_default();
 
     if context_manager.recent.is_empty() && context_manager.current.is_none() {
-        output::info("No vault contexts found");
-        println!("Hint: Use 'xv context use <vault-name>' to create a context");
+        output::info(&crate::utils::list_output::empty_state_message(
+            "vault contexts",
+            None,
+        ));
+        output::hint("Use 'xv context use <vault-name>' to create a context");
         return Ok(());
     }
 

--- a/src/cli/file.rs
+++ b/src/cli/file.rs
@@ -86,12 +86,17 @@ pub enum FileCommands {
         /// Number of rows per page
         #[arg(long)]
         page_size: Option<usize>,
-        /// Use an interactive pager for TTY output
-        #[arg(long)]
-        pager: bool,
+        /// Use an interactive pager for output. Optional WHEN is auto (default
+        /// when the flag is given), always, or never. e.g. `--pager` or `--pager auto`.
+        #[arg(long, value_name = "WHEN", num_args = 0..=1, default_missing_value = "auto")]
+        pager: Option<crate::cli::commands::PagerWhen>,
         /// List all files recursively (show all nested files instead of directory structure)
         #[arg(short, long)]
         recursive: bool,
+        /// Print one file name per line, no headers, no ANSI. Pipe-friendly.
+        /// Lists recursively; directory entries are omitted.
+        #[arg(long)]
+        names_only: bool,
         /// Bypass the local cache and fetch fresh data
         #[arg(long)]
         no_cache: bool,

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -189,9 +189,14 @@ pub(crate) async fn execute_file_command(command: FileCommands, config: Config) 
             page_size,
             pager,
             recursive,
+            names_only,
             no_cache,
         } => {
             use crate::utils::pagination::Pagination;
+
+            let pager = pager
+                .map(crate::cli::commands::PagerWhen::wants_pager)
+                .unwrap_or(false);
 
             if limit.is_some() && page_size.is_some() {
                 return Err(CrosstacheError::invalid_argument(
@@ -218,6 +223,7 @@ pub(crate) async fn execute_file_command(command: FileCommands, config: Config) 
                 pagination,
                 pager,
                 recursive,
+                names_only,
                 no_cache,
                 &config,
             )
@@ -536,12 +542,19 @@ pub(crate) fn display_file_list_items(
     use std::fmt::Write as _;
     use tabled::Tabled;
 
-    if items.is_empty() {
-        output::info("No files found");
+    let fmt = config.runtime_output_format.resolve_for_stdout();
+    let human_table_like = matches!(
+        fmt,
+        OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+    );
+
+    if items.is_empty() && human_table_like {
+        output::info(&crate::utils::list_output::empty_state_message(
+            "files", None,
+        ));
         return Ok(String::new());
     }
 
-    let fmt = config.runtime_output_format.resolve_for_stdout();
     let mut output = String::new();
 
     // Rows for `--format csv`: machine-oriented fields (not `format_size()` / joined strings).
@@ -659,20 +672,13 @@ pub(crate) fn display_file_list_items(
                 .filter(|i| matches!(i, BlobListItem::Directory { .. }))
                 .count();
 
-            if recursive {
-                output.push('\n');
-                let _ = writeln!(output, "Total files: {}", file_count);
-            } else if dir_count > 0 {
-                output.push('\n');
-                let _ = writeln!(
-                    output,
-                    "Total: {} directories, {} files",
-                    dir_count, file_count
-                );
-            } else {
-                output.push('\n');
-                let _ = writeln!(output, "Total files: {}", file_count);
+            output.push('\n');
+            let mut count_line =
+                crate::utils::list_output::count_label(file_count, file_count, "file", None, false);
+            if !recursive && dir_count > 0 {
+                let _ = write!(count_line, ", {} directory(ies)", dir_count);
             }
+            let _ = writeln!(output, "{}", count_line);
         }
         OutputFormat::Template => {
             let display_items: Vec<ListItem> = items
@@ -711,12 +717,16 @@ async fn execute_file_list(
     pagination: Pagination,
     pager: bool,
     recursive: bool,
+    names_only: bool,
     no_cache: bool,
     config: &Config,
 ) -> Result<()> {
     use crate::blob::models::{BlobListItem, FileListRequest};
     use crate::cache::{CacheKey, CacheManager};
     use crate::utils::pagination::{paginate_slice, pagination_footer_text};
+
+    // `--names-only` always needs the full recursive item set (no directory entries).
+    let recursive = recursive || names_only;
 
     let cache_manager = CacheManager::from_config(config);
     let vault_name = config.resolve_vault_name(None).await.unwrap_or_default();
@@ -730,6 +740,15 @@ async fn execute_file_list(
 
     if use_cache && is_unfiltered {
         if let Some(cached) = cache_manager.get::<Vec<BlobListItem>>(&cache_key) {
+            if names_only {
+                for item in &cached {
+                    if let BlobListItem::File(file) = item {
+                        println!("{}", file.name);
+                    }
+                }
+                return Ok(());
+            }
+
             let page = paginate_slice(&cached, pagination);
             let mut output = display_file_list_items(&page.items, recursive, config)?;
             if !output.is_empty() {
@@ -772,6 +791,15 @@ async fn execute_file_list(
 
     if use_cache && is_unfiltered {
         cache_manager.set(&cache_key, &items);
+    }
+
+    if names_only {
+        for item in &items {
+            if let BlobListItem::File(file) = item {
+                println!("{}", file.name);
+            }
+        }
+        return Ok(());
     }
 
     let page = paginate_slice(&items, pagination);

--- a/src/cli/file_ops_aws.rs
+++ b/src/cli/file_ops_aws.rs
@@ -234,9 +234,14 @@ pub(crate) async fn execute_file_command_aws(command: FileCommands, config: Conf
             page_size,
             pager,
             recursive,
+            names_only,
             no_cache,
         } => {
             use crate::utils::pagination::Pagination;
+
+            let pager = pager
+                .map(crate::cli::commands::PagerWhen::wants_pager)
+                .unwrap_or(false);
 
             if limit.is_some() && page_size.is_some() {
                 return Err(CrosstacheError::invalid_argument(
@@ -255,7 +260,8 @@ pub(crate) async fn execute_file_command_aws(command: FileCommands, config: Conf
             };
 
             execute_list(
-                &backend, &vault, prefix, group, pagination, pager, recursive, no_cache, &config,
+                &backend, &vault, prefix, group, pagination, pager, recursive, names_only,
+                no_cache, &config,
             )
             .await?;
         }
@@ -1042,11 +1048,15 @@ async fn execute_list(
     pagination: crate::utils::pagination::Pagination,
     pager: bool,
     recursive: bool,
+    names_only: bool,
     no_cache: bool,
     config: &Config,
 ) -> Result<()> {
     use crate::cache::{CacheKey, CacheManager};
     use crate::utils::pagination::{paginate_slice, pagination_footer_text};
+
+    // `--names-only` always needs the full recursive item set (no directory entries).
+    let recursive = recursive || names_only;
 
     let cache_manager = CacheManager::from_config(config);
     let cache_key = CacheKey::FileList {
@@ -1091,6 +1101,15 @@ async fn execute_list(
             fetched
         }
     };
+
+    if names_only {
+        for item in &items {
+            if let BlobListItem::File(file) = item {
+                println!("{}", file.name);
+            }
+        }
+        return Ok(());
+    }
 
     let page = paginate_slice(&items, pagination);
     let mut rendered = display_file_list_items(&page.items, recursive, config)?;

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -418,6 +418,27 @@ pub(crate) fn display_cached_secret_list(
         return Ok(());
     }
 
+    if scoped.subtree.is_empty() {
+        let scope_desc = if !path.is_empty() {
+            format!("folder '{path}'")
+        } else {
+            format!("vault '{vault_name}'")
+        };
+        let msg = if all {
+            crate::utils::list_output::empty_state_message("secrets", Some(&scope_desc))
+        } else {
+            format!(
+                "{} Use --all to show disabled secrets.",
+                crate::utils::list_output::empty_state_message(
+                    "enabled secrets",
+                    Some(&scope_desc)
+                )
+            )
+        };
+        crate::utils::output::info(&msg);
+        return Ok(());
+    }
+
     let mut output = String::new();
     output.push('\n');
     // Color only for styled table/grid; plain/raw must not emit ANSI escapes
@@ -428,29 +449,6 @@ pub(crate) fn display_cached_secret_list(
         let _ = writeln!(output, "Vault: {}", vault_name);
     }
     output.push('\n');
-
-    if scoped.subtree.is_empty() {
-        let msg = if !path.is_empty() {
-            if all {
-                format!("No secrets found in folder '{path}'.")
-            } else {
-                format!(
-                    "No enabled secrets found in folder '{path}'. Use --all to show disabled secrets."
-                )
-            }
-        } else if all {
-            "No secrets found in vault.".to_string()
-        } else {
-            "No enabled secrets found in vault. Use --all to show disabled secrets.".to_string()
-        };
-        output.push_str(&output::format_line(
-            output::Level::Info,
-            &msg,
-            output::should_use_rich_stdout(),
-        ));
-        crate::utils::pager::print_output(&output, pager)?;
-        return Ok(());
-    }
 
     // Legacy rounded table only on explicit --format table|plain|raw.
     if config.format_explicit && !long {
@@ -463,9 +461,10 @@ pub(crate) fn display_cached_secret_list(
         let _ = writeln!(
             output,
             "{} in vault '{}'",
-            secret_count_label(
+            crate::utils::list_output::count_label(
                 page.items.len(),
                 page.total_items,
+                "secret",
                 None,
                 page.page_size.is_some(),
             ),
@@ -504,12 +503,13 @@ pub(crate) fn display_cached_secret_list(
     };
     output.push_str(&rendered);
     output.push('\n');
-    let mut count_line = secret_count_label(
+    let mut count_line = crate::utils::list_output::count_label(
         page.items
             .iter()
             .filter(|e| matches!(e, LsEntry::Secret(_)))
             .count(),
         secret_count,
+        "secret",
         None,
         page.page_size.is_some(),
     );
@@ -762,7 +762,22 @@ pub(crate) async fn execute_secret_history_direct(
             );
             let table = formatter.format_table(&versions)?;
             println!("{table}");
-            output::info(&format!("{} version(s) of '{name}'", versions.len()));
+            let fmt = config.runtime_output_format;
+            if matches!(
+                fmt,
+                OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+            ) {
+                println!(
+                    "{} of '{name}'",
+                    crate::utils::list_output::count_label(
+                        versions.len(),
+                        versions.len(),
+                        "version",
+                        None,
+                        false
+                    )
+                );
+            }
         }
         return Ok(());
     }
@@ -2043,9 +2058,9 @@ async fn execute_secret_find(
     if matches.is_empty() {
         if all_vaults {
             if let Some(p) = pattern {
-                output::info(&format!("No secrets match '{p}' across all vaults"));
+                output::info(&format!("No secrets match '{p}' across all vaults."));
             } else {
-                output::info("No secrets found across all vaults");
+                output::info("No secrets found across all vaults.");
             }
         } else {
             let vault_name = single_vault.as_ref().ok_or_else(|| {
@@ -2054,9 +2069,9 @@ async fn execute_secret_find(
                 )
             })?;
             if let Some(p) = pattern {
-                output::info(&format!("No secrets match '{p}' in vault '{vault_name}'"));
+                output::info(&format!("No secrets match '{p}' in vault '{vault_name}'."));
             } else {
-                output::info(&format!("No secrets in vault '{vault_name}'"));
+                output::info(&format!("No secrets in vault '{vault_name}'."));
             }
         }
         return Ok(());

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -3977,6 +3977,16 @@ async fn execute_secret_share(
                 }
                 let table_output = formatter.format_table(&paged.items)?;
                 output.push_str(&table_output);
+                if human_table_like {
+                    output.push('\n');
+                    output.push_str(&crate::utils::list_output::count_label(
+                        paged.items.len(),
+                        paged.total_items,
+                        "assignment",
+                        None,
+                        paged.page_size.is_some(),
+                    ));
+                }
                 if let Some(footer) = pagination_footer_text(&paged, "assignment", fmt) {
                     output.push('\n');
                     output.push_str(&footer);

--- a/src/cli/system_ops.rs
+++ b/src/cli/system_ops.rs
@@ -359,12 +359,24 @@ pub(crate) async fn execute_audit_command(
     }
 
     if logs.is_empty() {
-        output::info("No audit log entries found for the specified criteria");
+        output::info(&crate::utils::list_output::empty_state_message(
+            "audit log entries",
+            None,
+        ));
         return Ok(());
     }
 
     println!();
-    output::info(&format!("Found {} audit log entries:\n", logs.len()));
+    output::info(&format!(
+        "{}:\n",
+        crate::utils::list_output::count_label(
+            logs.len(),
+            logs.len(),
+            "audit log entry",
+            None,
+            false
+        )
+    ));
 
     if raw {
         // Show raw JSON output
@@ -467,12 +479,24 @@ async fn execute_backend_audit(
     }
 
     if events.is_empty() {
-        output::info("No audit log entries found for the specified criteria");
+        output::info(&crate::utils::list_output::empty_state_message(
+            "audit log entries",
+            None,
+        ));
         return Ok(());
     }
 
     println!();
-    output::info(&format!("Found {} audit log entries:\n", events.len()));
+    output::info(&format!(
+        "{}:\n",
+        crate::utils::list_output::count_label(
+            events.len(),
+            events.len(),
+            "audit log entry",
+            None,
+            false
+        )
+    ));
 
     if raw {
         // Show raw JSON output

--- a/src/cli/vault_ops.rs
+++ b/src/cli/vault_ops.rs
@@ -411,6 +411,7 @@ fn render_vault_list(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn execute_vault_list(
     vault_manager: &VaultManager,
     resource_group: Option<String>,

--- a/src/cli/vault_ops.rs
+++ b/src/cli/vault_ops.rs
@@ -1229,26 +1229,55 @@ async fn execute_vault_share(
                 .resolve_and_filter_roles(&mut roles, all)
                 .await?;
 
+            let fmt = match format {
+                Some(f) => {
+                    crate::utils::output::warn("--fmt is deprecated; use the global --format");
+                    f.resolve_for_stdout()
+                }
+                None => config.runtime_output_format,
+            };
+            let human_table_like = matches!(
+                fmt,
+                crate::utils::format::OutputFormat::Table
+                    | crate::utils::format::OutputFormat::Plain
+                    | crate::utils::format::OutputFormat::Raw
+            );
+
             let pagination = Pagination::from_args(page, page_size)?;
             let paged = paginate_slice(&roles, pagination);
 
+            let formatter = crate::utils::format::TableFormatter::new(
+                fmt,
+                config.no_color,
+                config.template.clone(),
+            );
+
             if roles.is_empty() {
-                output::info(&format!(
-                    "No access assignments found for vault '{vault_name}'"
-                ));
+                if human_table_like {
+                    output::info(&format!(
+                        "No access assignments found for vault '{vault_name}'"
+                    ));
+                } else {
+                    println!("{}", formatter.format_table(&paged.items)?);
+                }
             } else {
-                let formatter = crate::utils::format::TableFormatter::new(
-                    format,
-                    config.no_color,
-                    config.template.clone(),
-                );
                 let table_output = formatter.format_table(&paged.items)?;
                 let mut output = String::new();
-                if format.resolve_for_stdout() == crate::utils::format::OutputFormat::Table {
+                if human_table_like {
                     let _ = writeln!(output, "Access assignments for vault '{vault_name}':");
                 }
                 output.push_str(&table_output);
-                if let Some(footer) = pagination_footer_text(&paged, "assignment", format) {
+                if human_table_like {
+                    output.push('\n');
+                    output.push_str(&crate::utils::list_output::count_label(
+                        paged.items.len(),
+                        paged.total_items,
+                        "assignment",
+                        None,
+                        paged.page_size.is_some(),
+                    ));
+                }
+                if let Some(footer) = pagination_footer_text(&paged, "assignment", fmt) {
                     output.push('\n');
                     output.push_str(&footer);
                 }

--- a/src/cli/vault_ops.rs
+++ b/src/cli/vault_ops.rs
@@ -63,41 +63,29 @@ pub(crate) async fn execute_vault_command(
                 output::success(&format!("Successfully created vault '{}'", vault.name));
             }
             VaultCommands::List {
-                format,
+                names_only,
                 page,
                 page_size,
                 pager,
                 ..
             } => {
-                use crate::utils::format::TableFormatter;
-                use crate::utils::pagination::{
-                    paginate_slice, pagination_footer_text, Pagination,
-                };
+                use crate::utils::pagination::Pagination;
 
                 let pager = pager
                     .map(crate::cli::commands::PagerWhen::wants_pager)
                     .unwrap_or(false);
                 let vaults = vaults_backend.list_vaults().await?;
-                let output_format = format.resolve_for_stdout();
+                let output_format = config.runtime_output_format;
                 let pagination = Pagination::from_args(page, page_size)?;
 
-                if vaults.is_empty() {
-                    output::info("No vaults found.");
-                } else {
-                    let page_data = paginate_slice(&vaults, pagination);
-                    let formatter = TableFormatter::new(
-                        output_format,
-                        config.no_color,
-                        config.template.clone(),
-                    );
-                    let mut out = formatter.format_table(&page_data.items)?;
-                    if let Some(footer) = pagination_footer_text(&page_data, "vault", output_format)
-                    {
-                        out.push('\n');
-                        out.push_str(&footer);
-                    }
-                    crate::utils::pager::print_output(&out, pager)?;
-                }
+                render_vault_list(
+                    &vaults,
+                    output_format,
+                    pagination,
+                    pager,
+                    names_only,
+                    &config,
+                )?;
             }
             VaultCommands::Delete { name, force, .. } => {
                 if !crate::cli::helpers::confirm_destructive(
@@ -167,7 +155,7 @@ pub(crate) async fn execute_vault_command(
         }
         VaultCommands::List {
             resource_group,
-            format,
+            names_only,
             no_cache,
             page,
             page_size,
@@ -176,7 +164,7 @@ pub(crate) async fn execute_vault_command(
             execute_vault_list(
                 &vault_manager,
                 resource_group,
-                format,
+                names_only,
                 no_cache,
                 page,
                 page_size,
@@ -366,10 +354,67 @@ async fn execute_vault_create(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Shared rendering for `vault list`'s cached and fresh branches: names-only
+/// output, empty-state messaging (stderr for humans, valid-empty JSON/etc. on
+/// stdout for machine formats), pagination, and the standard count label.
+fn render_vault_list(
+    vaults: &[crate::vault::models::VaultSummary],
+    output_format: crate::utils::format::OutputFormat,
+    pagination: crate::utils::pagination::Pagination,
+    pager: bool,
+    names_only: bool,
+    config: &Config,
+) -> Result<()> {
+    use crate::utils::format::{OutputFormat, TableFormatter};
+    use crate::utils::list_output::{count_label, empty_state_message};
+    use crate::utils::pagination::{paginate_slice, pagination_footer_text};
+
+    if names_only {
+        for v in vaults {
+            println!("{}", v.name);
+        }
+        return Ok(());
+    }
+
+    let human_table_like = matches!(
+        output_format,
+        OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+    );
+    let formatter = TableFormatter::new(output_format, config.no_color, config.template.clone());
+
+    if vaults.is_empty() {
+        if human_table_like {
+            crate::utils::output::info(&empty_state_message("vaults", None));
+        } else {
+            println!("{}", formatter.format_table(vaults)?);
+        }
+        return Ok(());
+    }
+
+    let page = paginate_slice(vaults, pagination);
+    let mut output = formatter.format_table(&page.items)?;
+    if human_table_like {
+        output.push('\n');
+        output.push_str(&count_label(
+            page.items.len(),
+            page.total_items,
+            "vault",
+            None,
+            page.page_size.is_some(),
+        ));
+    }
+    if let Some(footer) = pagination_footer_text(&page, "vault", output_format) {
+        output.push('\n');
+        output.push_str(&footer);
+    }
+    crate::utils::pager::print_output(&output, pager)?;
+    Ok(())
+}
+
 async fn execute_vault_list(
     vault_manager: &VaultManager,
     resource_group: Option<String>,
-    format: OutputFormat,
+    names_only: bool,
     no_cache: bool,
     page: Option<usize>,
     page_size: Option<usize>,
@@ -377,32 +422,25 @@ async fn execute_vault_list(
     config: &Config,
 ) -> Result<()> {
     use crate::cache::{CacheKey, CacheManager};
-    use crate::utils::format::TableFormatter;
-    use crate::utils::pagination::{paginate_slice, pagination_footer_text, Pagination};
+    use crate::utils::pagination::Pagination;
     use crate::vault::models::VaultSummary;
 
     let cache_manager = CacheManager::from_config(config);
     let cache_key = CacheKey::VaultList;
     let use_cache = cache_manager.is_enabled() && !no_cache;
-    let output_format = format.resolve_for_stdout();
+    let output_format = config.runtime_output_format;
     let pagination = Pagination::from_args(page, page_size)?;
 
     if use_cache && resource_group.is_none() {
         if let Some(cached) = cache_manager.get::<Vec<VaultSummary>>(&cache_key) {
-            if cached.is_empty() {
-                output::info("No vaults found.");
-            } else {
-                let page = paginate_slice(&cached, pagination);
-                let formatter =
-                    TableFormatter::new(output_format, config.no_color, config.template.clone());
-                let mut output = formatter.format_table(&page.items)?;
-                if let Some(footer) = pagination_footer_text(&page, "vault", output_format) {
-                    output.push('\n');
-                    output.push_str(&footer);
-                }
-                crate::utils::pager::print_output(&output, pager)?;
-            }
-            return Ok(());
+            return render_vault_list(
+                &cached,
+                output_format,
+                pagination,
+                pager,
+                names_only,
+                config,
+            );
         }
     }
 
@@ -414,21 +452,14 @@ async fn execute_vault_list(
         cache_manager.set(&cache_key, &vaults);
     }
 
-    if vaults.is_empty() {
-        output::info("No vaults found.");
-    } else {
-        let page = paginate_slice(&vaults, pagination);
-        let formatter =
-            TableFormatter::new(output_format, config.no_color, config.template.clone());
-        let mut output = formatter.format_table(&page.items)?;
-        if let Some(footer) = pagination_footer_text(&page, "vault", output_format) {
-            output.push('\n');
-            output.push_str(&footer);
-        }
-        crate::utils::pager::print_output(&output, pager)?;
-    }
-
-    Ok(())
+    render_vault_list(
+        &vaults,
+        output_format,
+        pagination,
+        pager,
+        names_only,
+        config,
+    )
 }
 
 async fn execute_vault_delete(

--- a/src/utils/list_output.rs
+++ b/src/utils/list_output.rs
@@ -1,0 +1,73 @@
+//! Shared wording for list-command empty-states and count lines.
+//!
+//! Every list-style command routes its human empty-state and count text
+//! through these helpers so the wording cannot drift per-command again.
+//! Streams are the caller's job: empty-states go to stderr via
+//! `output::info`, counts go to stdout on human formats only.
+
+/// "No <nouns> found[ in <scope>]." — scope is pre-formatted, e.g. "vault 'kv'".
+pub fn empty_state_message(noun_plural: &str, scope: Option<&str>) -> String {
+    match scope {
+        Some(scope) => format!("No {noun_plural} found in {scope}."),
+        None => format!("No {noun_plural} found."),
+    }
+}
+
+/// "N <noun>(s)[ in <scope>]", or "Showing X of Y <noun>(s)[ in <scope>]"
+/// when paginated. Matches the pre-existing "(s)" pluralization style.
+pub fn count_label(
+    displayed: usize,
+    total: usize,
+    noun: &str,
+    scope: Option<&str>,
+    paginated: bool,
+) -> String {
+    let base = if paginated {
+        format!("Showing {displayed} of {total} {noun}(s)")
+    } else {
+        format!("{displayed} {noun}(s)")
+    };
+    match scope {
+        Some(scope) => format!("{base} in {scope}"),
+        None => base,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_state_without_scope() {
+        assert_eq!(empty_state_message("vaults", None), "No vaults found.");
+    }
+
+    #[test]
+    fn empty_state_with_scope() {
+        assert_eq!(
+            empty_state_message("secrets", Some("folder 'prod'")),
+            "No secrets found in folder 'prod'."
+        );
+    }
+
+    #[test]
+    fn count_unpaginated_unscoped() {
+        assert_eq!(count_label(3, 3, "vault", None, false), "3 vault(s)");
+    }
+
+    #[test]
+    fn count_unpaginated_scoped() {
+        assert_eq!(
+            count_label(65, 65, "secret", Some("vault 'kv'"), false),
+            "65 secret(s) in vault 'kv'"
+        );
+    }
+
+    #[test]
+    fn count_paginated() {
+        assert_eq!(
+            count_label(10, 42, "secret", Some("vault 'kv'"), true),
+            "Showing 10 of 42 secret(s) in vault 'kv'"
+        );
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -20,6 +20,7 @@ pub mod format;
 pub mod fuzzy;
 pub mod helpers;
 pub mod interactive;
+pub mod list_output;
 pub mod network;
 pub mod output;
 pub mod pager;

--- a/src/utils/output.rs
+++ b/src/utils/output.rs
@@ -5,7 +5,17 @@
 
 use crossterm::style::{Color as CrosstermColor, Stylize};
 use std::io::IsTerminal;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
+
+/// Set once at CLI dispatch when the user passes --no-color; consulted by
+/// should_use_rich alongside the NO_COLOR env var.
+static COLOR_DISABLED: AtomicBool = AtomicBool::new(false);
+
+/// Disable colored/rich output process-wide (the --no-color flag).
+pub fn disable_color() {
+    COLOR_DISABLED.store(true, Ordering::Relaxed);
+}
 
 /// Message severity level
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -34,6 +44,9 @@ pub fn is_tty_stderr() -> bool {
 
 /// Whether to use rich (emoji + color) output
 fn should_use_rich(is_tty: bool) -> bool {
+    if COLOR_DISABLED.load(Ordering::Relaxed) {
+        return false;
+    }
     if std::env::var("NO_COLOR").is_ok() {
         return false;
     }

--- a/tests/file_commands_tests.rs
+++ b/tests/file_commands_tests.rs
@@ -389,8 +389,9 @@ async fn test_file_list_command() -> Result<()> {
         limit: Some(50),
         page: None,
         page_size: None,
-        pager: false,
+        pager: None,
         recursive: false,
+        names_only: false,
         no_cache: false,
     };
 
@@ -403,6 +404,7 @@ async fn test_file_list_command() -> Result<()> {
             page_size,
             pager,
             recursive: _,
+            names_only: _,
             no_cache: _,
         } => {
             assert_eq!(prefix, Some("config/".to_string()));
@@ -410,7 +412,7 @@ async fn test_file_list_command() -> Result<()> {
             assert_eq!(limit, Some(50));
             assert_eq!(page, None);
             assert_eq!(page_size, None);
-            assert!(!pager);
+            assert!(pager.is_none());
         }
         _ => panic!("Expected List command"),
     }


### PR DESCRIPTION
## Summary

Phase A of the P2 tier of the list-command UX review (P0 = #289, P1 = #290): the mechanical surface pass that stops the list commands drifting apart. Spec and plan included (`docs/superpowers/specs/2026-07-01-list-p2-surface-design.md`). Phase B (renderer unification, `--columns`, machine formats for the bespoke renderers) is a separate future spec.

- **Flag unification.** `vault list`'s local `--format` (which shadowed the identical global flag) is removed — user-invisible; `vault share list -f/--fmt` is deprecated (hidden `--fmt` still works with a stderr warning for one release, `-f` removed); `file list` gains the standard `--pager [auto|always|never]` (bare `--pager` unchanged) and `--names-only`; `vault list` gains `--names-only`.
- **Global `--no-color`** — covers table rendering *and* stderr status chrome (process-wide, same effect as the `NO_COLOR` env var).
- **One empty-state/count convention**, enforced by a new pure `src/utils/list_output.rs` helper module adopted by `ls`, `vault list`, `file list`, both `share list`s, `history`, `audit`, `find`, and `context list`: human empty-states → stderr; counts → stdout on human formats only, standard wording.
- **Behavior changes (deliberate, changelog-noted):** `xv ls`'s empty message moves from stdout to stderr (`xv ls > file` on an empty scope now writes an empty file); `history`'s count moves from stderr to stdout (human formats only); empty machine output for `vault list`/`vault share list`/`file list` becomes valid-empty (`[]`) instead of a stderr-only message that broke `| jq`.
- Machine output shapes are otherwise byte-identical. The AWS file path and trait-backend vault path were updated consistently (shared enum forced it).

## Test plan

- New unit tests for the wording helpers; full lib suite 618 passed; `cargo clippy --all-targets` zero warnings; `cargo fmt --check` clean; full `cargo test` incl. integration green.
- Live e2e against real Azure vault + storage: `--names-only` on vault/file list, `--format yaml/json` via the global flag, `--fmt` deprecation warning, empty-prefix `[]`, `xv ls` empty scope = zero stdout bytes with the stderr message, `history` count on stdout with clean piped JSON, `--no-color` stripping ANSI from both tables and stderr chrome, `share list` count line.
- Per-task adversarial reviews plus a final whole-branch review. Its two findings — the spec-mandated `share list` count that my plan dropped, and `--no-color` not covering stderr chrome — are fixed in the last commit.

## Notes for review

- Deferred to Phase B (recorded in the spec's out-of-scope): machine-format support and valid-empty for `history`/`find`/`audit`, `--columns`, renderer unification, plural-aware count grammar ("entry(s)"), and deleting the dead legacy `execute_secret_list`.
- `--names-only` bypasses pagination flags on all commands that have it (matches the pre-existing `ls --names-only` precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CLI presentation and scripting ergonomics with no auth or secret-handling changes; the intentional `xv ls` empty stdout and stream moves could surprise scripts that relied on old behavior.
> 
> **Overview**
> Phase A of the list-command P2 UX pass: list-style commands share one surface instead of each hand-rolling flags and messages.
> 
> **New shared helpers** in `list_output.rs` (`empty_state_message`, `count_label`) drive empty-state and count wording across `ls`, `vault list`, `file list`, share lists, `history`, `audit`, `find`, and `context list`.
> 
> **Flag changes:** global **`--no-color`** (sets `config.no_color` and **`output::disable_color()`** so tables and stderr status chrome lose ANSI); **`vault list`** drops its local `--format` and gains **`--names-only`**; **`vault share list`** deprecates **`-f`/`--fmt`** in favor of global `--format` (hidden `--fmt` still warns); **`file list`** gets **`--pager [auto|always|never]`** and **`--names-only`** (recursive, files only), mirrored on the AWS file path.
> 
> **Deliberate output behavior:** human empty states go to **stderr** (including **`xv ls`** — empty scope redirects to an empty stdout file); human counts go to **stdout** only; **`history`**’s version count moves from stderr to stdout for table-like formats; empty **JSON/YAML/CSV** for **`vault list`**, **`vault share list`**, and **`file list`** emits valid empty arrays on stdout instead of stderr-only messages that broke `| jq`. **`render_vault_list`** centralizes vault list rendering for cached and fresh paths.
> 
> CHANGELOG, README, and superpowers spec/plan docs are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8078c1999b206b8f749d6f2fd89986ccb017c231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->