### PR TITLE
fix: resolve .xv.toml backend before validation; stop XV_BACKEND outranking project profile

### DIFF
--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -1402,14 +1402,23 @@ async fn execute_env_list(config: &Config) -> Result<()> {
         .map(|(name, _)| name.to_string());
 
     use crate::config::project::resolve_effective_backend;
-    // Precedence for every row mirrors `resolve_effective_backend`:
-    //   cli_backend (--backend / XV_BACKEND via clap) > profile.backend > global.
-    // `cli_backend` is the raw flag/env snapshot; `disk_backend` is the global
-    // config value taken BEFORE main.rs folded the active env's profile in
-    // (using `effective_backend_name()` here would make inactive envs inherit
-    // the active env's backend). A `None` profile backend falls through to the
+    // Precedence for every row mirrors `resolve_effective_backend` as fixed
+    // by issue #305: a true `--backend` flag > profile.backend > global
+    // (which already folds in XV_BACKEND via `load_from_env`). `cli_backend`
+    // is the raw flag/env snapshot — clap cannot distinguish a real flag from
+    // one populated by `XV_BACKEND`, so it is only fed into the CLI slot when
+    // `cli_backend_was_arg` confirms it was an actual argument; otherwise it
+    // falls through to the profile / global layers like any other
+    // XV_BACKEND-sourced value. `disk_backend` is the global config value
+    // taken BEFORE main.rs folded the active env's profile in (using
+    // `effective_backend_name()` here would make inactive envs inherit the
+    // active env's backend). A `None` profile backend falls through to the
     // global layer rather than silently defaulting to "azure".
-    let cli_backend = config.cli_backend.as_deref();
+    let cli_backend = if config.cli_backend_was_arg {
+        config.cli_backend.as_deref()
+    } else {
+        None
+    };
     let global_backend = config.disk_backend.as_deref();
 
     #[derive(tabled::Tabled, serde::Serialize)]
@@ -1434,8 +1443,9 @@ async fn execute_env_list(config: &Config) -> Result<()> {
                 resolve_effective_backend(cli_backend, profile.backend.as_deref(), global_backend);
             // "(inherited)" marks rows whose env profile set no `backend` of
             // its own — the displayed value came from outside the profile.
-            // Keys strictly on the profile field: the CLI override is populated
-            // from XV_BACKEND even when --backend is absent.
+            // Keys strictly on the profile field, independent of where the
+            // resolved value ultimately came from (CLI flag / XV_BACKEND /
+            // global config / built-in default).
             let backend_note = if profile.backend.is_none() {
                 " (inherited)"
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,27 +84,13 @@ async fn run_complete_folders() -> Result<()> {
 async fn run(cli: Cli) -> Result<()> {
     info!("Starting crosstache");
 
-    // Load configuration differently based on command
-    let mut config = match &cli.command {
-        crate::cli::Commands::Config { .. }
-        | crate::cli::Commands::Init
-        | crate::cli::Commands::Upgrade { .. }
-        | crate::cli::Commands::Version
-        | crate::cli::Commands::Completion { .. }
-        | crate::cli::Commands::Migrate { .. } => {
-            // These commands don't talk to Azure — skip credential validation.
-            load_config_without_validation().await?
-        }
-        _ => {
-            // For other commands: load WITHOUT validation here. Validation is
-            // deferred until after the `.xv.toml` env-profile backend has
-            // been resolved and folded into `config.backend` below — a
-            // profile selecting `local`/`aws` must not be rejected against
-            // global Azure config that was never going to be used
-            // (issue #305).
-            load_config_without_validation().await?
-        }
-    };
+    // Load configuration WITHOUT validation for every command. Validation is
+    // deferred until after the `.xv.toml` env-profile backend has been
+    // resolved and folded into `config.backend` below (and only performed
+    // for commands that actually need a backend) — a profile selecting
+    // `local`/`aws` must not be rejected against global Azure config that
+    // was never going to be used (issue #305).
+    let mut config = load_config_without_validation().await?;
 
     // Apply CLI --env flag to config (used by resolve_vault_name and
     // resolve_resource_group when consulting .xv.toml).
@@ -117,7 +103,12 @@ async fn run(cli: Cli) -> Result<()> {
     // now gated on it rather than on `cli.backend.is_none()` — a real
     // `--backend` flag should suppress the profile lookup, but `XV_BACKEND`
     // alone must not (issue #305).
+    // Stop scanning at the `--` separator: tokens after it belong to a
+    // passthrough child command (e.g. `xv run -- echo --backend prod`) and
+    // must not be mistaken for a real `--backend` flag on `xv` itself.
     let cli_backend_was_arg = std::env::args_os()
+        .skip(1)
+        .take_while(|a| a != "--")
         .any(|a| a == "--backend" || a.to_string_lossy().starts_with("--backend="));
 
     // Resolve env-profile backend (validate early; fail before touching Azure).
@@ -211,13 +202,11 @@ Rebuild with `cargo build --features aws` or install an AWS-enabled binary.",
         ));
     }
 
-    // Commands that are purely local (Config, Init, Cache, Context, etc.) never
-    // talk to a secrets backend and so must not be validated against one —
-    // Config/Init/Upgrade/Version/Completion/Migrate already returned an
-    // unvalidated config from the match above; the rest are excluded here.
-    // Computed BEFORE validation (moved up from its original position just
-    // above the registry-construction block below) so `needs_backend` can
-    // gate both.
+    // Commands that never talk to a secrets backend (this `matches!` is the
+    // source of truth for exactly which ones) must not be validated against
+    // one. Computed BEFORE validation (moved up from its original position
+    // just above the registry-construction block below) so `needs_backend`
+    // can gate both.
     let needs_backend = !matches!(
         cli.command,
         crate::cli::Commands::Config { .. }

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,8 +96,13 @@ async fn run(cli: Cli) -> Result<()> {
             load_config_without_validation().await?
         }
         _ => {
-            // For other commands, load with validation
-            config::load_config().await?
+            // For other commands: load WITHOUT validation here. Validation is
+            // deferred until after the `.xv.toml` env-profile backend has
+            // been resolved and folded into `config.backend` below — a
+            // profile selecting `local`/`aws` must not be rejected against
+            // global Azure config that was never going to be used
+            // (issue #305).
+            load_config_without_validation().await?
         }
     };
 
@@ -105,9 +110,23 @@ async fn run(cli: Cli) -> Result<()> {
     // resolve_resource_group when consulting .xv.toml).
     config.env_flag = cli.env.clone();
 
+    // Determine whether `--backend` was actually passed as a CLI argument, as
+    // opposed to merely populated by clap from `XV_BACKEND` via `env =
+    // "XV_BACKEND"` on the flag (see src/cli/commands.rs). This must be
+    // computed BEFORE the profile-backend lookup below, since the lookup is
+    // now gated on it rather than on `cli.backend.is_none()` — a real
+    // `--backend` flag should suppress the profile lookup, but `XV_BACKEND`
+    // alone must not (issue #305).
+    let cli_backend_was_arg = std::env::args_os()
+        .any(|a| a == "--backend" || a.to_string_lossy().starts_with("--backend="));
+
     // Resolve env-profile backend (validate early; fail before touching Azure).
-    // Precedence: CLI --backend > env-profile backend > config-file backend > "azure".
-    let profile_backend: Option<String> = if cli.backend.is_none() {
+    // Precedence: true `--backend` flag > .xv.toml env-profile backend >
+    // XV_BACKEND / global config-file backend > built-in "azure".
+    // Gated on `!cli_backend_was_arg` (not `cli.backend.is_none()`) so that
+    // `XV_BACKEND` — which clap folds into `cli.backend` indistinguishably
+    // from a real flag — does not suppress the profile lookup.
+    let profile_backend: Option<String> = if !cli_backend_was_arg {
         match std::env::current_dir() {
             Err(_) => None, // degenerate env — skip project-config walk
             Ok(cwd) => {
@@ -159,12 +178,21 @@ async fn run(cli: Cli) -> Result<()> {
     // correctly when values across layers coincide.
     config.disk_backend = config.backend.clone();
     config.cli_backend = cli.backend.clone();
-    config.cli_backend_was_arg = std::env::args_os()
-        .any(|a| a == "--backend" || a.to_string_lossy().starts_with("--backend="));
+    config.cli_backend_was_arg = cli_backend_was_arg;
+
+    // Only feed the CLI slot when `--backend` was a real argument — when it
+    // was merely populated from `XV_BACKEND`, that value already flows into
+    // `config.backend` via `load_from_env` and participates at the
+    // config-file layer instead, letting the .xv.toml profile outrank it.
+    let cli_backend_for_resolution = if cli_backend_was_arg {
+        cli.backend.as_deref()
+    } else {
+        None
+    };
 
     config.backend = Some(
         crate::config::project::resolve_effective_backend(
-            cli.backend.as_deref(),
+            cli_backend_for_resolution,
             profile_backend.as_deref(),
             config.backend.as_deref(),
         )
@@ -183,12 +211,13 @@ Rebuild with `cargo build --features aws` or install an AWS-enabled binary.",
         ));
     }
 
-    // Build the backend registry for commands that talk to a secrets backend.
-    // Commands that are purely local (Config, Init, Cache, Context, etc.) skip
-    // this entirely.  For commands that *may* need the backend we attempt
-    // construction but treat failure as non-fatal: the registry becomes `None`
-    // and individual command handlers will create their own auth provider on
-    // demand via `get_azure_auth_provider(None, config)`.
+    // Commands that are purely local (Config, Init, Cache, Context, etc.) never
+    // talk to a secrets backend and so must not be validated against one —
+    // Config/Init/Upgrade/Version/Completion/Migrate already returned an
+    // unvalidated config from the match above; the rest are excluded here.
+    // Computed BEFORE validation (moved up from its original position just
+    // above the registry-construction block below) so `needs_backend` can
+    // gate both.
     let needs_backend = !matches!(
         cli.command,
         crate::cli::Commands::Config { .. }
@@ -221,6 +250,20 @@ Rebuild with `cargo build --features aws` or install an AWS-enabled binary.",
             }
     );
 
+    // Validate the effective backend config only for commands that actually
+    // need it. Validating unconditionally (as the pre-#305 code did, before
+    // the profile backend had even been folded in) rejects setup-oriented
+    // commands like `context init --backend aws` for lacking config that
+    // they exist to create in the first place.
+    if needs_backend {
+        config.validate()?;
+    }
+
+    // Build the backend registry for commands that talk to a secrets backend.
+    // For commands that *may* need the backend we attempt construction but
+    // treat failure as non-fatal: the registry becomes `None` and individual
+    // command handlers will create their own auth provider on demand via
+    // `get_azure_auth_provider(None, config)`.
     let registry = if needs_backend {
         match backend::BackendRegistry::from_config(&config) {
             Ok(r) => Some(r),

--- a/tests/e2e_backend_resolution.rs
+++ b/tests/e2e_backend_resolution.rs
@@ -229,3 +229,37 @@ failed (exit {:?})\nstdout: {stdout}\nstderr: {stderr}",
         "XV_BACKEND=local should have selected the local backend: {stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Test E: a literal `--backend` token after `--` (passthrough child-command
+// args) must not be mistaken for a real `--backend` flag on `xv` itself.
+// ---------------------------------------------------------------------------
+//
+// `xv run -- echo --backend prod` carries a `--backend` token that belongs
+// to the child command, not to `xv`. Before the fix, the `cli_backend_was_arg`
+// scan over `std::env::args_os()` did not stop at the `--` separator, so it
+// matched this passthrough token, set `cli_backend_was_arg = true`, and
+// suppressed the `.xv.toml` profile lookup — with `cli.backend` still `None`
+// (clap correctly left the real `--backend` flag unset), the effective
+// backend silently fell through to the global/azure layer instead of the
+// profile's `local` backend.
+#[test]
+fn backend_token_after_separator_is_not_mistaken_for_cli_flag() {
+    let env = BackendResolutionEnv::new();
+    env.write_local_profile();
+
+    let output = env.run(&mut env.xv(), &["run", "--", "echo", "--backend", "prod"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected the .xv.toml local profile to still win when a passthrough child-command arg \
+contains a literal `--backend` token, but the command failed (exit {:?})\nstdout: {stdout}\n\
+stderr: {stderr}",
+        output.status.code(),
+    );
+    assert!(
+        !stderr.contains("Subscription ID is required"),
+        "a passthrough `--backend` token after `--` must not suppress the .xv.toml profile: {stderr}"
+    );
+}

--- a/tests/e2e_backend_resolution.rs
+++ b/tests/e2e_backend_resolution.rs
@@ -1,0 +1,231 @@
+//! End-to-end regression tests for issue #305: `.xv.toml` env-profile
+//! backend resolution ordering.
+//!
+//! Two bugs shared a root cause in `main::run()`:
+//!   1. The global config was validated (`Config::validate`) BEFORE the
+//!      `.xv.toml` env-profile backend was folded into `config.backend`, so
+//!      a profile selecting `local`/`aws` could be rejected against
+//!      incomplete global Azure config that was never going to be used.
+//!   2. `XV_BACKEND` populates `cli.backend` via clap's `env = "XV_BACKEND"`
+//!      attribute, indistinguishable from a real `--backend` flag. The
+//!      profile lookup was gated on `cli.backend.is_none()`, so setting
+//!      `XV_BACKEND` silently skipped the profile lookup entirely and won
+//!      the CLI slot in `resolve_effective_backend`, outranking the
+//!      profile — even though documented precedence places the profile
+//!      above `XV_BACKEND` / global config.
+//!
+//! This harness is intentionally separate from `tests/e2e_local_backend.rs`:
+//! that suite's `TestEnv` hard-sets `XV_BACKEND=local` on every invocation,
+//! which would mask both bugs above.
+//!
+//! Run with:
+//!   cargo test --test e2e_backend_resolution
+
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::TempDir;
+
+/// A test environment with a global `xv.conf` (azure backend, no/empty
+/// credentials, valid `[local]` block) and an isolated project directory
+/// that may contain a `.xv.toml` env profile.
+struct BackendResolutionEnv {
+    _tmp: TempDir,
+    config_dir: PathBuf,
+    project_dir: PathBuf,
+}
+
+impl BackendResolutionEnv {
+    /// Global config: no `backend` key (defaults fall through to "azure"),
+    /// empty Azure credentials (would fail `validate()` if ever reached),
+    /// plus a valid `[local]` block so the local backend can actually run.
+    fn new() -> Self {
+        let tmp = TempDir::new().expect("create temp dir");
+        let config_dir = tmp.path().join("config");
+        let project_dir = tmp.path().join("project");
+        let store_dir = tmp.path().join("store");
+        let key_file = tmp.path().join("key.txt");
+        let xv_dir = config_dir.join("xv");
+
+        std::fs::create_dir_all(&xv_dir).expect("create config dir");
+        std::fs::create_dir_all(&project_dir).expect("create project dir");
+        std::fs::create_dir_all(&store_dir).expect("create store dir");
+
+        let config_content = format!(
+            r#"debug = false
+subscription_id = ""
+default_vault = "default"
+default_resource_group = ""
+default_location = ""
+tenant_id = ""
+output_json = false
+no_color = true
+cache_enabled = false
+cache_ttl_secs = 0
+clipboard_timeout = 0
+
+[local]
+store_path = "{store}"
+key_file = "{key}"
+default_vault = "default"
+"#,
+            store = store_dir.display(),
+            key = key_file.display(),
+        );
+        std::fs::write(xv_dir.join("xv.conf"), config_content).expect("write config");
+
+        Self {
+            _tmp: tmp,
+            config_dir,
+            project_dir,
+        }
+    }
+
+    /// Write a `.xv.toml` in the project dir with a single `dev` env
+    /// profile (the active/default env) whose `backend` field is `local`.
+    fn write_local_profile(&self) {
+        let xv_toml = r#"default_env = "dev"
+
+[env.dev]
+backend = "local"
+"#;
+        std::fs::write(self.project_dir.join(".xv.toml"), xv_toml).expect("write .xv.toml");
+    }
+
+    /// Base command with cwd set to the project dir, isolated config, and
+    /// Azure env vars scrubbed. Deliberately does NOT set `XV_BACKEND` —
+    /// callers add it explicitly when a test needs it.
+    fn xv(&self) -> Command {
+        let binary = env!("CARGO_BIN_EXE_xv");
+        let mut cmd = Command::new(binary);
+        cmd.current_dir(&self.project_dir);
+        cmd.env("XDG_CONFIG_HOME", &self.config_dir);
+        cmd.env_remove("XV_BACKEND");
+        cmd.env_remove("AZURE_SUBSCRIPTION_ID");
+        cmd.env_remove("AZURE_TENANT_ID");
+        cmd.env_remove("DEFAULT_VAULT");
+        cmd.env_remove("XV_ENV");
+        cmd.env("NO_COLOR", "1");
+        cmd
+    }
+
+    fn run(&self, cmd: &mut Command, args: &[&str]) -> std::process::Output {
+        cmd.args(args).output().expect("execute xv binary")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test A (bug 1): profile backend must be folded in BEFORE validation.
+// ---------------------------------------------------------------------------
+//
+// Global config has no `backend` key and empty Azure credentials, so
+// `validate()` would fail if the effective backend were still "azure" at
+// validation time. The project's `.xv.toml` selects `local`. No
+// `XV_BACKEND` is set. Before the fix, `load_config()` validated the
+// global config (still "azure") first and failed with "Subscription ID is
+// required" — the profile was resolved too late to matter.
+#[test]
+fn profile_backend_resolved_before_validation() {
+    let env = BackendResolutionEnv::new();
+    env.write_local_profile();
+
+    let output = env.run(&mut env.xv(), &["list"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected `xv list` to succeed using the .xv.toml local profile, but it failed \
+(exit {:?})\nstdout: {stdout}\nstderr: {stderr}",
+        output.status.code(),
+    );
+    assert!(
+        !stderr.contains("Subscription ID is required"),
+        "must not hit Azure validation when the profile selects local: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test B (bug 2): XV_BACKEND must not outrank the .xv.toml profile.
+// ---------------------------------------------------------------------------
+//
+// Same setup as Test A, plus `XV_BACKEND=azure` in the environment. The
+// profile's `local` backend must still win. Before the fix, clap folded
+// XV_BACKEND into `cli.backend`, which (a) suppressed the profile lookup
+// entirely (`cli.backend.is_none()` was false) and (b) won the CLI slot in
+// `resolve_effective_backend`, so the command failed azure validation.
+#[test]
+fn xv_backend_env_does_not_outrank_profile() {
+    let env = BackendResolutionEnv::new();
+    env.write_local_profile();
+
+    let mut cmd = env.xv();
+    cmd.env("XV_BACKEND", "azure");
+    let output = env.run(&mut cmd, &["list"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected the .xv.toml profile's `local` backend to win over XV_BACKEND=azure, \
+but the command failed (exit {:?})\nstdout: {stdout}\nstderr: {stderr}",
+        output.status.code(),
+    );
+    assert!(
+        !stderr.contains("Subscription ID is required"),
+        "XV_BACKEND must not outrank the .xv.toml profile: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test C: a real --backend flag still outranks the profile.
+// ---------------------------------------------------------------------------
+//
+// Same setup, but this time `--backend azure` is passed as an actual CLI
+// argument. The explicit flag must still win over the profile, proving the
+// fix didn't also break the top of the precedence chain. Global config has
+// empty Azure credentials, so this is expected to fail validation.
+#[test]
+fn explicit_backend_flag_still_wins_over_profile() {
+    let env = BackendResolutionEnv::new();
+    env.write_local_profile();
+
+    let output = env.run(&mut env.xv(), &["--backend", "azure", "list"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "expected `--backend azure` to outrank the local profile and fail azure validation, \
+but the command succeeded"
+    );
+    assert!(
+        stderr.contains("Subscription ID"),
+        "expected an azure-validation failure mentioning \"Subscription ID\", got: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test D: no .xv.toml — XV_BACKEND still wins over config file / default.
+// ---------------------------------------------------------------------------
+//
+// No project profile exists. `XV_BACKEND=local` must still take effect via
+// the config-file layer (`load_from_env` copies it into `config.backend`),
+// proving the fix didn't regress the case where XV_BACKEND is the only
+// override in play.
+#[test]
+fn xv_backend_env_wins_when_no_profile_present() {
+    let env = BackendResolutionEnv::new();
+    // Deliberately no .xv.toml written.
+
+    let mut cmd = env.xv();
+    cmd.env("XV_BACKEND", "local");
+    let output = env.run(&mut cmd, &["list"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected XV_BACKEND=local to take effect with no .xv.toml present, but the command \
+failed (exit {:?})\nstdout: {stdout}\nstderr: {stderr}",
+        output.status.code(),
+    );
+    assert!(
+        !stderr.contains("Subscription ID is required"),
+        "XV_BACKEND=local should have selected the local backend: {stderr}"
+    );
+}


### PR DESCRIPTION
Fixes #305 — both P0 findings from the 2026-07-03 repo review.

## Problems

1. **`.xv.toml` backend override was applied after global config validation.** Non-config commands validated the config before the project profile's backend was resolved, so a profile selecting `local` failed with "Subscription ID is required" whenever the global Azure config was incomplete — contradicting the documented precedence in docs/env-profiles.md.
2. **`XV_BACKEND` silently outranked the `.xv.toml` profile.** Clap populates `cli.backend` from `env = "XV_BACKEND"`, indistinguishable from a real `--backend` flag, so the env var both suppressed the profile lookup and won the CLI slot in `resolve_effective_backend` — inverting the documented order (`--backend` flag > profile > `XV_BACKEND`/global config > `azure`).

## Changes

- `main::run()` now loads config **without validation**, resolves the effective backend (profile included), folds it into `config.backend`, and only then validates — gated on `needs_backend`, so purely-local commands (Context/Cache/Local/Parse/etc.) no longer demand Azure/AWS credentials they never use.
- The profile lookup and the CLI resolution slot are gated on `cli_backend_was_arg` (a real `--backend` argument) instead of `cli.backend.is_none()`. `XV_BACKEND` still participates at the config layer via `load_from_env`, preserving `XV_BACKEND` > config file > default.
- The `cli_backend_was_arg` arg scan stops at the `--` separator, so passthrough child args like `xv run -- echo --backend prod` can no longer be mistaken for the flag (caught in review, reproduced end-to-end, regression-tested).
- `xv env list` display resolution aligned with the corrected runtime precedence; `config show --resolved` attribution was already correct.

## Tests

New `tests/e2e_backend_resolution.rs` (isolated harness that deliberately does not set `XV_BACKEND`):

- profile backend resolved before validation (fails on main with "Subscription ID is required")
- `XV_BACKEND` does not outrank the profile (fails on main)
- a real `--backend` flag still outranks the profile
- `XV_BACKEND` still wins when no profile exists
- `--backend` token after `--` is not mistaken for the CLI flag (fails with the old arg scan)

`cargo test --features aws`: all 28 test binaries green (743 lib unit tests + integration/e2e). `cargo clippy --all-targets --features aws`: 0 warnings. Separate code-review pass performed; its MAJOR finding (the `--` passthrough misfire) is fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core startup ordering for every command that needs a backend; mistakes could mis-select backends or skip validation, though behavior is heavily regression-tested in the new e2e suite.
> 
> **Overview**
> Fixes **#305** by aligning runtime backend resolution with documented precedence: real `--backend` > `.xv.toml` profile > `XV_BACKEND`/global config > default `azure`.
> 
> **`main::run()`** now loads config without validating, detects a true `--backend` via `cli_backend_was_arg` (scan stops at `--` so passthrough args like `xv run -- echo --backend prod` are ignored), resolves the env profile backend when no real flag was passed, folds the result into `config.backend`, and only then runs `config.validate()` when `needs_backend` is true. `XV_BACKEND` no longer fills the CLI resolution slot—only an explicit flag does—so the profile can outrank env-sourced values while `XV_BACKEND` still applies at the global config layer.
> 
> **`xv env list`** uses the same `cli_backend_was_arg` gating when displaying per-env backends and clarifies `(inherited)` labeling.
> 
> Adds **`tests/e2e_backend_resolution.rs`** with isolated e2e cases for profile-before-validation, profile over `XV_BACKEND`, explicit flag over profile, `XV_BACKEND` without a profile, and `--` passthrough safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec68c94aad2a192c9fe6d8620c366cb617c9d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->