### PR TITLE
feat: list-command P3 — deleted-secret listing, group list, --sort, folder ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **`xv find --format csv`** now works (previously find had no CSV output).
 - **`xv context list` and `xv env list` honor the global `--format`** (json/yaml/csv/…): `context list` rows are `{status, vault, resource_group, last_used, usage_count}`; `env list` renders `Name/Active/Backend/Vault/Resource Group` rows instead of a hand-rolled line format.
 - **`xv config show --format yaml`** serializes the whole `Config` object (like `--format json` always did — `config show` is a resource view, not a list; this documented exception is the one command whose machine output is not the table's row set).
+- **`xv update --enabled <true|false>`** enables or disables a secret directly (disabled secrets are excluded from `xv ls` and `xv group list` by default).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **`xv ls --deleted`** lists soft-deleted secrets (name + deleted date + scheduled-purge date where the backend can supply them: Azure has both, local and AWS report the deleted date only). Capability-gated — backends without soft delete get a clear error. Machine formats emit a `{name, deleted, purge_scheduled}` row array; the default view is the usual grid, `-l` is a `NAME/DELETED/PURGE SCHEDULED` long listing. Conflicts with the `FOLDER` positional, `-r`, `--group`, `--all`, `--expiring`, and `--expired`.
+- **`xv group list`**: lists secret groups with member counts, derived from the comma-separated `groups` metadata. Full `--format`/`--columns` support; `--no-cache` to bypass the shared secrets cache.
+- **`xv ls --sort name|updated`** (default `name`): `updated` shows the most recently updated secrets first in every output mode, including machine formats (in `--deleted` mode it sorts by deleted date).
+- **`xv find --folder <path>`** scopes fuzzy search to a folder subtree (segment-boundary rule: `prod` matches `prod/db`, not `production`); composes with `--all-vaults`.
+- **Hidden `xv __complete-folders`** emits cached folder paths (including ancestor prefixes) one per line for shell tab-completion, mirroring `__complete-secrets` (cache-only, silent when cold).
 - **Global `--no-color` flag** (complements the `NO_COLOR` env var and config key).
 - **`--names-only` on `vault list` and `file list`** (one name per line, pipe-friendly; `file list --names-only` lists recursively).
 - **`file list --pager [auto|always|never]`** matching every other list command (bare `--pager` unchanged).
@@ -15,6 +20,8 @@
 
 ### Changed
 
+- **`xv ls -r` shows folder-qualified names** (`prod/db-pass`, relative to the listing root) in the grid, long, and `--names-only` views. Non-recursive output and machine formats are unchanged.
+- **`context envs` is deprecated**: hidden from help, warns `context envs is deprecated; use env list`, and delegates unchanged.
 - **List empty-states now go to stderr** for human formats across all list commands (including `xv ls`, whose empty message previously landed on stdout — `xv ls > file` on an empty scope now writes an empty file), and empty-state/count wording is standardized via shared helpers. `xv history`'s count line moved from stderr to stdout (human formats only).
 - **`vault share list -f/--fmt` is deprecated**: use the global `--format`. `--fmt` still works with a warning for one release; `-f` is removed. `vault list`'s redundant local `--format` was removed (the identical global flag takes over transparently).
 - **BREAKING (machine shapes normalized).** Pre-1.0 breaking changes, deliberate and grouped here:
@@ -26,6 +33,10 @@
 
 ### Fixed
 
+- **CJK-safe list rendering**: grid/long listings and note wrapping now measure terminal display width (via `unicode-width`) instead of char count, so full-width characters no longer misalign columns.
+- **`xv parse` printed its table twice** (and leaked a table into `--fmt json` output); the manager no longer prints — the CLI renders once.
+- **Pagination footers are plural-aware** (`… of 1 secret`, `… of 3 secrets`) — the last `"{noun}(s)"` holdout is gone.
+- **`xv cache refresh --key vaults` no longer dumps the vault list to stdout**; the refresh fetches and caches silently.
 - **Empty `history`, `find`, and `audit` machine-format output is now valid-empty** (`[]` for JSON, headers-only for CSV) on stdout instead of nothing, so `| jq` works on empty results. Same for empty `context list`/`env list` machine output.
 - **Empty machine-format output is now valid-empty** (`[]` for JSON) on stdout for `vault list`, `vault share list`, and `file list`, instead of a stderr-only message that broke `| jq` on empty results.
 - **`xv ls` table rendering.** Columns whose cells are all empty are no longer rendered as blank zero-width headers, narrow terminals now shrink the widest column first instead of chopping every column (no more `UT`/`C` timestamp wrapping), and the `Updated` column shows the date only (`2026-05-17`). Machine formats (JSON/YAML/CSV) are unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,6 +1764,7 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
+ "unicode-width 0.2.2",
  "url",
  "urlencoding",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ chrono = { version = "0.4", features = ["serde"] }
 time = { version = "0.3", features = ["macros"] }
 
 # Additional utilities
+unicode-width = "0.2"
 url = "2.0"
 urlencoding = "2"
 base64 = "0.22"

--- a/README.md
+++ b/README.md
@@ -510,8 +510,10 @@ The "did you mean" suggestion uses fuzzy matching (Levenshtein, distance ≤ 2).
 xv ls                                    # grid of folders (prod/) and root secrets
 xv ls prod                               # inside a folder
 xv ls prod -l                            # long listing: name, updated, groups, note
-xv ls -r                                 # every secret, flattened
+xv ls -r                                 # every secret, flattened (with folder-qualified names)
 xv ls --format table                     # the classic table
+xv ls --sort updated                     # most recently updated secrets first
+xv ls --deleted                          # soft-deleted secrets (capability-gated)
 xv list --group production               # filter by group
 xv list --all                            # include disabled / soft-deleted
 xv list --expiring 30d                   # secrets with expiry in next 30 days
@@ -556,6 +558,7 @@ xv find db                               # rank by name
 xv find db --in folder                   # also search folder field
 xv find db --in folder --in groups       # multiple fields
 xv find db --in tags                     # search custom tags
+xv find db --folder prod                 # scope to prod/* subtree
 xv find db --limit 10                    # cap rows (default 50)
 xv find db --min-score 0.5               # tighter threshold (0.0..=1.0; default 0.3)
 xv find db --all-vaults                  # search every vault you can list
@@ -579,6 +582,14 @@ xv run --include "$selected" -- ./debug.sh
 ```
 
 The previous interactive `xv find` was replaced in v0.6.1; see [`docs/find.md`](docs/find.md) for the migration table.
+
+### Groups — list and filter
+
+```bash
+xv group list                            # all groups with member counts
+xv group list --format json              # machine-friendly output
+xv list --group production               # filter by group (shown earlier)
+```
 
 ---
 
@@ -1245,7 +1256,7 @@ xv vault list                            # if this works, DNS is fine — typo i
 ### `error[xv-env-not-defined]: Environment 'X' not defined in .xv.toml`
 
 ```bash
-xv context envs                          # see what's defined
+xv env list                              # see what's defined
 xv context show                          # see which .xv.toml is being used
 ```
 

--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ xv update API_KEY --note "rotated 2026-04-30 by ops"
 xv update API_KEY --group production --group api-tier   # repeatable
 xv update API_KEY --folder myapp/edge                    # move to another folder
 xv update API_KEY --tag rotated-by=alice                 # custom tag
+xv update API_KEY --enabled false                        # disable secret (hidden from ls/group list by default)
 ```
 
 ### Delete and recover

--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ xv ls --format table                     # the classic table
 xv ls --sort updated                     # most recently updated secrets first
 xv ls --deleted                          # soft-deleted secrets (capability-gated)
 xv list --group production               # filter by group
-xv list --all                            # include disabled / soft-deleted
+xv list --all                            # include disabled (soft-deleted: xv ls --deleted)
 xv list --expiring 30d                   # secrets with expiry in next 30 days
 xv list --expired                        # already expired
 xv list --no-cache                       # bypass local cache
@@ -1221,7 +1221,7 @@ The structured-error layer makes most failures self-explanatory. A few common on
 
 ```bash
 xv list                                  # see what's actually in the vault
-xv list --all                            # include disabled / soft-deleted
+xv list --all                            # include disabled (soft-deleted: xv ls --deleted)
 xv find X --names-only                   # fuzzy search
 ```
 

--- a/docs/superpowers/plans/2026-07-02-list-p3.md
+++ b/docs/superpowers/plans/2026-07-02-list-p3.md
@@ -1,0 +1,2427 @@
+# List Command P3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the P3 spec (`docs/superpowers/specs/2026-07-02-list-p3-design.md`): `xv ls --deleted` (capability-gated, dates where each backend has them), `xv group list`, `xv ls --sort name|updated`, `context envs` deprecation, `find --folder`, hidden `__complete-folders`, folder-qualified `ls -r` names, unicode-width display math, and three inherited fixes (`xv parse` double-print, plural pagination footers, silent vault-cache refresh).
+
+**Architecture:** The `SecretBackend::list_deleted_secrets` trait method (already implemented by all three backends) changes return type to a new `DeletedSecretSummary` carrying deleted/purge dates each backend can actually supply; a new CLI path renders it through the shared `TableFormatter`/grid/long machinery. Everything else is additive CLI surface (`--sort`, `--deleted`, `group list`, `--folder`, `__complete-folders`) layered on the existing `ls_view` + `TableFormatter` renderers, plus targeted fixes in `pagination.rs`, `manager.rs`, and `config_ops.rs`.
+
+**Tech Stack:** Rust, `clap` derive (`ValueEnum`), `tabled` 0.15, `serde`, existing `TableFormatter`/`list_output`/`pagination` helpers, `chrono`. One new dependency: `unicode-width`.
+
+## Global Constraints
+
+- Branch: `list-p3` (exists; commit this plan and its spec on it before executing tasks).
+- **NEVER run `xv init` and NEVER write to `~/.config/xv/`** (a prior agent clobbered the user's real config). All local-backend testing goes through `tests/e2e_local_backend.rs`'s `TestEnv` harness (isolated temp `XDG_CONFIG_HOME` + `XV_BACKEND=local`) or an explicit temp config path. Never invoke bare `xv`/`cargo run` without an isolating `XDG_CONFIG_HOME` unless the command is provably read-only.
+- **Any e2e that creates vault fixtures must clean up — delete AND purge — even on failure** (the local harness uses self-deleting temp dirs, which satisfies this; do not add tests against real Azure/AWS vaults without a cleanup guard).
+- **Machine-shape additions only**: new commands/rows (`ls --deleted` rows, `group list` rows) are fine; no breaking changes to shipped machine shapes this time (`xv ls --format json|yaml|csv` and `--names-only` without `-r` stay byte-identical).
+- **Commit style `feat:`/`fix:`/`docs:`** and every commit message ends with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- **`cargo fmt` before every commit.**
+- **Locate anchors by symbol, not line number** — line numbers cited below are current as of writing and may drift.
+- Human empty-states go to stderr via `crate::utils::output::info`; counts appear on human formats only; machine formats emit valid-empty output (`TableFormatter::format_table(&[])` handles this).
+- Capability errors reuse `xv restore`'s wording pattern (`execute_secret_restore_direct` in `src/cli/secret_ops.rs`).
+- Out of scope: `xv parse`'s bespoke `--format` string flag, restore/purge UX, group verbs beyond `list`, `xv completion` script generation changes, `vault share list --fmt` removal, TUI.
+
+---
+
+### Task 1: Unicode-width display math (foundation)
+
+**Files:**
+- Modify: `Cargo.toml` (`[dependencies]`)
+- Modify: `src/cli/ls_view.rs` (`render_grid`, `render_long`, `truncate_note`, new `display_width`/`pad_to`, tests)
+- Modify: `src/cli/secret_ops.rs` (`push_wrapped_word` and its callers' width math, one test)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces (later tasks rely on these):
+  - `pub(crate) fn display_width(s: &str) -> usize` in `src/cli/ls_view.rs` — Unicode-aware terminal column width.
+  - `pub(crate) fn pad_to(s: &str, w: usize) -> String` in `src/cli/ls_view.rs` — left-aligns `s` in `w` display columns with trailing spaces.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/cli/ls_view.rs`'s `#[cfg(test)] mod tests`, add:
+
+```rust
+    #[test]
+    fn display_width_counts_columns_not_chars() {
+        assert_eq!(display_width("abc"), 3);
+        assert_eq!(display_width("秘密"), 4); // 2 full-width chars = 4 columns
+        assert_eq!(pad_to("秘密", 6), "秘密  ");
+        assert_eq!(pad_to("abc", 5), "abc  ");
+    }
+
+    #[test]
+    fn grid_accounts_for_full_width_characters() {
+        let entries = vec![
+            secret_entry("数据库密码"),
+            secret_entry("api-key"),
+            secret_entry("另一个秘密名字"),
+        ];
+        let out = render_grid(&entries, 20, false);
+        for line in out.lines() {
+            assert!(display_width(line) <= 20, "line exceeds width:\n{out}");
+        }
+    }
+
+    #[test]
+    fn long_listing_aligns_full_width_names() {
+        let entries = vec![secret_entry("秘密"), secret_entry("abcd")];
+        let out = render_long(&entries, false);
+        let lines: Vec<&str> = out.lines().collect();
+        let idx_a = lines[1].find("2026-05-17").unwrap();
+        let idx_b = lines[2].find("2026-05-17").unwrap();
+        assert_eq!(
+            display_width(&lines[1][..idx_a]),
+            display_width(&lines[2][..idx_b]),
+            "UPDATED column misaligned:\n{out}"
+        );
+    }
+
+    #[test]
+    fn note_truncation_is_width_aware() {
+        let mut s = summary("a", None);
+        s.note = Some("秘".repeat(60)); // 120 columns wide
+        let out = render_long(&[LsEntry::Secret(s)], false);
+        let data_line = out.lines().nth(1).unwrap();
+        let note_cell = data_line.rsplit("  ").next().unwrap();
+        assert!(display_width(note_cell) <= LONG_NOTE_MAX, "note not width-capped:\n{out}");
+        assert!(out.contains('…'));
+    }
+```
+
+In `src/cli/secret_ops.rs`'s test module (next to the existing `wrap_text_to_width` tests around the `SECRET_LIST_NOTE_WRAP_WIDTH` assertion):
+
+```rust
+    #[test]
+    fn wrap_is_display_width_aware_for_cjk() {
+        // 6 full-width chars = 12 columns; budget of 4 columns = 2 chars/line.
+        let wrapped = wrap_text_to_width("秘密秘密秘密", 4);
+        assert_eq!(wrapped.lines().count(), 3, "{wrapped:?}");
+        for line in wrapped.lines() {
+            assert!(crate::cli::ls_view::display_width(line) <= 4, "{wrapped:?}");
+        }
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib cli::ls_view -- --nocapture && cargo test --lib wrap_is_display_width`
+Expected: compile error (`display_width`/`pad_to` not found), which is the failure we want.
+
+- [ ] **Step 3: Add the dependency and helpers**
+
+`Cargo.toml`, in `[dependencies]` (alphabetical near `tracing`/`url`):
+
+```toml
+unicode-width = "0.2"
+```
+
+`src/cli/ls_view.rs`, below the existing `use` lines:
+
+```rust
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+/// Terminal display width of `s` (Unicode-aware: CJK/full-width chars = 2 columns).
+pub(crate) fn display_width(s: &str) -> usize {
+    UnicodeWidthStr::width(s)
+}
+
+/// Left-align `s` in `w` display columns. `format!("{:<w$}")` pads by char
+/// count, which breaks on full-width characters — always pad manually.
+pub(crate) fn pad_to(s: &str, w: usize) -> String {
+    let pad = w.saturating_sub(display_width(s));
+    format!("{s}{}", " ".repeat(pad))
+}
+```
+
+- [ ] **Step 4: Convert the width math**
+
+In `render_grid`, replace the `lens` line:
+
+```rust
+    let lens: Vec<usize> = labels.iter().map(|l| display_width(l)).collect();
+```
+
+Replace `truncate_note` entirely:
+
+```rust
+fn truncate_note(note: &str, max: usize) -> String {
+    let first = note.lines().next().unwrap_or("");
+    if display_width(first) <= max {
+        return first.to_string();
+    }
+    let budget = max.saturating_sub(1); // reserve one column for the ellipsis
+    let mut cut = String::new();
+    let mut used = 0usize;
+    for ch in first.chars() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + w > budget {
+            break;
+        }
+        used += w;
+        cut.push(ch);
+    }
+    format!("{cut}…")
+}
+```
+
+In `render_long`, replace the three width computations and the two format-padding sites:
+
+```rust
+    let name_w = rows
+        .iter()
+        .map(|r| display_width(&r.name))
+        .chain(["NAME".len()])
+        .max()
+        .unwrap_or(4);
+    let updated_w = rows
+        .iter()
+        .map(|r| display_width(&r.updated))
+        .chain(["UPDATED".len()])
+        .max()
+        .unwrap_or(7);
+    let groups_w = rows
+        .iter()
+        .map(|r| display_width(&r.groups))
+        .chain(["GROUPS".len()])
+        .max()
+        .unwrap_or(6);
+
+    let mut out = String::new();
+    let header = format!(
+        "{}  {}  {}  NOTE",
+        pad_to("NAME", name_w),
+        pad_to("UPDATED", updated_w),
+        pad_to("GROUPS", groups_w)
+    );
+    out.push_str(header.trim_end());
+    out.push('\n');
+    for row in rows {
+        let padded_name = pad_to(&row.name, name_w);
+        let name_cell = if color && row.is_folder {
+            format!("{CYAN}{padded_name}{RESET}")
+        } else {
+            padded_name
+        };
+        let line = format!(
+            "{name_cell}  {}  {}  {}",
+            pad_to(&row.updated, updated_w),
+            pad_to(&row.groups, groups_w),
+            row.note
+        );
+        out.push_str(line.trim_end());
+        out.push('\n');
+    }
+    out
+```
+
+Also update the existing grid test assertion `line.chars().count() <= 40` (in `grid_fills_column_major_within_width`) to `display_width(line) <= 40`.
+
+In `src/cli/secret_ops.rs`, replace `push_wrapped_word` (the only place in the wrap trio that measures):
+
+```rust
+fn push_wrapped_word(word: &str, width: usize, current: &mut String, lines: &mut Vec<String>) {
+    use unicode_width::UnicodeWidthChar;
+    let display_width = crate::cli::ls_view::display_width;
+    let word_len = display_width(word);
+
+    if word_len > width {
+        if !current.is_empty() {
+            lines.push(std::mem::take(current));
+        }
+        let mut chunk = String::new();
+        let mut chunk_w = 0usize;
+        for ch in word.chars() {
+            let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if chunk_w + w > width && !chunk.is_empty() {
+                lines.push(std::mem::take(&mut chunk));
+                chunk_w = 0;
+            }
+            chunk.push(ch);
+            chunk_w += w;
+        }
+        if !chunk.is_empty() {
+            *current = chunk;
+        }
+        return;
+    }
+
+    if current.is_empty() {
+        current.push_str(word);
+        return;
+    }
+
+    let projected_len = display_width(current) + 1 + word_len;
+    if projected_len <= width {
+        current.push(' ');
+        current.push_str(word);
+    } else {
+        lines.push(std::mem::take(current));
+        current.push_str(word);
+    }
+}
+```
+
+(`wrap_text_to_width`/`wrap_paragraph_to_width` are unchanged — they only delegate.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --lib cli::ls_view && cargo test --lib wrap_ && cargo clippy --all-targets`
+Expected: all pass, 0 warnings. Confirm no other list-rendering width math remains: `rg -n "chars\(\).count\(\)" src/cli/ src/utils/format.rs` — remaining hits must be truncation/validation on plain-ASCII contexts, not display-width math (do NOT touch `tabled` internals; it handles its own widths).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt
+git add Cargo.toml Cargo.lock src/cli/ls_view.rs src/cli/secret_ops.rs
+git commit -m "fix: measure list display widths with unicode-width (CJK-safe grids, long listings, note wrap)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `xv parse` prints once (manager returns data; CLI renders)
+
+**Files:**
+- Modify: `src/secret/manager.rs` (`SecretManager::parse_connection_string`, ~line 1956)
+- Test: `tests/e2e_local_backend.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `SecretManager::parse_connection_string` keeps its signature (`pub async fn parse_connection_string(&self, connection_string: &str) -> Result<Vec<ConnectionComponent>>`) but no longer prints. Its only caller, `execute_secret_parse` (`src/cli/secret_ops.rs` ~3589), already renders both formats and is untouched.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+In `tests/e2e_local_backend.rs`, add:
+
+```rust
+#[test]
+fn parse_prints_exactly_one_table() {
+    let env = TestEnv::new();
+    // `xv parse` has its own local `--fmt` flag (default "table").
+    let out = env.xv_ok(&["parse", "Server=myhost;Database=mydb"]);
+    assert_eq!(
+        out.matches("myhost").count(),
+        1,
+        "connection-string table printed more than once:\n{out}"
+    );
+
+    // JSON format must not leak a human table before the JSON document.
+    let json_out = env.xv_ok(&["parse", "Server=myhost;Database=mydb", "--fmt", "json"]);
+    assert!(
+        json_out.trim_start().starts_with('['),
+        "json output polluted by a table:\n{json_out}"
+    );
+}
+```
+
+(`xv parse` builds an Azure credential provider lazily and never fetches a token, so it runs fine under the hermetic local harness.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --test e2e_local_backend parse_prints_exactly_one_table`
+Expected: FAIL — `myhost` appears twice for `table`, and the JSON output starts with the table.
+
+- [ ] **Step 3: Stop printing in the manager**
+
+In `src/secret/manager.rs`, `parse_connection_string` (anchor: `pub async fn parse_connection_string`), delete the display block at the end of the method:
+
+```rust
+        // DELETE these lines:
+        // Display formatted table
+        let formatter = TableFormatter::new(OutputFormat::Table, self.no_color, None, None);
+        let table_output = formatter.format_table(&result)?;
+        println!("{table_output}");
+```
+
+leaving:
+
+```rust
+        Ok(result)
+    }
+```
+
+Verify no other caller depended on the printing: `rg -n "parse_connection_string" src/` must show only the helper fn in `utils/helpers.rs`, the manager method, and `src/cli/secret_ops.rs:~3596`. If `TableFormatter`/`OutputFormat` imports in `manager.rs` become unused, clippy will say so — they are used elsewhere in the file (`display_secret_details` etc.), so expect no import change.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --test e2e_local_backend parse_prints && cargo clippy --all-targets`
+Expected: PASS, 0 warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add src/secret/manager.rs tests/e2e_local_backend.rs
+git commit -m "fix: xv parse prints its table once (manager returns data; the CLI renders)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Plural-aware pagination footers
+
+**Files:**
+- Modify: `src/utils/pagination.rs` (`Page::human_summary`, `pagination_footer_text`, delete `print_pagination_footer`, tests)
+- Modify: `src/cli/file_ops.rs` (2 call sites, ~lines 700, 752), `src/cli/file_ops_aws.rs` (~1118), `src/cli/vault_ops.rs` (~413, ~1290), `src/cli/secret_ops.rs` (~466, ~523, ~3762)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces (Task 8 relies on this exact signature):
+  - `pub fn pagination_footer_text<T>(page: &Page<T>, noun_singular: &str, noun_plural: &str, output_format: OutputFormat) -> Option<String>`
+  - `Page::human_summary(&self, noun_singular: &str, noun_plural: &str) -> Option<String>` — plural keyed on `total_items` (zero is plural), same rule as `list_output::count_label`.
+  - `print_pagination_footer` is DELETED (it was `#[allow(dead_code)]` with no callers).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/utils/pagination.rs`'s test module, add:
+
+```rust
+    #[test]
+    fn human_summary_is_plural_aware() {
+        let one = paginate_slice(&[1], Pagination::from_args(None, Some(5)).unwrap());
+        assert_eq!(
+            one.human_summary("secret", "secrets").unwrap(),
+            "Showing 1-1 of 1 secret — page 1 of 1 (page size 5)"
+        );
+
+        let many = paginate_slice(&[1, 2, 3], Pagination::from_args(None, Some(2)).unwrap());
+        assert_eq!(
+            many.human_summary("secret", "secrets").unwrap(),
+            "Showing 1-2 of 3 secrets — page 1 of 2 (page size 2)"
+        );
+
+        let empty = paginate_slice(
+            &[] as &[i32],
+            Pagination::from_args(None, Some(2)).unwrap(),
+        );
+        assert_eq!(
+            empty.human_summary("entry", "entries").unwrap(),
+            "Showing 0 of 0 entries — page 1 of 0"
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib utils::pagination`
+Expected: compile error — `human_summary` takes 1 noun argument.
+
+- [ ] **Step 3: Implement**
+
+Replace `human_summary` (anchor: `pub fn human_summary`):
+
+```rust
+    pub fn human_summary(&self, noun_singular: &str, noun_plural: &str) -> Option<String> {
+        let page_size = self.page_size?;
+        let total_pages = self.total_pages.unwrap_or(0);
+        let noun = if self.total_items == 1 {
+            noun_singular
+        } else {
+            noun_plural
+        };
+
+        if self.total_items == 0 || self.items.is_empty() {
+            return Some(format!(
+                "Showing 0 of {} {} — page {} of {}",
+                self.total_items, noun, self.page, total_pages
+            ));
+        }
+
+        Some(format!(
+            "Showing {}-{} of {} {} — page {} of {} (page size {})",
+            self.start_index_1_based.unwrap_or(0),
+            self.end_index_1_based.unwrap_or(0),
+            self.total_items,
+            noun,
+            self.page,
+            total_pages,
+            page_size
+        ))
+    }
+```
+
+Delete `print_pagination_footer` entirely (anchor: `pub fn print_pagination_footer`; confirm zero callers with `rg -n "print_pagination_footer" src/`). Replace `pagination_footer_text`:
+
+```rust
+/// Return footer text for human-readable output formats.
+pub fn pagination_footer_text<T>(
+    page: &Page<T>,
+    noun_singular: &str,
+    noun_plural: &str,
+    output_format: OutputFormat,
+) -> Option<String> {
+    let human_output = matches!(
+        output_format.resolve_for_stdout(),
+        OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+    );
+
+    human_output
+        .then(|| page.human_summary(noun_singular, noun_plural))
+        .flatten()
+}
+```
+
+- [ ] **Step 4: Update all 8 call sites**
+
+Each caller adds the plural form (anchor by the string literal shown):
+
+| File | Old | New |
+|---|---|---|
+| `src/cli/file_ops.rs` (×2) | `pagination_footer_text(&page, "item", config.runtime_output_format)` | `pagination_footer_text(&page, "item", "items", config.runtime_output_format)` |
+| `src/cli/file_ops_aws.rs` | `pagination_footer_text(&page, "item", config.runtime_output_format)` | `pagination_footer_text(&page, "item", "items", config.runtime_output_format)` |
+| `src/cli/vault_ops.rs` (~413) | `pagination_footer_text(&page, "vault", output_format)` | `pagination_footer_text(&page, "vault", "vaults", output_format)` |
+| `src/cli/vault_ops.rs` (~1290) | `pagination_footer_text(&paged, "assignment", fmt)` | `pagination_footer_text(&paged, "assignment", "assignments", fmt)` |
+| `src/cli/secret_ops.rs` (~466) | `pagination_footer_text(&page, "secret", fmt)` | `pagination_footer_text(&page, "secret", "secrets", fmt)` |
+| `src/cli/secret_ops.rs` (~523) | `pagination_footer_text(&page, "entry", fmt)` | `pagination_footer_text(&page, "entry", "entries", fmt)` |
+| `src/cli/secret_ops.rs` (~3762) | `pagination_footer_text(&paged, "assignment", fmt)` | `pagination_footer_text(&paged, "assignment", "assignments", fmt)` |
+
+Verify completeness: `rg -n "pagination_footer_text\(" src/` — every remaining call has 4 arguments.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --lib utils::pagination && cargo clippy --all-targets && cargo test --lib`
+Expected: all pass, 0 warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt
+git add src/utils/pagination.rs src/cli/file_ops.rs src/cli/file_ops_aws.rs src/cli/vault_ops.rs src/cli/secret_ops.rs
+git commit -m "fix: plural-aware pagination footers (drop the last '{noun}(s)' style)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Silent `refresh_vault_list`
+
+**Files:**
+- Modify: `src/cli/config_ops.rs` (`refresh_vault_list`, ~line 884)
+
+**Interfaces:**
+- Consumes: `VaultManager::vault_ops()` accessor (`src/vault/manager.rs:41`) and `VaultOperations::list_vaults(subscription_id, resource_group) -> Result<Vec<VaultSummary>>` — both exist.
+- Produces: nothing new; `xv cache refresh --key vaults` stops printing the vault list to stdout.
+
+- [ ] **Step 1: Replace the printing call**
+
+In `refresh_vault_list` (anchor: `async fn refresh_vault_list`), replace:
+
+```rust
+    let vaults = vault_manager
+        .list_vaults_formatted(
+            Some(&config.subscription_id),
+            None,
+            crate::utils::format::OutputFormat::Json,
+            None,
+        )
+        .await?;
+```
+
+with:
+
+```rust
+    // Fetch WITHOUT rendering: this runs as a cache refresh (often spawned by
+    // `xv cache refresh --key vaults`), so nothing may reach stdout.
+    let vaults = vault_manager
+        .vault_ops()
+        .list_vaults(Some(&config.subscription_id), None)
+        .await?;
+```
+
+The subsequent `cache_manager.set(&CacheKey::VaultList, &vaults);` is unchanged (`list_vaults` returns the same `Vec<VaultSummary>` that `list_vaults_formatted` returned).
+
+- [ ] **Step 2: Verify**
+
+Run: `cargo check && cargo clippy --all-targets`
+Expected: clean; if the `OutputFormat` import in `config_ops.rs` becomes unused clippy will flag it — remove only then. Confirm `rg -n "list_vaults_formatted" src/cli/config_ops.rs` has no hits (the printing variant remains for `vault list` proper in `vault_ops.rs`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cargo fmt
+git add src/cli/config_ops.rs
+git commit -m "fix: make 'xv cache refresh --key vaults' silent (fetch + cache without rendering)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `xv ls --sort name|updated`
+
+**Files:**
+- Modify: `src/cli/commands.rs` (new `LsSort` enum next to `PagerWhen`; `Commands::List` variant; the `Commands::List` dispatch arm ~line 1500)
+- Modify: `src/cli/secret_ops.rs` (`execute_secret_list_direct`, `display_cached_secret_list`)
+- Modify: `src/cli/ls_view.rs` (new `sort_secrets_by_updated_desc` + tests)
+- Test: `tests/e2e_local_backend.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces (Task 8 reuses these):
+  - `pub enum LsSort { Name, Updated }` in `src/cli/commands.rs` (`Debug, Clone, Copy, clap::ValueEnum, PartialEq, Eq, Default`, `Name` is `#[default]`).
+  - `pub(crate) fn sort_secrets_by_updated_desc(secrets: &mut [SecretSummary])` in `src/cli/ls_view.rs`.
+  - `display_cached_secret_list(..)` and `execute_secret_list_direct(..)` each gain a `sort: LsSort` parameter (inserted immediately after `recursive`).
+
+- [ ] **Step 1: Write the failing unit test**
+
+In `src/cli/ls_view.rs` tests:
+
+```rust
+    #[test]
+    fn updated_sort_is_descending_with_name_tiebreak() {
+        let mut a = summary("alpha", None);
+        a.updated_on = "2026-06-01 10:00:00 UTC".to_string();
+        let mut b = summary("beta", None);
+        b.updated_on = "2026-06-30 10:00:00 UTC".to_string();
+        let mut c = summary("charlie", None);
+        c.updated_on = "2026-06-01 10:00:00 UTC".to_string();
+
+        let mut secrets = vec![c, a, b];
+        sort_secrets_by_updated_desc(&mut secrets);
+        assert_eq!(secrets[0].name, "beta"); // newest first
+        assert_eq!(secrets[1].name, "alpha"); // tie → name ascending
+        assert_eq!(secrets[2].name, "charlie");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib cli::ls_view::tests::updated_sort`
+Expected: compile error — `sort_secrets_by_updated_desc` not found.
+
+- [ ] **Step 3: Implement the sort helper**
+
+In `src/cli/ls_view.rs` (near `scope_secrets`):
+
+```rust
+/// `--sort updated`: newest first (backend timestamps are ISO-shaped, so
+/// lexicographic order is chronological), display-name ascending on ties.
+pub(crate) fn sort_secrets_by_updated_desc(secrets: &mut [SecretSummary]) {
+    secrets.sort_by(|a, b| {
+        b.updated_on
+            .cmp(&a.updated_on)
+            .then_with(|| display_name(a).cmp(display_name(b)))
+    });
+}
+```
+
+Run: `cargo test --lib cli::ls_view::tests::updated_sort` — PASS.
+
+- [ ] **Step 4: Add the CLI flag and thread it through**
+
+`src/cli/commands.rs`, next to `PagerWhen`:
+
+```rust
+/// Sort order for `xv ls`.
+#[derive(Debug, Clone, Copy, clap::ValueEnum, PartialEq, Eq, Default)]
+pub enum LsSort {
+    /// Alphabetical by display name (default).
+    #[default]
+    Name,
+    /// Most recently updated first (deleted date in `--deleted` mode).
+    Updated,
+}
+```
+
+In the `Commands::List` variant, after `names_only`:
+
+```rust
+        /// Sort order: name (A→Z, default) or updated (newest first)
+        #[arg(long, value_enum, default_value_t = LsSort::Name)]
+        sort: LsSort,
+```
+
+In the `Commands::List` dispatch arm, add `sort` to the pattern and pass it to `execute_secret_list_direct` right after `recursive`:
+
+```rust
+            Commands::List {
+                path,
+                long,
+                recursive,
+                group,
+                all,
+                expiring,
+                expired,
+                no_cache,
+                page,
+                page_size,
+                pager,
+                names_only,
+                sort,
+            } => {
+                let pagination = crate::utils::pagination::Pagination::from_args(page, page_size)?;
+                let pager = pager.map(PagerWhen::wants_pager).unwrap_or(false);
+                let path = match path {
+                    Some(raw) => {
+                        let trimmed = raw.trim_end_matches('/').to_string();
+                        if !trimmed.is_empty() {
+                            crate::utils::helpers::validate_folder_path(&trimmed)?;
+                        }
+                        trimmed
+                    }
+                    None => String::new(),
+                };
+                crate::cli::secret_ops::execute_secret_list_direct(
+                    path, group, all, expiring, expired, no_cache, pagination, pager, names_only,
+                    long, recursive, sort, config, registry,
+                )
+                .await
+            }
+```
+
+In `src/cli/secret_ops.rs`:
+- `execute_secret_list_direct` signature gains `sort: crate::cli::commands::LsSort,` after `recursive: bool,`; both of its `display_cached_secret_list(..)` calls pass `sort` after `recursive`.
+- `display_cached_secret_list` signature gains `sort: crate::cli::commands::LsSort,` after `recursive: bool,`, and right after the `scope_secrets` call:
+
+```rust
+    let mut scoped = ls_view::scope_secrets(filtered, path);
+    if sort == crate::cli::commands::LsSort::Updated {
+        ls_view::sort_secrets_by_updated_desc(&mut scoped.secrets);
+        ls_view::sort_secrets_by_updated_desc(&mut scoped.subtree);
+    }
+```
+
+(`let scoped` becomes `let mut scoped`. Every output mode — names-only, machine row array, explicit table, grid, long — renders from `scoped.secrets`/`scoped.subtree`, so this one site covers all of them. Folder cells keep alphabetical order.)
+
+- [ ] **Step 5: Add the e2e test**
+
+In `tests/e2e_local_backend.rs`:
+
+```rust
+#[test]
+fn ls_sort_flag_is_accepted_and_lists_everything() {
+    let env = TestEnv::new();
+    env.set_secret("older", "v");
+    env.set_secret("newer", "v");
+
+    // Local timestamps have minute resolution, so ordering is covered by the
+    // unit test; here we assert the flag parses and output is complete.
+    let out = env.xv_ok(&["ls", "--sort", "updated"]);
+    assert!(out.contains("older") && out.contains("newer"), "{out}");
+
+    let json = env.xv_ok(&["ls", "--sort", "updated", "--format", "json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert_eq!(parsed.as_array().map(Vec::len), Some(2));
+
+    let (_, stderr) = env.xv_fail(&["ls", "--sort", "bogus"]);
+    assert!(stderr.contains("possible values"), "{stderr}");
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test --lib cli:: && cargo test --test e2e_local_backend ls_sort && cargo clippy --all-targets`
+Expected: PASS, 0 warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt
+git add src/cli/commands.rs src/cli/secret_ops.rs src/cli/ls_view.rs tests/e2e_local_backend.rs
+git commit -m "feat: xv ls --sort name|updated (updated = newest first, all output modes)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Folder scope helpers + folder-qualified `ls -r` names
+
+**Files:**
+- Modify: `src/cli/ls_view.rs` (`relative_to_scope`, `folder_in_scope`, `qualified_display_name`; refactor `scope_secrets`; tests)
+- Modify: `src/cli/secret_ops.rs` (`display_cached_secret_list`: names-only branch + recursive entries)
+- Test: `tests/e2e_local_backend.rs`
+
+**Interfaces:**
+- Consumes: `display_name` (existing).
+- Produces (Task 11 relies on `folder_in_scope`):
+  - `pub(crate) fn relative_to_scope<'a>(folder: &'a str, path: &str) -> Option<&'a str>` — `Some(rel)` when `folder` is at/under `path` (segment boundary), `rel` is the remainder (`""` for exact match); `path = ""` scopes everything.
+  - `pub(crate) fn folder_in_scope(folder: &str, path: &str) -> bool` — `relative_to_scope(..).is_some()`.
+  - `pub(crate) fn qualified_display_name(s: &SecretSummary, root: &str) -> String` — `rel/name` relative to the listing root, bare `display_name` at the root.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/cli/ls_view.rs` tests:
+
+```rust
+    #[test]
+    fn folder_scope_helper_enforces_segment_boundary() {
+        assert!(folder_in_scope("prod", "prod"));
+        assert!(folder_in_scope("prod/db", "prod"));
+        assert!(folder_in_scope("prod/db/replica", "prod/db"));
+        assert!(!folder_in_scope("production", "prod"));
+        assert!(!folder_in_scope("dev", "prod"));
+        assert!(folder_in_scope("", "")); // root scopes everything
+        assert!(folder_in_scope("prod", ""));
+        assert!(!folder_in_scope("", "prod"));
+        assert_eq!(relative_to_scope("prod/db", "prod"), Some("db"));
+        assert_eq!(relative_to_scope("prod", "prod"), Some(""));
+    }
+
+    #[test]
+    fn qualified_names_are_relative_to_the_listing_root() {
+        let root_secret = summary("root-a", None);
+        let nested = summary("db-pass", Some("prod/db"));
+        assert_eq!(qualified_display_name(&root_secret, ""), "root-a");
+        assert_eq!(qualified_display_name(&nested, ""), "prod/db/db-pass");
+        assert_eq!(qualified_display_name(&nested, "prod"), "db/db-pass");
+        assert_eq!(qualified_display_name(&nested, "prod/db"), "db-pass");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib cli::ls_view::tests::folder_scope`
+Expected: compile error — helpers not found.
+
+- [ ] **Step 3: Implement the helpers and refactor `scope_secrets`**
+
+In `src/cli/ls_view.rs`:
+
+```rust
+/// Remainder of `folder` relative to scope `path` ("" = vault root):
+/// `Some("")` for an exact match, `Some(rest)` when `folder` is under
+/// `path` (segment boundary enforced), `None` when out of scope.
+pub(crate) fn relative_to_scope<'a>(folder: &'a str, path: &str) -> Option<&'a str> {
+    if path.is_empty() {
+        Some(folder)
+    } else if folder == path {
+        Some("")
+    } else {
+        folder
+            .strip_prefix(path)
+            .and_then(|rest| rest.strip_prefix('/'))
+    }
+}
+
+/// True when `folder` is at or under scope `path` (exact-or-prefix with
+/// segment boundary — the `xv ls` scoping rule, shared with `find --folder`).
+pub(crate) fn folder_in_scope(folder: &str, path: &str) -> bool {
+    relative_to_scope(folder, path).is_some()
+}
+
+/// Display name qualified by the folder path relative to the listing root
+/// (`prod/db` listed from root → `prod/db/name`; from `prod` → `db/name`;
+/// secrets directly at the root stay unqualified).
+pub(crate) fn qualified_display_name(s: &SecretSummary, root: &str) -> String {
+    let folder = s.folder.as_deref().unwrap_or("");
+    match relative_to_scope(folder, root) {
+        Some("") | None => display_name(s).to_string(),
+        Some(rel) => format!("{rel}/{}", display_name(s)),
+    }
+}
+```
+
+Refactor `scope_secrets`'s inline `rel` computation to use the helper (behavior identical — the existing `scope_secrets` tests are the regression net):
+
+```rust
+    for s in secrets {
+        let folder = s.folder.as_deref().unwrap_or("");
+        let Some(rel) = relative_to_scope(folder, path) else {
+            continue;
+        };
+        if rel.is_empty() {
+            direct.push(s.clone());
+        } else if let Some(segment) = rel.split('/').next() {
+            folders.insert(segment.to_string());
+        }
+        subtree.push(s);
+    }
+```
+
+Run: `cargo test --lib cli::ls_view` — all pass (old and new).
+
+- [ ] **Step 4: Qualify recursive output in `display_cached_secret_list`**
+
+In `src/cli/secret_ops.rs`, `display_cached_secret_list`:
+
+Names-only branch (anchor: `if names_only {`) becomes:
+
+```rust
+    // Pipe-friendly modes: flat recursive subtree, unchanged schema.
+    // Qualification is opt-in via -r (the bare --names-only shape is shipped).
+    if names_only {
+        for s in &scoped.subtree {
+            if recursive {
+                println!("{}", ls_view::qualified_display_name(s, path));
+            } else {
+                println!("{}", ls_view::display_name(s));
+            }
+        }
+        return Ok(());
+    }
+```
+
+Recursive entries (anchor: `let entries: Vec<LsEntry> = if recursive {`) become:
+
+```rust
+    let entries: Vec<LsEntry> = if recursive {
+        scoped
+            .subtree
+            .iter()
+            .map(|s| {
+                // Grid/long render `display_name` (== original_name when set);
+                // overriding it here is how the qualified label reaches them.
+                let mut q = s.clone();
+                q.original_name = ls_view::qualified_display_name(s, path);
+                LsEntry::Secret(q)
+            })
+            .collect()
+    } else {
+        ls_view::entries_for_display(&scoped)
+    };
+```
+
+Machine formats and the explicit `--format table` path still render `scoped.subtree` unmodified (they carry a Folder column already) — do not touch them.
+
+- [ ] **Step 5: Add the e2e test**
+
+In `tests/e2e_local_backend.rs`:
+
+```rust
+#[test]
+fn recursive_ls_qualifies_names_by_folder() {
+    let env = TestEnv::new();
+    env.set_secret_with_args("db-pass", "v", &["--folder", "prod/db"]);
+    env.set_secret("root-a", "v");
+
+    let names = env.xv_ok(&["ls", "-r", "--names-only"]);
+    assert!(names.lines().any(|l| l == "prod/db/db-pass"), "{names}");
+    assert!(names.lines().any(|l| l == "root-a"), "{names}");
+
+    // Scoped recursion is relative to the listing root.
+    let scoped = env.xv_ok(&["ls", "prod", "-r", "--names-only"]);
+    assert!(scoped.lines().any(|l| l == "db/db-pass"), "{scoped}");
+
+    // Non-recursive --names-only keeps the shipped unqualified shape.
+    let flat = env.xv_ok(&["ls", "--names-only"]);
+    assert!(flat.lines().any(|l| l == "db-pass"), "{flat}");
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test --lib cli::ls_view && cargo test --test e2e_local_backend recursive_ls && cargo clippy --all-targets`
+Expected: PASS, 0 warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt
+git add src/cli/ls_view.rs src/cli/secret_ops.rs tests/e2e_local_backend.rs
+git commit -m "feat: folder-qualified names in recursive ls output (grid/long/--names-only)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: `DeletedSecretSummary` across the backend stack
+
+**Files:**
+- Modify: `src/secret/manager.rs` (new struct near `SecretSummary`; `SecretOperations::list_deleted_secrets` trait method ~236; `parse_deleted_secret_summary` ~449; impl ~1251; test mock ~2489)
+- Modify: `src/backend/secret.rs` (trait method ~110)
+- Modify: `src/backend/azure/secrets.rs` (adapter ~244)
+- Modify: `src/backend/local/secrets.rs` (impl ~1793 + its tests)
+- Modify: `src/backend/aws/secrets.rs` (impl ~849)
+
+**Interfaces:**
+- Consumes: nothing (no CLI caller of `list_deleted_secrets` exists yet — verified by grep; `xv restore` restores by name without listing).
+- Produces (Task 8 relies on these exact shapes):
+
+```rust
+// src/secret/manager.rs
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeletedSecretSummary {
+    pub name: String,
+    pub original_name: String,
+    /// When the secret was deleted (backend-formatted timestamp), when known.
+    pub deleted_on: Option<String>,
+    /// When the backend will permanently purge it (None = no schedule).
+    pub scheduled_purge_on: Option<String>,
+}
+```
+
+  - `SecretBackend::list_deleted_secrets(&self, vault: &str) -> Result<Vec<DeletedSecretSummary>, BackendError>` (default still `Err(Unsupported("list deleted secrets"))`).
+  - Per-backend date reality (encode in code + tests): Azure fills both dates (REST `deletedDate`/`scheduledPurgeDate`), local fills `deleted_on` from the trash-dir `@millis` suffix and never `scheduled_purge_on`, AWS fills `deleted_on` from `SecretListEntry.deleted_date` and never `scheduled_purge_on` (`ListSecrets` doesn't expose the recovery window).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/secret/manager.rs`'s test module, add:
+
+```rust
+    #[test]
+    fn parse_deleted_secret_summary_reads_deletion_dates() {
+        let item = serde_json::json!({
+            "id": "https://kv.vault.azure.net/deletedsecrets/my-secret",
+            "deletedDate": 1_750_000_000,
+            "scheduledPurgeDate": 1_757_776_000,
+            "tags": { "original_name": "My Secret" }
+        });
+        let summary = parse_deleted_secret_summary(&item).unwrap();
+        assert_eq!(summary.name, "my-secret");
+        assert_eq!(summary.original_name, "My Secret");
+        assert!(summary.deleted_on.as_deref().unwrap().starts_with("2025-06-15"));
+        assert!(summary.scheduled_purge_on.is_some());
+    }
+
+    #[test]
+    fn parse_deleted_secret_summary_tolerates_missing_dates() {
+        let item = serde_json::json!({
+            "id": "https://kv.vault.azure.net/deletedsecrets/bare"
+        });
+        let summary = parse_deleted_secret_summary(&item).unwrap();
+        assert_eq!(summary.name, "bare");
+        assert_eq!(summary.original_name, "bare");
+        assert!(summary.deleted_on.is_none());
+        assert!(summary.scheduled_purge_on.is_none());
+    }
+```
+
+(Compute-check: `1_750_000_000` is 2025-06-15T15:06:40Z — adjust the assertion if you change the fixture.)
+
+In `src/backend/local/secrets.rs`'s test module, add:
+
+```rust
+    #[tokio::test]
+    async fn deleted_listing_carries_deletion_date_but_no_purge_schedule() {
+        let (backend, _tmp) = test_backend();
+        backend
+            .set_secret("default", make_request("dated", "v1"))
+            .await
+            .unwrap();
+        backend.delete_secret("default", "dated").await.unwrap();
+
+        let deleted = backend.list_deleted_secrets("default").await.unwrap();
+        assert_eq!(deleted.len(), 1);
+        assert_eq!(deleted[0].name, "dated");
+        assert!(
+            deleted[0].deleted_on.is_some(),
+            "deleted_on must come from the trash dir's @millis suffix"
+        );
+        assert!(deleted[0].scheduled_purge_on.is_none(), "local trash never auto-purges");
+    }
+```
+
+(`make_request(name, value)` and `test_backend()` are the existing helpers in that test module.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib secret::manager && cargo test --lib backend::local`
+Expected: compile errors / assertion failures (`parse_deleted_secret_summary` returns `SecretSummary`; `deleted_on` doesn't exist).
+
+- [ ] **Step 3: Add the struct and change the manager**
+
+In `src/secret/manager.rs`, immediately after `SecretSummary`, add the `DeletedSecretSummary` struct from the Interfaces block above.
+
+Change the `SecretOperations` trait method (anchor: `async fn list_deleted_secrets`):
+
+```rust
+    /// List soft-deleted secrets awaiting purge.
+    async fn list_deleted_secrets(&self, vault_name: &str) -> Result<Vec<DeletedSecretSummary>>;
+```
+
+Replace `parse_deleted_secret_summary` (anchor: `fn parse_deleted_secret_summary`) with:
+
+```rust
+/// Parse one item from Azure's `GET {vault}/deletedsecrets` (api 7.4).
+/// `deletedDate`/`scheduledPurgeDate` are top-level epoch-second fields on
+/// the deleted-secret item (not under `attributes`).
+fn parse_deleted_secret_summary(item: &serde_json::Value) -> Option<DeletedSecretSummary> {
+    let id = item.get("id").and_then(|v| v.as_str())?;
+    let name = id.rsplit('/').next().unwrap_or(id).to_string();
+    if name.is_empty() {
+        return None;
+    }
+
+    let epoch_string = |key: &str| {
+        item.get(key)
+            .and_then(|v| v.as_i64())
+            .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
+            .map(|dt| dt.to_string())
+    };
+
+    let original_name = item
+        .get("tags")
+        .and_then(|v| v.as_object())
+        .and_then(|tags| {
+            tags.get("original_name")
+                .or_else(|| tags.get("name"))
+                .and_then(|v| v.as_str())
+        })
+        .map(str::to_string)
+        .unwrap_or_else(|| name.clone());
+
+    Some(DeletedSecretSummary {
+        name,
+        original_name,
+        deleted_on: epoch_string("deletedDate"),
+        scheduled_purge_on: epoch_string("scheduledPurgeDate"),
+    })
+}
+```
+
+In the manager's `list_deleted_secrets` impl (anchor: the method with the `deletedsecrets` URL), change only the vec type and keep the rest:
+
+```rust
+        let mut summaries: Vec<DeletedSecretSummary> = Vec::new();
+```
+
+(the final `summaries.sort_by(|a, b| a.original_name.cmp(&b.original_name));` still compiles). Update the test mock (anchor: the `list_deleted_secrets` inside `mod tests`):
+
+```rust
+        async fn list_deleted_secrets(
+            &self,
+            _vault_name: &str,
+        ) -> Result<Vec<DeletedSecretSummary>> {
+            Ok(vec![])
+        }
+```
+
+- [ ] **Step 4: Change the backend trait + Azure adapter**
+
+`src/backend/secret.rs`: add `DeletedSecretSummary` to the `crate::secret::manager` import and change the default method:
+
+```rust
+    /// List deleted secrets (only meaningful when soft-delete is supported).
+    async fn list_deleted_secrets(
+        &self,
+        _vault: &str,
+    ) -> Result<Vec<DeletedSecretSummary>, BackendError> {
+        Err(BackendError::Unsupported("list deleted secrets".into()))
+    }
+```
+
+`src/backend/azure/secrets.rs`: add `DeletedSecretSummary` to the manager import and change the adapter's return type (body unchanged):
+
+```rust
+    async fn list_deleted_secrets(
+        &self,
+        vault: &str,
+    ) -> Result<Vec<DeletedSecretSummary>, BackendError> {
+        self.inner
+            .list_deleted_secrets(vault)
+            .await
+            .map_err(map_error)
+    }
+```
+
+- [ ] **Step 5: Local backend — recover the deletion time from the trash dir name**
+
+`src/backend/local/secrets.rs`: add `DeletedSecretSummary` to the `crate::secret::manager` import, then replace the `list_deleted_secrets` impl (anchor: `async fn list_deleted_secrets`):
+
+```rust
+    async fn list_deleted_secrets(
+        &self,
+        vault: &str,
+    ) -> Result<Vec<DeletedSecretSummary>, BackendError> {
+        let tbase = trash_base_dir(&self.store_path, vault)?;
+        if !tbase.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut results = Vec::new();
+        let entries = fs::read_dir(&tbase)
+            .map_err(|e| BackendError::Internal(format!("read trash dir: {e}")))?;
+
+        for entry in entries.flatten() {
+            if !entry.path().is_dir() {
+                continue;
+            }
+
+            // Trash entry dirs are named `{stem}@{deleted_at_millis}` (see
+            // `trash_entry_dir`); legacy unsuffixed dirs simply yield None.
+            let dir_name = entry.file_name().to_string_lossy().to_string();
+            let deleted_on = dir_name
+                .rsplit('@')
+                .next()
+                .and_then(|ms| ms.parse::<i64>().ok())
+                .and_then(chrono::DateTime::from_timestamp_millis)
+                .map(|dt| dt.to_string());
+
+            // Look for .meta.json files in this trash entry
+            let dir_path = entry.path();
+            if let Ok(inner_entries) = fs::read_dir(&dir_path) {
+                for inner in inner_entries.flatten() {
+                    let fname = inner.file_name().to_string_lossy().to_string();
+                    if fname.ends_with(".meta.json") {
+                        if let Ok(meta) = read_meta(&inner.path(), &self.identity) {
+                            results.push(DeletedSecretSummary {
+                                name: meta.name.clone(),
+                                original_name: meta.original_name.clone(),
+                                deleted_on: deleted_on.clone(),
+                                // Local trash persists until an explicit
+                                // `xv purge` — no schedule to report.
+                                scheduled_purge_on: None,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        results.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(results)
+    }
+```
+
+Then fix the local test module compile fallout: `rg -n "list_deleted_secrets" src/backend/local/secrets.rs` lists ~15 test call sites. They mostly assert `.len()` and `[i].name`, which still compile; any assertion on removed fields (e.g. `groups`, `updated_on`, `original_name` still exists) switches to the new fields (`deleted_on`, `scheduled_purge_on`). Do not weaken assertions — where a test asserted `updated_on` non-empty on a deleted entry, assert `deleted_on.is_some()` instead.
+
+- [ ] **Step 6: AWS backend — keep the date it was throwing away**
+
+`src/backend/aws/secrets.rs`: add `DeletedSecretSummary` to the manager import, change the signature, and replace the `summaries.push(..)` block (anchor: inside `list_deleted_secrets`):
+
+```rust
+    async fn list_deleted_secrets(
+        &self,
+        vault: &str,
+    ) -> Result<Vec<DeletedSecretSummary>, BackendError> {
+```
+
+```rust
+                summaries.push(DeletedSecretSummary {
+                    name: secret_name.clone(),
+                    original_name: secret_name,
+                    deleted_on: entry
+                        .deleted_date()
+                        .and_then(|d| chrono::DateTime::from_timestamp(d.secs(), 0))
+                        .map(|dt| dt.to_string()),
+                    // ListSecrets doesn't expose the recovery window, so the
+                    // purge time (DeletedDate + window) is unknowable here.
+                    scheduled_purge_on: None,
+                });
+```
+
+and `let mut summaries: Vec<DeletedSecretSummary> = Vec::new();`.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+```bash
+cargo test --lib secret::manager
+cargo test --lib backend::local
+cargo check --features aws
+cargo clippy --all-targets && cargo clippy --all-targets --features aws
+cargo test --lib
+```
+Expected: all green, 0 warnings (the AWS feature must at least compile — its API calls aren't unit-testable without LocalStack; `tests/aws_localstack_tests.rs` covers it when the env is up).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cargo fmt
+git add src/secret/manager.rs src/backend/secret.rs src/backend/azure/secrets.rs src/backend/local/secrets.rs src/backend/aws/secrets.rs
+git commit -m "feat: deleted-secret summaries carry deleted/purge dates across all backends
+
+Azure parses deletedDate/scheduledPurgeDate from the REST items; local
+recovers the deletion time from the trash dir's @millis suffix; AWS keeps
+the DeletedDate it previously discarded. Purge schedule is Azure-only.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: `xv ls --deleted`
+
+**Files:**
+- Modify: `src/cli/commands.rs` (`Commands::List` variant + dispatch arm)
+- Modify: `src/cli/secret_ops.rs` (new `DeletedSecretListRow`, `execute_deleted_secret_list`)
+- Modify: `src/cli/ls_view.rs` (`render_name_grid`, `render_deleted_long` + tests)
+- Test: `tests/e2e_local_backend.rs`
+
+**Interfaces:**
+- Consumes: `DeletedSecretSummary` (Task 7), `LsSort` (Task 5), `pagination_footer_text(page, singular, plural, fmt)` (Task 3), `display_width`/`pad_to` (Task 1), `date_portion_for_display` (existing).
+- Produces: `pub(crate) async fn execute_deleted_secret_list(pagination: Pagination, pager: bool, names_only: bool, long: bool, sort: LsSort, config: Config, registry: Option<&BackendRegistry>) -> Result<()>`; `pub(crate) fn render_name_grid(names: &[String], width: usize) -> String` and `pub(crate) fn render_deleted_long(items: &[DeletedSecretSummary]) -> String` in `ls_view.rs`.
+
+- [ ] **Step 1: Write the failing renderer tests**
+
+In `src/cli/ls_view.rs` tests:
+
+```rust
+    fn deleted(name: &str, deleted_on: Option<&str>, purge: Option<&str>) -> DeletedSecretSummary {
+        DeletedSecretSummary {
+            name: name.to_string(),
+            original_name: name.to_string(),
+            deleted_on: deleted_on.map(str::to_string),
+            scheduled_purge_on: purge.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn deleted_long_lists_dates_with_placeholders() {
+        let items = vec![
+            deleted("gone", Some("2026-06-30 10:00:00 UTC"), Some("2026-09-28 10:00:00 UTC")),
+            deleted("trashed", Some("2026-06-01 09:00:00 UTC"), None),
+        ];
+        let out = render_deleted_long(&items);
+        let lines: Vec<&str> = out.lines().collect();
+        assert!(lines[0].starts_with("NAME"), "{out}");
+        assert!(lines[0].contains("DELETED") && lines[0].contains("PURGE SCHEDULED"));
+        assert!(lines[1].starts_with("gone") && lines[1].contains("2026-06-30") && lines[1].contains("2026-09-28"));
+        assert!(lines[2].starts_with("trashed") && lines[2].ends_with('-'), "missing purge date renders '-': {out}");
+        for line in &lines {
+            assert_eq!(line.trim_end(), *line);
+        }
+    }
+
+    #[test]
+    fn name_grid_renders_bare_labels() {
+        let out = render_name_grid(&["alpha".to_string(), "beta".to_string()], 40);
+        assert!(out.contains("alpha") && out.contains("beta"));
+        assert!(!out.contains('/'), "no folder markers in a deleted grid: {out}");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib cli::ls_view::tests::deleted_long`
+Expected: compile error — renderers not found.
+
+- [ ] **Step 3: Implement the renderers**
+
+In `src/cli/ls_view.rs`, change the manager import to `use crate::secret::manager::{DeletedSecretSummary, SecretSummary};` and add:
+
+```rust
+/// Grid of bare labels (no folder entries) — `xv ls --deleted`'s default view.
+pub(crate) fn render_name_grid(names: &[String], width: usize) -> String {
+    let entries: Vec<LsEntry> = names
+        .iter()
+        .map(|n| {
+            LsEntry::Secret(SecretSummary {
+                name: n.clone(),
+                original_name: n.clone(),
+                note: None,
+                folder: None,
+                groups: None,
+                updated_on: String::new(),
+                enabled: true,
+                content_type: String::new(),
+            })
+        })
+        .collect();
+    render_grid(&entries, width, false)
+}
+
+/// Borderless long listing for deleted secrets: NAME  DELETED  PURGE SCHEDULED.
+/// Missing dates render as `-`, mirroring `render_long`'s folder placeholders.
+pub(crate) fn render_deleted_long(items: &[DeletedSecretSummary]) -> String {
+    let cell = |v: &Option<String>| match v {
+        Some(ts) => sanitize_control_chars(&date_portion_for_display(ts)),
+        None => "-".to_string(),
+    };
+    let rows: Vec<(String, String, String)> = items
+        .iter()
+        .map(|s| {
+            let name = if s.original_name.is_empty() {
+                &s.name
+            } else {
+                &s.original_name
+            };
+            (
+                sanitize_control_chars(name),
+                cell(&s.deleted_on),
+                cell(&s.scheduled_purge_on),
+            )
+        })
+        .collect();
+
+    let name_w = rows
+        .iter()
+        .map(|r| display_width(&r.0))
+        .chain(["NAME".len()])
+        .max()
+        .unwrap_or(4);
+    let deleted_w = rows
+        .iter()
+        .map(|r| display_width(&r.1))
+        .chain(["DELETED".len()])
+        .max()
+        .unwrap_or(7);
+
+    let mut out = String::new();
+    let header = format!(
+        "{}  {}  PURGE SCHEDULED",
+        pad_to("NAME", name_w),
+        pad_to("DELETED", deleted_w)
+    );
+    out.push_str(header.trim_end());
+    out.push('\n');
+    for (name, deleted, purge) in rows {
+        let line = format!(
+            "{}  {}  {}",
+            pad_to(&name, name_w),
+            pad_to(&deleted, deleted_w),
+            purge
+        );
+        out.push_str(line.trim_end());
+        out.push('\n');
+    }
+    out
+}
+```
+
+Run: `cargo test --lib cli::ls_view` — PASS.
+
+- [ ] **Step 4: Add the CLI flag and dispatch branch**
+
+`src/cli/commands.rs`, in `Commands::List` after `sort`:
+
+```rust
+        /// List soft-deleted secrets awaiting restore/purge instead of live
+        /// secrets (backend must support soft delete)
+        #[arg(
+            long,
+            conflicts_with_all = ["path", "recursive", "group", "all", "expiring", "expired"]
+        )]
+        deleted: bool,
+```
+
+Dispatch arm (this supersedes Task 5's arm — final form):
+
+```rust
+            Commands::List {
+                path,
+                long,
+                recursive,
+                group,
+                all,
+                expiring,
+                expired,
+                no_cache,
+                page,
+                page_size,
+                pager,
+                names_only,
+                sort,
+                deleted,
+            } => {
+                let pagination = crate::utils::pagination::Pagination::from_args(page, page_size)?;
+                let pager = pager.map(PagerWhen::wants_pager).unwrap_or(false);
+                if deleted {
+                    crate::cli::secret_ops::execute_deleted_secret_list(
+                        pagination, pager, names_only, long, sort, config, registry,
+                    )
+                    .await
+                } else {
+                    let path = match path {
+                        Some(raw) => {
+                            let trimmed = raw.trim_end_matches('/').to_string();
+                            if !trimmed.is_empty() {
+                                crate::utils::helpers::validate_folder_path(&trimmed)?;
+                            }
+                            trimmed
+                        }
+                        None => String::new(),
+                    };
+                    crate::cli::secret_ops::execute_secret_list_direct(
+                        path, group, all, expiring, expired, no_cache, pagination, pager,
+                        names_only, long, recursive, sort, config, registry,
+                    )
+                    .await
+                }
+            }
+```
+
+- [ ] **Step 5: Implement `execute_deleted_secret_list`**
+
+In `src/cli/secret_ops.rs` (near `display_cached_secret_list`):
+
+```rust
+/// Row shape for `xv ls --deleted` — machine formats get this array; empty
+/// strings mark dates the backend cannot supply (AWS/local purge schedule).
+#[derive(Debug, Clone, serde::Serialize, tabled::Tabled)]
+struct DeletedSecretListRow {
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Deleted")]
+    deleted: String,
+    #[tabled(rename = "Purge Scheduled")]
+    purge_scheduled: String,
+}
+
+fn deleted_display_name(s: &crate::secret::manager::DeletedSecretSummary) -> &str {
+    if s.original_name.is_empty() {
+        &s.name
+    } else {
+        &s.original_name
+    }
+}
+
+fn deleted_list_rows(
+    items: &[crate::secret::manager::DeletedSecretSummary],
+    human: bool,
+) -> Vec<DeletedSecretListRow> {
+    items
+        .iter()
+        .map(|s| {
+            let fmt_date = |d: &Option<String>| {
+                let v = d.clone().unwrap_or_default();
+                if human {
+                    crate::cli::ls_view::date_portion_for_display(&v)
+                } else {
+                    v
+                }
+            };
+            DeletedSecretListRow {
+                name: deleted_display_name(s).to_string(),
+                deleted: fmt_date(&s.deleted_on),
+                purge_scheduled: fmt_date(&s.scheduled_purge_on),
+            }
+        })
+        .collect()
+}
+
+pub(crate) async fn execute_deleted_secret_list(
+    pagination: Pagination,
+    pager: bool,
+    names_only: bool,
+    long: bool,
+    sort: crate::cli::commands::LsSort,
+    config: Config,
+    registry: Option<&BackendRegistry>,
+) -> Result<()> {
+    use crate::cli::commands::LsSort;
+    use crate::cli::ls_view;
+    use crate::utils::format::TableFormatter;
+    use crate::utils::pagination::{paginate_slice, pagination_footer_text};
+    use std::fmt::Write as _;
+
+    if !use_trait_path(registry) {
+        return Err(CrosstacheError::config(
+            "No backend registry available. Run 'xv config show' to check your configuration.",
+        ));
+    }
+    let reg = registry.expect("use_trait_path guarantees Some");
+
+    // Capability gate — same shape as `xv restore`'s.
+    let unsupported = || {
+        CrosstacheError::InvalidArgument(format!(
+            "The {} backend does not support listing deleted secrets (soft-delete not available).",
+            reg.active().name()
+        ))
+    };
+    if !reg.active().capabilities().has_soft_delete {
+        return Err(unsupported());
+    }
+
+    let vault_name = resolve_vault_for_trait(&config, registry).await?;
+    // Always live — the SecretsList cache holds live secrets only, and trash
+    // freshness matters right after a delete.
+    let mut items = match reg
+        .active()
+        .secrets()
+        .list_deleted_secrets(&vault_name)
+        .await
+    {
+        Ok(items) => items,
+        Err(crate::backend::BackendError::Unsupported(_)) => return Err(unsupported()),
+        Err(e) => return Err(e.into()),
+    };
+
+    match sort {
+        LsSort::Name => {
+            items.sort_by(|a, b| deleted_display_name(a).cmp(deleted_display_name(b)))
+        }
+        // In deleted mode "updated" means the deleted date (newest first).
+        LsSort::Updated => items.sort_by(|a, b| {
+            b.deleted_on
+                .cmp(&a.deleted_on)
+                .then_with(|| deleted_display_name(a).cmp(deleted_display_name(b)))
+        }),
+    }
+
+    if names_only {
+        for s in &items {
+            println!("{}", deleted_display_name(s));
+        }
+        return Ok(());
+    }
+
+    let fmt = config.runtime_output_format;
+    let human_table_like = matches!(
+        fmt,
+        OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+    );
+    let page = paginate_slice(&items, pagination);
+
+    if !human_table_like {
+        if long {
+            crate::utils::output::warn("--long is ignored for machine-readable formats");
+        }
+        let formatter = TableFormatter::new(
+            fmt,
+            config.no_color,
+            config.template.clone(),
+            config.runtime_columns.clone(),
+        );
+        let rows = deleted_list_rows(&page.items, false);
+        let output = formatter.format_table(&rows)?;
+        crate::utils::pager::print_output(&output, pager)?;
+        return Ok(());
+    }
+
+    if items.is_empty() {
+        crate::utils::output::info(&crate::utils::list_output::empty_state_message(
+            "deleted secrets",
+            Some(&format!("vault '{vault_name}'")),
+        ));
+        return Ok(());
+    }
+
+    let mut output = String::new();
+    output.push('\n');
+    let color = !config.no_color && fmt == OutputFormat::Table;
+    if color {
+        let _ = writeln!(output, "\x1b[36mVault: {} (deleted secrets)\x1b[0m", vault_name);
+    } else {
+        let _ = writeln!(output, "Vault: {} (deleted secrets)", vault_name);
+    }
+    output.push('\n');
+
+    if config.format_explicit && !long {
+        let formatter = TableFormatter::new(
+            fmt,
+            config.no_color,
+            config.template.clone(),
+            config.runtime_columns.clone(),
+        );
+        let rows = deleted_list_rows(&page.items, true);
+        output.push_str(&formatter.format_table(&rows)?);
+        output.push('\n');
+    } else {
+        if config.runtime_columns.is_some() {
+            crate::utils::output::warn(
+                "--columns is ignored for the grid/long view; use --format table",
+            );
+        }
+        if long {
+            output.push_str(&ls_view::render_deleted_long(&page.items));
+        } else {
+            let width = crossterm::terminal::size()
+                .map(|(w, _)| w as usize)
+                .unwrap_or(80);
+            let labels: Vec<String> = page
+                .items
+                .iter()
+                .map(|s| deleted_display_name(s).to_string())
+                .collect();
+            output.push_str(&ls_view::render_name_grid(&labels, width));
+        }
+        output.push('\n');
+    }
+
+    let _ = writeln!(
+        output,
+        "{} in vault '{}'",
+        crate::utils::list_output::count_label(
+            page.items.len(),
+            page.total_items,
+            "deleted secret",
+            "deleted secrets",
+            None,
+            page.page_size.is_some(),
+        ),
+        vault_name
+    );
+    if let Some(footer) = pagination_footer_text(&page, "deleted secret", "deleted secrets", fmt) {
+        output.push('\n');
+        output.push_str(&footer);
+    }
+    crate::utils::pager::print_output(&output, pager)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 6: Add the e2e tests**
+
+In `tests/e2e_local_backend.rs`:
+
+```rust
+#[test]
+fn ls_deleted_lists_soft_deleted_secrets() {
+    let env = TestEnv::new();
+    env.set_secret("doomed", "v");
+    env.set_secret("kept", "v");
+    env.xv_ok(&["delete", "doomed", "--force"]);
+
+    // Piped stdout resolves Auto → JSON, so the human views need the
+    // explicit format (same convention as the live `xv ls` e2e tests).
+    let out = env.xv_ok(&["ls", "--deleted", "--format", "table"]);
+    assert!(out.contains("doomed") && !out.contains("kept"), "{out}");
+    assert!(out.contains("1 deleted secret"), "count line: {out}");
+
+    // Long view has the date columns (explicit table format + -l takes the
+    // borderless long path, mirroring live `xv ls`).
+    let long = env.xv_ok(&["ls", "--deleted", "-l", "--format", "table"]);
+    assert!(long.contains("DELETED") && long.contains("PURGE SCHEDULED"), "{long}");
+
+    // Machine format: row array with a populated deleted date (local backend);
+    // purge schedule is empty (local trash never auto-purges).
+    let json = env.xv_ok(&["ls", "--deleted", "--format", "json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    let rows = parsed.as_array().expect("array");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["name"], "doomed");
+    assert!(!rows[0]["deleted"].as_str().unwrap().is_empty());
+    assert_eq!(rows[0]["purge_scheduled"], "");
+}
+
+#[test]
+fn ls_deleted_conflicts_and_empty_states() {
+    let env = TestEnv::new();
+
+    // clap conflicts: FOLDER positional and -r.
+    let (_, err1) = env.xv_fail(&["ls", "prod", "--deleted"]);
+    assert!(err1.contains("cannot be used with"), "{err1}");
+    let (_, err2) = env.xv_fail(&["ls", "--deleted", "-r"]);
+    assert!(err2.contains("cannot be used with"), "{err2}");
+
+    // Empty: human info on stderr, valid-empty JSON on stdout.
+    let json = env.xv_ok(&["ls", "--deleted", "--format", "json"]);
+    assert_eq!(json.trim(), "[]");
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cargo test --lib && cargo test --test e2e_local_backend ls_deleted && cargo clippy --all-targets`
+Expected: PASS, 0 warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cargo fmt
+git add src/cli/commands.rs src/cli/secret_ops.rs src/cli/ls_view.rs tests/e2e_local_backend.rs
+git commit -m "feat: xv ls --deleted lists soft-deleted secrets with deleted/purge dates
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: `xv group list`
+
+**Files:**
+- Modify: `src/cli/commands.rs` (new `Commands::Group` variant + `GroupCommands` enum + dispatch arm)
+- Modify: `src/cli/secret_ops.rs` (`GroupListRow`, `derive_group_rows`, `execute_group_command` + tests)
+- Test: `tests/e2e_local_backend.rs`
+
+**Interfaces:**
+- Consumes: `trait_secret_cache_key`, `use_trait_path`, `resolve_vault_for_trait`, `TableFormatter`, `list_output` helpers (all existing).
+- Produces: `pub(crate) async fn execute_group_command(command: GroupCommands, config: Config, registry: Option<&BackendRegistry>) -> Result<()>`; `pub enum GroupCommands { List { no_cache: bool } }`.
+
+- [ ] **Step 1: Write the failing unit test**
+
+In `src/cli/secret_ops.rs` tests:
+
+```rust
+    #[test]
+    fn group_rows_derive_from_comma_separated_tags() {
+        fn s(name: &str, groups: Option<&str>) -> crate::secret::manager::SecretSummary {
+            crate::secret::manager::SecretSummary {
+                name: name.to_string(),
+                original_name: name.to_string(),
+                note: None,
+                folder: None,
+                groups: groups.map(str::to_string),
+                updated_on: String::new(),
+                enabled: true,
+                content_type: String::new(),
+            }
+        }
+        let rows = derive_group_rows(&[
+            s("a", Some("team-a, team-b")),
+            s("b", Some("team-a")),
+            s("c", Some(" team-b ,, team-b ")), // dup within one secret counts once
+            s("d", None),
+        ]);
+        assert_eq!(rows.len(), 2);
+        assert_eq!((rows[0].group.as_str(), rows[0].secrets), ("team-a", 2));
+        assert_eq!((rows[1].group.as_str(), rows[1].secrets), ("team-b", 2));
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib group_rows_derive`
+Expected: compile error — `derive_group_rows` not found.
+
+- [ ] **Step 3: Implement derivation + executor**
+
+In `src/cli/secret_ops.rs` (near `secret_summary_matches_group`, whose `split(',')`/`trim` tokenization this mirrors):
+
+```rust
+/// Row shape for `xv group list`.
+#[derive(Debug, Clone, serde::Serialize, tabled::Tabled)]
+struct GroupListRow {
+    #[tabled(rename = "Group")]
+    group: String,
+    #[tabled(rename = "Secrets")]
+    secrets: usize,
+}
+
+/// Fold summaries into (group → member count), tokenizing the comma-separated
+/// `groups` tag exactly like `secret_summary_matches_group`. A group repeated
+/// within one secret counts that secret once.
+fn derive_group_rows(secrets: &[crate::secret::manager::SecretSummary]) -> Vec<GroupListRow> {
+    let mut counts: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+    for s in secrets {
+        let Some(groups) = s.groups.as_deref() else {
+            continue;
+        };
+        let mut seen = std::collections::HashSet::new();
+        for g in groups.split(',') {
+            let g = g.trim();
+            if !g.is_empty() && seen.insert(g) {
+                *counts.entry(g.to_string()).or_insert(0) += 1;
+            }
+        }
+    }
+    counts
+        .into_iter()
+        .map(|(group, secrets)| GroupListRow { group, secrets })
+        .collect()
+}
+
+pub(crate) async fn execute_group_command(
+    command: crate::cli::commands::GroupCommands,
+    config: Config,
+    registry: Option<&BackendRegistry>,
+) -> Result<()> {
+    match command {
+        crate::cli::commands::GroupCommands::List { no_cache } => {
+            execute_group_list(no_cache, config, registry).await
+        }
+    }
+}
+
+async fn execute_group_list(
+    no_cache: bool,
+    config: Config,
+    registry: Option<&BackendRegistry>,
+) -> Result<()> {
+    use crate::cache::CacheManager;
+    use crate::utils::format::TableFormatter;
+
+    if !use_trait_path(registry) {
+        return Err(CrosstacheError::config(
+            "No backend registry available. Run 'xv config show' to check your configuration.",
+        ));
+    }
+    let reg = registry.expect("use_trait_path guarantees Some");
+    let vault_name = resolve_vault_for_trait(&config, registry).await?;
+
+    // Same fetch-or-cache flow as `xv ls` (shared CacheKey::SecretsList dataset).
+    let cache_manager = CacheManager::from_config(&config);
+    let cache_key = trait_secret_cache_key(&vault_name);
+    let use_cache = cache_manager.is_enabled() && !no_cache;
+    let cached = if use_cache {
+        cache_manager.get::<Vec<crate::secret::manager::SecretSummary>>(&cache_key)
+    } else {
+        None
+    };
+    let secrets = match cached {
+        Some(secrets) => secrets,
+        None => {
+            let fetched = reg.active().secrets().list_secrets(&vault_name, None).await?;
+            if use_cache {
+                cache_manager.set(&cache_key, &fetched);
+            }
+            fetched
+        }
+    };
+
+    let rows = derive_group_rows(&secrets);
+    let fmt = config.runtime_output_format;
+    let human = matches!(
+        fmt,
+        OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+    );
+
+    if rows.is_empty() && human {
+        crate::utils::output::info(&crate::utils::list_output::empty_state_message(
+            "groups",
+            Some(&format!("vault '{vault_name}'")),
+        ));
+        return Ok(());
+    }
+
+    let formatter = TableFormatter::new(
+        fmt,
+        config.no_color,
+        config.template.clone(),
+        config.runtime_columns.clone(),
+    );
+    println!("{}", formatter.format_table(&rows)?);
+    if human {
+        println!(
+            "{}",
+            crate::utils::list_output::count_label(
+                rows.len(),
+                rows.len(),
+                "group",
+                "groups",
+                Some(&format!("vault '{vault_name}'")),
+                false,
+            )
+        );
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Add the command surface**
+
+`src/cli/commands.rs`, after the `Env { .. }` variant:
+
+```rust
+    /// Inspect secret groups in the current vault context
+    Group {
+        #[command(subcommand)]
+        command: GroupCommands,
+    },
+```
+
+Next to `EnvCommands`:
+
+```rust
+#[derive(Subcommand)]
+pub enum GroupCommands {
+    /// List groups and member counts derived from secret metadata
+    List {
+        /// Bypass the local cache and fetch fresh data
+        #[arg(long)]
+        no_cache: bool,
+    },
+}
+```
+
+Dispatch arm (next to `Commands::Env`):
+
+```rust
+            Commands::Group { command } => {
+                crate::cli::secret_ops::execute_group_command(command, config, registry).await
+            }
+```
+
+- [ ] **Step 5: Add the e2e test**
+
+In `tests/e2e_local_backend.rs`:
+
+```rust
+#[test]
+fn group_list_counts_members_across_formats() {
+    let env = TestEnv::new();
+    env.set_secret_with_args("a", "v", &["--group", "team-a"]);
+    env.set_secret_with_args("b", "v", &["--group", "team-a"]);
+    env.set_secret_with_args("c", "v", &["--group", "team-b"]);
+    env.set_secret("ungrouped", "v");
+
+    // Piped stdout resolves Auto → JSON; force the human table for the
+    // count-line assertion.
+    let table = env.xv_ok(&["group", "list", "--format", "table"]);
+    assert!(table.contains("team-a") && table.contains("team-b"), "{table}");
+    assert!(table.contains("2 groups"), "count line: {table}");
+
+    let csv = env.xv_ok(&["group", "list", "--format", "csv"]);
+    let mut lines = csv.lines();
+    assert_eq!(lines.next(), Some("Group,Secrets"), "{csv}");
+    assert!(csv.contains("team-a,2") && csv.contains("team-b,1"), "{csv}");
+
+    let json = env.xv_ok(&["group", "list", "--format", "json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert_eq!(parsed.as_array().map(Vec::len), Some(2));
+
+    // Empty vault → valid-empty machine output.
+    let fresh = TestEnv::new();
+    assert_eq!(fresh.xv_ok(&["group", "list", "--format", "json"]).trim(), "[]");
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test --lib group_rows && cargo test --test e2e_local_backend group_list && cargo clippy --all-targets`
+Expected: PASS, 0 warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt
+git add src/cli/commands.rs src/cli/secret_ops.rs tests/e2e_local_backend.rs
+git commit -m "feat: xv group list derives group membership counts from secret metadata
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Deprecate `context envs`
+
+**Files:**
+- Modify: `src/cli/commands.rs` (`ContextCommands::Envs` variant, ~line 1284)
+- Modify: `src/cli/config_ops.rs` (`execute_context_envs`, ~line 1218)
+- Test: `tests/e2e_local_backend.rs`
+
+**Interfaces:** none new; behavior-preserving deprecation.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+```rust
+#[test]
+fn context_envs_is_hidden_and_warns() {
+    let env = TestEnv::new();
+
+    // Hidden from help.
+    let help = env.xv_ok(&["context", "--help"]);
+    assert!(!help.contains("envs"), "context envs still visible in help:\n{help}");
+
+    // Still works, but warns on stderr.
+    let output = env
+        .xv()
+        .args(["context", "envs"])
+        .output()
+        .expect("run context envs");
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("context envs is deprecated; use env list"),
+        "missing deprecation warning:\n{stderr}"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test e2e_local_backend context_envs`
+Expected: FAIL — `envs` appears in help; no warning emitted.
+
+- [ ] **Step 3: Implement**
+
+`src/cli/commands.rs` (anchor: the `Envs,` variant in `ContextCommands`):
+
+```rust
+    /// (deprecated) List environment profiles in the resolved .xv.toml — use `env list`
+    #[command(hide = true)]
+    Envs,
+```
+
+`src/cli/config_ops.rs` (anchor: `async fn execute_context_envs`):
+
+```rust
+async fn execute_context_envs(config: &Config) -> Result<()> {
+    crate::utils::output::warn("context envs is deprecated; use env list");
+    execute_env_list(config).await
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --test e2e_local_backend context_envs && cargo clippy --all-targets`
+Expected: PASS, 0 warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add src/cli/commands.rs src/cli/config_ops.rs tests/e2e_local_backend.rs
+git commit -m "fix: deprecate 'context envs' (hidden from help, warns, delegates to env list)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: `find --folder <path>`
+
+**Files:**
+- Modify: `src/cli/commands.rs` (`Commands::Find` variant + dispatch arm ~1479)
+- Modify: `src/cli/secret_ops.rs` (`execute_secret_find_direct` ~1851, `execute_secret_find` ~1965)
+- Test: `tests/e2e_local_backend.rs`
+
+**Interfaces:**
+- Consumes: `ls_view::folder_in_scope` (Task 6), `CandidateItem.folder` (`src/utils/fuzzy.rs:14`), `validate_folder_path` (`src/utils/helpers.rs:160`).
+- Produces: `execute_secret_find_direct` gains `folder: Option<String>` (after `min_score`); `execute_secret_find` gains `folder: Option<&str>` (after `min_score`) receiving the already-normalized path.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+```rust
+#[test]
+fn find_folder_scopes_by_segment_boundary() {
+    let env = TestEnv::new();
+    env.set_secret_with_args("db-pass", "v", &["--folder", "prod/db"]);
+    env.set_secret_with_args("api-key", "v", &["--folder", "prod"]);
+    env.set_secret_with_args("trap", "v", &["--folder", "production"]);
+    env.set_secret("root-a", "v");
+
+    // No pattern: everything in scope, unranked.
+    let out = env.xv_ok(&["find", "--folder", "prod", "--names-only"]);
+    let names: Vec<&str> = out.lines().collect();
+    assert!(names.contains(&"db-pass") && names.contains(&"api-key"), "{out}");
+    assert!(!names.contains(&"trap"), "segment boundary violated: {out}");
+    assert!(!names.contains(&"root-a"), "{out}");
+
+    // Trailing slash tolerated; invalid path errors.
+    let out2 = env.xv_ok(&["find", "--folder", "prod/", "--names-only"]);
+    assert!(out2.contains("db-pass"), "{out2}");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test e2e_local_backend find_folder`
+Expected: FAIL — `--folder` is an unknown argument.
+
+- [ ] **Step 3: Add the flag**
+
+`src/cli/commands.rs`, in `Commands::Find` after `min_score`:
+
+```rust
+        /// Only search secrets in this folder (or its subfolders, segment
+        /// boundary enforced: `prod` matches `prod/db` but not `production`).
+        #[arg(long, value_name = "PATH")]
+        folder: Option<String>,
+```
+
+Dispatch arm (anchor: `Commands::Find {`) — add `folder` to the pattern and pass it after `min_score`:
+
+```rust
+            Commands::Find {
+                pattern,
+                in_fields,
+                limit,
+                min_score,
+                folder,
+                all_vaults,
+                names_only,
+            } => {
+                crate::cli::secret_ops::execute_secret_find_direct(
+                    pattern, in_fields, limit, min_score, folder, all_vaults, names_only,
+                    self.format, config, registry,
+                )
+                .await
+            }
+```
+
+- [ ] **Step 4: Normalize and filter in both find paths**
+
+`src/cli/secret_ops.rs`, `execute_secret_find_direct` gains `folder: Option<String>,` after `min_score: f32,`. At the top of its body (before the trait-path branch), normalize once:
+
+```rust
+    // Normalize --folder: trim trailing '/', validate, treat empty as absent.
+    let folder_scope: Option<String> = match folder {
+        Some(raw) => {
+            let trimmed = raw.trim_end_matches('/').to_string();
+            if trimmed.is_empty() {
+                None
+            } else {
+                crate::utils::helpers::validate_folder_path(&trimmed)?;
+                Some(trimmed)
+            }
+        }
+        None => None,
+    };
+```
+
+Trait path — immediately after the `let items: Vec<CandidateItem> = ..;` binding (anchor: just before `let pattern_str = pattern.as_deref().unwrap_or("");`):
+
+```rust
+        let items: Vec<CandidateItem> = match folder_scope.as_deref() {
+            Some(path) => items
+                .into_iter()
+                .filter(|i| {
+                    crate::cli::ls_view::folder_in_scope(i.folder.as_deref().unwrap_or(""), path)
+                })
+                .collect(),
+            None => items,
+        };
+```
+
+Legacy Azure path — `execute_secret_find` gains `folder: Option<&str>,` after `min_score: f32,`; the `execute_secret_find_direct` tail call passes `folder_scope.as_deref()`. Inside `execute_secret_find`, insert the identical filter immediately after its own `items` binding (anchor: just before `let pattern_str = pattern.unwrap_or("");`):
+
+```rust
+    let items: Vec<CandidateItem> = match folder {
+        Some(path) => items
+            .into_iter()
+            .filter(|i| {
+                crate::cli::ls_view::folder_in_scope(i.folder.as_deref().unwrap_or(""), path)
+            })
+            .collect(),
+        None => items,
+    };
+```
+
+(`--folder` composes with `--all-vaults`: folder tags are vault-agnostic, so the filter simply applies to the combined candidate list in both paths.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --test e2e_local_backend find_folder && cargo test --lib && cargo clippy --all-targets`
+Expected: PASS, 0 warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt
+git add src/cli/commands.rs src/cli/secret_ops.rs tests/e2e_local_backend.rs
+git commit -m "feat: find --folder scopes fuzzy search to a folder subtree
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Hidden `__complete-folders` completion feed
+
+**Files:**
+- Modify: `src/main.rs` (pre-clap intercept, next to `__complete-secrets` ~line 40)
+- Modify: `src/cli/secret_ops.rs` (`folder_completion_paths` + `execute_complete_folders`, next to `execute_complete_secrets` ~2110; tests)
+
+**Interfaces:**
+- Consumes: `CacheKey::SecretsList` (`src/cache/models.rs:34`), `load_config_without_validation` (existing in `main.rs`).
+- Produces: `xv __complete-folders` — cache-only, silent on cold cache, one folder path per line including ancestor prefixes (`prod/db` yields `prod` and `prod/db`), `BTreeSet`-sorted. Wired exactly like secret names: a hidden pre-clap intercept for shell completion scripts to call; it never hits a backend on a Tab press.
+
+- [ ] **Step 1: Write the failing unit test**
+
+In `src/cli/secret_ops.rs` tests:
+
+```rust
+    #[test]
+    fn folder_completion_includes_ancestor_prefixes_sorted() {
+        fn s(folder: Option<&str>) -> crate::secret::manager::SecretSummary {
+            crate::secret::manager::SecretSummary {
+                name: "x".to_string(),
+                original_name: "x".to_string(),
+                note: None,
+                folder: folder.map(str::to_string),
+                groups: None,
+                updated_on: String::new(),
+                enabled: true,
+                content_type: String::new(),
+            }
+        }
+        let paths = folder_completion_paths(&[
+            s(Some("prod/db/replica")),
+            s(Some("prod")),
+            s(Some("dev")),
+            s(None),
+            s(Some("")),
+        ]);
+        assert_eq!(
+            paths,
+            vec![
+                "dev".to_string(),
+                "prod".to_string(),
+                "prod/db".to_string(),
+                "prod/db/replica".to_string(),
+            ]
+        );
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib folder_completion`
+Expected: compile error — `folder_completion_paths` not found.
+
+- [ ] **Step 3: Implement**
+
+In `src/cli/secret_ops.rs`, next to `execute_complete_secrets`:
+
+```rust
+/// Distinct folder paths (including ancestor prefixes, so `prod/db` also
+/// offers `prod`), sorted — the completion feed for FOLDER-taking args.
+fn folder_completion_paths(secrets: &[crate::secret::manager::SecretSummary]) -> Vec<String> {
+    let mut folders = std::collections::BTreeSet::new();
+    for s in secrets {
+        let Some(folder) = s.folder.as_deref().filter(|f| !f.is_empty()) else {
+            continue;
+        };
+        let mut prefix = String::new();
+        for seg in folder.split('/') {
+            if !prefix.is_empty() {
+                prefix.push('/');
+            }
+            prefix.push_str(seg);
+            folders.insert(prefix.clone());
+        }
+    }
+    folders.into_iter().collect()
+}
+
+#[allow(dead_code)] // called from src/main.rs::run_complete_folders (binary-only path)
+pub(crate) async fn execute_complete_folders(config: Config) -> Result<()> {
+    use crate::cache::{CacheKey, CacheManager};
+
+    let vault_name = config.resolve_vault_name(None).await?;
+
+    // Cache-only path, mirroring execute_complete_secrets: a cold cache
+    // means no completions — never a backend round-trip on a Tab press.
+    let cache_manager = CacheManager::from_config(&config);
+    if !cache_manager.is_enabled() {
+        return Ok(());
+    }
+    let cache_key = CacheKey::SecretsList { vault_name };
+    if let Some(cached) =
+        cache_manager.get::<Vec<crate::secret::manager::SecretSummary>>(&cache_key)
+    {
+        for f in folder_completion_paths(&cached) {
+            println!("{f}");
+        }
+    }
+    Ok(())
+}
+```
+
+In `src/main.rs`, extend the pre-clap intercept (anchor: `args[1] == "__complete-secrets"`) with a sibling branch:
+
+```rust
+    if args.len() > 1 && args[1] == "__complete-folders" {
+        let format = OutputFormat::Plain; // Default format for completion
+        if let Err(e) = run_complete_folders().await {
+            error!("Error: {}", e);
+            print_user_friendly_error(&e, format);
+            std::process::exit(e.exit_code());
+        }
+        return;
+    }
+```
+
+and next to `run_complete_secrets`:
+
+```rust
+async fn run_complete_folders() -> Result<()> {
+    // Load config without validation for the internal completion command
+    let config = load_config_without_validation().await?;
+    crate::cli::secret_ops::execute_complete_folders(config).await
+}
+```
+
+- [ ] **Step 4: Add the e2e smoke test**
+
+In `tests/e2e_local_backend.rs` (the harness disables the cache, so the contract here is "exit 0, silent"):
+
+```rust
+#[test]
+fn complete_folders_is_silent_without_cache() {
+    let env = TestEnv::new();
+    env.set_secret_with_args("db-pass", "v", &["--folder", "prod/db"]);
+    let out = env.xv_ok(&["__complete-folders"]);
+    assert_eq!(out.trim(), "", "cache disabled → no completions, no errors");
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --lib folder_completion && cargo test --test e2e_local_backend complete_folders && cargo clippy --all-targets`
+Expected: PASS, 0 warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt
+git add src/main.rs src/cli/secret_ops.rs tests/e2e_local_backend.rs
+git commit -m "feat: hidden __complete-folders emits cached folder paths for shell completion
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Docs, gates, and final verification
+
+**Files:**
+- Modify: `CHANGELOG.md` (`## Unreleased`)
+- Modify: `README.md` (ls/find/group sections — anchor by searching for the existing `xv ls` and `xv find` docs)
+
+- [ ] **Step 1: CHANGELOG entries**
+
+Append to the existing `## Unreleased` sections (create a section only if missing):
+
+Under `### Added`:
+
+```markdown
+- **`xv ls --deleted`** lists soft-deleted secrets (name + deleted date + scheduled-purge date where the backend can supply them: Azure has both, local and AWS report the deleted date only). Capability-gated — backends without soft delete get a clear error. Machine formats emit a `{name, deleted, purge_scheduled}` row array; the default view is the usual grid, `-l` is a `NAME/DELETED/PURGE SCHEDULED` long listing. Conflicts with the `FOLDER` positional, `-r`, `--group`, `--all`, `--expiring`, and `--expired`.
+- **`xv group list`**: lists secret groups with member counts, derived from the comma-separated `groups` metadata. Full `--format`/`--columns` support; `--no-cache` to bypass the shared secrets cache.
+- **`xv ls --sort name|updated`** (default `name`): `updated` shows the most recently updated secrets first in every output mode, including machine formats (in `--deleted` mode it sorts by deleted date).
+- **`xv find --folder <path>`** scopes fuzzy search to a folder subtree (segment-boundary rule: `prod` matches `prod/db`, not `production`); composes with `--all-vaults`.
+- **Hidden `xv __complete-folders`** emits cached folder paths (including ancestor prefixes) one per line for shell tab-completion, mirroring `__complete-secrets` (cache-only, silent when cold).
+```
+
+Under `### Changed`:
+
+```markdown
+- **`xv ls -r` shows folder-qualified names** (`prod/db-pass`, relative to the listing root) in the grid, long, and `--names-only` views. Non-recursive output and machine formats are unchanged.
+- **`context envs` is deprecated**: hidden from help, warns `context envs is deprecated; use env list`, and delegates unchanged.
+```
+
+Under `### Fixed`:
+
+```markdown
+- **CJK-safe list rendering**: grid/long listings and note wrapping now measure terminal display width (via `unicode-width`) instead of char count, so full-width characters no longer misalign columns.
+- **`xv parse` printed its table twice** (and leaked a table into `--fmt json` output); the manager no longer prints — the CLI renders once.
+- **Pagination footers are plural-aware** (`… of 1 secret`, `… of 3 secrets`) — the last `"{noun}(s)"` holdout is gone.
+- **`xv cache refresh --key vaults` no longer dumps the vault list to stdout**; the refresh fetches and caches silently.
+```
+
+- [ ] **Step 2: README updates**
+
+In the `xv ls` documentation block: add `--deleted`, `--sort name|updated`, and a one-line note that `-r` shows folder-qualified names. In the `xv find` block: add `--folder <path>`. Add a short `xv group list` entry near the group-filter docs. Match the surrounding style; keep each addition to 1–3 lines. Check `rg -n "context envs" README.md docs/` and update any example to `xv env list`.
+
+- [ ] **Step 3: Gates**
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets
+cargo clippy --all-targets --features aws
+cargo test --lib
+cargo test --test e2e_local_backend
+cargo test
+```
+Expected: all clean/green, clippy 0 warnings (the full `cargo test` needs Azure creds on this machine for some suites; report environment-blocked failures honestly — the local e2e suite must be fully green).
+
+- [ ] **Step 4: E2E spot-check (hermetic only)**
+
+The behavioral surface is covered by the `tests/e2e_local_backend.rs` additions from Tasks 2, 5, 6, 8, 9, 10, 11, 12 — run them once more as a block:
+
+```bash
+cargo test --test e2e_local_backend -- --nocapture 2>&1 | tail -20
+```
+
+Do NOT run `xv` against the developer's real config to "double-check" — the harness is the sanctioned environment (Global Constraints). Azure/AWS deleted-listing paths compile-verified + unit-tested here; live verification happens on the existing cred-gated suites (`tests/e2e_azure_backend.rs`, `tests/aws_localstack_tests.rs`) and is out of this plan's scope.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add CHANGELOG.md README.md
+git commit -m "docs: changelog and README for the list P3 pass
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Spec coverage map
+
+| Spec section | Task |
+|---|---|
+| §1 `DeletedSecretSummary` + per-backend dates (Azure both, local deleted-only from `@millis`, AWS deleted-only from `DeletedDate`) | Task 7 |
+| §1 `xv ls --deleted`: flag + conflicts, capability gate (`has_soft_delete` + `Unsupported` mapping), no cache, row array via `TableFormatter`, grid/long views, count/empty wording, `--sort` in deleted mode | Task 8 |
+| §2 `xv group list` (top-level `group` subcommand, derivation, `{Group, Secrets}` rows, formats, empty/count, `--no-cache`) | Task 9 |
+| §3 `xv ls --sort name\|updated` (value_enum, default name, every output mode, updated = descending) | Task 5 (deleted mode: Task 8) |
+| §4 `context envs` deprecation (hidden, warn, delegate) | Task 10 |
+| §5 `find --folder` (shared segment-boundary helper, filter before scoring, both find paths, `--all-vaults` composition) | Task 11 (helper defined in Task 6) |
+| §6 `__complete-folders` (pre-clap intercept, cache-only, ancestor prefixes) | Task 12 |
+| §7 folder-qualified `ls -r` names (grid/long/names-only, relative to root, non-recursive shape preserved) | Task 6 |
+| §8 unicode-width (grid, long, note truncation, note wrap; `pad_to` replaces format-padding; tabled untouched) | Task 1 (new deleted-long renderer born width-aware: Task 8) |
+| §9a `xv parse` double-print | Task 2 |
+| §9b plural `pagination_footer_text`/`human_summary` + all 8 callers + dead `print_pagination_footer` deleted | Task 3 |
+| §9c silent `refresh_vault_list` | Task 4 |
+| Resolved ambiguities (extra `--deleted` conflicts, empty-cell convention, names-only qualification opt-in, group `--no-cache`) | Tasks 8, 6, 9 |
+| Testing: unit + behavioral + gates + safety constraints | Every task's test steps; Task 13 gates; Global Constraints |
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-02-list-p3.md`. Execute with superpowers:subagent-driven-development (fresh subagent per task, review between tasks) or superpowers:executing-plans (inline with checkpoints).

--- a/docs/superpowers/specs/2026-07-02-list-p3-design.md
+++ b/docs/superpowers/specs/2026-07-02-list-p3-design.md
@@ -1,0 +1,142 @@
+# List Command P3 — Deleted Listing, Groups, Sort, Folder Ergonomics Design
+
+> **Status:** 📋 Approved design — not yet implemented. | **Date:** 2026-07-02 | **Author:** Claude + Scott
+> P3 tier of the 2026-07-01 list-command UX review (P0 = PR #289, P1 = PR #290, P2 Phase A = PR #291, Phase B = the `list-p3` branch base). Executed autonomously under Scott's standing "recommended options, don't stop" instruction; the batched up-front decisions are recorded below.
+
+---
+
+## Problem
+
+Phases 0–2 unified flags, wording, and rendering, but the listing surface still has functional holes and inherited defects:
+
+1. **No way to see soft-deleted secrets.** All three backends can enumerate them — `SecretBackend::list_deleted_secrets` exists on the trait (`src/backend/secret.rs:110`) and is implemented by Azure (`src/backend/azure/secrets.rs:244` → REST `GET {vault}/deletedsecrets`, `src/secret/manager.rs:1251`), local (`src/backend/local/secrets.rs:1793`, trash scan), and AWS (`src/backend/aws/secrets.rs:849`, `ListSecrets` + `include_planned_deletion`) — but no CLI command calls it; `xv restore` restores blind.
+2. **No group overview.** Groups exist only as a `--group` filter; nothing lists which groups exist or how many secrets each holds.
+3. **`xv ls` has exactly one sort order** (name ascending, baked into `scope_secrets`, `src/cli/ls_view.rs:57-58`); "what changed recently" requires piping JSON through `jq`.
+4. **`context envs` duplicates `env list`** (`execute_context_envs` at `src/cli/config_ops.rs:1218` already delegates) but is still visible in help with no deprecation signal.
+5. **`find` cannot scope by folder** even though `xv ls prod` can and `CandidateItem` already carries a `folder` field (`src/utils/fuzzy.rs:14`).
+6. **Tab completion knows secret names but not folders** — the `FOLDER` positional of `xv ls` and the new `find --folder` have nothing to complete from, although the cached summaries contain every folder tag (`__complete-secrets` pattern: `src/main.rs:40-48`, `execute_complete_secrets` at `src/cli/secret_ops.rs:2110`).
+7. **`xv ls -r` flattens folders into ambiguity**: two secrets named `db-pass` in `prod/` and `dev/` render as two identical `db-pass` cells.
+8. **Display-width math counts chars, not columns.** `render_grid`/`render_long`/`truncate_note` (`src/cli/ls_view.rs:123,180,223,229,235`) and the note-wrap helpers (`src/cli/secret_ops.rs:322,331,346`) use `chars().count()`, so CJK/full-width names misalign every grid and long listing.
+9. **Inherited defects:** (a) `xv parse` prints its table twice — `SecretManager::parse_connection_string` prints (`src/secret/manager.rs:~1973-1976`) and the CLI arm renders again (`src/cli/secret_ops.rs:3599-3624`); (b) `pagination_footer_text` still emits the abolished `"{noun}(s)"` style via `Page::human_summary` (`src/utils/pagination.rs:63,69`); (c) `xv cache refresh --key vaults` dumps the whole vault list as JSON to stdout because `refresh_vault_list` (`src/cli/config_ops.rs:884`) calls the printing `list_vaults_formatted` (`src/vault/manager.rs:116-139`).
+
+## Decisions (adopted from the up-front batch, 2026-07-02)
+
+1. **`xv ls --deleted` lists soft-deleted secrets**, capability-gated per backend via `BackendCapabilities.has_soft_delete` (all three backends declare `true`: `src/backend/azure/mod.rs:197`, `src/backend/local/mod.rs:222`, `src/backend/aws/mod.rs:94`) with the same error shape as `xv restore`'s gate (`src/cli/secret_ops.rs:1277-1286`); a `BackendError::Unsupported` from the trait call maps to the same capability message. Output: name + deleted date + scheduled-purge date **where available** (see per-backend reality below), through the shared `TableFormatter` (machine formats = row array). `--deleted` conflicts with the positional `FOLDER` arg and `-r` (clap `conflicts_with`); grid/long render as usual.
+2. **`xv group list`**: new top-level `group` subcommand with `list`; derives groups from the secret summaries' comma-separated `groups` values (same parsing as `secret_summary_matches_group`, `src/cli/secret_ops.rs:223-232`); rows `{ Group, Secrets }` (member count); full format support via `TableFormatter`; empty-state/count via the `list_output` helpers.
+3. **`xv ls --sort name|updated`** (clap `value_enum`, default `name`): applies before rendering in every ls output mode including machine formats; `updated` sorts descending (newest first).
+4. **`context envs` is deprecated**: hidden from help (`#[command(hide = true)]`), warns `context envs is deprecated; use env list` on stderr, delegates unchanged.
+5. **`find --folder <path>`** filters candidates by folder (exact-or-prefix with segment boundary, the same rule as `ls_view::scope_secrets` — the logic is extracted into a shared helper) before scoring.
+6. **Folder completion**: hidden `__complete-folders` command mirroring the `__complete-secrets` pattern (pre-clap intercept in `src/main.rs`, cache-only executor in `secret_ops.rs`) that emits distinct folder paths derived from the cached summaries; wired into the shell-completion story exactly the way secret names are.
+7. **Folder-qualified `ls -r` names**: recursive grid/long/names-only display shows `folder/name` qualified names relative to the listing root (root-level secrets unqualified).
+8. **CJK-safe widths**: add the `unicode-width` crate; replace `chars().count()` display-width math in `ls_view.rs` (grid + long + note truncation) and the `xv ls` table note-wrap helpers in `secret_ops.rs`. `tabled`'s own width machinery is NOT touched — it already handles this.
+9. **Inherited fixes ship in this tier**: (a) `xv parse` double-print — the manager stops printing (managers return data; the CLI renders; `execute_secret_parse` at `src/cli/secret_ops.rs:3589` is the only caller); (b) `pagination_footer_text` becomes plural-aware (takes singular + plural noun forms, like `count_label`); all 8 call sites updated; (c) `refresh_vault_list` fetches + caches silently via `vault_ops().list_vaults(..)` instead of the printing `list_vaults_formatted`.
+
+### Resolved ambiguities (recorded, not re-litigated)
+
+- **`--deleted` also conflicts with `--group`, `--all`, `--expiring`, `--expired`** (clap `conflicts_with`): those flags operate on live secrets (expiry filters even call `get_secret`, which 404s on deleted names). The settled decision named only `FOLDER`/`-r`; the extra conflicts are the same principle applied to flags that cannot mean anything in deleted mode.
+- **`--sort` in `--deleted` mode:** `name` (default) sorts by name ascending; `updated` sorts by *deleted* date descending (it is the "when did this change state" axis of that view).
+- **`--deleted` bypasses the cache** — the `SecretsList` cache holds live secrets only, and trash freshness matters right after a delete.
+- **Missing dates render as empty cells** in `TableFormatter` rows (matching the `SecretListDisplayRow` empty-string convention and the hide-empty-columns machinery) and `-` in the borderless long view (matching folder placeholder rows).
+- **`--names-only` without `-r` keeps its current flat, unqualified output** (shipped pipe shape); qualification applies only when `-r` is explicitly passed. The `-r --names-only` / `-r` grid/long change is a human/pipe display change, changelog-noted — machine formats (`--format json|yaml|csv`) keep the `SecretSummary`/display-row shapes, which already carry a Folder column.
+- **`find --folder` composes with `--all-vaults`** (folder tags are vault-agnostic; the filter applies to the combined candidate list).
+- **`__complete-folders` emits ancestor prefixes too** (`prod/db` yields `prod` and `prod/db`), sorted, one per line — completing `xv ls pr<Tab>` must offer intermediate folders that exist only as prefixes.
+- **`xv group list` takes `--no-cache`** mirroring `xv ls` (it reads the same `CacheKey::SecretsList` dataset).
+
+## Design
+
+### 1. `xv ls --deleted`
+
+**Per-backend deleted-listing reality** (this determines the data shape):
+
+| Backend | Enumeration | Deleted date | Scheduled purge date |
+|---|---|---|---|
+| Azure | `GET {vault}/deletedsecrets` api-version 7.4, `nextLink`-paginated (`SecretManager::list_deleted_secrets`, `src/secret/manager.rs:1251-1324`) | ✅ `deletedDate` (epoch) per item — currently **discarded** by `parse_deleted_secret_summary` (`src/secret/manager.rs:449`) | ✅ `scheduledPurgeDate` (epoch) per item — currently discarded |
+| Local | `.trash/` scan (`src/backend/local/secrets.rs:1793-1824`) | ✅ recoverable from the trash-entry dir name `{stem}@{deleted_at_millis}` (`trash_entry_dir`, `src/backend/local/secrets.rs:120-126`; also `.deleted.json`'s `deleted_at`, written at `:1099`) — currently discarded | ❌ none — trash persists until manual `xv purge` |
+| AWS | `ListSecrets` + `include_planned_deletion(true)`, filtered to `deleted_date().is_some()` (`src/backend/aws/secrets.rs:849-906`) | ✅ `SecretListEntry.deleted_date` — currently **discarded** (`updated_on` set to `""`) | ❌ not in the list response (purge time = DeletedDate + per-secret recovery window, which `ListSecrets` doesn't return) |
+
+**Data shape.** The trait's `Vec<SecretSummary>` return can't carry the dates, so `list_deleted_secrets` changes return type across the stack to a new dedicated type (internal refactor; the CLI never exposed the old shape):
+
+```rust
+// src/secret/manager.rs, near SecretSummary
+pub struct DeletedSecretSummary {
+    pub name: String,
+    pub original_name: String,
+    pub deleted_on: Option<String>,          // formatted timestamp, None when unknown
+    pub scheduled_purge_on: Option<String>,  // None when the backend has no purge schedule
+}
+```
+
+Touched: `SecretBackend::list_deleted_secrets` (`src/backend/secret.rs:110`), `SecretOperations::list_deleted_secrets` (`src/secret/manager.rs:236`) + Azure impl + `parse_deleted_secret_summary` (now reads `deletedDate`/`scheduledPurgeDate`), the Azure adapter (`src/backend/azure/secrets.rs:244`), local (parses the `@millis` dir suffix), AWS (keeps `entry.deleted_date()`), and the mock at `src/secret/manager.rs:2489`. Local-backend tests calling `list_deleted_secrets` update mechanically to the new fields.
+
+**CLI.** New `--deleted` flag on `Commands::List` with the conflicts listed above. Dispatch routes to a new `execute_deleted_secret_list` (separate from the live-list path — different data, no cache, no folder scoping):
+
+- Gate: registry active backend `capabilities().has_soft_delete`, else `InvalidArgument("The {name} backend does not support listing deleted secrets (soft-delete not available).")`; `BackendError::Unsupported` from the call maps to the same message.
+- Sort per `--sort` (see §3 resolution above), then paginate with `paginate_slice`.
+- Render:
+  - `--names-only`: one display name per line.
+  - Machine formats + explicit `--format table|plain|raw`: `TableFormatter` over `DeletedSecretListRow { Name, Deleted, Purge Scheduled }` (Tabled + Serialize, empty strings for unavailable dates) — machine formats get the row array, valid-empty via `format_table(&[])`'s existing empty branch (`src/utils/format.rs:205-220`).
+  - Default (no explicit format): the usual ls-style views — grid of names, or `-l` → new borderless `render_deleted_long` (`NAME  DELETED  PURGE SCHEDULED`, `-` placeholders) in `ls_view.rs`, built on the same width helpers as `render_long`.
+- Human count/empty: `count_label(n, total, "deleted secret", "deleted secrets", Some("vault 'X'"), paginated)` / `empty_state_message("deleted secrets", Some("vault 'X'"))`.
+
+### 2. `xv group list`
+
+New top-level `Commands::Group { command: GroupCommands }` (subcommand enum with `List { no_cache }`, modeled on `Commands::Env`). Executor in `secret_ops.rs` reuses the ls trait path's fetch-or-cache flow (`trait_secret_cache_key`, `CacheKey::SecretsList`), then folds summaries into a `BTreeMap<String, usize>` by splitting each `groups` value on `','` and trimming (empty segments skipped — identical tokenization to `secret_summary_matches_group`). Rows:
+
+```rust
+struct GroupListRow { group: String /* "Group" */, secrets: usize /* "Secrets" */ }
+```
+
+Rendered through `TableFormatter` with the global `--format`/`--columns`/`--template`/`--no-color`; human output adds `count_label(n, n, "group", "groups", Some("vault 'X'"), false)`; empty state via `empty_state_message("groups", Some("vault 'X'"))` on human formats, valid-empty rows on machine formats.
+
+### 3. `xv ls --sort name|updated`
+
+`LsSort` value-enum (`Name` default, `Updated`) on `Commands::List`, threaded through `execute_secret_list_direct` into `display_cached_secret_list` (`src/cli/secret_ops.rs:357`). `scope_secrets` keeps producing name-sorted output (its contract); when `Updated` is requested, a new `ls_view::sort_secrets_by_updated_desc` re-sorts `scoped.secrets` and `scoped.subtree` (descending `updated_on`, display-name ascending tiebreak — the backend timestamps are ISO-shaped so lexicographic order is chronological). Because every output mode (names-only, machine row array, explicit table, grid, long) renders from those two vectors, one sort site covers all modes. Folder cells in the grid stay alphabetical (folders have no update time).
+
+### 4. `context envs` deprecation
+
+`ContextCommands::Envs` (`src/cli/commands.rs:1284`) gains `#[command(hide = true)]`; `execute_context_envs` (`src/cli/config_ops.rs:1218`) emits `output::warn("context envs is deprecated; use env list")` before its existing delegation to `execute_env_list`. No behavior change otherwise; removal is a future release decision.
+
+### 5. `find --folder <path>`
+
+The segment-boundary scope rule currently inlined in `scope_secrets` (`src/cli/ls_view.rs:39-47`) is extracted into `ls_view::folder_in_scope(folder: &str, path: &str) -> bool` (exact match, or `folder` starts with `path + "/"`); `scope_secrets` is refactored onto it. `Commands::Find` gains `#[arg(long, value_name = "PATH")] folder: Option<String>`; the executor trims trailing `/`, validates via `validate_folder_path`, and filters `items` (the `CandidateItem` vec) with `folder_in_scope` **before** `score_matches` — in both the trait path (`src/cli/secret_ops.rs:~1880-1924`) and the legacy Azure path (`:~2013-2082`). `--names-only`, `--limit`, `--min-score`, and `--all-vaults` compose unchanged.
+
+### 6. Folder completion (`__complete-folders`)
+
+Mirror of the secret-name completion: `src/main.rs` intercepts `args[1] == "__complete-folders"` before clap (exactly like `__complete-secrets` at `src/main.rs:40-48`) and calls a new `execute_complete_folders(config)` in `secret_ops.rs` — cache-only (`CacheKey::SecretsList`), silent on cold cache, emitting every distinct folder path *and its ancestor prefixes* from the cached summaries, `BTreeSet`-sorted, one per line. Never touches a backend on a Tab press.
+
+### 7. Folder-qualified `ls -r` names
+
+New `ls_view::qualified_display_name(s: &SecretSummary, root: &str) -> String`: the secret's folder tag relative to the listing root (root itself stripped with the same segment-boundary rule) joined to `display_name` with `/`; secrets directly at the root stay unqualified. `display_cached_secret_list` applies it when `recursive` is set: names-only prints qualified names, and the grid/long entries are built from summaries whose display name has been qualified (so `xv ls -r` shows `prod/db-pass`, `xv ls prod -r` shows `db/db-pass`). Non-recursive output and machine formats are untouched.
+
+### 8. CJK-safe display widths
+
+Add `unicode-width` (workspace dependency). `ls_view.rs` gains `display_width(&str) -> usize` (`UnicodeWidthStr::width`) and a `pad_to(s, w)` helper (manual space padding — `format!("{:<w$}")` pads by char count and is abandoned where widths matter). Converted sites:
+
+- `render_grid` label lengths (`src/cli/ls_view.rs:123`),
+- `render_long` column widths and padding (`:223,229,235` + the `{:<name_w$}` format strings),
+- `truncate_note` (`:180` — truncation accumulates per-char `UnicodeWidthChar` widths against the max column budget),
+- the `xv ls` table note-wrap helpers `wrap_paragraph_to_width`/`push_wrapped_word` (`src/cli/secret_ops.rs:322,331,346`),
+- the new `render_deleted_long` (§1) is born width-aware.
+
+Grep confirms no other list-rendering site measures display width by chars; `tabled` (used by `TableFormatter`) has its own width handling and is not modified.
+
+### 9. Inherited fixes
+
+- **`xv parse` double-print:** `SecretManager::parse_connection_string` (`src/secret/manager.rs:1956`) drops its `TableFormatter` + `println!` block and just returns the components; `execute_secret_parse` (`src/cli/secret_ops.rs:3589`), its only caller (verified by grep), keeps rendering. One table per invocation, and `parse --fmt json` stops leaking a table.
+- **Plural-aware pagination footer:** `Page::human_summary` and `pagination_footer_text` (`src/utils/pagination.rs:57,142`) take `noun_singular` + `noun_plural` (plural chosen from `total_items`, zero is plural — same rule as `count_label`); the dead `print_pagination_footer` (`:134`, `#[allow(dead_code)]`, no callers) is deleted. All 8 call sites updated: `file_ops.rs:700,752` and `file_ops_aws.rs:1118` (`item/items`), `vault_ops.rs:413` (`vault/vaults`), `vault_ops.rs:1290` + `secret_ops.rs:3762` (`assignment/assignments`), `secret_ops.rs:466` (`secret/secrets`), `secret_ops.rs:523` (`entry/entries`).
+- **Silent vault-cache refresh:** `refresh_vault_list` (`src/cli/config_ops.rs:884`) calls `vault_manager.vault_ops().list_vaults(Some(&config.subscription_id), None)` (`src/vault/manager.rs:41` accessor) instead of `list_vaults_formatted`, then caches the same `Vec<VaultSummary>`. Nothing reaches stdout. (The background-spawned refresh already nulls stdio — `src/cache/refresh.rs:43-48` — the bug bit manual `xv cache refresh --key vaults` runs.)
+
+## Out of scope
+
+- `xv parse`'s bespoke `--fmt json|table` string flag (it predates the global `--format`; normalizing it is a separate breaking change).
+- Any restore/purge UX changes (interactive pickers over the new deleted listing, purge-all, etc.).
+- Group management verbs (`group add/rename/rm`) — `group` ships with `list` only.
+- Completion-script generation changes (`xv completion` output stays vanilla clap; `__complete-folders`, like `__complete-secrets`, is for user shell wiring).
+- `vault share list --fmt` removal (still release-gated), TUI changes, AWS `file sync`.
+
+## Testing
+
+- Unit: `DeletedSecretSummary` parsing (Azure `deletedDate`/`scheduledPurgeDate` epochs, local `@millis` trash stems, AWS entry mapping where testable), `folder_in_scope` boundary cases (`prod` vs `production`), `qualified_display_name` (root/nested/relative-root), `sort_secrets_by_updated_desc` (desc + name tiebreak), group derivation (split/trim/dedupe counts), plural `human_summary`, `display_width`/`pad_to`/CJK grid + long alignment + note wrap, `render_deleted_long` snapshot.
+- Behavioral (local backend, temp config): delete → `xv ls --deleted` shows name + deleted date (purge column empty) in table and grid; `--deleted --format json | jq type` = array (empty vault ⇒ `[]`); `xv ls --deleted prod` and `--deleted -r` are clap errors; `xv group list --format csv` headers `Group,Secrets`; `xv ls --sort updated` newest-first in grid and JSON; `xv ls -r` shows `folder/name`; `xv find x --folder prod` excludes `production`; `xv __complete-folders` emits `prod` and `prod/db`; `xv context envs` warns on stderr and still lists; `xv parse "a=b;c=d"` prints exactly one table; `xv cache refresh --key vaults` prints nothing to stdout.
+- Gates: `cargo fmt --check`, `cargo clippy --all-targets` (0 warnings), `cargo test --lib`, full `cargo test`.
+- Safety: implementers never run `xv init` or write to `~/.config/xv/`; local-backend tests use `XV_BACKEND=local` with a temp `XDG_CONFIG_HOME`; any e2e vault fixtures are deleted **and purged** even on failure.

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -3,7 +3,8 @@
 use crate::backend::error::BackendError;
 use crate::backend::SecretBackend;
 use crate::secret::manager::{
-    FieldUpdate, SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest,
+    DeletedSecretSummary, FieldUpdate, SecretProperties, SecretRequest, SecretSummary,
+    SecretUpdateRequest,
 };
 use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
@@ -846,13 +847,16 @@ impl SecretBackend for AwsSecretBackend {
         self.get_secret(vault, name, false).await
     }
 
-    async fn list_deleted_secrets(&self, vault: &str) -> Result<Vec<SecretSummary>, BackendError> {
+    async fn list_deleted_secrets(
+        &self,
+        vault: &str,
+    ) -> Result<Vec<DeletedSecretSummary>, BackendError> {
         use crate::backend::aws::encoding::{is_marker, strip_prefix};
         use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
 
         let prefix = format!("{vault}/");
         let mut next_token: Option<String> = None;
-        let mut summaries: Vec<SecretSummary> = Vec::new();
+        let mut summaries: Vec<DeletedSecretSummary> = Vec::new();
 
         loop {
             let mut req = self
@@ -884,15 +888,16 @@ impl SecretBackend for AwsSecretBackend {
                 if is_marker(aws_full_name) {
                     continue;
                 }
-                summaries.push(SecretSummary {
+                summaries.push(DeletedSecretSummary {
                     name: secret_name.clone(),
                     original_name: secret_name,
-                    note: None,
-                    folder: None,
-                    groups: None,
-                    updated_on: String::new(),
-                    enabled: true,
-                    content_type: String::new(),
+                    deleted_on: entry
+                        .deleted_date()
+                        .and_then(|d| chrono::DateTime::from_timestamp(d.secs(), 0))
+                        .map(|dt| dt.to_string()),
+                    // ListSecrets doesn't expose the recovery window, so the
+                    // purge time (DeletedDate + window) is unknowable here.
+                    scheduled_purge_on: None,
                 });
             }
 

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -663,6 +663,14 @@ impl SecretBackend for AwsSecretBackend {
         use crate::backend::aws::metadata::{TAG_EXPIRES_AT, TAG_FOLDER, TAG_GROUPS};
         use aws_sdk_secretsmanager::types::Tag;
 
+        // AWS Secrets Manager has no enable/disable concept — fail loudly
+        // instead of silently dropping the flag.
+        if request.enabled.is_some() {
+            return Err(BackendError::Unsupported(
+                "enable/disable secrets".to_string(),
+            ));
+        }
+
         let aws_full_name = aws_name(vault, name);
 
         // Update description (note): Set writes the new text, Clear empties it.

--- a/src/backend/azure/secrets.rs
+++ b/src/backend/azure/secrets.rs
@@ -87,8 +87,10 @@ fn build_patched_tags(
     };
 
     // Resolve groups: honor replace_groups semantics.
+    // When request.groups is None, preserve existing groups (no change requested).
     let groups = match &request.groups {
         Some(new_groups) if !request.replace_groups => {
+            // Merge: append new_groups to existing
             let mut existing: Vec<String> = current_tags
                 .get("groups")
                 .map(|g| g.split(',').map(|s| s.trim().to_string()).collect())
@@ -100,16 +102,33 @@ fn build_patched_tags(
             }
             Some(existing)
         }
-        other => other.clone(),
+        Some(new_groups) => {
+            // Replace: use new_groups as-is (may be empty)
+            Some(new_groups.clone())
+        }
+        None => {
+            // No change requested: preserve existing groups
+            current_tags.get("groups").map(|g| {
+                g.split(',')
+                    .map(|s| s.trim().to_string())
+                    .collect::<Vec<_>>()
+            })
+        }
     };
 
     tags.insert("original_name".to_string(), request.name.clone());
     tags.insert("created_by".to_string(), "crosstache".to_string());
+
+    // Handle groups: remove first, then conditionally insert.
+    tags.remove("groups");
     if let Some(groups) = groups {
         if !groups.is_empty() {
             tags.insert("groups".to_string(), groups.join(","));
         }
     }
+
+    // Handle note: remove first, then conditionally insert.
+    tags.remove("note");
     if let Some(note) = request
         .note
         .clone()
@@ -117,6 +136,9 @@ fn build_patched_tags(
     {
         tags.insert("note".to_string(), note);
     }
+
+    // Handle folder: remove first, then conditionally insert.
+    tags.remove("folder");
     if let Some(folder) = request
         .folder
         .clone()
@@ -124,6 +146,7 @@ fn build_patched_tags(
     {
         tags.insert("folder".to_string(), folder);
     }
+
     tags
 }
 
@@ -517,5 +540,84 @@ mod build_patched_tags_tests {
         let result = build_patched_tags(&request, &current);
 
         assert_eq!(result.get("groups").map(String::as_str), Some("team-a,b"));
+    }
+
+    #[test]
+    fn clear_note_removes_existing_note() {
+        let current = current_tags();
+        let mut request = base_request("my-secret");
+        request.note = FieldUpdate::Clear;
+
+        let result = build_patched_tags(&request, &current);
+
+        // Note key should be completely removed
+        assert!(!result.contains_key("note"));
+        // Other tags should be preserved
+        assert_eq!(result.get("custom").map(String::as_str), Some("keep"));
+        assert_eq!(result.get("groups").map(String::as_str), Some("team-a"));
+    }
+
+    #[test]
+    fn clear_folder_removes_existing_folder() {
+        let mut current = current_tags();
+        current.insert("folder".to_string(), "app/db".to_string());
+        let mut request = base_request("my-secret");
+        request.folder = FieldUpdate::Clear;
+
+        let result = build_patched_tags(&request, &current);
+
+        // Folder key should be completely removed
+        assert!(!result.contains_key("folder"));
+        // Other tags should be preserved
+        assert_eq!(result.get("custom").map(String::as_str), Some("keep"));
+        assert_eq!(result.get("groups").map(String::as_str), Some("team-a"));
+        assert_eq!(result.get("note").map(String::as_str), Some("old"));
+    }
+
+    #[test]
+    fn clear_groups_via_replace_empty_list() {
+        let current = current_tags();
+        let mut request = base_request("my-secret");
+        request.groups = Some(vec![]); // Empty list with replace_groups=true
+        request.replace_groups = true;
+
+        let result = build_patched_tags(&request, &current);
+
+        // Groups key should be completely removed
+        assert!(!result.contains_key("groups"));
+        // Other tags should be preserved
+        assert_eq!(result.get("custom").map(String::as_str), Some("keep"));
+        assert_eq!(result.get("note").map(String::as_str), Some("old"));
+    }
+
+    #[test]
+    fn unchanged_note_preserves_existing_value() {
+        let current = current_tags();
+        let mut request = base_request("my-secret");
+        request.note = FieldUpdate::Unchanged; // Explicitly unchanged
+
+        let result = build_patched_tags(&request, &current);
+
+        // Note should be preserved from current_tags
+        assert_eq!(result.get("note").map(String::as_str), Some("old"));
+        // Other tags should be preserved
+        assert_eq!(result.get("custom").map(String::as_str), Some("keep"));
+        assert_eq!(result.get("groups").map(String::as_str), Some("team-a"));
+    }
+
+    #[test]
+    fn unchanged_folder_preserves_existing_value() {
+        let mut current = current_tags();
+        current.insert("folder".to_string(), "app/db".to_string());
+        let mut request = base_request("my-secret");
+        request.folder = FieldUpdate::Unchanged; // Explicitly unchanged
+
+        let result = build_patched_tags(&request, &current);
+
+        // Folder should be preserved from current_tags
+        assert_eq!(result.get("folder").map(String::as_str), Some("app/db"));
+        // Other tags should be preserved
+        assert_eq!(result.get("custom").map(String::as_str), Some("keep"));
+        assert_eq!(result.get("groups").map(String::as_str), Some("team-a"));
     }
 }

--- a/src/backend/azure/secrets.rs
+++ b/src/backend/azure/secrets.rs
@@ -8,11 +8,13 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use std::collections::HashMap;
+
 use crate::backend::error::BackendError;
 use crate::backend::secret::SecretBackend;
 use crate::secret::manager::{
-    DeletedSecretSummary, SecretOperations, SecretProperties, SecretRequest, SecretSummary,
-    SecretUpdateRequest,
+    DeletedSecretSummary, FieldUpdate, SecretAttributesUpdate, SecretOperations, SecretProperties,
+    SecretRequest, SecretSummary, SecretUpdateRequest,
 };
 
 use super::map_error;
@@ -30,6 +32,95 @@ impl AzureSecretBackend {
     pub fn new(inner: Arc<dyn SecretOperations>) -> Self {
         Self { inner }
     }
+
+    /// Fetch the current tags of a secret, tolerating disabled secrets.
+    ///
+    /// `GET {vault}/secrets/{name}` returns HTTP 403 `SecretDisabled` for a
+    /// disabled secret, but the versions list (`GET .../versions`) still
+    /// exposes attributes and tags, so use it as the second source.
+    async fn current_tags(
+        &self,
+        vault: &str,
+        name: &str,
+    ) -> Result<HashMap<String, String>, BackendError> {
+        let get_err = match self.inner.get_secret(vault, name, false).await {
+            Ok(current) => return Ok(current.tags),
+            Err(e) => e,
+        };
+        let mut versions = self
+            .inner
+            .get_secret_versions(vault, name)
+            .await
+            .map_err(|_| map_error(get_err))?;
+        versions.sort_by_key(|v| v.created_timestamp);
+        versions
+            .pop()
+            .map(|v| v.tags)
+            .ok_or_else(|| BackendError::NotFound {
+                name: name.to_string(),
+                suggestion: None,
+            })
+    }
+}
+
+/// Build the full replacement tag map for an attributes-only `PATCH`,
+/// mirroring the legacy full-write pipeline: resolve merge/replace semantics
+/// against the current tags, then stamp crosstache's metadata tags exactly as
+/// `prepare_secret_request` does.
+fn build_patched_tags(
+    request: &SecretUpdateRequest,
+    current_tags: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    // Resolve tags: honor replace_tags semantics.
+    let mut tags = match &request.tags {
+        Some(new_tags) if !request.replace_tags => {
+            let mut merged = current_tags.clone();
+            merged.extend(new_tags.clone());
+            merged
+        }
+        Some(new_tags) => new_tags.clone(),
+        None => HashMap::new(),
+    };
+
+    // Resolve groups: honor replace_groups semantics.
+    let groups = match &request.groups {
+        Some(new_groups) if !request.replace_groups => {
+            let mut existing: Vec<String> = current_tags
+                .get("groups")
+                .map(|g| g.split(',').map(|s| s.trim().to_string()).collect())
+                .unwrap_or_default();
+            for g in new_groups {
+                if !existing.contains(g) {
+                    existing.push(g.clone());
+                }
+            }
+            Some(existing)
+        }
+        other => other.clone(),
+    };
+
+    tags.insert("original_name".to_string(), request.name.clone());
+    tags.insert("created_by".to_string(), "crosstache".to_string());
+    if let Some(groups) = groups {
+        if !groups.is_empty() {
+            tags.insert("groups".to_string(), groups.join(","));
+        }
+    }
+    if let Some(note) = request
+        .note
+        .clone()
+        .apply(current_tags.get("note").cloned())
+    {
+        tags.insert("note".to_string(), note);
+    }
+    if let Some(folder) = request
+        .folder
+        .clone()
+        .apply(current_tags.get("folder").cloned())
+    {
+        tags.insert("folder".to_string(), folder);
+    }
+    tags
 }
 
 #[async_trait]
@@ -94,6 +185,53 @@ impl SecretBackend for AzureSecretBackend {
         name: &str,
         request: SecretUpdateRequest,
     ) -> Result<SecretProperties, BackendError> {
+        // Attributes/tags-only updates (no value change, no rename) go
+        // through `PATCH {vault}/secrets/{name}` instead of the full-write
+        // path below: the full write must read the current value first and
+        // confirm afterwards, both of which return HTTP 403 `SecretDisabled`
+        // on a disabled secret — making `xv update --enabled true` (re-enable)
+        // impossible. PATCH touches only attributes/tags, works on disabled
+        // secrets, and creates no new version.
+        //
+        // Clearing exp/nbf still needs the full write: omitted PATCH
+        // attribute fields are left unchanged, so a clear cannot be expressed.
+        let attributes_only = request.value.is_none() && request.new_name.is_none();
+        let clears_dates = matches!(request.expires_on, FieldUpdate::Clear)
+            || matches!(request.not_before, FieldUpdate::Clear);
+        if attributes_only && !clears_dates {
+            // PATCH replaces the whole tag map when `tags` is present, so a
+            // tag-affecting change needs the current tags to build the full
+            // desired map; otherwise omit `tags` and Azure leaves them as-is.
+            let tag_affecting = request.tags.is_some()
+                || request.groups.is_some()
+                || !request.note.is_unchanged()
+                || !request.folder.is_unchanged();
+            let tags = if tag_affecting {
+                let current_tags = self.current_tags(vault, name).await?;
+                Some(build_patched_tags(&request, &current_tags))
+            } else {
+                None
+            };
+            let update = SecretAttributesUpdate {
+                enabled: request.enabled,
+                content_type: request.content_type.clone(),
+                expires_on: match request.expires_on {
+                    FieldUpdate::Set(v) => Some(v),
+                    _ => None,
+                },
+                not_before: match request.not_before {
+                    FieldUpdate::Set(v) => Some(v),
+                    _ => None,
+                },
+                tags,
+            };
+            return self
+                .inner
+                .update_secret_attributes(vault, name, &update)
+                .await
+                .map_err(map_error);
+        }
+
         // The old SecretOperations::update_secret takes &SecretRequest, but
         // the new trait takes SecretUpdateRequest. Translate by building a
         // SecretRequest from the update request fields.

--- a/src/backend/azure/secrets.rs
+++ b/src/backend/azure/secrets.rs
@@ -11,7 +11,8 @@ use async_trait::async_trait;
 use crate::backend::error::BackendError;
 use crate::backend::secret::SecretBackend;
 use crate::secret::manager::{
-    SecretOperations, SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest,
+    DeletedSecretSummary, SecretOperations, SecretProperties, SecretRequest, SecretSummary,
+    SecretUpdateRequest,
 };
 
 use super::map_error;
@@ -241,7 +242,10 @@ impl SecretBackend for AzureSecretBackend {
             .map_err(map_error)
     }
 
-    async fn list_deleted_secrets(&self, vault: &str) -> Result<Vec<SecretSummary>, BackendError> {
+    async fn list_deleted_secrets(
+        &self,
+        vault: &str,
+    ) -> Result<Vec<DeletedSecretSummary>, BackendError> {
         self.inner
             .list_deleted_secrets(vault)
             .await

--- a/src/backend/azure/secrets.rs
+++ b/src/backend/azure/secrets.rs
@@ -79,7 +79,11 @@ fn build_patched_tags(
             merged
         }
         Some(new_tags) => new_tags.clone(),
-        None => HashMap::new(),
+        // No tag change requested: preserve every existing tag (including
+        // custom user tags and `groups`) rather than starting from an empty
+        // map. The crosstache-managed keys below are re-stamped on top, and
+        // note/folder/groups overrides (if any) still apply after that.
+        None => current_tags.clone(),
     };
 
     // Resolve groups: honor replace_groups semantics.
@@ -406,5 +410,112 @@ impl SecretBackend for AzureSecretBackend {
             .restore_secret_from_backup(vault, backup)
             .await
             .map_err(map_error)
+    }
+}
+
+#[cfg(test)]
+mod build_patched_tags_tests {
+    use super::*;
+    use crate::secret::manager::FieldUpdate;
+
+    fn base_request(name: &str) -> SecretUpdateRequest {
+        SecretUpdateRequest {
+            name: name.to_string(),
+            new_name: None,
+            value: None,
+            content_type: None,
+            enabled: None,
+            expires_on: FieldUpdate::Unchanged,
+            not_before: FieldUpdate::Unchanged,
+            tags: None,
+            groups: None,
+            note: FieldUpdate::Unchanged,
+            folder: FieldUpdate::Unchanged,
+            replace_tags: false,
+            replace_groups: false,
+        }
+    }
+
+    fn current_tags() -> HashMap<String, String> {
+        let mut tags = HashMap::new();
+        tags.insert("groups".to_string(), "team-a".to_string());
+        tags.insert("custom".to_string(), "keep".to_string());
+        tags.insert("note".to_string(), "old".to_string());
+        tags
+    }
+
+    #[test]
+    fn none_tags_preserves_existing_custom_tags_and_groups() {
+        let current = current_tags();
+        let mut request = base_request("my-secret");
+        request.note = FieldUpdate::Set("new".to_string());
+
+        let result = build_patched_tags(&request, &current);
+
+        assert_eq!(result.get("custom").map(String::as_str), Some("keep"));
+        assert_eq!(result.get("groups").map(String::as_str), Some("team-a"));
+        assert_eq!(result.get("note").map(String::as_str), Some("new"));
+        assert_eq!(
+            result.get("original_name").map(String::as_str),
+            Some("my-secret")
+        );
+        assert_eq!(
+            result.get("created_by").map(String::as_str),
+            Some("crosstache")
+        );
+    }
+
+    #[test]
+    fn some_tags_without_replace_merges_over_current() {
+        let current = current_tags();
+        let mut request = base_request("my-secret");
+        let mut new_tags = HashMap::new();
+        new_tags.insert("x".to_string(), "1".to_string());
+        request.tags = Some(new_tags);
+        request.replace_tags = false;
+
+        let result = build_patched_tags(&request, &current);
+
+        assert_eq!(result.get("x").map(String::as_str), Some("1"));
+        // Existing custom tag and groups survive the merge.
+        assert_eq!(result.get("custom").map(String::as_str), Some("keep"));
+        assert_eq!(result.get("groups").map(String::as_str), Some("team-a"));
+    }
+
+    #[test]
+    fn some_tags_with_replace_drops_current_custom_tags() {
+        let current = current_tags();
+        let mut request = base_request("my-secret");
+        let mut new_tags = HashMap::new();
+        new_tags.insert("x".to_string(), "1".to_string());
+        request.tags = Some(new_tags);
+        request.replace_tags = true;
+
+        let result = build_patched_tags(&request, &current);
+
+        assert_eq!(result.get("x").map(String::as_str), Some("1"));
+        // Full replacement: old custom tag is gone...
+        assert!(!result.contains_key("custom"));
+        // ...but crosstache-managed keys are always re-stamped.
+        assert_eq!(
+            result.get("original_name").map(String::as_str),
+            Some("my-secret")
+        );
+        assert_eq!(
+            result.get("created_by").map(String::as_str),
+            Some("crosstache")
+        );
+    }
+
+    #[test]
+    fn groups_merge_appends_to_existing_groups() {
+        let current = current_tags();
+        let mut request = base_request("my-secret");
+        request.groups = Some(vec!["b".to_string()]);
+        request.replace_groups = false;
+
+        let result = build_patched_tags(&request, &current);
+
+        assert_eq!(result.get("groups").map(String::as_str), Some("team-a,b"));
     }
 }

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -24,7 +24,9 @@ use zeroize::Zeroizing;
 
 use crate::backend::error::BackendError;
 use crate::backend::secret::SecretBackend;
-use crate::secret::manager::{SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest};
+use crate::secret::manager::{
+    DeletedSecretSummary, SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest,
+};
 
 use super::{crypto, opaque, paths};
 
@@ -1790,7 +1792,10 @@ impl SecretBackend for LocalSecretBackend {
         Ok(())
     }
 
-    async fn list_deleted_secrets(&self, vault: &str) -> Result<Vec<SecretSummary>, BackendError> {
+    async fn list_deleted_secrets(
+        &self,
+        vault: &str,
+    ) -> Result<Vec<DeletedSecretSummary>, BackendError> {
         let tbase = trash_base_dir(&self.store_path, vault)?;
         if !tbase.exists() {
             return Ok(Vec::new());
@@ -1805,6 +1810,16 @@ impl SecretBackend for LocalSecretBackend {
                 continue;
             }
 
+            // Trash entry dirs are named `{stem}@{deleted_at_millis}` (see
+            // `trash_entry_dir`); legacy unsuffixed dirs simply yield None.
+            let dir_name = entry.file_name().to_string_lossy().to_string();
+            let deleted_on = dir_name
+                .rsplit('@')
+                .next()
+                .and_then(|ms| ms.parse::<i64>().ok())
+                .and_then(chrono::DateTime::from_timestamp_millis)
+                .map(|dt| dt.to_string());
+
             // Look for .meta.json files in this trash entry
             let dir_path = entry.path();
             if let Ok(inner_entries) = fs::read_dir(&dir_path) {
@@ -1812,7 +1827,14 @@ impl SecretBackend for LocalSecretBackend {
                     let fname = inner.file_name().to_string_lossy().to_string();
                     if fname.ends_with(".meta.json") {
                         if let Ok(meta) = read_meta(&inner.path(), &self.identity) {
-                            results.push(meta_to_summary(&meta));
+                            results.push(DeletedSecretSummary {
+                                name: meta.name.clone(),
+                                original_name: meta.original_name.clone(),
+                                deleted_on: deleted_on.clone(),
+                                // Local trash persists until an explicit
+                                // `xv purge` — no schedule to report.
+                                scheduled_purge_on: None,
+                            });
                         }
                     }
                 }
@@ -2309,6 +2331,28 @@ mod tests {
         // Deleted list should be empty
         let deleted = backend.list_deleted_secrets("default").await.unwrap();
         assert!(deleted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn deleted_listing_carries_deletion_date_but_no_purge_schedule() {
+        let (backend, _tmp) = test_backend();
+        backend
+            .set_secret("default", make_request("dated", "v1"))
+            .await
+            .unwrap();
+        backend.delete_secret("default", "dated").await.unwrap();
+
+        let deleted = backend.list_deleted_secrets("default").await.unwrap();
+        assert_eq!(deleted.len(), 1);
+        assert_eq!(deleted[0].name, "dated");
+        assert!(
+            deleted[0].deleted_on.is_some(),
+            "deleted_on must come from the trash dir's @millis suffix"
+        );
+        assert!(
+            deleted[0].scheduled_purge_on.is_none(),
+            "local trash never auto-purges"
+        );
     }
 
     #[tokio::test]

--- a/src/backend/secret.rs
+++ b/src/backend/secret.rs
@@ -6,7 +6,9 @@
 
 use async_trait::async_trait;
 
-use crate::secret::manager::{SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest};
+use crate::secret::manager::{
+    DeletedSecretSummary, SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest,
+};
 
 use super::error::BackendError;
 
@@ -107,7 +109,10 @@ pub trait SecretBackend: Send + Sync {
     }
 
     /// List deleted secrets (only meaningful when soft-delete is supported).
-    async fn list_deleted_secrets(&self, _vault: &str) -> Result<Vec<SecretSummary>, BackendError> {
+    async fn list_deleted_secrets(
+        &self,
+        _vault: &str,
+    ) -> Result<Vec<DeletedSecretSummary>, BackendError> {
         Err(BackendError::Unsupported("list deleted secrets".into()))
     }
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -43,6 +43,16 @@ impl PagerWhen {
     }
 }
 
+/// Sort order for `xv ls`.
+#[derive(Debug, Clone, Copy, clap::ValueEnum, PartialEq, Eq, Default)]
+pub enum LsSort {
+    /// Alphabetical by display name (default).
+    #[default]
+    Name,
+    /// Most recently updated first (deleted date in `--deleted` mode).
+    Updated,
+}
+
 #[derive(Debug, Clone, clap::ValueEnum, PartialEq, Eq, Default)]
 pub enum OnConflict {
     /// Skip secrets that already exist in the target (default)
@@ -509,6 +519,9 @@ pub enum Commands {
         /// Overrides --format and disables auto-format-resolution.
         #[arg(long)]
         names_only: bool,
+        /// Sort order: name (A→Z, default) or updated (newest first)
+        #[arg(long, value_enum, default_value_t = LsSort::Name)]
+        sort: LsSort,
     },
     /// Delete a secret from the current vault context (alias: rm)
     #[command(alias = "rm")]
@@ -1510,6 +1523,7 @@ impl Cli {
                 page_size,
                 pager,
                 names_only,
+                sort,
             } => {
                 let pagination = crate::utils::pagination::Pagination::from_args(page, page_size)?;
                 let pager = pager.map(PagerWhen::wants_pager).unwrap_or(false);
@@ -1525,7 +1539,7 @@ impl Cli {
                 };
                 crate::cli::secret_ops::execute_secret_list_direct(
                     path, group, all, expiring, expired, no_cache, pagination, pager, names_only,
-                    long, recursive, config, registry,
+                    long, recursive, sort, config, registry,
                 )
                 .await
             }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -696,6 +696,9 @@ pub enum Commands {
         /// Clear the folder
         #[arg(long, conflicts_with = "folder")]
         clear_folder: bool,
+        /// Enable or disable the secret (true/false)
+        #[arg(long)]
+        enabled: Option<bool>,
     },
     /// Compare secrets between two vaults
     Diff {
@@ -1667,6 +1670,7 @@ impl Cli {
                 clear_not_before,
                 clear_note,
                 clear_folder,
+                enabled,
             } => {
                 crate::cli::secret_ops::execute_secret_update_direct(
                     &name,
@@ -1686,6 +1690,7 @@ impl Cli {
                     clear_not_before,
                     clear_note,
                     clear_folder,
+                    enabled,
                     config,
                     registry,
                 )

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1308,7 +1308,8 @@ pub enum ContextCommands {
         #[arg(long)]
         global: bool,
     },
-    /// List environment profiles in the resolved .xv.toml
+    /// (deprecated) List environment profiles in the resolved .xv.toml — use `env list`
+    #[command(hide = true)]
     Envs,
     /// Create a new .xv.toml in the current directory
     Init {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -522,6 +522,13 @@ pub enum Commands {
         /// Sort order: name (A→Z, default) or updated (newest first)
         #[arg(long, value_enum, default_value_t = LsSort::Name)]
         sort: LsSort,
+        /// List soft-deleted secrets awaiting restore/purge instead of live
+        /// secrets (backend must support soft delete)
+        #[arg(
+            long,
+            conflicts_with_all = ["path", "recursive", "group", "all", "expiring", "expired"]
+        )]
+        deleted: bool,
     },
     /// Delete a secret from the current vault context (alias: rm)
     #[command(alias = "rm")]
@@ -1524,24 +1531,32 @@ impl Cli {
                 pager,
                 names_only,
                 sort,
+                deleted,
             } => {
                 let pagination = crate::utils::pagination::Pagination::from_args(page, page_size)?;
                 let pager = pager.map(PagerWhen::wants_pager).unwrap_or(false);
-                let path = match path {
-                    Some(raw) => {
-                        let trimmed = raw.trim_end_matches('/').to_string();
-                        if !trimmed.is_empty() {
-                            crate::utils::helpers::validate_folder_path(&trimmed)?;
+                if deleted {
+                    crate::cli::secret_ops::execute_deleted_secret_list(
+                        pagination, pager, names_only, long, sort, config, registry,
+                    )
+                    .await
+                } else {
+                    let path = match path {
+                        Some(raw) => {
+                            let trimmed = raw.trim_end_matches('/').to_string();
+                            if !trimmed.is_empty() {
+                                crate::utils::helpers::validate_folder_path(&trimmed)?;
+                            }
+                            trimmed
                         }
-                        trimmed
-                    }
-                    None => String::new(),
-                };
-                crate::cli::secret_ops::execute_secret_list_direct(
-                    path, group, all, expiring, expired, no_cache, pagination, pager, names_only,
-                    long, recursive, sort, config, registry,
-                )
-                .await
+                        None => String::new(),
+                    };
+                    crate::cli::secret_ops::execute_secret_list_direct(
+                        path, group, all, expiring, expired, no_cache, pagination, pager,
+                        names_only, long, recursive, sort, config, registry,
+                    )
+                    .await
+                }
             }
             Commands::Delete { name, group, force } => {
                 crate::cli::secret_ops::execute_secret_delete_direct(

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -800,6 +800,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: EnvCommands,
     },
+    /// Inspect secret groups in the current vault context
+    Group {
+        #[command(subcommand)]
+        command: GroupCommands,
+    },
     /// Show audit history for secrets or vaults
     Audit {
         /// Secret name to show audit history for (exclusive with --vault)
@@ -1394,6 +1399,16 @@ pub enum EnvCommands {
 }
 
 #[derive(Subcommand)]
+pub enum GroupCommands {
+    /// List groups and member counts derived from secret metadata
+    List {
+        /// Bypass the local cache and fetch fresh data
+        #[arg(long)]
+        no_cache: bool,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum ScanCommands {
     /// Install a pre-commit hook that runs `xv scan --staged --hook`.
     Install {
@@ -1752,6 +1767,9 @@ impl Cli {
             }
             Commands::Env { command } => {
                 crate::cli::config_ops::execute_env_command(command, config, registry).await
+            }
+            Commands::Group { command } => {
+                crate::cli::secret_ops::execute_group_command(command, config, registry).await
             }
             Commands::Audit {
                 name,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -465,6 +465,11 @@ pub enum Commands {
         )]
         min_score: f32,
 
+        /// Only search secrets in this folder (or its subfolders, segment
+        /// boundary enforced: `prod` matches `prod/db` but not `production`).
+        #[arg(long, value_name = "PATH")]
+        folder: Option<String>,
+
         /// Search every vault the caller has list rights on. Slow on
         /// cold cache. Mutually exclusive with vault-resolved context.
         #[arg(long)]
@@ -1520,6 +1525,7 @@ impl Cli {
                 in_fields,
                 limit,
                 min_score,
+                folder,
                 all_vaults,
                 names_only,
             } => {
@@ -1528,6 +1534,7 @@ impl Cli {
                     in_fields,
                     limit,
                     min_score,
+                    folder,
                     all_vaults,
                     names_only,
                     self.format,

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -913,13 +913,11 @@ async fn refresh_vault_list(config: Config) -> Result<()> {
         config.no_color,
     )?;
 
+    // Fetch WITHOUT rendering: this runs as a cache refresh (often spawned by
+    // `xv cache refresh --key vaults`), so nothing may reach stdout.
     let vaults = vault_manager
-        .list_vaults_formatted(
-            Some(&config.subscription_id),
-            None,
-            crate::utils::format::OutputFormat::Json,
-            None,
-        )
+        .vault_ops()
+        .list_vaults(Some(&config.subscription_id), None)
         .await?;
 
     let cache_manager = CacheManager::from_config(&config);

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -1227,6 +1227,7 @@ async fn execute_context_clear(global: bool, _config: &Config) -> Result<()> {
 }
 
 async fn execute_context_envs(config: &Config) -> Result<()> {
+    crate::utils::output::warn("context envs is deprecated; use env list");
     execute_env_list(config).await
 }
 

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -704,7 +704,7 @@ async fn execute_file_list(
             if !output.is_empty() {
                 output.push('\n');
                 if let Some(footer) =
-                    pagination_footer_text(&page, "item", config.runtime_output_format)
+                    pagination_footer_text(&page, "item", "items", config.runtime_output_format)
                 {
                     output.push_str(&footer);
                 }
@@ -756,7 +756,9 @@ async fn execute_file_list(
     let mut output = display_file_list_items(&page.items, recursive, config)?;
     if !output.is_empty() {
         output.push('\n');
-        if let Some(footer) = pagination_footer_text(&page, "item", config.runtime_output_format) {
+        if let Some(footer) =
+            pagination_footer_text(&page, "item", "items", config.runtime_output_format)
+        {
             output.push_str(&footer);
         }
         crate::utils::pager::print_output(&output, pager)?;

--- a/src/cli/file_ops_aws.rs
+++ b/src/cli/file_ops_aws.rs
@@ -1115,7 +1115,9 @@ async fn execute_list(
     let mut rendered = display_file_list_items(&page.items, recursive, config)?;
     if !rendered.is_empty() {
         rendered.push('\n');
-        if let Some(footer) = pagination_footer_text(&page, "item", config.runtime_output_format) {
+        if let Some(footer) =
+            pagination_footer_text(&page, "item", "items", config.runtime_output_format)
+        {
             rendered.push_str(&footer);
         }
         crate::utils::pager::print_output(&rendered, pager)?;

--- a/src/cli/ls_view.rs
+++ b/src/cli/ls_view.rs
@@ -38,6 +38,41 @@ pub(crate) fn display_name(s: &SecretSummary) -> &str {
     }
 }
 
+/// Remainder of `folder` relative to scope `path` ("" = vault root):
+/// `Some("")` for an exact match, `Some(rest)` when `folder` is under
+/// `path` (segment boundary enforced), `None` when out of scope.
+pub(crate) fn relative_to_scope<'a>(folder: &'a str, path: &str) -> Option<&'a str> {
+    if path.is_empty() {
+        Some(folder)
+    } else if folder == path {
+        Some("")
+    } else {
+        folder
+            .strip_prefix(path)
+            .and_then(|rest| rest.strip_prefix('/'))
+    }
+}
+
+/// True when `folder` is at or under scope `path` (exact-or-prefix with
+/// segment boundary — the `xv ls` scoping rule, shared with `find --folder`).
+/// Not yet called outside tests: reused by the upcoming `find --folder`
+/// implementation (Task 11).
+#[allow(dead_code)]
+pub(crate) fn folder_in_scope(folder: &str, path: &str) -> bool {
+    relative_to_scope(folder, path).is_some()
+}
+
+/// Display name qualified by the folder path relative to the listing root
+/// (`prod/db` listed from root → `prod/db/name`; from `prod` → `db/name`;
+/// secrets directly at the root stay unqualified).
+pub(crate) fn qualified_display_name(s: &SecretSummary, root: &str) -> String {
+    let folder = s.folder.as_deref().unwrap_or("");
+    match relative_to_scope(folder, root) {
+        Some("") | None => display_name(s).to_string(),
+        Some(rel) => format!("{rel}/{}", display_name(s)),
+    }
+}
+
 /// Partition `secrets` relative to folder `path` ("" = vault root).
 /// A secret with folder tag F is in scope when F == path or F starts with
 /// "path/" (segment boundary enforced); its next path segment becomes a
@@ -49,16 +84,9 @@ pub(crate) fn scope_secrets(secrets: Vec<SecretSummary>, path: &str) -> ScopedLi
 
     for s in secrets {
         let folder = s.folder.as_deref().unwrap_or("");
-        let rel: Option<&str> = if path.is_empty() {
-            Some(folder)
-        } else if folder == path {
-            Some("")
-        } else {
-            folder
-                .strip_prefix(path)
-                .and_then(|rest| rest.strip_prefix('/'))
+        let Some(rel) = relative_to_scope(folder, path) else {
+            continue;
         };
-        let Some(rel) = rel else { continue };
         if rel.is_empty() {
             direct.push(s.clone());
         } else if let Some(segment) = rel.split('/').next() {
@@ -340,6 +368,30 @@ mod tests {
             enabled: true,
             content_type: "text/plain".to_string(),
         }
+    }
+
+    #[test]
+    fn folder_scope_helper_enforces_segment_boundary() {
+        assert!(folder_in_scope("prod", "prod"));
+        assert!(folder_in_scope("prod/db", "prod"));
+        assert!(folder_in_scope("prod/db/replica", "prod/db"));
+        assert!(!folder_in_scope("production", "prod"));
+        assert!(!folder_in_scope("dev", "prod"));
+        assert!(folder_in_scope("", "")); // root scopes everything
+        assert!(folder_in_scope("prod", ""));
+        assert!(!folder_in_scope("", "prod"));
+        assert_eq!(relative_to_scope("prod/db", "prod"), Some("db"));
+        assert_eq!(relative_to_scope("prod", "prod"), Some(""));
+    }
+
+    #[test]
+    fn qualified_names_are_relative_to_the_listing_root() {
+        let root_secret = summary("root-a", None);
+        let nested = summary("db-pass", Some("prod/db"));
+        assert_eq!(qualified_display_name(&root_secret, ""), "root-a");
+        assert_eq!(qualified_display_name(&nested, ""), "prod/db/db-pass");
+        assert_eq!(qualified_display_name(&nested, "prod"), "db/db-pass");
+        assert_eq!(qualified_display_name(&nested, "prod/db"), "db-pass");
     }
 
     #[test]

--- a/src/cli/ls_view.rs
+++ b/src/cli/ls_view.rs
@@ -70,6 +70,33 @@ pub(crate) fn qualified_display_name(s: &SecretSummary, root: &str) -> String {
     }
 }
 
+/// Subtree secrets with display names qualified relative to `root`, for the
+/// recursive (`-r`) views. `scope_secrets` sorts the subtree by the
+/// *unqualified* name, which would print `zeta/alpha` before `beta` — when
+/// `sort_by_name`, re-sort by the qualified label so output order matches
+/// what is displayed. Pass `false` to preserve the incoming order (e.g.
+/// `--sort updated`).
+pub(crate) fn qualified_subtree(
+    subtree: &[SecretSummary],
+    root: &str,
+    sort_by_name: bool,
+) -> Vec<SecretSummary> {
+    let mut qualified: Vec<SecretSummary> = subtree
+        .iter()
+        .map(|s| {
+            // Grid/long render `display_name` (== original_name when set);
+            // overriding it here is how the qualified label reaches them.
+            let mut q = s.clone();
+            q.original_name = qualified_display_name(s, root);
+            q
+        })
+        .collect();
+    if sort_by_name {
+        qualified.sort_by(|a, b| display_name(a).cmp(display_name(b)));
+    }
+    qualified
+}
+
 /// Partition `secrets` relative to folder `path` ("" = vault root).
 /// A secret with folder tag F is in scope when F == path or F starts with
 /// "path/" (segment boundary enforced); its next path segment becomes a
@@ -466,6 +493,27 @@ mod tests {
         assert_eq!(qualified_display_name(&nested, ""), "prod/db/db-pass");
         assert_eq!(qualified_display_name(&nested, "prod"), "db/db-pass");
         assert_eq!(qualified_display_name(&nested, "prod/db"), "db-pass");
+    }
+
+    #[test]
+    fn recursive_subtree_sorts_by_qualified_label() {
+        // Unqualified sort puts `alpha` (in zeta/) before `beta`; the
+        // recursive view prints `zeta/alpha`, so name sort must use the
+        // qualified label: beta < zeta/alpha.
+        let scoped = scope_secrets(
+            vec![summary("beta", None), summary("alpha", Some("zeta"))],
+            "",
+        );
+        assert_eq!(display_name(&scoped.subtree[0]), "alpha");
+
+        let by_name = qualified_subtree(&scoped.subtree, "", true);
+        assert_eq!(display_name(&by_name[0]), "beta");
+        assert_eq!(display_name(&by_name[1]), "zeta/alpha");
+
+        // sort_by_name=false (e.g. --sort updated) keeps the incoming order.
+        let stable = qualified_subtree(&scoped.subtree, "", false);
+        assert_eq!(display_name(&stable[0]), "zeta/alpha");
+        assert_eq!(display_name(&stable[1]), "beta");
     }
 
     #[test]

--- a/src/cli/ls_view.rs
+++ b/src/cli/ls_view.rs
@@ -3,7 +3,7 @@
 //! Folders are a client-side view derived from each secret's hierarchical
 //! `folder` tag (e.g. `prod/db`). Nothing here talks to a backend.
 
-use crate::secret::manager::SecretSummary;
+use crate::secret::manager::{DeletedSecretSummary, SecretSummary};
 use crate::utils::format::sanitize_control_chars;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -353,6 +353,83 @@ pub(crate) fn render_long(entries: &[LsEntry], color: bool) -> String {
     out
 }
 
+/// Grid of bare labels (no folder entries) — `xv ls --deleted`'s default view.
+pub(crate) fn render_name_grid(names: &[String], width: usize) -> String {
+    let entries: Vec<LsEntry> = names
+        .iter()
+        .map(|n| {
+            LsEntry::Secret(SecretSummary {
+                name: n.clone(),
+                original_name: n.clone(),
+                note: None,
+                folder: None,
+                groups: None,
+                updated_on: String::new(),
+                enabled: true,
+                content_type: String::new(),
+            })
+        })
+        .collect();
+    render_grid(&entries, width, false)
+}
+
+/// Borderless long listing for deleted secrets: NAME  DELETED  PURGE SCHEDULED.
+/// Missing dates render as `-`, mirroring `render_long`'s folder placeholders.
+pub(crate) fn render_deleted_long(items: &[DeletedSecretSummary]) -> String {
+    let cell = |v: &Option<String>| match v {
+        Some(ts) => sanitize_control_chars(&date_portion_for_display(ts)),
+        None => "-".to_string(),
+    };
+    let rows: Vec<(String, String, String)> = items
+        .iter()
+        .map(|s| {
+            let name = if s.original_name.is_empty() {
+                &s.name
+            } else {
+                &s.original_name
+            };
+            (
+                sanitize_control_chars(name),
+                cell(&s.deleted_on),
+                cell(&s.scheduled_purge_on),
+            )
+        })
+        .collect();
+
+    let name_w = rows
+        .iter()
+        .map(|r| display_width(&r.0))
+        .chain(["NAME".len()])
+        .max()
+        .unwrap_or(4);
+    let deleted_w = rows
+        .iter()
+        .map(|r| display_width(&r.1))
+        .chain(["DELETED".len()])
+        .max()
+        .unwrap_or(7);
+
+    let mut out = String::new();
+    let header = format!(
+        "{}  {}  PURGE SCHEDULED",
+        pad_to("NAME", name_w),
+        pad_to("DELETED", deleted_w)
+    );
+    out.push_str(header.trim_end());
+    out.push('\n');
+    for (name, deleted, purge) in rows {
+        let line = format!(
+            "{}  {}  {}",
+            pad_to(&name, name_w),
+            pad_to(&deleted, deleted_w),
+            purge
+        );
+        out.push_str(line.trim_end());
+        out.push('\n');
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -667,6 +744,53 @@ mod tests {
         assert_eq!(secrets[0].name, "beta"); // newest first
         assert_eq!(secrets[1].name, "alpha"); // tie → name ascending
         assert_eq!(secrets[2].name, "charlie");
+    }
+
+    fn deleted(name: &str, deleted_on: Option<&str>, purge: Option<&str>) -> DeletedSecretSummary {
+        DeletedSecretSummary {
+            name: name.to_string(),
+            original_name: name.to_string(),
+            deleted_on: deleted_on.map(str::to_string),
+            scheduled_purge_on: purge.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn deleted_long_lists_dates_with_placeholders() {
+        let items = vec![
+            deleted(
+                "gone",
+                Some("2026-06-30 10:00:00 UTC"),
+                Some("2026-09-28 10:00:00 UTC"),
+            ),
+            deleted("trashed", Some("2026-06-01 09:00:00 UTC"), None),
+        ];
+        let out = render_deleted_long(&items);
+        let lines: Vec<&str> = out.lines().collect();
+        assert!(lines[0].starts_with("NAME"), "{out}");
+        assert!(lines[0].contains("DELETED") && lines[0].contains("PURGE SCHEDULED"));
+        assert!(
+            lines[1].starts_with("gone")
+                && lines[1].contains("2026-06-30")
+                && lines[1].contains("2026-09-28")
+        );
+        assert!(
+            lines[2].starts_with("trashed") && lines[2].ends_with('-'),
+            "missing purge date renders '-': {out}"
+        );
+        for line in &lines {
+            assert_eq!(line.trim_end(), *line);
+        }
+    }
+
+    #[test]
+    fn name_grid_renders_bare_labels() {
+        let out = render_name_grid(&["alpha".to_string(), "beta".to_string()], 40);
+        assert!(out.contains("alpha") && out.contains("beta"));
+        assert!(
+            !out.contains('/'),
+            "no folder markers in a deleted grid: {out}"
+        );
     }
 
     #[test]

--- a/src/cli/ls_view.rs
+++ b/src/cli/ls_view.rs
@@ -55,9 +55,6 @@ pub(crate) fn relative_to_scope<'a>(folder: &'a str, path: &str) -> Option<&'a s
 
 /// True when `folder` is at or under scope `path` (exact-or-prefix with
 /// segment boundary — the `xv ls` scoping rule, shared with `find --folder`).
-/// Not yet called outside tests: reused by the upcoming `find --folder`
-/// implementation (Task 11).
-#[allow(dead_code)]
 pub(crate) fn folder_in_scope(folder: &str, path: &str) -> bool {
     relative_to_scope(folder, path).is_some()
 }

--- a/src/cli/ls_view.rs
+++ b/src/cli/ls_view.rs
@@ -5,6 +5,19 @@
 
 use crate::secret::manager::SecretSummary;
 use crate::utils::format::sanitize_control_chars;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+/// Terminal display width of `s` (Unicode-aware: CJK/full-width chars = 2 columns).
+pub(crate) fn display_width(s: &str) -> usize {
+    UnicodeWidthStr::width(s)
+}
+
+/// Left-align `s` in `w` display columns. `format!("{:<w$}")` pads by char
+/// count, which breaks on full-width characters — always pad manually.
+pub(crate) fn pad_to(s: &str, w: usize) -> String {
+    let pad = w.saturating_sub(display_width(s));
+    format!("{s}{}", " ".repeat(pad))
+}
 
 /// The result of scoping a secret list to a folder path.
 pub(crate) struct ScopedList {
@@ -120,7 +133,7 @@ pub(crate) fn render_grid(entries: &[LsEntry], width: usize, color: bool) -> Str
         return String::new();
     }
     let labels: Vec<String> = entries.iter().map(entry_label).collect();
-    let lens: Vec<usize> = labels.iter().map(|l| l.chars().count()).collect();
+    let lens: Vec<usize> = labels.iter().map(|l| display_width(l)).collect();
     let n = labels.len();
 
     // Find the largest column count whose per-column max widths fit.
@@ -177,12 +190,21 @@ const LONG_NOTE_MAX: usize = 60;
 
 fn truncate_note(note: &str, max: usize) -> String {
     let first = note.lines().next().unwrap_or("");
-    if first.chars().count() <= max {
-        first.to_string()
-    } else {
-        let cut: String = first.chars().take(max.saturating_sub(1)).collect();
-        format!("{cut}…")
+    if display_width(first) <= max {
+        return first.to_string();
     }
+    let budget = max.saturating_sub(1); // reserve one column for the ellipsis
+    let mut cut = String::new();
+    let mut used = 0usize;
+    for ch in first.chars() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + w > budget {
+            break;
+        }
+        used += w;
+        cut.push(ch);
+    }
+    format!("{cut}…")
 }
 
 /// Borderless long listing: NAME  UPDATED  GROUPS  NOTE. Folders render as
@@ -220,40 +242,44 @@ pub(crate) fn render_long(entries: &[LsEntry], color: bool) -> String {
 
     let name_w = rows
         .iter()
-        .map(|r| r.name.chars().count())
+        .map(|r| display_width(&r.name))
         .chain(["NAME".len()])
         .max()
         .unwrap_or(4);
     let updated_w = rows
         .iter()
-        .map(|r| r.updated.chars().count())
+        .map(|r| display_width(&r.updated))
         .chain(["UPDATED".len()])
         .max()
         .unwrap_or(7);
     let groups_w = rows
         .iter()
-        .map(|r| r.groups.chars().count())
+        .map(|r| display_width(&r.groups))
         .chain(["GROUPS".len()])
         .max()
         .unwrap_or(6);
 
     let mut out = String::new();
     let header = format!(
-        "{:<name_w$}  {:<updated_w$}  {:<groups_w$}  NOTE",
-        "NAME", "UPDATED", "GROUPS"
+        "{}  {}  {}  NOTE",
+        pad_to("NAME", name_w),
+        pad_to("UPDATED", updated_w),
+        pad_to("GROUPS", groups_w)
     );
     out.push_str(header.trim_end());
     out.push('\n');
     for row in rows {
-        let padded_name = format!("{:<name_w$}", row.name);
+        let padded_name = pad_to(&row.name, name_w);
         let name_cell = if color && row.is_folder {
             format!("{CYAN}{padded_name}{RESET}")
         } else {
             padded_name
         };
         let line = format!(
-            "{name_cell}  {:<updated_w$}  {:<groups_w$}  {}",
-            row.updated, row.groups, row.note
+            "{name_cell}  {}  {}  {}",
+            pad_to(&row.updated, updated_w),
+            pad_to(&row.groups, groups_w),
+            row.note
         );
         out.push_str(line.trim_end());
         out.push('\n');
@@ -396,7 +422,7 @@ mod tests {
         assert!(out.contains("gamma-long-name"));
         for line in &lines {
             assert_eq!(line.trim_end(), *line, "no trailing whitespace");
-            assert!(line.chars().count() <= 40, "line exceeds width:\n{out}");
+            assert!(display_width(line) <= 40, "line exceeds width:\n{out}");
         }
     }
 
@@ -486,5 +512,54 @@ mod tests {
         s.note = Some("bad\x1b]0;title\x07note".to_string());
         let out = render_long(&[LsEntry::Secret(s)], false);
         assert!(!out.contains('\x1b') && !out.contains('\x07'), "{out:?}");
+    }
+
+    #[test]
+    fn display_width_counts_columns_not_chars() {
+        assert_eq!(display_width("abc"), 3);
+        assert_eq!(display_width("秘密"), 4); // 2 full-width chars = 4 columns
+        assert_eq!(pad_to("秘密", 6), "秘密  ");
+        assert_eq!(pad_to("abc", 5), "abc  ");
+    }
+
+    #[test]
+    fn grid_accounts_for_full_width_characters() {
+        let entries = vec![
+            secret_entry("数据库密码"),
+            secret_entry("api-key"),
+            secret_entry("另一个秘密名字"),
+        ];
+        let out = render_grid(&entries, 20, false);
+        for line in out.lines() {
+            assert!(display_width(line) <= 20, "line exceeds width:\n{out}");
+        }
+    }
+
+    #[test]
+    fn long_listing_aligns_full_width_names() {
+        let entries = vec![secret_entry("秘密"), secret_entry("abcd")];
+        let out = render_long(&entries, false);
+        let lines: Vec<&str> = out.lines().collect();
+        let idx_a = lines[1].find("2026-05-17").unwrap();
+        let idx_b = lines[2].find("2026-05-17").unwrap();
+        assert_eq!(
+            display_width(&lines[1][..idx_a]),
+            display_width(&lines[2][..idx_b]),
+            "UPDATED column misaligned:\n{out}"
+        );
+    }
+
+    #[test]
+    fn note_truncation_is_width_aware() {
+        let mut s = summary("a", None);
+        s.note = Some("秘".repeat(60)); // 120 columns wide
+        let out = render_long(&[LsEntry::Secret(s)], false);
+        let data_line = out.lines().nth(1).unwrap();
+        let note_cell = data_line.rsplit("  ").next().unwrap();
+        assert!(
+            display_width(note_cell) <= LONG_NOTE_MAX,
+            "note not width-capped:\n{out}"
+        );
+        assert!(out.contains('…'));
     }
 }

--- a/src/cli/ls_view.rs
+++ b/src/cli/ls_view.rs
@@ -77,6 +77,16 @@ pub(crate) fn scope_secrets(secrets: Vec<SecretSummary>, path: &str) -> ScopedLi
     }
 }
 
+/// `--sort updated`: newest first (backend timestamps are ISO-shaped, so
+/// lexicographic order is chronological), display-name ascending on ties.
+pub(crate) fn sort_secrets_by_updated_desc(secrets: &mut [SecretSummary]) {
+    secrets.sort_by(|a, b| {
+        b.updated_on
+            .cmp(&a.updated_on)
+            .then_with(|| display_name(a).cmp(display_name(b)))
+    });
+}
+
 /// Reduce a backend timestamp like "2026-05-17 01:19:00 UTC" to its date
 /// portion for human tables. Values that don't lead with a YYYY-MM-DD token
 /// pass through unmodified; machine formats always get the full timestamp.
@@ -561,5 +571,21 @@ mod tests {
             "note not width-capped:\n{out}"
         );
         assert!(out.contains('…'));
+    }
+
+    #[test]
+    fn updated_sort_is_descending_with_name_tiebreak() {
+        let mut a = summary("alpha", None);
+        a.updated_on = "2026-06-01 10:00:00 UTC".to_string();
+        let mut b = summary("beta", None);
+        b.updated_on = "2026-06-30 10:00:00 UTC".to_string();
+        let mut c = summary("charlie", None);
+        c.updated_on = "2026-06-01 10:00:00 UTC".to_string();
+
+        let mut secrets = vec![c, a, b];
+        sort_secrets_by_updated_desc(&mut secrets);
+        assert_eq!(secrets[0].name, "beta"); // newest first
+        assert_eq!(secrets[1].name, "alpha"); // tie → name ascending
+        assert_eq!(secrets[2].name, "charlie");
     }
 }

--- a/src/cli/ls_view.rs
+++ b/src/cli/ls_view.rs
@@ -77,13 +77,46 @@ pub(crate) fn scope_secrets(secrets: Vec<SecretSummary>, path: &str) -> ScopedLi
     }
 }
 
+/// Check if a value starts with a YYYY-MM-DD token (date-shaped).
+/// Used to classify timestamps for sorting and display.
+fn is_date_shaped(value: &str) -> bool {
+    let first = value.split_whitespace().next().unwrap_or("");
+    first.len() == 10
+        && first.chars().enumerate().all(|(i, c)| {
+            if i == 4 || i == 7 {
+                c == '-'
+            } else {
+                c.is_ascii_digit()
+            }
+        })
+}
+
 /// `--sort updated`: newest first (backend timestamps are ISO-shaped, so
 /// lexicographic order is chronological), display-name ascending on ties.
+/// Non-date-shaped values (e.g., "Unknown" sentinel) sort LAST to avoid
+/// incorrectly ranking them as most recent. When both values are non-date-shaped,
+/// they are sorted by display_name only (their timestamp strings are meaningless).
 pub(crate) fn sort_secrets_by_updated_desc(secrets: &mut [SecretSummary]) {
     secrets.sort_by(|a, b| {
-        b.updated_on
-            .cmp(&a.updated_on)
-            .then_with(|| display_name(a).cmp(display_name(b)))
+        let a_shaped = is_date_shaped(&a.updated_on);
+        let b_shaped = is_date_shaped(&b.updated_on);
+
+        match (b_shaped, a_shaped) {
+            (true, true) => {
+                // Both are dates: sort by timestamp descending, then name ascending
+                b.updated_on
+                    .cmp(&a.updated_on)
+                    .then_with(|| display_name(a).cmp(display_name(b)))
+            }
+            (false, false) => {
+                // Both are non-dates: sort by name only (timestamp values are meaningless)
+                display_name(a).cmp(display_name(b))
+            }
+            _ => {
+                // Mixed: dates (true) sort before non-dates (false) in descending order
+                b_shaped.cmp(&a_shaped)
+            }
+        }
     });
 }
 
@@ -91,17 +124,12 @@ pub(crate) fn sort_secrets_by_updated_desc(secrets: &mut [SecretSummary]) {
 /// portion for human tables. Values that don't lead with a YYYY-MM-DD token
 /// pass through unmodified; machine formats always get the full timestamp.
 pub(crate) fn date_portion_for_display(timestamp: &str) -> String {
-    let first = timestamp.split_whitespace().next().unwrap_or("");
-    let is_date_shaped = first.len() == 10
-        && first.chars().enumerate().all(|(i, c)| {
-            if i == 4 || i == 7 {
-                c == '-'
-            } else {
-                c.is_ascii_digit()
-            }
-        });
-    if is_date_shaped {
-        first.to_string()
+    if is_date_shaped(timestamp) {
+        timestamp
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .to_string()
     } else {
         timestamp.to_string()
     }
@@ -587,5 +615,39 @@ mod tests {
         assert_eq!(secrets[0].name, "beta"); // newest first
         assert_eq!(secrets[1].name, "alpha"); // tie → name ascending
         assert_eq!(secrets[2].name, "charlie");
+    }
+
+    #[test]
+    fn updated_sort_ranks_non_date_values_last() {
+        let mut oldest_date = summary("oldest-date", None);
+        oldest_date.updated_on = "2026-06-01 10:00:00 UTC".to_string();
+
+        let mut unknown = summary("zulu-unknown", None);
+        unknown.updated_on = "Unknown".to_string();
+
+        let mut empty = summary("alpha-empty", None);
+        empty.updated_on = "".to_string();
+
+        let mut newest_date = summary("newest-date", None);
+        newest_date.updated_on = "2026-07-01 09:00:00 UTC".to_string();
+
+        let mut secrets = vec![empty, unknown, oldest_date, newest_date];
+        sort_secrets_by_updated_desc(&mut secrets);
+
+        // Dates should come first (descending by date), non-dates should come last
+        assert_eq!(
+            secrets[0].name, "newest-date",
+            "newest date should be first"
+        );
+        assert_eq!(
+            secrets[1].name, "oldest-date",
+            "older date should be second"
+        );
+        // Non-dates should be last, tie-broken by name
+        assert_eq!(
+            secrets[2].name, "alpha-empty",
+            "non-date values should be last, sorted by name"
+        );
+        assert_eq!(secrets[3].name, "zulu-unknown");
     }
 }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -256,6 +256,119 @@ fn filter_secret_summaries_for_display(
     secrets
 }
 
+/// Fold summaries into (group → member count), tokenizing the comma-separated
+/// `groups` tag exactly like `secret_summary_matches_group`. A group repeated
+/// within one secret counts that secret once.
+fn derive_group_rows(secrets: &[crate::secret::manager::SecretSummary]) -> Vec<GroupListRow> {
+    let mut counts: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+    for s in secrets {
+        let Some(groups) = s.groups.as_deref() else {
+            continue;
+        };
+        let mut seen = std::collections::HashSet::new();
+        for g in groups.split(',') {
+            let g = g.trim();
+            if !g.is_empty() && seen.insert(g) {
+                *counts.entry(g.to_string()).or_insert(0) += 1;
+            }
+        }
+    }
+    counts
+        .into_iter()
+        .map(|(group, secrets)| GroupListRow { group, secrets })
+        .collect()
+}
+
+pub(crate) async fn execute_group_command(
+    command: crate::cli::commands::GroupCommands,
+    config: Config,
+    registry: Option<&BackendRegistry>,
+) -> Result<()> {
+    match command {
+        crate::cli::commands::GroupCommands::List { no_cache } => {
+            execute_group_list(no_cache, config, registry).await
+        }
+    }
+}
+
+async fn execute_group_list(
+    no_cache: bool,
+    config: Config,
+    registry: Option<&BackendRegistry>,
+) -> Result<()> {
+    use crate::cache::CacheManager;
+    use crate::utils::format::TableFormatter;
+
+    if !use_trait_path(registry) {
+        return Err(CrosstacheError::config(
+            "No backend registry available. Run 'xv config show' to check your configuration.",
+        ));
+    }
+    let reg = registry.expect("use_trait_path guarantees Some");
+    let vault_name = resolve_vault_for_trait(&config, registry).await?;
+
+    // Same fetch-or-cache flow as `xv ls` (shared CacheKey::SecretsList dataset).
+    let cache_manager = CacheManager::from_config(&config);
+    let cache_key = trait_secret_cache_key(&vault_name);
+    let use_cache = cache_manager.is_enabled() && !no_cache;
+    let cached = if use_cache {
+        cache_manager.get::<Vec<crate::secret::manager::SecretSummary>>(&cache_key)
+    } else {
+        None
+    };
+    let secrets = match cached {
+        Some(secrets) => secrets,
+        None => {
+            let fetched = reg
+                .active()
+                .secrets()
+                .list_secrets(&vault_name, None)
+                .await?;
+            if use_cache {
+                cache_manager.set(&cache_key, &fetched);
+            }
+            fetched
+        }
+    };
+
+    let rows = derive_group_rows(&secrets);
+    let fmt = config.runtime_output_format;
+    let human = matches!(
+        fmt,
+        OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+    );
+
+    if rows.is_empty() && human {
+        crate::utils::output::info(&crate::utils::list_output::empty_state_message(
+            "groups",
+            Some(&format!("vault '{vault_name}'")),
+        ));
+        return Ok(());
+    }
+
+    let formatter = TableFormatter::new(
+        fmt,
+        config.no_color,
+        config.template.clone(),
+        config.runtime_columns.clone(),
+    );
+    println!("{}", formatter.format_table(&rows)?);
+    if human {
+        println!(
+            "{}",
+            crate::utils::list_output::count_label(
+                rows.len(),
+                rows.len(),
+                "group",
+                "groups",
+                Some(&format!("vault '{vault_name}'")),
+                false,
+            )
+        );
+    }
+    Ok(())
+}
+
 const SECRET_LIST_NOTE_WRAP_WIDTH: usize = 40;
 
 #[derive(Debug, Clone, serde::Serialize, tabled::Tabled)]
@@ -270,6 +383,15 @@ struct SecretListDisplayRow {
     groups: String,
     #[tabled(rename = "Updated")]
     updated_on: String,
+}
+
+/// Row shape for `xv group list`.
+#[derive(Debug, Clone, serde::Serialize, tabled::Tabled)]
+struct GroupListRow {
+    #[tabled(rename = "Group")]
+    group: String,
+    #[tabled(rename = "Secrets")]
+    secrets: usize,
 }
 
 fn format_secret_list_rows_for_human(
@@ -4860,6 +4982,31 @@ mod tests {
             &summary_with_groups(None),
             "prod"
         ));
+    }
+
+    #[test]
+    fn group_rows_derive_from_comma_separated_tags() {
+        fn s(name: &str, groups: Option<&str>) -> crate::secret::manager::SecretSummary {
+            crate::secret::manager::SecretSummary {
+                name: name.to_string(),
+                original_name: name.to_string(),
+                note: None,
+                folder: None,
+                groups: groups.map(str::to_string),
+                updated_on: String::new(),
+                enabled: true,
+                content_type: String::new(),
+            }
+        }
+        let rows = derive_group_rows(&[
+            s("a", Some("team-a, team-b")),
+            s("b", Some("team-a")),
+            s("c", Some(" team-b ,, team-b ")), // dup within one secret counts once
+            s("d", None),
+        ]);
+        assert_eq!(rows.len(), 2);
+        assert_eq!((rows[0].group.as_str(), rows[0].secrets), ("team-a", 2));
+        assert_eq!((rows[1].group.as_str(), rows[1].secrets), ("team-b", 2));
     }
 
     #[test]

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -367,6 +367,7 @@ pub(crate) fn display_cached_secret_list(
     path: &str,
     long: bool,
     recursive: bool,
+    sort: crate::cli::commands::LsSort,
     pagination: Pagination,
     pager: bool,
     vault_name: &str,
@@ -379,7 +380,11 @@ pub(crate) fn display_cached_secret_list(
     use std::fmt::Write as _;
 
     let filtered = filter_secret_summaries_for_display(secrets, group.as_deref(), all);
-    let scoped = ls_view::scope_secrets(filtered, path);
+    let mut scoped = ls_view::scope_secrets(filtered, path);
+    if sort == crate::cli::commands::LsSort::Updated {
+        ls_view::sort_secrets_by_updated_desc(&mut scoped.secrets);
+        ls_view::sort_secrets_by_updated_desc(&mut scoped.subtree);
+    }
 
     // Pipe-friendly modes: flat recursive subtree, unchanged schema.
     if names_only {
@@ -574,6 +579,7 @@ pub(crate) async fn execute_secret_list_direct(
     names_only: bool,
     long: bool,
     recursive: bool,
+    sort: crate::cli::commands::LsSort,
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
@@ -599,6 +605,7 @@ pub(crate) async fn execute_secret_list_direct(
                     &path,
                     long,
                     recursive,
+                    sort,
                     pagination,
                     pager,
                     &vault_name,
@@ -683,6 +690,7 @@ pub(crate) async fn execute_secret_list_direct(
             &path,
             long,
             recursive,
+            sort,
             pagination,
             pager,
             &vault_name,

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -644,17 +644,14 @@ pub(crate) fn display_cached_secret_list(
         );
     }
     let entries: Vec<LsEntry> = if recursive {
-        scoped
-            .subtree
-            .iter()
-            .map(|s| {
-                // Grid/long render `display_name` (== original_name when set);
-                // overriding it here is how the qualified label reaches them.
-                let mut q = s.clone();
-                q.original_name = ls_view::qualified_display_name(s, path);
-                LsEntry::Secret(q)
-            })
-            .collect()
+        ls_view::qualified_subtree(
+            &scoped.subtree,
+            path,
+            sort == crate::cli::commands::LsSort::Name,
+        )
+        .into_iter()
+        .map(LsEntry::Secret)
+        .collect()
     } else {
         ls_view::entries_for_display(&scoped)
     };
@@ -1561,6 +1558,13 @@ pub(crate) async fn execute_secret_update_direct(
     }
 
     // ── Azure legacy path (unchanged) ─────────────────────────────────
+    // The legacy signature has no enabled parameter; erroring here beats
+    // silently dropping the flag when the registry failed to initialize.
+    if enabled.is_some() {
+        return Err(CrosstacheError::config(
+            "--enabled requires the backend registry",
+        ));
+    }
     let auth_provider = get_azure_auth_provider(registry, &config)?;
 
     // Create secret manager
@@ -2590,7 +2594,7 @@ pub(crate) async fn execute_complete_secrets(config: Config) -> Result<()> {
             } else {
                 &s.original_name
             };
-            println!("{display}");
+            println!("{}", crate::utils::format::sanitize_control_chars(display));
         }
     }
     Ok(())
@@ -2633,7 +2637,7 @@ pub(crate) async fn execute_complete_folders(config: Config) -> Result<()> {
         cache_manager.get::<Vec<crate::secret::manager::SecretSummary>>(&cache_key)
     {
         for f in folder_completion_paths(&cached) {
-            println!("{f}");
+            println!("{}", crate::utils::format::sanitize_control_chars(&f));
         }
     }
     Ok(())

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2596,6 +2596,49 @@ pub(crate) async fn execute_complete_secrets(config: Config) -> Result<()> {
     Ok(())
 }
 
+/// Distinct folder paths (including ancestor prefixes, so `prod/db` also
+/// offers `prod`), sorted — the completion feed for FOLDER-taking args.
+fn folder_completion_paths(secrets: &[crate::secret::manager::SecretSummary]) -> Vec<String> {
+    let mut folders = std::collections::BTreeSet::new();
+    for s in secrets {
+        let Some(folder) = s.folder.as_deref().filter(|f| !f.is_empty()) else {
+            continue;
+        };
+        let mut prefix = String::new();
+        for seg in folder.split('/') {
+            if !prefix.is_empty() {
+                prefix.push('/');
+            }
+            prefix.push_str(seg);
+            folders.insert(prefix.clone());
+        }
+    }
+    folders.into_iter().collect()
+}
+
+#[allow(dead_code)] // called from src/main.rs::run_complete_folders (binary-only path)
+pub(crate) async fn execute_complete_folders(config: Config) -> Result<()> {
+    use crate::cache::{CacheKey, CacheManager};
+
+    let vault_name = config.resolve_vault_name(None).await?;
+
+    // Cache-only path, mirroring execute_complete_secrets: a cold cache
+    // means no completions — never a backend round-trip on a Tab press.
+    let cache_manager = CacheManager::from_config(&config);
+    if !cache_manager.is_enabled() {
+        return Ok(());
+    }
+    let cache_key = CacheKey::SecretsList { vault_name };
+    if let Some(cached) =
+        cache_manager.get::<Vec<crate::secret::manager::SecretSummary>>(&cache_key)
+    {
+        for f in folder_completion_paths(&cached) {
+            println!("{f}");
+        }
+    }
+    Ok(())
+}
+
 /// Resolve a user-friendly version identifier (e.g. "v6", "6") to the Azure Key Vault hex GUID.
 /// If the version string is already a hex GUID, it is returned as-is.
 async fn resolve_version_to_guid(
@@ -5297,5 +5340,37 @@ mod tests {
         for line in wrapped.lines() {
             assert!(crate::cli::ls_view::display_width(line) <= 4, "{wrapped:?}");
         }
+    }
+
+    #[test]
+    fn folder_completion_includes_ancestor_prefixes_sorted() {
+        fn s(folder: Option<&str>) -> crate::secret::manager::SecretSummary {
+            crate::secret::manager::SecretSummary {
+                name: "x".to_string(),
+                original_name: "x".to_string(),
+                note: None,
+                folder: folder.map(str::to_string),
+                groups: None,
+                updated_on: String::new(),
+                enabled: true,
+                content_type: String::new(),
+            }
+        }
+        let paths = folder_completion_paths(&[
+            s(Some("prod/db/replica")),
+            s(Some("prod")),
+            s(Some("dev")),
+            s(None),
+            s(Some("")),
+        ]);
+        assert_eq!(
+            paths,
+            vec![
+                "dev".to_string(),
+                "prod".to_string(),
+                "prod/db".to_string(),
+                "prod/db/replica".to_string(),
+            ]
+        );
     }
 }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -496,7 +496,7 @@ pub(crate) fn display_cached_secret_list(
             ),
             vault_name
         );
-        if let Some(footer) = pagination_footer_text(&page, "secret", fmt) {
+        if let Some(footer) = pagination_footer_text(&page, "secret", "secrets", fmt) {
             output.push('\n');
             output.push_str(&footer);
         }
@@ -553,7 +553,7 @@ pub(crate) fn display_cached_secret_list(
         );
     }
     let _ = writeln!(output, "{} in vault '{}'", count_line, vault_name);
-    if let Some(footer) = pagination_footer_text(&page, "entry", fmt) {
+    if let Some(footer) = pagination_footer_text(&page, "entry", "entries", fmt) {
         output.push('\n');
         output.push_str(&footer);
     }
@@ -3796,7 +3796,9 @@ async fn execute_secret_share(
                         paged.page_size.is_some(),
                     ));
                 }
-                if let Some(footer) = pagination_footer_text(&paged, "assignment", fmt) {
+                if let Some(footer) =
+                    pagination_footer_text(&paged, "assignment", "assignments", fmt)
+                {
                     output.push('\n');
                     output.push_str(&footer);
                 }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2252,12 +2252,27 @@ pub(crate) async fn execute_secret_find_direct(
     in_fields: Vec<String>,
     limit: usize,
     min_score: f32,
+    folder: Option<String>,
     all_vaults: bool,
     names_only: bool,
     format: crate::utils::format::OutputFormat,
     config: Config,
     registry: Option<&crate::backend::BackendRegistry>,
 ) -> Result<()> {
+    // Normalize --folder: trim trailing '/', validate, treat empty as absent.
+    let folder_scope: Option<String> = match folder {
+        Some(raw) => {
+            let trimmed = raw.trim_end_matches('/').to_string();
+            if trimmed.is_empty() {
+                None
+            } else {
+                crate::utils::helpers::validate_folder_path(&trimmed)?;
+                Some(trimmed)
+            }
+        }
+        None => None,
+    };
+
     // ── Trait-based path (non-Azure backends) ──────────────────────────
     if use_trait_path(registry) {
         let reg = registry.expect("use_trait_path guarantees Some");
@@ -2319,6 +2334,16 @@ pub(crate) async fn execute_secret_find_direct(
                 .collect()
         };
 
+        let items: Vec<CandidateItem> = match folder_scope.as_deref() {
+            Some(path) => items
+                .into_iter()
+                .filter(|i| {
+                    crate::cli::ls_view::folder_in_scope(i.folder.as_deref().unwrap_or(""), path)
+                })
+                .collect(),
+            None => items,
+        };
+
         let pattern_str = pattern.as_deref().unwrap_or("");
         let mut matches = score_matches(pattern_str, &items, &fields);
 
@@ -2352,6 +2377,7 @@ pub(crate) async fn execute_secret_find_direct(
         in_fields,
         limit,
         min_score,
+        folder_scope.as_deref(),
         all_vaults,
         names_only,
         format,
@@ -2367,6 +2393,7 @@ async fn execute_secret_find(
     in_fields: Vec<String>,
     limit: usize,
     min_score: f32,
+    folder: Option<&str>,
     all_vaults: bool,
     names_only: bool,
     format: crate::utils::format::OutputFormat,
@@ -2477,6 +2504,17 @@ async fn execute_secret_find(
             .map(CandidateItem::from_secret_summary)
             .collect()
     };
+
+    let items: Vec<CandidateItem> = match folder {
+        Some(path) => items
+            .into_iter()
+            .filter(|i| {
+                crate::cli::ls_view::folder_in_scope(i.folder.as_deref().unwrap_or(""), path)
+            })
+            .collect(),
+        None => items,
+    };
+
     let pattern_str = pattern.unwrap_or("");
     let mut matches = score_matches(pattern_str, &items, &fields);
 

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -387,9 +387,14 @@ pub(crate) fn display_cached_secret_list(
     }
 
     // Pipe-friendly modes: flat recursive subtree, unchanged schema.
+    // Qualification is opt-in via -r (the bare --names-only shape is shipped).
     if names_only {
         for s in &scoped.subtree {
-            println!("{}", ls_view::display_name(s));
+            if recursive {
+                println!("{}", ls_view::qualified_display_name(s, path));
+            } else {
+                println!("{}", ls_view::display_name(s));
+            }
         }
         return Ok(());
     }
@@ -519,8 +524,13 @@ pub(crate) fn display_cached_secret_list(
         scoped
             .subtree
             .iter()
-            .cloned()
-            .map(LsEntry::Secret)
+            .map(|s| {
+                // Grid/long render `display_name` (== original_name when set);
+                // overriding it here is how the qualified label reaches them.
+                let mut q = s.clone();
+                q.original_name = ls_view::qualified_display_name(s, path);
+                LsEntry::Secret(q)
+            })
             .collect()
     } else {
         ls_view::entries_for_display(&scoped)

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2561,12 +2561,7 @@ async fn execute_secret_find(
         return Ok(());
     }
 
-    let empty_msg = find_empty_message(
-        pattern,
-        all_vaults,
-        single_vault.as_deref(),
-        folder.as_deref(),
-    );
+    let empty_msg = find_empty_message(pattern, all_vaults, single_vault.as_deref(), folder);
     render_find_matches(&matches, format, &empty_msg, config)
 }
 

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -319,18 +319,24 @@ fn wrap_paragraph_to_width(paragraph: &str, width: usize) -> String {
 }
 
 fn push_wrapped_word(word: &str, width: usize, current: &mut String, lines: &mut Vec<String>) {
-    let word_len = word.chars().count();
+    use unicode_width::UnicodeWidthChar;
+    let display_width = crate::cli::ls_view::display_width;
+    let word_len = display_width(word);
 
     if word_len > width {
         if !current.is_empty() {
             lines.push(std::mem::take(current));
         }
         let mut chunk = String::new();
+        let mut chunk_w = 0usize;
         for ch in word.chars() {
-            chunk.push(ch);
-            if chunk.chars().count() == width {
+            let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if chunk_w + w > width && !chunk.is_empty() {
                 lines.push(std::mem::take(&mut chunk));
+                chunk_w = 0;
             }
+            chunk.push(ch);
+            chunk_w += w;
         }
         if !chunk.is_empty() {
             *current = chunk;
@@ -343,7 +349,7 @@ fn push_wrapped_word(word: &str, width: usize, current: &mut String, lines: &mut
         return;
     }
 
-    let projected_len = current.chars().count() + 1 + word_len;
+    let projected_len = display_width(current) + 1 + word_len;
     if projected_len <= width {
         current.push(' ');
         current.push_str(word);
@@ -4631,7 +4637,7 @@ mod tests {
             rows[0]
                 .note
                 .lines()
-                .all(|line| line.chars().count() <= SECRET_LIST_NOTE_WRAP_WIDTH),
+                .all(|line| crate::cli::ls_view::display_width(line) <= SECRET_LIST_NOTE_WRAP_WIDTH),
             "wrapped note lines should fit the notes column width: {:?}",
             rows[0].note
         );
@@ -4831,5 +4837,15 @@ mod tests {
         assert_eq!(read_secret_value(&mut reader, false).unwrap(), "");
         let mut reader = std::io::Cursor::new("  \n  ");
         assert_eq!(read_secret_value(&mut reader, true).unwrap(), "");
+    }
+
+    #[test]
+    fn wrap_is_display_width_aware_for_cjk() {
+        // 6 full-width chars = 12 columns; budget of 4 columns = 2 chars/line.
+        let wrapped = wrap_text_to_width("秘密秘密秘密", 4);
+        assert_eq!(wrapped.lines().count(), 3, "{wrapped:?}");
+        for line in wrapped.lines() {
+            assert!(crate::cli::ls_view::display_width(line) <= 4, "{wrapped:?}");
+        }
     }
 }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -576,6 +576,227 @@ pub(crate) fn display_cached_secret_list(
     Ok(())
 }
 
+/// Row shape for `xv ls --deleted` — machine formats get this array; empty
+/// strings mark dates the backend cannot supply (AWS/local purge schedule).
+#[derive(Debug, Clone, serde::Serialize, tabled::Tabled)]
+struct DeletedSecretListRow {
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Deleted")]
+    deleted: String,
+    #[tabled(rename = "Purge Scheduled")]
+    purge_scheduled: String,
+}
+
+fn deleted_display_name(s: &crate::secret::manager::DeletedSecretSummary) -> &str {
+    if s.original_name.is_empty() {
+        &s.name
+    } else {
+        &s.original_name
+    }
+}
+
+fn deleted_list_rows(
+    items: &[crate::secret::manager::DeletedSecretSummary],
+    human: bool,
+) -> Vec<DeletedSecretListRow> {
+    items
+        .iter()
+        .map(|s| {
+            let fmt_date = |d: &Option<String>| {
+                let v = d.clone().unwrap_or_default();
+                if human {
+                    crate::cli::ls_view::date_portion_for_display(&v)
+                } else {
+                    v
+                }
+            };
+            DeletedSecretListRow {
+                name: deleted_display_name(s).to_string(),
+                deleted: fmt_date(&s.deleted_on),
+                purge_scheduled: fmt_date(&s.scheduled_purge_on),
+            }
+        })
+        .collect()
+}
+
+/// `xv ls --deleted`: list soft-deleted secrets awaiting restore/purge.
+/// Always bypasses the secrets-list cache (which only holds live secrets)
+/// and requires the backend to advertise `has_soft_delete`.
+pub(crate) async fn execute_deleted_secret_list(
+    pagination: Pagination,
+    pager: bool,
+    names_only: bool,
+    long: bool,
+    sort: crate::cli::commands::LsSort,
+    config: Config,
+    registry: Option<&BackendRegistry>,
+) -> Result<()> {
+    use crate::cli::commands::LsSort;
+    use crate::cli::ls_view;
+    use crate::utils::format::TableFormatter;
+    use crate::utils::pagination::{paginate_slice, pagination_footer_text};
+    use std::fmt::Write as _;
+
+    if !use_trait_path(registry) {
+        return Err(CrosstacheError::config(
+            "No backend registry available. Run 'xv config show' to check your configuration.",
+        ));
+    }
+    let reg = registry.expect("use_trait_path guarantees Some");
+
+    // Capability gate — same shape as `xv restore`'s.
+    let unsupported = || {
+        CrosstacheError::InvalidArgument(format!(
+            "The {} backend does not support listing deleted secrets (soft-delete not available).",
+            reg.active().name()
+        ))
+    };
+    if !reg.active().capabilities().has_soft_delete {
+        return Err(unsupported());
+    }
+
+    let vault_name = resolve_vault_for_trait(&config, registry).await?;
+    // Always live — the SecretsList cache holds live secrets only, and trash
+    // freshness matters right after a delete.
+    let mut items = match reg
+        .active()
+        .secrets()
+        .list_deleted_secrets(&vault_name)
+        .await
+    {
+        Ok(items) => items,
+        Err(crate::backend::BackendError::Unsupported(_)) => return Err(unsupported()),
+        Err(e) => return Err(e.into()),
+    };
+
+    match sort {
+        LsSort::Name => items.sort_by(|a, b| deleted_display_name(a).cmp(deleted_display_name(b))),
+        // In deleted mode "updated" means the deleted date (newest first).
+        LsSort::Updated => items.sort_by(|a, b| {
+            b.deleted_on
+                .cmp(&a.deleted_on)
+                .then_with(|| deleted_display_name(a).cmp(deleted_display_name(b)))
+        }),
+    }
+
+    if names_only {
+        for s in &items {
+            println!("{}", deleted_display_name(s));
+        }
+        return Ok(());
+    }
+
+    let fmt = config.runtime_output_format;
+    let human_table_like = matches!(
+        fmt,
+        OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+    );
+    let page = paginate_slice(&items, pagination);
+
+    if !human_table_like {
+        if long {
+            crate::utils::output::warn("--long is ignored for machine-readable formats");
+        }
+        let formatter = TableFormatter::new(
+            fmt,
+            config.no_color,
+            config.template.clone(),
+            config.runtime_columns.clone(),
+        );
+        let rows = deleted_list_rows(&page.items, false);
+        let output = formatter.format_table(&rows)?;
+        crate::utils::pager::print_output(&output, pager)?;
+        return Ok(());
+    }
+
+    // Validate --columns up front so an unknown selection errors even when
+    // the result set is empty (branch-wide rule shared with `display_cached_secret_list`).
+    if config.runtime_columns.is_some() {
+        let formatter = TableFormatter::new(
+            fmt,
+            config.no_color,
+            config.template.clone(),
+            config.runtime_columns.clone(),
+        );
+        formatter.validate_columns::<DeletedSecretListRow>()?;
+    }
+
+    if items.is_empty() {
+        crate::utils::output::info(&crate::utils::list_output::empty_state_message(
+            "deleted secrets",
+            Some(&format!("vault '{vault_name}'")),
+        ));
+        return Ok(());
+    }
+
+    let mut output = String::new();
+    output.push('\n');
+    let color = !config.no_color && fmt == OutputFormat::Table;
+    if color {
+        let _ = writeln!(
+            output,
+            "\x1b[36mVault: {} (deleted secrets)\x1b[0m",
+            vault_name
+        );
+    } else {
+        let _ = writeln!(output, "Vault: {} (deleted secrets)", vault_name);
+    }
+    output.push('\n');
+
+    if config.format_explicit && !long {
+        let formatter = TableFormatter::new(
+            fmt,
+            config.no_color,
+            config.template.clone(),
+            config.runtime_columns.clone(),
+        );
+        let rows = deleted_list_rows(&page.items, true);
+        output.push_str(&formatter.format_table(&rows)?);
+        output.push('\n');
+    } else {
+        if config.runtime_columns.is_some() {
+            crate::utils::output::warn(
+                "--columns is ignored for the grid/long view; use --format table",
+            );
+        }
+        if long {
+            output.push_str(&ls_view::render_deleted_long(&page.items));
+        } else {
+            let width = crossterm::terminal::size()
+                .map(|(w, _)| w as usize)
+                .unwrap_or(80);
+            let labels: Vec<String> = page
+                .items
+                .iter()
+                .map(|s| deleted_display_name(s).to_string())
+                .collect();
+            output.push_str(&ls_view::render_name_grid(&labels, width));
+        }
+        output.push('\n');
+    }
+
+    let _ = writeln!(
+        output,
+        "{} in vault '{}'",
+        crate::utils::list_output::count_label(
+            page.items.len(),
+            page.total_items,
+            "deleted secret",
+            "deleted secrets",
+            None,
+            page.page_size.is_some(),
+        ),
+        vault_name
+    );
+    if let Some(footer) = pagination_footer_text(&page, "deleted secret", "deleted secrets", fmt) {
+        output.push('\n');
+        output.push_str(&footer);
+    }
+    crate::utils::pager::print_output(&output, pager)?;
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_secret_list_direct(
     path: String,

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2192,13 +2192,30 @@ struct FindRow {
 }
 
 /// Empty-state wording for `xv find`, shared by the trait and legacy paths.
-fn find_empty_message(pattern: Option<&str>, all_vaults: bool, vault_name: Option<&str>) -> String {
-    match (all_vaults, pattern, vault_name) {
-        (true, Some(p), _) => format!("No secrets match '{p}' across all vaults."),
-        (true, None, _) => "No secrets found across all vaults.".to_string(),
-        (false, Some(p), Some(v)) => format!("No secrets match '{p}' in vault '{v}'."),
-        (false, None, Some(v)) => format!("No secrets in vault '{v}'."),
-        (false, _, None) => "No matching secrets found.".to_string(),
+fn find_empty_message(
+    pattern: Option<&str>,
+    all_vaults: bool,
+    vault_name: Option<&str>,
+    folder_scope: Option<&str>,
+) -> String {
+    match (all_vaults, pattern, vault_name, folder_scope) {
+        // All vaults cases
+        (true, Some(p), _, Some(f)) => {
+            format!("No secrets match '{p}' in folder '{f}' across all vaults.")
+        }
+        (true, Some(p), _, None) => format!("No secrets match '{p}' across all vaults."),
+        (true, None, _, Some(f)) => format!("No secrets found in folder '{f}' across all vaults."),
+        (true, None, _, None) => "No secrets found across all vaults.".to_string(),
+        // Single vault cases
+        (false, Some(p), Some(v), Some(f)) => {
+            format!("No secrets match '{p}' in folder '{f}' of vault '{v}'.")
+        }
+        (false, Some(p), Some(v), None) => format!("No secrets match '{p}' in vault '{v}'."),
+        (false, None, Some(v), Some(f)) => {
+            format!("No secrets found in folder '{f}' of vault '{v}'.")
+        }
+        (false, None, Some(v), None) => format!("No secrets in vault '{v}'."),
+        (false, _, None, _) => "No matching secrets found.".to_string(),
     }
 }
 
@@ -2363,7 +2380,12 @@ pub(crate) async fn execute_secret_find_direct(
             return Ok(());
         }
 
-        let empty_msg = find_empty_message(pattern.as_deref(), all_vaults, scope_vault.as_deref());
+        let empty_msg = find_empty_message(
+            pattern.as_deref(),
+            all_vaults,
+            scope_vault.as_deref(),
+            folder_scope.as_deref(),
+        );
         render_find_matches(&matches, format, &empty_msg, &config)?;
         return Ok(());
     }
@@ -2539,7 +2561,12 @@ async fn execute_secret_find(
         return Ok(());
     }
 
-    let empty_msg = find_empty_message(pattern, all_vaults, single_vault.as_deref());
+    let empty_msg = find_empty_message(
+        pattern,
+        all_vaults,
+        single_vault.as_deref(),
+        folder.as_deref(),
+    );
     render_find_matches(&matches, format, &empty_msg, config)
 }
 

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -331,7 +331,8 @@ async fn execute_group_list(
         }
     };
 
-    let rows = derive_group_rows(&secrets);
+    let filtered = filter_secret_summaries_for_display(secrets, None, false);
+    let rows = derive_group_rows(&filtered);
     let fmt = config.runtime_output_format;
     let human = matches!(
         fmt,
@@ -1473,6 +1474,7 @@ pub(crate) async fn execute_secret_update_direct(
     clear_not_before: bool,
     clear_note: bool,
     clear_folder: bool,
+    enabled: Option<bool>,
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
@@ -1534,7 +1536,7 @@ pub(crate) async fn execute_secret_update_direct(
             new_name: rename,
             value: resolved_value,
             content_type: None,
-            enabled: None,
+            enabled,
             expires_on: expires_update,
             not_before: not_before_update,
             tags: merged_tags,

--- a/src/cli/vault_ops.rs
+++ b/src/cli/vault_ops.rs
@@ -411,7 +411,7 @@ fn render_vault_list(
             page.page_size.is_some(),
         ));
     }
-    if let Some(footer) = pagination_footer_text(&page, "vault", output_format) {
+    if let Some(footer) = pagination_footer_text(&page, "vault", "vaults", output_format) {
         output.push('\n');
         output.push_str(&footer);
     }
@@ -1289,7 +1289,9 @@ async fn execute_vault_share(
                         paged.page_size.is_some(),
                     ));
                 }
-                if let Some(footer) = pagination_footer_text(&paged, "assignment", fmt) {
+                if let Some(footer) =
+                    pagination_footer_text(&paged, "assignment", "assignments", fmt)
+                {
                     output.push('\n');
                     output.push_str(&footer);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,16 @@ async fn main() {
         return;
     }
 
+    if args.len() > 1 && args[1] == "__complete-folders" {
+        let format = OutputFormat::Plain; // Default format for completion
+        if let Err(e) = run_complete_folders().await {
+            error!("Error: {}", e);
+            print_user_friendly_error(&e, format);
+            std::process::exit(e.exit_code());
+        }
+        return;
+    }
+
     // Parse command-line arguments
     let cli = Cli::parse();
     let format = cli.format; // OutputFormat is Copy
@@ -63,6 +73,12 @@ async fn run_complete_secrets() -> Result<()> {
     // Load config without validation for internal complete-secrets command
     let config = load_config_without_validation().await?;
     crate::cli::secret_ops::execute_complete_secrets(config).await
+}
+
+async fn run_complete_folders() -> Result<()> {
+    // Load config without validation for the internal completion command
+    let config = load_config_without_validation().await?;
+    crate::cli::secret_ops::execute_complete_folders(config).await
 }
 
 async fn run(cli: Cli) -> Result<()> {

--- a/src/secret/manager.rs
+++ b/src/secret/manager.rs
@@ -112,6 +112,21 @@ impl<T> FieldUpdate<T> {
     }
 }
 
+/// Attribute/tag-only update for [`SecretOperations::update_secret_attributes`].
+///
+/// `None` fields are left unchanged by the backend. `tags`, when `Some`,
+/// replaces the entire tag map (Azure `PATCH /secrets/{name}` semantics), so
+/// callers must supply the full desired map including crosstache's metadata
+/// tags.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SecretAttributesUpdate {
+    pub enabled: Option<bool>,
+    pub content_type: Option<String>,
+    pub expires_on: Option<DateTime<Utc>>,
+    pub not_before: Option<DateTime<Utc>>,
+    pub tags: Option<HashMap<String, String>>,
+}
+
 /// Secret update request for advanced operations
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SecretUpdateRequest {
@@ -234,6 +249,26 @@ pub trait SecretOperations: Send + Sync {
         _secret_name: &str,
         request: &SecretRequest,
     ) -> Result<SecretProperties>;
+
+    /// Update only the attributes/tags of an existing secret — no new
+    /// version, no value read or write.
+    ///
+    /// Azure implements this with `PATCH {vault}/secrets/{name}` (the
+    /// UpdateSecret operation), which works on *disabled* secrets — the
+    /// full-write path cannot, because reading or confirming the value of a
+    /// disabled secret returns HTTP 403 `SecretDisabled`. Implementors
+    /// without a dedicated attributes call keep this default error so
+    /// callers can fall back to a full write.
+    async fn update_secret_attributes(
+        &self,
+        _vault_name: &str,
+        _secret_name: &str,
+        _update: &SecretAttributesUpdate,
+    ) -> Result<SecretProperties> {
+        Err(CrosstacheError::azure_api(
+            "attribute-only secret updates are not supported by this backend",
+        ))
+    }
 
     /// Restore a deleted secret
     async fn restore_secret(&self, vault_name: &str, secret_name: &str)
@@ -785,13 +820,15 @@ impl SecretOperations for AzureSecretOperations {
             )));
         }
 
-        // Parse the response and convert to SecretProperties
-        let _json: serde_json::Value =
+        // Parse the response and convert to SecretProperties. The PUT
+        // response is a full secret bundle (id, value, attributes, tags), so
+        // build the result from it directly instead of a confirmation GET —
+        // a follow-up GET would return HTTP 403 `SecretDisabled` when this
+        // write just disabled the secret (enabled=false), failing the
+        // operation *after* the write succeeded.
+        let json: serde_json::Value =
             read_json_body(response, crate::utils::MAX_RESPONSE_BYTES).await?;
-
-        // Return the created secret properties
-        self.get_secret(vault_name.as_str(), &sanitized_name, true)
-            .await
+        parse_secret_properties_bundle(&json, &sanitized_name, true, "")
     }
 
     async fn get_secret(
@@ -1118,6 +1155,96 @@ impl SecretOperations for AzureSecretOperations {
         self.set_secret(vault_name, request).await
     }
 
+    async fn update_secret_attributes(
+        &self,
+        vault_name: &str,
+        secret_name: &str,
+        update: &SecretAttributesUpdate,
+    ) -> Result<SecretProperties> {
+        let vault_name = self.validated_vault_name(vault_name)?;
+        let sanitized_name = sanitize_secret_name(secret_name)?;
+
+        // `PATCH {vault}/secrets/{name}?api-version=7.4` (UpdateSecret):
+        // updates attributes/tags of the latest version without reading or
+        // writing the value, so it works on disabled secrets and never
+        // creates a new version. Omitted body fields are left unchanged.
+        let secret_url = self.key_vault_api_url(&vault_name, &["secrets", &sanitized_name])?;
+
+        // Get an access token for Key Vault
+        let token = self
+            .auth_provider
+            .get_token(&["https://vault.azure.net/.default"])
+            .await?;
+
+        // Build the request body from only the fields being changed.
+        let mut body = serde_json::json!({});
+        let mut attributes = serde_json::json!({});
+        if let Some(enabled) = update.enabled {
+            attributes["enabled"] = serde_json::json!(enabled);
+        }
+        if let Some(expires_on) = update.expires_on {
+            attributes["exp"] = serde_json::json!(expires_on.timestamp());
+        }
+        if let Some(not_before) = update.not_before {
+            attributes["nbf"] = serde_json::json!(not_before.timestamp());
+        }
+        if attributes.as_object().is_some_and(|obj| !obj.is_empty()) {
+            body["attributes"] = attributes;
+        }
+        if let Some(ref content_type) = update.content_type {
+            body["contentType"] = serde_json::json!(content_type);
+        }
+        if let Some(ref tags) = update.tags {
+            if let Some(folder) = tags.get("folder") {
+                validate_folder_path(folder)?;
+            }
+            body["tags"] = serde_json::json!(tags);
+        }
+
+        // Create HTTP client with proper timeout configuration
+        let network_config = NetworkConfig::default();
+        let client = create_http_client(&network_config)?;
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {}", token.token.secret())
+                .parse()
+                .map_err(|e| CrosstacheError::azure_api(format!("Invalid token format: {e}")))?,
+        );
+        headers.insert(
+            reqwest::header::CONTENT_TYPE,
+            reqwest::header::HeaderValue::from_static("application/json"),
+        );
+
+        // Make the REST API call
+        let response = client
+            .patch(&secret_url)
+            .headers(headers)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| classify_network_error(&e, &secret_url))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            if status == 404 {
+                return Err(CrosstacheError::SecretNotFound {
+                    name: secret_name.to_string(),
+                    suggestion: None,
+                });
+            }
+            let error_text = read_error_body(response).await;
+            return Err(CrosstacheError::azure_api(format!(
+                "Failed to update secret attributes: HTTP {status} - {error_text}"
+            )));
+        }
+
+        // The PATCH response is a secret bundle without the value.
+        let json: serde_json::Value =
+            read_json_body(response, crate::utils::MAX_RESPONSE_BYTES).await?;
+        parse_secret_properties_bundle(&json, &sanitized_name, false, "")
+    }
+
     async fn restore_secret(
         &self,
         vault_name: &str,
@@ -1184,9 +1311,12 @@ impl SecretOperations for AzureSecretOperations {
         let vault_name = self.validated_vault_name(vault_name)?;
         let sanitized_name = sanitize_secret_name(secret_name)?;
 
-        // Use REST API to permanently purge a deleted secret
+        // Use REST API to permanently purge a deleted secret.
+        // The purge operation is `DELETE {vault}/deletedsecrets/{name}` —
+        // no trailing `/purge` segment; that returns HTTP 400 BadParameter
+        // ("Method DELETE does not allow operation 'purge'").
         let purge_url =
-            self.key_vault_api_url(&vault_name, &["deletedsecrets", &sanitized_name, "purge"])?;
+            self.key_vault_api_url(&vault_name, &["deletedsecrets", &sanitized_name])?;
 
         // Get an access token for Key Vault
         let token = self

--- a/src/secret/manager.rs
+++ b/src/secret/manager.rs
@@ -1969,11 +1969,6 @@ impl SecretManager {
             });
         }
 
-        // Display formatted table
-        let formatter = TableFormatter::new(OutputFormat::Table, self.no_color, None, None);
-        let table_output = formatter.format_table(&result)?;
-        println!("{table_output}");
-
         Ok(result)
     }
 

--- a/src/secret/manager.rs
+++ b/src/secret/manager.rs
@@ -168,6 +168,17 @@ pub struct SecretSummary {
     pub content_type: String,
 }
 
+/// Summary of a soft-deleted secret awaiting purge.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeletedSecretSummary {
+    pub name: String,
+    pub original_name: String,
+    /// When the secret was deleted (backend-formatted timestamp), when known.
+    pub deleted_on: Option<String>,
+    /// When the backend will permanently purge it (None = no schedule).
+    pub scheduled_purge_on: Option<String>,
+}
+
 /// Connection string component
 #[derive(Debug, Clone, Serialize, Deserialize, Tabled)]
 pub struct ConnectionComponent {
@@ -231,9 +242,8 @@ pub trait SecretOperations: Send + Sync {
     /// Permanently purge a deleted secret
     async fn purge_secret(&self, vault_name: &str, secret_name: &str) -> Result<()>;
 
-    /// List deleted secrets
-    #[allow(dead_code)]
-    async fn list_deleted_secrets(&self, vault_name: &str) -> Result<Vec<SecretSummary>>;
+    /// List soft-deleted secrets awaiting purge.
+    async fn list_deleted_secrets(&self, vault_name: &str) -> Result<Vec<DeletedSecretSummary>>;
 
     /// Check if secret exists
     async fn secret_exists(&self, vault_name: &str, secret_name: &str) -> Result<bool>;
@@ -438,68 +448,39 @@ async fn read_error_body(response: reqwest::Response) -> String {
         .unwrap_or_else(|e| format!("(failed to read error body: {e})"))
 }
 
-/// Parse one entry of a `GET /deletedsecrets` response page into a
-/// [`SecretSummary`].
-///
-/// Deleted secret items carry the original secret `id`
-/// (`https://<vault>.vault.azure.net/secrets/<name>`) alongside their
-/// attributes and tags, so the summary can be built without a follow-up
-/// `get_secret` call (which would 404 for a deleted secret anyway).
-/// Returns `None` when the entry has no usable `id`.
-fn parse_deleted_secret_summary(item: &serde_json::Value) -> Option<SecretSummary> {
+/// Parse one item from Azure's `GET {vault}/deletedsecrets` (api 7.4).
+/// `deletedDate`/`scheduledPurgeDate` are top-level epoch-second fields on
+/// the deleted-secret item (not under `attributes`).
+fn parse_deleted_secret_summary(item: &serde_json::Value) -> Option<DeletedSecretSummary> {
     let id = item.get("id").and_then(|v| v.as_str())?;
     let name = id.rsplit('/').next().unwrap_or(id).to_string();
     if name.is_empty() {
         return None;
     }
 
-    let attributes = item.get("attributes").unwrap_or(&serde_json::Value::Null);
-    let enabled = attributes
-        .get("enabled")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(true);
-    let updated_on = attributes
-        .get("updated")
-        .and_then(|v| v.as_i64())
-        .map(|ts| {
-            chrono::DateTime::from_timestamp(ts, 0)
-                .map(|dt| dt.to_string())
-                .unwrap_or_else(|| "Unknown".to_string())
+    let epoch_string = |key: &str| {
+        item.get(key)
+            .and_then(|v| v.as_i64())
+            .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
+            .map(|dt| dt.to_string())
+    };
+
+    let original_name = item
+        .get("tags")
+        .and_then(|v| v.as_object())
+        .and_then(|tags| {
+            tags.get("original_name")
+                .or_else(|| tags.get("name"))
+                .and_then(|v| v.as_str())
         })
-        .unwrap_or_else(|| "Unknown".to_string());
-
-    let mut tags = HashMap::new();
-    if let Some(tags_obj) = item.get("tags").and_then(|v| v.as_object()) {
-        for (key, value) in tags_obj {
-            if let Some(tag_value) = value.as_str() {
-                tags.insert(key.clone(), tag_value.to_string());
-            }
-        }
-    }
-
-    let original_name = tags
-        .get("original_name")
-        .or_else(|| tags.get("name"))
-        .cloned()
+        .map(str::to_string)
         .unwrap_or_else(|| name.clone());
-    let groups = tags
-        .get("groups")
-        .map(|g| g.trim().to_string())
-        .filter(|g| !g.is_empty());
 
-    Some(SecretSummary {
-        name: original_name.clone(),
+    Some(DeletedSecretSummary {
+        name,
         original_name,
-        note: tags.get("note").cloned(),
-        folder: tags.get("folder").cloned(),
-        groups,
-        updated_on,
-        enabled,
-        content_type: item
-            .get("contentType")
-            .and_then(|v| v.as_str())
-            .unwrap_or("text/plain")
-            .to_string(),
+        deleted_on: epoch_string("deletedDate"),
+        scheduled_purge_on: epoch_string("scheduledPurgeDate"),
     })
 }
 
@@ -1248,7 +1229,7 @@ impl SecretOperations for AzureSecretOperations {
         Ok(())
     }
 
-    async fn list_deleted_secrets(&self, vault_name: &str) -> Result<Vec<SecretSummary>> {
+    async fn list_deleted_secrets(&self, vault_name: &str) -> Result<Vec<DeletedSecretSummary>> {
         let vault_name = self.validated_vault_name(vault_name)?;
 
         // Use REST API to list soft-deleted secrets
@@ -2481,7 +2462,10 @@ mod tests {
             Ok(())
         }
 
-        async fn list_deleted_secrets(&self, _vault_name: &str) -> Result<Vec<SecretSummary>> {
+        async fn list_deleted_secrets(
+            &self,
+            _vault_name: &str,
+        ) -> Result<Vec<DeletedSecretSummary>> {
             Err(CrosstacheError::unknown("not implemented in fake"))
         }
 
@@ -2659,7 +2643,7 @@ mod tests {
     #[test]
     fn test_parse_deleted_secret_summary_full() {
         let item = serde_json::json!({
-            "id": "https://myvault.vault.azure.net/secrets/my-secret",
+            "id": "https://myvault.vault.azure.net/deletedsecrets/my-secret",
             "recoveryId": "https://myvault.vault.azure.net/deletedsecrets/my-secret",
             "deletedDate": 1_700_000_100,
             "scheduledPurgeDate": 1_707_776_100,
@@ -2679,49 +2663,49 @@ mod tests {
         });
 
         let summary = parse_deleted_secret_summary(&item).unwrap();
-        assert_eq!(summary.name, "My Secret");
+        assert_eq!(summary.name, "my-secret");
         assert_eq!(summary.original_name, "My Secret");
-        assert_eq!(summary.note.as_deref(), Some("a note"));
-        assert_eq!(summary.folder.as_deref(), Some("apps/web"));
-        assert_eq!(summary.groups.as_deref(), Some("alpha,beta"));
-        assert!(!summary.enabled);
-        assert_eq!(summary.content_type, "application/json");
         assert_eq!(
-            summary.updated_on,
-            chrono::DateTime::from_timestamp(1_700_000_050, 0)
-                .unwrap()
-                .to_string()
+            summary.deleted_on,
+            Some(
+                chrono::DateTime::from_timestamp(1_700_000_100, 0)
+                    .unwrap()
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.scheduled_purge_on,
+            Some(
+                chrono::DateTime::from_timestamp(1_707_776_100, 0)
+                    .unwrap()
+                    .to_string()
+            )
         );
     }
 
     #[test]
     fn test_parse_deleted_secret_summary_minimal() {
         let item = serde_json::json!({
-            "id": "https://myvault.vault.azure.net/secrets/bare-secret"
+            "id": "https://myvault.vault.azure.net/deletedsecrets/bare-secret"
         });
 
         let summary = parse_deleted_secret_summary(&item).unwrap();
         assert_eq!(summary.name, "bare-secret");
         assert_eq!(summary.original_name, "bare-secret");
-        assert_eq!(summary.note, None);
-        assert_eq!(summary.folder, None);
-        assert_eq!(summary.groups, None);
-        assert!(summary.enabled);
-        assert_eq!(summary.content_type, "text/plain");
-        assert_eq!(summary.updated_on, "Unknown");
+        assert_eq!(summary.deleted_on, None);
+        assert_eq!(summary.scheduled_purge_on, None);
     }
 
     #[test]
     fn test_parse_deleted_secret_summary_legacy_name_tag_and_empty_groups() {
         let item = serde_json::json!({
-            "id": "https://myvault.vault.azure.net/secrets/legacy",
+            "id": "https://myvault.vault.azure.net/deletedsecrets/legacy",
             "tags": { "name": "Legacy Name", "groups": "   " }
         });
 
         let summary = parse_deleted_secret_summary(&item).unwrap();
-        assert_eq!(summary.name, "Legacy Name");
-        // Whitespace-only groups tag is treated as no groups
-        assert_eq!(summary.groups, None);
+        assert_eq!(summary.name, "legacy");
+        assert_eq!(summary.original_name, "Legacy Name");
     }
 
     #[test]
@@ -2729,6 +2713,37 @@ mod tests {
         assert!(parse_deleted_secret_summary(&serde_json::json!({})).is_none());
         assert!(parse_deleted_secret_summary(&serde_json::json!({ "id": 42 })).is_none());
         assert!(parse_deleted_secret_summary(&serde_json::json!({ "id": "" })).is_none());
+    }
+
+    #[test]
+    fn parse_deleted_secret_summary_reads_deletion_dates() {
+        let item = serde_json::json!({
+            "id": "https://kv.vault.azure.net/deletedsecrets/my-secret",
+            "deletedDate": 1_750_000_000,
+            "scheduledPurgeDate": 1_757_776_000,
+            "tags": { "original_name": "My Secret" }
+        });
+        let summary = parse_deleted_secret_summary(&item).unwrap();
+        assert_eq!(summary.name, "my-secret");
+        assert_eq!(summary.original_name, "My Secret");
+        assert!(summary
+            .deleted_on
+            .as_deref()
+            .unwrap()
+            .starts_with("2025-06-15"));
+        assert!(summary.scheduled_purge_on.is_some());
+    }
+
+    #[test]
+    fn parse_deleted_secret_summary_tolerates_missing_dates() {
+        let item = serde_json::json!({
+            "id": "https://kv.vault.azure.net/deletedsecrets/bare"
+        });
+        let summary = parse_deleted_secret_summary(&item).unwrap();
+        assert_eq!(summary.name, "bare");
+        assert_eq!(summary.original_name, "bare");
+        assert!(summary.deleted_on.is_none());
+        assert!(summary.scheduled_purge_on.is_none());
     }
 
     #[test]

--- a/src/secret/manager.rs
+++ b/src/secret/manager.rs
@@ -2774,21 +2774,10 @@ mod tests {
     fn test_parse_deleted_secret_summary_full() {
         let item = serde_json::json!({
             "id": "https://myvault.vault.azure.net/deletedsecrets/my-secret",
-            "recoveryId": "https://myvault.vault.azure.net/deletedsecrets/my-secret",
             "deletedDate": 1_700_000_100,
             "scheduledPurgeDate": 1_707_776_100,
-            "contentType": "application/json",
-            "attributes": {
-                "enabled": false,
-                "created": 1_700_000_000,
-                "updated": 1_700_000_050,
-                "recoveryLevel": "Recoverable+Purgeable"
-            },
             "tags": {
-                "original_name": "My Secret",
-                "groups": "alpha,beta",
-                "note": "a note",
-                "folder": "apps/web"
+                "original_name": "My Secret"
             }
         });
 
@@ -2843,37 +2832,6 @@ mod tests {
         assert!(parse_deleted_secret_summary(&serde_json::json!({})).is_none());
         assert!(parse_deleted_secret_summary(&serde_json::json!({ "id": 42 })).is_none());
         assert!(parse_deleted_secret_summary(&serde_json::json!({ "id": "" })).is_none());
-    }
-
-    #[test]
-    fn parse_deleted_secret_summary_reads_deletion_dates() {
-        let item = serde_json::json!({
-            "id": "https://kv.vault.azure.net/deletedsecrets/my-secret",
-            "deletedDate": 1_750_000_000,
-            "scheduledPurgeDate": 1_757_776_000,
-            "tags": { "original_name": "My Secret" }
-        });
-        let summary = parse_deleted_secret_summary(&item).unwrap();
-        assert_eq!(summary.name, "my-secret");
-        assert_eq!(summary.original_name, "My Secret");
-        assert!(summary
-            .deleted_on
-            .as_deref()
-            .unwrap()
-            .starts_with("2025-06-15"));
-        assert!(summary.scheduled_purge_on.is_some());
-    }
-
-    #[test]
-    fn parse_deleted_secret_summary_tolerates_missing_dates() {
-        let item = serde_json::json!({
-            "id": "https://kv.vault.azure.net/deletedsecrets/bare"
-        });
-        let summary = parse_deleted_secret_summary(&item).unwrap();
-        assert_eq!(summary.name, "bare");
-        assert_eq!(summary.original_name, "bare");
-        assert!(summary.deleted_on.is_none());
-        assert!(summary.scheduled_purge_on.is_none());
     }
 
     #[test]

--- a/src/utils/pagination.rs
+++ b/src/utils/pagination.rs
@@ -54,19 +54,24 @@ pub struct Page<T> {
 }
 
 impl<T> Page<T> {
-    pub fn human_summary(&self, noun: &str) -> Option<String> {
+    pub fn human_summary(&self, noun_singular: &str, noun_plural: &str) -> Option<String> {
         let page_size = self.page_size?;
         let total_pages = self.total_pages.unwrap_or(0);
+        let noun = if self.total_items == 1 {
+            noun_singular
+        } else {
+            noun_plural
+        };
 
         if self.total_items == 0 || self.items.is_empty() {
             return Some(format!(
-                "Showing 0 of {} {}(s) — page {} of {}",
+                "Showing 0 of {} {} — page {} of {}",
                 self.total_items, noun, self.page, total_pages
             ));
         }
 
         Some(format!(
-            "Showing {}-{} of {} {}(s) — page {} of {} (page size {})",
+            "Showing {}-{} of {} {} — page {} of {} (page size {})",
             self.start_index_1_based.unwrap_or(0),
             self.end_index_1_based.unwrap_or(0),
             self.total_items,
@@ -131,17 +136,11 @@ pub fn paginate_slice<T: Clone>(items: &[T], pagination: Pagination) -> Page<T> 
     }
 }
 
-#[allow(dead_code)]
-pub fn print_pagination_footer<T>(page: &Page<T>, noun: &str, output_format: OutputFormat) {
-    if let Some(text) = pagination_footer_text(page, noun, output_format) {
-        println!("\n{text}");
-    }
-}
-
 /// Return footer text for human-readable output formats.
 pub fn pagination_footer_text<T>(
     page: &Page<T>,
-    noun: &str,
+    noun_singular: &str,
+    noun_plural: &str,
     output_format: OutputFormat,
 ) -> Option<String> {
     let human_output = matches!(
@@ -149,7 +148,9 @@ pub fn pagination_footer_text<T>(
         OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
     );
 
-    human_output.then(|| page.human_summary(noun)).flatten()
+    human_output
+        .then(|| page.human_summary(noun_singular, noun_plural))
+        .flatten()
 }
 
 #[cfg(test)]
@@ -199,5 +200,26 @@ mod tests {
         assert!(Pagination::from_args(Some(0), Some(10)).is_err());
         assert!(Pagination::from_args(Some(1), Some(0)).is_err());
         assert!(Pagination::from_args(Some(1), None).is_err());
+    }
+
+    #[test]
+    fn human_summary_is_plural_aware() {
+        let one = paginate_slice(&[1], Pagination::from_args(None, Some(5)).unwrap());
+        assert_eq!(
+            one.human_summary("secret", "secrets").unwrap(),
+            "Showing 1-1 of 1 secret — page 1 of 1 (page size 5)"
+        );
+
+        let many = paginate_slice(&[1, 2, 3], Pagination::from_args(None, Some(2)).unwrap());
+        assert_eq!(
+            many.human_summary("secret", "secrets").unwrap(),
+            "Showing 1-2 of 3 secrets — page 1 of 2 (page size 2)"
+        );
+
+        let empty = paginate_slice(&[] as &[i32], Pagination::from_args(None, Some(2)).unwrap());
+        assert_eq!(
+            empty.human_summary("entry", "entries").unwrap(),
+            "Showing 0 of 0 entries — page 1 of 0"
+        );
     }
 }

--- a/src/vault/manager.rs
+++ b/src/vault/manager.rs
@@ -112,32 +112,6 @@ impl VaultManager {
             .await
     }
 
-    /// List vaults with formatted output
-    pub async fn list_vaults_formatted(
-        &self,
-        subscription_id: Option<&str>,
-        resource_group: Option<&str>,
-        output_format: OutputFormat,
-        template: Option<String>,
-    ) -> Result<Vec<VaultSummary>> {
-        let vaults = self
-            .vault_ops
-            .list_vaults(subscription_id, resource_group)
-            .await?;
-
-        if vaults.is_empty() {
-            output::info("No vaults found.");
-            return Ok(vaults);
-        }
-
-        // Format and display results
-        let formatter = TableFormatter::new(output_format, self.no_color, template, None);
-        let table_output = formatter.format_table(&vaults)?;
-        println!("{table_output}");
-
-        Ok(vaults)
-    }
-
     /// Delete vault with confirmation
     pub async fn delete_vault_safe(
         &self,

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -465,6 +465,44 @@ async fn set_secret_update_path_when_already_exists() {
 }
 
 #[tokio::test]
+async fn update_secret_enabled_flag_is_unsupported() {
+    use aws_sdk_secretsmanager::operation::list_secrets::ListSecretsOutput;
+    use crosstache::backend::{BackendError, SecretBackend};
+    use crosstache::secret::manager::{FieldUpdate, SecretUpdateRequest};
+
+    // AWS has no enable/disable concept; the flag must fail loudly before
+    // any API call is made (no mock rules are consumed).
+    let rule = mock!(Client::list_secrets).then_output(|| ListSecretsOutput::builder().build());
+    let client = mock_client!(aws_sdk_secretsmanager, RuleMode::Sequential, &[&rule]);
+    let backend = aws_secret_backend(client);
+
+    let request = SecretUpdateRequest {
+        name: "db-password".to_string(),
+        new_name: None,
+        value: None,
+        content_type: None,
+        enabled: Some(false),
+        expires_on: FieldUpdate::Unchanged,
+        not_before: FieldUpdate::Unchanged,
+        tags: None,
+        groups: None,
+        note: FieldUpdate::Unchanged,
+        folder: FieldUpdate::Unchanged,
+        replace_tags: false,
+        replace_groups: false,
+    };
+
+    let err = backend
+        .update_secret("myproj-kv", "db-password", request)
+        .await
+        .expect_err("--enabled must not be a silent no-op on AWS");
+    assert!(
+        matches!(&err, BackendError::Unsupported(feature) if feature == "enable/disable secrets"),
+        "expected Unsupported, got: {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn list_versions_returns_history() {
     use aws_sdk_secretsmanager::operation::list_secret_version_ids::ListSecretVersionIdsOutput;
     use aws_sdk_secretsmanager::types::SecretVersionsListEntry;

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -933,3 +933,22 @@ fn parse_prints_exactly_one_table() {
         "json output polluted by a table:\n{json_out}"
     );
 }
+
+#[test]
+fn ls_sort_flag_is_accepted_and_lists_everything() {
+    let env = TestEnv::new();
+    env.set_secret("older", "v");
+    env.set_secret("newer", "v");
+
+    // Local timestamps have minute resolution, so ordering is covered by the
+    // unit test; here we assert the flag parses and output is complete.
+    let out = env.xv_ok(&["ls", "--sort", "updated"]);
+    assert!(out.contains("older") && out.contains("newer"), "{out}");
+
+    let json = env.xv_ok(&["ls", "--sort", "updated", "--format", "json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert_eq!(parsed.as_array().map(Vec::len), Some(2));
+
+    let (_, stderr) = env.xv_fail(&["ls", "--sort", "bogus"]);
+    assert!(stderr.contains("possible values"), "{stderr}");
+}

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -1109,6 +1109,29 @@ fn group_list_excludes_disabled_secrets() {
 }
 
 #[test]
+fn find_folder_scopes_by_segment_boundary() {
+    let env = TestEnv::new();
+    env.set_secret_with_args("db-pass", "v", &["--folder", "prod/db"]);
+    env.set_secret_with_args("api-key", "v", &["--folder", "prod"]);
+    env.set_secret_with_args("trap", "v", &["--folder", "production"]);
+    env.set_secret("root-a", "v");
+
+    // No pattern: everything in scope, unranked.
+    let out = env.xv_ok(&["find", "--folder", "prod", "--names-only"]);
+    let names: Vec<&str> = out.lines().collect();
+    assert!(
+        names.contains(&"db-pass") && names.contains(&"api-key"),
+        "{out}"
+    );
+    assert!(!names.contains(&"trap"), "segment boundary violated: {out}");
+    assert!(!names.contains(&"root-a"), "{out}");
+
+    // Trailing slash tolerated; invalid path errors.
+    let out2 = env.xv_ok(&["find", "--folder", "prod/", "--names-only"]);
+    assert!(out2.contains("db-pass"), "{out2}");
+}
+
+#[test]
 fn context_envs_is_hidden_and_warns() {
     let env = TestEnv::new();
 

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -1077,3 +1077,33 @@ fn group_list_counts_members_across_formats() {
         "[]"
     );
 }
+
+#[test]
+fn group_list_excludes_disabled_secrets() {
+    let env = TestEnv::new();
+    // Create secrets with groups
+    env.set_secret_with_args("active-a", "v", &["--group", "team-x"]);
+    env.set_secret_with_args("active-b", "v", &["--group", "team-x"]);
+    env.set_secret_with_args("disabled-member", "v", &["--group", "team-x"]);
+
+    // Disable the third secret
+    env.xv_ok(&["update", "disabled-member", "--enabled", "false"]);
+
+    // Verify the group count excludes the disabled secret
+    let csv = env.xv_ok(&["group", "list", "--format", "csv"]);
+    assert!(
+        csv.contains("team-x,2"),
+        "disabled secret should not be counted: {csv}"
+    );
+
+    let json = env.xv_ok(&["group", "list", "--format", "json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert_eq!(
+        parsed
+            .as_array()
+            .and_then(|a| a.first())
+            .and_then(|v| v.get("secrets")),
+        Some(&serde_json::json!(2)),
+        "disabled secret should not contribute to count: {json}"
+    );
+}

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -1107,3 +1107,28 @@ fn group_list_excludes_disabled_secrets() {
         "disabled secret should not contribute to count: {json}"
     );
 }
+
+#[test]
+fn context_envs_is_hidden_and_warns() {
+    let env = TestEnv::new();
+
+    // Hidden from help.
+    let help = env.xv_ok(&["context", "--help"]);
+    assert!(
+        !help.contains("envs"),
+        "context envs still visible in help:\n{help}"
+    );
+
+    // Still works, but warns on stderr.
+    let output = env
+        .xv()
+        .args(["context", "envs"])
+        .output()
+        .expect("run context envs");
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("context envs is deprecated; use env list"),
+        "missing deprecation warning:\n{stderr}"
+    );
+}

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -231,6 +231,30 @@ fn update_secret_metadata() {
 }
 
 #[test]
+fn update_note_only_preserves_group_membership() {
+    let env = TestEnv::new();
+    env.set_secret_with_args("GROUPED_KEY", "original", &["--group", "team-a"]);
+
+    // Sanity check: the secret starts out counted in its group.
+    let before = env.xv_ok(&["group", "list", "--format", "csv"]);
+    assert!(before.contains("team-a,1"), "before update: {before}");
+
+    // A note-only update must not silently drop the existing `groups` tag
+    // (or any other tag) via a full-replacement PATCH/write.
+    env.xv_ok(&["update", "GROUPED_KEY", "--note", "note only update"]);
+
+    let after = env.xv_ok(&["group", "list", "--format", "csv"]);
+    assert!(
+        after.contains("team-a,1"),
+        "group membership should survive a note-only update: {after}"
+    );
+
+    // Value and note should both reflect the expected post-update state.
+    let value = env.get_raw("GROUPED_KEY");
+    assert_eq!(value, "original");
+}
+
+#[test]
 fn delete_and_verify() {
     let env = TestEnv::new();
     env.set_secret("TEMP_SECRET", "temp-value");

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -542,6 +542,25 @@ fn set_with_metadata() {
     assert_eq!(value, "meta-value");
 }
 
+#[test]
+fn recursive_ls_qualifies_names_by_folder() {
+    let env = TestEnv::new();
+    env.set_secret_with_args("db-pass", "v", &["--folder", "prod/db"]);
+    env.set_secret("root-a", "v");
+
+    let names = env.xv_ok(&["ls", "-r", "--names-only"]);
+    assert!(names.lines().any(|l| l == "prod/db/db-pass"), "{names}");
+    assert!(names.lines().any(|l| l == "root-a"), "{names}");
+
+    // Scoped recursion is relative to the listing root.
+    let scoped = env.xv_ok(&["ls", "prod", "-r", "--names-only"]);
+    assert!(scoped.lines().any(|l| l == "db/db-pass"), "{scoped}");
+
+    // Non-recursive --names-only keeps the shipped unqualified shape.
+    let flat = env.xv_ok(&["ls", "--names-only"]);
+    assert!(flat.lines().any(|l| l == "db-pass"), "{flat}");
+}
+
 // ===========================================================================
 // Delete without --force in a non-interactive session should REFUSE (exit
 // non-zero) and not delete — never silently no-op.

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -255,6 +255,42 @@ fn update_note_only_preserves_group_membership() {
 }
 
 #[test]
+fn clear_note_and_folder_in_update() {
+    let env = TestEnv::new();
+    // Create secret with note and folder
+    env.set_secret_with_args(
+        "CLEAR_METADATA_KEY",
+        "value",
+        &["--note", "initial note", "--folder", "app/db"],
+    );
+
+    // Verify the secret value is correct
+    let value = env.get_raw("CLEAR_METADATA_KEY");
+    assert_eq!(value, "value");
+
+    // Clear the note and folder via update
+    env.xv_ok(&[
+        "update",
+        "CLEAR_METADATA_KEY",
+        "--clear-note",
+        "--clear-folder",
+    ]);
+
+    // Verify value is still correct after clearing metadata
+    let value_after = env.get_raw("CLEAR_METADATA_KEY");
+    assert_eq!(value_after, "value");
+
+    // Verify that the secret is NOT found when searching by its former folder
+    // (this indirectly confirms the folder was cleared)
+    let found_by_folder = env.xv_ok(&["find", "--folder", "app/db", "--names-only"]);
+    assert!(
+        !found_by_folder.contains("CLEAR_METADATA_KEY"),
+        "secret should not be found by its former folder after clearing: {}",
+        found_by_folder
+    );
+}
+
+#[test]
 fn delete_and_verify() {
     let env = TestEnv::new();
     env.set_secret("TEMP_SECRET", "temp-value");

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -971,3 +971,72 @@ fn ls_sort_flag_is_accepted_and_lists_everything() {
     let (_, stderr) = env.xv_fail(&["ls", "--sort", "bogus"]);
     assert!(stderr.contains("possible values"), "{stderr}");
 }
+
+#[test]
+fn ls_deleted_lists_soft_deleted_secrets() {
+    let env = TestEnv::new();
+    env.set_secret("doomed", "v");
+    env.set_secret("kept", "v");
+    env.xv_ok(&["delete", "doomed", "--force"]);
+
+    // Piped stdout resolves Auto → JSON, so the human views need the
+    // explicit format (same convention as the live `xv ls` e2e tests).
+    let out = env.xv_ok(&["ls", "--deleted", "--format", "table"]);
+    assert!(out.contains("doomed") && !out.contains("kept"), "{out}");
+    assert!(out.contains("1 deleted secret"), "count line: {out}");
+
+    // Long view has the date columns (explicit table format + -l takes the
+    // borderless long path, mirroring live `xv ls`).
+    let long = env.xv_ok(&["ls", "--deleted", "-l", "--format", "table"]);
+    assert!(
+        long.contains("DELETED") && long.contains("PURGE SCHEDULED"),
+        "{long}"
+    );
+
+    // Machine format: row array with a populated deleted date (local backend);
+    // purge schedule is empty (local trash never auto-purges).
+    let json = env.xv_ok(&["ls", "--deleted", "--format", "json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    let rows = parsed.as_array().expect("array");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["name"], "doomed");
+    assert!(!rows[0]["deleted"].as_str().unwrap().is_empty());
+    assert_eq!(rows[0]["purge_scheduled"], "");
+}
+
+#[test]
+fn ls_deleted_conflicts_and_empty_states() {
+    let env = TestEnv::new();
+
+    // clap conflicts: FOLDER positional and -r.
+    let (_, err1) = env.xv_fail(&["ls", "prod", "--deleted"]);
+    assert!(err1.contains("cannot be used with"), "{err1}");
+    let (_, err2) = env.xv_fail(&["ls", "--deleted", "-r"]);
+    assert!(err2.contains("cannot be used with"), "{err2}");
+
+    // Empty: human info on stderr, valid-empty JSON on stdout.
+    let json = env.xv_ok(&["ls", "--deleted", "--format", "json"]);
+    assert_eq!(json.trim(), "[]");
+}
+
+#[test]
+fn ls_deleted_columns_selection_and_validation() {
+    let env = TestEnv::new();
+    env.set_secret("doomed", "v");
+    env.xv_ok(&["delete", "doomed", "--force"]);
+
+    // --columns projects the requested subset on the deleted table.
+    let out = env.xv_ok(&["ls", "--deleted", "--format", "table", "--columns", "Name"]);
+    assert!(out.contains("doomed"), "{out}");
+    assert!(!out.contains("Purge Scheduled"), "{out}");
+
+    // Unknown column errors, even on the empty grid/long path (human table
+    // formats validate --columns regardless of Auto/JSON's empty-array
+    // fast path, matching the branch-wide rule in `display_cached_secret_list`).
+    let env2 = TestEnv::new();
+    let (_, err) = env2.xv_fail(&["ls", "--deleted", "--format", "table", "--columns", "Nope"]);
+    assert!(
+        !err.is_empty(),
+        "expected an error for unknown column: {err}"
+    );
+}

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -1040,3 +1040,40 @@ fn ls_deleted_columns_selection_and_validation() {
         "expected an error for unknown column: {err}"
     );
 }
+
+#[test]
+fn group_list_counts_members_across_formats() {
+    let env = TestEnv::new();
+    env.set_secret_with_args("a", "v", &["--group", "team-a"]);
+    env.set_secret_with_args("b", "v", &["--group", "team-a"]);
+    env.set_secret_with_args("c", "v", &["--group", "team-b"]);
+    env.set_secret("ungrouped", "v");
+
+    // Piped stdout resolves Auto → JSON; force the human table for the
+    // count-line assertion.
+    let table = env.xv_ok(&["group", "list", "--format", "table"]);
+    assert!(
+        table.contains("team-a") && table.contains("team-b"),
+        "{table}"
+    );
+    assert!(table.contains("2 groups"), "count line: {table}");
+
+    let csv = env.xv_ok(&["group", "list", "--format", "csv"]);
+    let mut lines = csv.lines();
+    assert_eq!(lines.next(), Some("Group,Secrets"), "{csv}");
+    assert!(
+        csv.contains("team-a,2") && csv.contains("team-b,1"),
+        "{csv}"
+    );
+
+    let json = env.xv_ok(&["group", "list", "--format", "json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert_eq!(parsed.as_array().map(Vec::len), Some(2));
+
+    // Empty vault → valid-empty machine output.
+    let fresh = TestEnv::new();
+    assert_eq!(
+        fresh.xv_ok(&["group", "list", "--format", "json"]).trim(),
+        "[]"
+    );
+}

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -914,3 +914,22 @@ fn env_push_imports_secrets() {
     assert_eq!(env.get_raw("GAMMA"), "three");
     assert_eq!(env.get_raw("DELTA"), "four");
 }
+
+#[test]
+fn parse_prints_exactly_one_table() {
+    let env = TestEnv::new();
+    // `xv parse` has its own local `--fmt` flag (default "table").
+    let out = env.xv_ok(&["parse", "Server=myhost;Database=mydb"]);
+    assert_eq!(
+        out.matches("myhost").count(),
+        1,
+        "connection-string table printed more than once:\n{out}"
+    );
+
+    // JSON format must not leak a human table before the JSON document.
+    let json_out = env.xv_ok(&["parse", "Server=myhost;Database=mydb", "--fmt", "json"]);
+    assert!(
+        json_out.trim_start().starts_with('['),
+        "json output polluted by a table:\n{json_out}"
+    );
+}

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -1155,3 +1155,11 @@ fn context_envs_is_hidden_and_warns() {
         "missing deprecation warning:\n{stderr}"
     );
 }
+
+#[test]
+fn complete_folders_is_silent_without_cache() {
+    let env = TestEnv::new();
+    env.set_secret_with_args("db-pass", "v", &["--folder", "prod/db"]);
+    let out = env.xv_ok(&["__complete-folders"]);
+    assert_eq!(out.trim(), "", "cache disabled → no completions, no errors");
+}

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -1106,6 +1106,27 @@ fn group_list_excludes_disabled_secrets() {
         Some(&serde_json::json!(2)),
         "disabled secret should not contribute to count: {json}"
     );
+
+    // ls (default view) must exclude it while disabled...
+    let ls = env.xv_ok(&["ls", "--names-only"]);
+    assert!(
+        !ls.lines().any(|l| l == "disabled-member"),
+        "disabled secret should not be listed: {ls}"
+    );
+
+    // ...and the full roundtrip must work: RE-ENABLE and reappear.
+    env.xv_ok(&["update", "disabled-member", "--enabled", "true"]);
+
+    let csv = env.xv_ok(&["group", "list", "--format", "csv"]);
+    assert!(
+        csv.contains("team-x,3"),
+        "re-enabled secret should be counted again: {csv}"
+    );
+    let ls = env.xv_ok(&["ls", "--names-only"]);
+    assert!(
+        ls.lines().any(|l| l == "disabled-member"),
+        "re-enabled secret should be listed again: {ls}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The P3 tier of the list-command UX review, stacked on #292 (Phase B) — GitHub will retarget this to `main` automatically when #292 merges. Spec and plan included (`docs/superpowers/specs/2026-07-02-list-p3-design.md`).

- **`xv ls --deleted`** — lists soft-deleted secrets with deleted/purge dates through the shared renderer, on all three backends (Azure: both dates from the deleted-secrets API; local: deleted date from trash metadata; AWS: deletion date). Capability-gated, cache-bypassing, conflicts with live-listing filters. Backend trait now returns rich `DeletedSecretSummary` rows.
- **`xv group list`** — new command deriving groups + member counts from secret metadata (disabled secrets excluded, matching `ls` defaults). Rider: **`xv update --enabled <true|false>`** to disable/re-enable secrets.
- **`xv ls --sort name|updated`** — `updated` is newest-first with unknown-date entries last.
- **Folder ergonomics:** `find --folder` (segment-boundary subtree filter, folder-aware empty messages), folder-qualified names in recursive listings (sorted by the displayed label), hidden `__complete-folders` for shell completion (ancestor prefixes, cache-only, sanitized output).
- **Inherited fixes:** `xv parse` no longer double-prints; pagination footers are plural-aware ("1 item" / "3 items"); `xv cache refresh --key vaults` is silent; CJK-safe display widths via `unicode-width`; `context envs` deprecated (hidden, warns, delegates to `env list`).
- **Bugs found by the review loop and fixed here:** `xv update --enabled` was broken on Azure in both directions (403 on the confirmation read; fixed with an attributes-only `PATCH` and PUT-response parsing, live-verified disable→re-enable roundtrip on the real vault); AWS now errors loudly on `--enabled` instead of faking success; **`xv purge` used a wrong Azure endpoint and always failed with HTTP 400** — corrected to the documented `DELETE /deletedsecrets/{name}` route.

## Test plan

- 642 lib tests, 53 hermetic local-backend e2e (incl. deleted-listing, group counts, disable/re-enable roundtrip, qualified `-r` sort, completion silence-on-cold-cache), 29 AWS mock tests, full `cargo test` green (credential-gated suites properly ignored); clippy zero warnings on default and `--features aws`; fmt clean.
- Live real-vault verification: `ls --deleted` rendering actual deleted fixtures with correct dates; `group list` counts; `--enabled` disable→re-enable roundtrip with a scratch secret (soft-deleted afterward; purge blocked by the vault's purge protection — auto-expires).
- Per-task adversarial reviews (4 fix waves), final whole-branch review, and a bounded deslop pass (-43 lines of test slop) with post-cleanup regression rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret listing, update, and purge paths across Azure/AWS/local with new CLI surface area, but changes are additive with capability gates and targeted backend fixes; Azure enable/disable and purge URL corrections reduce prior failure modes.
> 
> **Overview**
> **List-command P3** adds soft-delete visibility, group overview, sorting, and folder-scoped search/completion, plus several listing UX fixes.
> 
> **New commands and flags:** `xv ls --deleted` (capability-gated, live fetch, grid/long/table/JSON with deleted and purge dates per backend); `xv group list` (member counts from `groups` metadata); `xv ls --sort name|updated`; `xv find --folder`; `xv update --enabled`; hidden `xv __complete-folders` for tab completion. `context envs` is hidden and warns toward `env list`.
> 
> **Data and backends:** `list_deleted_secrets` now returns `DeletedSecretSummary` (Azure/local/AWS populate `deleted_on`; purge schedule mainly on Azure). Recursive `xv ls -r` shows folder-qualified names and sorts by the displayed label when sorting by name.
> 
> **Rendering and fixes:** Terminal layout uses `unicode-width` for grids, long listings, and note wrap. `xv parse` no longer double-prints; pagination footers use proper plurals; `xv cache refresh --key vaults` no longer dumps JSON to stdout. **Azure:** metadata-only updates (including enable/disable) use attributes `PATCH` with merged tags via `build_patched_tags`. **AWS:** `--enabled` returns `Unsupported` instead of silently ignoring. **Azure purge:** `DELETE …/deletedsecrets/{name}` replaces the broken `/purge` URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83adc53f8c67eeee0fadbae0ae2aeebb9dca1b47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->