### PR TITLE
fix: AWS list folder tags + mv collision pre-check on backend names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- AWS: `list_secrets` now exposes the folder/note/original-name tags, fixing folder-qualified `xv mv`/`xv ls` on AWS; `xv mv` collision pre-check also matches backend (sanitized) names.
 - **`xv update --rename` works again on every backend (#295).** Rename is now a real trait-level operation (`SecretBackend::rename_secret`): read value + metadata, create under the new name (user tags, groups, note, folder, content type, and expiry ride along), then delete the old name with the backend's normal delete. Previously Azure created the duplicate and never deleted the original, while local and AWS silently ignored the flag; the `SecretUpdateRequest.new_name` field is gone so a backend can never ignore a rename again. Combined with other update flags, the in-place updates apply first, then the rename. Renaming onto an existing name is refused (`xv-conflict`); version history does not carry over. On Azure the old name is left soft-deleted (visible in `xv ls --deleted`; renaming back within the retention window conflicts); on AWS it sits in the standard 30-day recovery window; on local it lands in trash.
 - **`RenameIncomplete` is restored** (removed in the v0.17.0 legacy cleanup while unreachable): if the new secret is created but deleting the original fails, `xv update --rename` exits 43 with code `xv-rename-incomplete`, names both copies and the vault, and prints the recovery steps (`xv get <new>`, then `xv delete <old>` or retry). The new secret is deliberately never rolled back. The 43 row is back in `docs/exit-codes.md`.
 

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -565,7 +565,7 @@ impl SecretBackend for AwsSecretBackend {
         group_filter: Option<&str>,
     ) -> Result<Vec<SecretSummary>, BackendError> {
         use crate::backend::aws::encoding::{is_marker, strip_prefix};
-        use crate::backend::aws::metadata::TAG_GROUPS;
+        use crate::backend::aws::metadata::{TAG_FOLDER, TAG_GROUPS, TAG_ORIGINAL_NAME};
         use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
 
         let prefix = format!("{vault}/");
@@ -619,11 +619,34 @@ impl SecretBackend for AwsSecretBackend {
                     .map(|s| crate::backend::aws::metadata::decode_groups(s).join(","))
                     .filter(|s| !s.is_empty());
 
+                // Extract folder/original-name tags the same way
+                // props_from_describe does for get_secret, so folder-qualified
+                // `xv mv`/`xv ls` work on AWS-listed summaries too.
+                let folder_val = entry
+                    .tags()
+                    .iter()
+                    .find(|t| t.key() == Some(TAG_FOLDER))
+                    .and_then(|t| t.value())
+                    .map(String::from)
+                    .filter(|f| !f.is_empty());
+                let original_name_val = entry
+                    .tags()
+                    .iter()
+                    .find(|t| t.key() == Some(TAG_ORIGINAL_NAME))
+                    .and_then(|t| t.value())
+                    .map(String::from)
+                    .filter(|n| !n.is_empty())
+                    .unwrap_or_else(|| secret_name.clone());
+                let note_val = entry
+                    .description()
+                    .map(String::from)
+                    .filter(|n| !n.is_empty());
+
                 summaries.push(SecretSummary {
-                    name: secret_name.clone(),
-                    original_name: secret_name,
-                    note: None,
-                    folder: None,
+                    name: secret_name,
+                    original_name: original_name_val,
+                    note: note_val,
+                    folder: folder_val,
                     groups: groups_val,
                     updated_on: String::new(),
                     enabled: true,

--- a/src/cli/mv_ops.rs
+++ b/src/cli/mv_ops.rs
@@ -124,6 +124,17 @@ fn norm_folder(folder: Option<&str>) -> Option<&str> {
     folder.filter(|f| !f.is_empty())
 }
 
+/// True if any secret in `secrets` already occupies `dest_name` — either as
+/// its display name or as its raw backend (sanitized) name. A secret whose
+/// backend key equals the destination but whose display label differs would
+/// otherwise slip past the pre-check, letting the folder update apply before
+/// `rename_secret`'s own exists-guard fails and leaving a half-applied move.
+fn dest_collides(secrets: &[SecretSummary], dest_name: &str) -> bool {
+    secrets
+        .iter()
+        .any(|s| display_name(s) == dest_name || s.name == dest_name)
+}
+
 pub(crate) async fn execute_mv(
     source: String,
     dest: String,
@@ -235,7 +246,7 @@ async fn execute_secret_mv(
 
     // Collision pre-check — before any mutation — only relevant when the
     // name is actually changing.
-    if dest_name != src_name && secrets.iter().any(|s| display_name(s) == dest_name) {
+    if dest_name != src_name && dest_collides(&secrets, &dest_name) {
         return Err(CrosstacheError::conflict(format!(
             "secret '{dest_name}' already exists in vault '{vault_name}' — delete it first or pick another name"
         )));
@@ -516,5 +527,39 @@ mod tests {
         assert!(parse_mv("db/pass", "app//").is_err());
         // Folder source with an internal empty segment.
         assert!(parse_mv("app//db/", "svc/").is_err());
+    }
+
+    fn summary(name: &str, original_name: &str) -> SecretSummary {
+        SecretSummary {
+            name: name.to_string(),
+            original_name: original_name.to_string(),
+            note: None,
+            folder: None,
+            groups: None,
+            updated_on: String::new(),
+            enabled: true,
+            content_type: String::new(),
+        }
+    }
+
+    #[test]
+    fn dest_collides_matches_display_name() {
+        let secrets = vec![summary("sanitized-name", "pretty-name")];
+        assert!(dest_collides(&secrets, "pretty-name"));
+    }
+
+    #[test]
+    fn dest_collides_matches_backend_name_only() {
+        // Backend (sanitized) name equals the destination, but the display
+        // label (original_name) differs — this is exactly the case that
+        // slipped past the old display-name-only pre-check.
+        let secrets = vec![summary("dest-name", "some-other-display-name")];
+        assert!(dest_collides(&secrets, "dest-name"));
+    }
+
+    #[test]
+    fn dest_collides_no_match() {
+        let secrets = vec![summary("sanitized-name", "pretty-name")];
+        assert!(!dest_collides(&secrets, "unrelated-name"));
     }
 }

--- a/tests/aws_localstack_tests.rs
+++ b/tests/aws_localstack_tests.rs
@@ -260,6 +260,46 @@ async fn localstack_list_paginates() {
     }
 }
 
+/// list_secrets must expose the folder/original-name tags in its summaries,
+/// the same way get_secret does via props_from_describe — otherwise
+/// folder-qualified `xv mv`/`xv ls` appear folderless on AWS (Bugbot #300).
+#[tokio::test]
+async fn localstack_list_secrets_exposes_folder_tag() {
+    if skip_unless_enabled() {
+        return;
+    }
+    let backend = build_backend().await;
+    let vault = format!("xv-test-{}", uuid::Uuid::new_v4());
+
+    let request = SecretRequest {
+        name: "db-pass".into(),
+        value: Zeroizing::new("folder-value".into()),
+        groups: None,
+        note: None,
+        content_type: None,
+        enabled: None,
+        expires_on: None,
+        not_before: None,
+        tags: None,
+        folder: Some("db".into()),
+    };
+    backend.secrets().set_secret(&vault, request).await.unwrap();
+
+    let listed = backend.secrets().list_secrets(&vault, None).await.unwrap();
+    let found = listed
+        .iter()
+        .find(|s| s.name == "db-pass")
+        .unwrap_or_else(|| panic!("db-pass not found in listing: {listed:?}"));
+    assert_eq!(found.folder.as_deref(), Some("db"));
+    assert_eq!(found.original_name, "db-pass");
+
+    backend
+        .secrets()
+        .purge_secret(&vault, "db-pass")
+        .await
+        .unwrap();
+}
+
 #[tokio::test]
 async fn localstack_vault_marker_create_list_delete() {
     if skip_unless_enabled() {


### PR DESCRIPTION
Fixes the two Cursor Bugbot findings posted on #300 at merge time, both verified real:

- **High — folder paths failed on AWS:** `list_secrets` hardcoded `folder: None` (and `note`/`original_name`), so folder-qualified `xv mv db/pass app/`, bulk `xv mv app/ svc/`, and folder views in `xv ls` saw every AWS secret as folderless. The summary loop now maps `TAG_FOLDER`/`TAG_ORIGINAL_NAME` (+ description as note) exactly like `get_secret` does. New LocalStack test `localstack_list_secrets_exposes_folder_tag` proves the fix; both LocalStack roundtrip regressions pass.
- **Medium — rename collision missed backend names:** the `mv` collision pre-check compared only display names, so a destination equal to a secret's backend (sanitized) key slipped past and the folder update applied before the rename conflicted. The check is now a pure `dest_collides` predicate matching display and backend names, unit-tested for both match shapes.

Verification: lib 672/672; local-backend mv e2e 10/10; LocalStack new test + 2 regressions pass (community image 4.5); clippy `--features aws` zero warnings.

Follow-up noted on #301: `list_deleted_secrets` has the same hardcoded `original_name` pattern (`xv ls --deleted` on AWS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted AWS listing metadata and a pre-mutation CLI guard with tests; no auth, persistence format, or rename semantics changes beyond avoiding partial mv failures.
> 
> **Overview**
> **AWS listings** now populate `folder`, `original_name`, and `note` on each `SecretSummary` from the same `xv:` tags and description that `get_secret` already used, so folder-scoped **`xv ls`** and **`xv mv`** behave on AWS instead of treating every secret as vault-root.
> 
> **`xv mv`** collision detection runs through **`dest_collides`**, which treats a destination as taken if it matches either the user-facing name or the raw backend (`SecretSummary.name`) key—blocking half-applied moves when only the sanitized name conflicts. Unit tests cover both match shapes; LocalStack **`localstack_list_secrets_exposes_folder_tag`** locks in the AWS listing fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561c3fa783672040becb3f710f502640518c71ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->