### PR TITLE
chore: bump version to 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.17.0 — Folder-aware listing, unified renderers, and legacy cleanup (2026-07-02)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"


### PR DESCRIPTION
## Summary

Release prep for v0.17.0 — the list-command UX overhaul (#288–#296): folder-aware ls-style listing, unified rendering through TableFormatter with `--columns` and machine formats everywhere, `ls --deleted`/`group list`/`--sort`, deliberate breaking machine-shape changes, removed deprecated aliases, and the -1,400-line legacy cleanup (incl. the tag-drop and purge-endpoint bug fixes).

- Cargo.toml + Cargo.lock → 0.17.0
- CHANGELOG `## Unreleased` → `## v0.17.0 — Folder-aware listing, unified renderers, and legacy cleanup (2026-07-02)`

After merge I'll tag `v0.17.0` on the merge commit; the tag push triggers `release.yml` (version-match gate → GitHub release → multi-platform binaries for `xv upgrade`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog header only; no runtime code changes in this PR.
> 
> **Overview**
> Release prep for **v0.17.0**: bumps the crate version from `0.16.0` to `0.17.0` in `Cargo.toml` and the matching `crosstache` entry in `Cargo.lock`.
> 
> The changelog **`## Unreleased`** section is retitled to **`## v0.17.0 — Folder-aware listing, unified renderers, and legacy cleanup (2026-07-02)`**; the release notes underneath are unchanged in this diff. No application source or behavior changes—this is metadata for tagging and CI release builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a28dc7909454e8412bc061cce2aeddfbe06b1d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->