### PR TITLE
chore: bump version to 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.18.0 — Filesystem verbs: xv mv, ls aliases everywhere, and reliable rename (2026-07-02)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive command-line tool for managing Azure Key Vaults"


### PR DESCRIPTION
Release prep for v0.18.0 — Filesystem verbs: xv mv, ls aliases everywhere, and reliable rename.

- Cargo.toml 0.17.0 → 0.18.0 (+ Cargo.lock)
- CHANGELOG Unreleased → v0.18.0 heading (2026-07-02)

Contains: #299 (ls aliases), #300 (xv mv), #302 (Bugbot fixes: AWS folder tags in list_secrets, mv collision pre-check), plus the #295/#298 rename fixes that landed after v0.17.0.

Tag v0.18.0 goes on the merged commit; release.yml verify-version gates on the match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no runtime code; risk is limited to a mismatched tag vs Cargo version if release tagging is done incorrectly.
> 
> **Overview**
> Prepares **v0.18.0** by aligning release metadata with the already-landed feature work (documented in the changelog, not introduced in this diff).
> 
> **`Cargo.toml`** and **`Cargo.lock`** move the `crosstache` package from **0.17.0 → 0.18.0**. **`CHANGELOG.md`** retitles **Unreleased** to **v0.18.0 — Filesystem verbs: xv mv, ls aliases everywhere, and reliable rename (2026-07-02)** so the release notes match what ships when **`v0.18.0`** is tagged (gated by **`release.yml`** `verify-version`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4d5de9bab1fd8011d06eb8f482515826bf16573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->