### PR TITLE
fix: xv run aborts on secret fetch failures by default; add --best-effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- **Breaking: `xv run` now aborts before launching the child when any selected secret or `xv://` reference fails to fetch; use `--best-effort` for the old behavior** (#306). Previously a per-secret fetch failure only printed a warning and the command ran anyway, which could silently launch a process missing an env var (e.g. after a transient backend error or a permission problem). All failures across both the selected-secret list and `xv://` reference resolution are now collected and reported together before the exit.
+
 ### Fixed
 
 - AWS: `list_deleted_secrets` now exposes the `xv:original_name` tag in its summaries (matching `list_secrets`), so `xv ls --deleted` no longer loses the user-facing name on AWS (#301).

--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ xv run --include DB_PASSWORD --include API_KEY -- ./script.sh
 xv run --exclude LEGACY_TOKEN -- ./script.sh
 xv run --no-masking -- ./debug.sh                 # don't mask values in stdout/stderr
 xv run --vault other-vault -- env                 # one-off vault override
+xv run --best-effort -- ./script.sh               # launch even if some secrets fail to fetch
 ```
 
 Values are masked in stdout/stderr by default — accidental `echo $DB_PASSWORD`
@@ -653,6 +654,12 @@ shows `[REDACTED]`. Masking streams in bounded chunks (64 KiB read windows with
 overlap for secrets split across chunk boundaries), so newline-free or very
 large child output does not grow memory without limit. Use `--no-masking` only
 when you understand the consequences.
+
+By default, `xv run` aborts **before** launching the child if any selected
+secret or `xv://` reference fails to fetch (transient backend error, missing
+secret, permission problem, etc.) — every failure is printed, and the command
+never runs with a variable silently missing. Pass `--best-effort` to restore
+the previous behavior: warn on each failure and launch the child anyway.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -94,7 +94,7 @@ a two-decimal string, `folder`/`groups` default to empty strings.
 
 | Command | Description |
 |---------|-------------|
-| `xv run -- <command>` | Run a process with secrets as env vars (`--group`, `--include`, `--exclude`, `--no-masking`) |
+| `xv run -- <command>` | Run a process with secrets as env vars (`--group`, `--include`, `--exclude`, `--no-masking`, `--best-effort`) |
 | `xv inject` | Render templates with `{{ secret:name }}` and `xv://vault/secret` refs |
 
 Advanced workflows (`run`, `inject`, default `rotate`, `scan`, `env pull`, and
@@ -112,6 +112,11 @@ the original user-facing name shown by `xv list` or the backend-specific stored
 name. If an explicit `--group`/`--include` filter matches nothing, `xv run`
 exits non-zero; an empty vault or an exclusion that removes everything warns
 and still runs the child process.
+
+By default, `xv run` also aborts before spawning the child if any selected
+secret or `xv://` reference fails to fetch — every failure is reported before
+the non-zero exit. Pass `--best-effort` to fall back to the previous
+warn-and-continue behavior.
 
 ---
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -633,6 +633,9 @@ pub enum Commands {
         /// Inherit the parent process environment (default: child starts with a clean env)
         #[arg(long)]
         inherit_env: bool,
+        /// Continue and launch the command even if some secrets fail to fetch (previous default)
+        #[arg(long)]
+        best_effort: bool,
         /// Command and arguments to run
         #[arg(last = true, required = true)]
         command: Vec<String>,
@@ -1643,6 +1646,7 @@ impl Cli {
                 exclude,
                 no_masking,
                 inherit_env,
+                best_effort,
                 command,
             } => {
                 crate::cli::secret_ops::execute_secret_run_direct(
@@ -1651,6 +1655,7 @@ impl Cli {
                     exclude,
                     no_masking,
                     inherit_env,
+                    best_effort,
                     command,
                     config,
                     registry,

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2871,6 +2871,10 @@ async fn execute_secret_run(
                     if !no_masking && !value.is_empty() {
                         secret_values.push(value.clone());
                     }
+                } else {
+                    let msg = format!("Secret '{}' resolved but has no value", secret.name);
+                    output::warn(&msg);
+                    fetch_failures.push(msg);
                 }
             }
             Err(e) => {
@@ -2923,7 +2927,9 @@ async fn execute_secret_run(
                             secret_values.push(value);
                         }
                     } else {
-                        output::warn(&format!("URI '{uri}' resolved but has no value"));
+                        let msg = format!("URI '{uri}' resolved but has no value");
+                        output::warn(&msg);
+                        fetch_failures.push(msg);
                     }
                 }
                 Err(e) => {

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -1407,6 +1407,7 @@ pub(crate) async fn execute_secret_run_direct(
     exclude: Vec<String>,
     no_masking: bool,
     inherit_env: bool,
+    best_effort: bool,
     command: Vec<String>,
     config: Config,
     registry: Option<&BackendRegistry>,
@@ -1428,6 +1429,7 @@ pub(crate) async fn execute_secret_run_direct(
         exclude,
         no_masking,
         inherit_env,
+        best_effort,
         command,
         &config,
     )
@@ -2719,6 +2721,7 @@ async fn execute_secret_run(
     exclude: Vec<String>,
     no_masking: bool,
     inherit_env: bool,
+    best_effort: bool,
     command: Vec<String>,
     config: &Config,
 ) -> Result<()> {
@@ -2844,6 +2847,12 @@ async fn execute_secret_run(
     let mut secret_values: Vec<Zeroizing<String>> = Vec::new(); // For masking
     let mut uri_values: HashMap<String, Zeroizing<String>> = HashMap::new(); // URI -> value mapping
 
+    // Fetch failures are collected rather than aborting immediately, so the
+    // user sees every failing secret/reference in one shot. By default any
+    // failure aborts before the child is spawned; `--best-effort` restores
+    // the old warn-and-continue behavior.
+    let mut fetch_failures: Vec<String> = Vec::new();
+
     // Fetch secrets from current vault (group-filtered)
     for secret in filtered_secrets {
         // Get the secret value
@@ -2865,10 +2874,9 @@ async fn execute_secret_run(
                 }
             }
             Err(e) => {
-                output::warn(&format!(
-                    "Failed to get value for secret '{}': {}",
-                    secret.name, e
-                ));
+                let msg = format!("Failed to get value for secret '{}': {}", secret.name, e);
+                output::warn(&msg);
+                fetch_failures.push(msg);
             }
         }
     }
@@ -2919,10 +2927,30 @@ async fn execute_secret_run(
                     }
                 }
                 Err(e) => {
-                    output::warn(&format!("Failed to resolve URI '{uri}': {e}"));
+                    let msg = format!("Failed to resolve URI '{uri}': {e}");
+                    output::warn(&msg);
+                    fetch_failures.push(msg);
                 }
             }
         }
+    }
+
+    // Abort before the child is built/spawned if any secret or xv:// reference
+    // failed to fetch, unless --best-effort was requested (the previous
+    // default: warn-and-continue).
+    if !fetch_failures.is_empty() && !best_effort {
+        output::error(&format!(
+            "Aborting: {} secret(s)/reference(s) failed to fetch. Use --best-effort to launch anyway.",
+            fetch_failures.len()
+        ));
+        for failure in &fetch_failures {
+            output::error(&format!("  - {failure}"));
+        }
+        return Err(CrosstacheError::config(format!(
+            "xv run aborted: {} secret(s)/reference(s) failed to fetch: {}",
+            fetch_failures.len(),
+            fetch_failures.join("; ")
+        )));
     }
 
     // Set up the command

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -173,6 +173,12 @@ default_vault = "default"
     fn get_raw_exact(&self, name: &str) -> String {
         self.xv_ok(&["get", name, "--raw"])
     }
+
+    /// Path to this test's isolated temp directory (for scratch files such as
+    /// markers written by child processes spawned via `xv run`).
+    fn tmp_path(&self) -> &std::path::Path {
+        self._tmp.path()
+    }
 }
 
 // ===========================================================================
@@ -1566,4 +1572,112 @@ fn mv_folder_to_root() {
     // 'a' is now at the root; 'b' keeps its remainder 'db'.
     assert!(!json.contains("\"app\""), "{json}");
     assert!(json.contains("\"db\""), "remainder folder lost: {json}");
+}
+
+// ===========================================================================
+// xv run — fail-fast on secret fetch failures (#306)
+// ===========================================================================
+
+#[test]
+fn run_happy_path_launches_child() {
+    let env = TestEnv::new();
+    env.set_secret("HAPPY_KEY", "happy-value");
+    let marker = env.tmp_path().join("happy_marker.txt");
+
+    let output = env
+        .xv()
+        .args([
+            "run",
+            "--",
+            "sh",
+            "-c",
+            &format!("touch '{}'", marker.display()),
+        ])
+        .output()
+        .expect("execute xv run");
+
+    assert!(
+        output.status.success(),
+        "xv run should succeed when all secrets fetch:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        marker.exists(),
+        "child process should have run and created the marker file"
+    );
+}
+
+#[test]
+fn run_aborts_on_failing_uri_reference() {
+    let env = TestEnv::new();
+    env.set_secret("PRESENT", "present-value");
+    let marker = env.tmp_path().join("uri_fail_marker.txt");
+
+    // A parent-environment variable holding an xv:// reference to a secret
+    // that does not exist. Reference resolution only scans the parent
+    // environment when --inherit-env is passed.
+    let mut cmd = env.xv();
+    cmd.env("REF_VAR", "xv://default/does-not-exist");
+    cmd.args([
+        "run",
+        "--inherit-env",
+        "--",
+        "sh",
+        "-c",
+        &format!("touch '{}'", marker.display()),
+    ]);
+    let output = cmd.output().expect("execute xv run");
+
+    assert!(
+        !output.status.success(),
+        "xv run should fail (non-zero exit) when a referenced secret cannot be fetched:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("does-not-exist"),
+        "stderr should mention the failing reference: {stderr}"
+    );
+    assert!(
+        !marker.exists(),
+        "child process must NOT run when a secret fetch fails (fail-fast default)"
+    );
+}
+
+#[test]
+fn run_best_effort_launches_child_despite_failing_uri_reference() {
+    let env = TestEnv::new();
+    env.set_secret("PRESENT", "present-value");
+    let marker = env.tmp_path().join("uri_fail_best_effort_marker.txt");
+
+    let mut cmd = env.xv();
+    cmd.env("REF_VAR", "xv://default/does-not-exist");
+    cmd.args([
+        "run",
+        "--inherit-env",
+        "--best-effort",
+        "--",
+        "sh",
+        "-c",
+        &format!("touch '{}'", marker.display()),
+    ]);
+    let output = cmd.output().expect("execute xv run");
+
+    assert!(
+        output.status.success(),
+        "--best-effort should launch the child (and reflect its exit code) despite the failing reference:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("does-not-exist"),
+        "a warning should still be emitted for the failing reference: {stderr}"
+    );
+    assert!(
+        marker.exists(),
+        "child process should have run under --best-effort"
+    );
 }

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -1629,9 +1629,13 @@ fn run_aborts_on_failing_uri_reference() {
     ]);
     let output = cmd.output().expect("execute xv run");
 
-    assert!(
-        !output.status.success(),
-        "xv run should fail (non-zero exit) when a referenced secret cannot be fetched:\nstdout: {}\nstderr: {}",
+    // Pin the exact exit code (3 == CrosstacheError::Config, see src/error.rs)
+    // so an accidental change of error variant is caught, not just "any
+    // non-zero exit".
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "xv run should fail with the config-error exit code (3) when a referenced secret cannot be fetched:\nstdout: {}\nstderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
@@ -1645,6 +1649,25 @@ fn run_aborts_on_failing_uri_reference() {
         "child process must NOT run when a secret fetch fails (fail-fast default)"
     );
 }
+
+// Note: there is no equivalent test here for the selected-secrets fetch loop
+// (the non-URI path in `execute_secret_run`). On the local backend,
+// `get_secret` reads directly from a file this test harness fully controls —
+// there is no network/permission layer to fail transiently, and corrupting
+// an on-disk entry to force a decode error would couple this test tightly to
+// internal storage format details rather than the abort/collect logic under
+// test (which is shared with the URI path above and already covered by it).
+//
+// The "resolved but has no value" branch (added for both loops: a backend
+// returning `Ok` with `value: None`) is likewise not independently testable
+// here: local's `get_secret` always returns `Some(value)` when
+// `include_value: true` (verified in `src/backend/local/secrets.rs`), and
+// `xv set --stdin` with empty input is rejected at write time
+// ("Secret value cannot be empty", exit 3) — so an empty-but-present value,
+// which would still be `Some("")` rather than `None`, isn't reachable via the
+// local backend either. That branch is exercised for the URI path only
+// indirectly through code review / manual reasoning about the shared
+// `fetch_failures` collection logic.
 
 #[test]
 fn run_best_effort_launches_child_despite_failing_uri_reference() {


### PR DESCRIPTION
Fixes #306 — P1 finding from the 2026-07-03 repo review.

## Problem

`xv run` only warned on per-secret fetch failures — both the selected-secrets loop and `xv://` URI-reference resolution — and launched the child process anyway. A transient backend error or a permission problem on one secret meant a production command ran with that env var silently missing, returning the child's success code.

## Changes (breaking)

- **Fetch failures now abort by default.** Both loops collect every failure (secret name + error) into one report; if any exist, `xv run` prints them all and exits with code 3 **before** the child command is built or spawned.
- **`--best-effort`** restores the previous warn-and-continue behavior (child launches, exit code is the child's).
- Secrets/URIs that resolve **without a value** are treated as failures too (caught in review): previously an empty-value URI left the literal `xv://...` string in the child's env, and an empty selected secret was silently dropped.
- README, docs/FEATURES.md, and CHANGELOG (`### Changed`, breaking) updated.

## Tests

New e2e tests in `tests/e2e_local_backend.rs` (real binary, local backend):

- failing `xv://` reference → exit code 3, error names the failing reference, child marker file proves the child never ran (fails on main: child ran, exit 0)
- same setup with `--best-effort` → warning emitted, child runs, child's exit code preserved
- happy path unaffected

A comment documents why the selected-secrets loop isn't independently testable on the local backend (its `get_secret` always returns a value, and `xv set` rejects empty values at write time); both loops feed the same collection/abort logic, which the URI test pins.

`cargo test --features aws`: full suite green (one pre-existing, unrelated clipboard timing flake passes in isolation). `cargo clippy --all-targets --features aws`: 0 warnings. Separate code-review pass performed; its two empty-value findings are fixed in the second commit. Review also surfaced the same defect class in `xv inject` — filed as #313 for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default `xv run` behavior for all backends and can break scripts that relied on partial env injection; the new flag preserves old behavior but operators must opt in.
> 
> **Overview**
> **Breaking change for `xv run`:** secret and `xv://` fetch failures are collected across both resolution paths, reported together, and cause a non-zero exit **before** the child is built or spawned. Successful fetches are unchanged; masking and env injection behavior are only reached when every fetch succeeds (or `--best-effort` is set).
> 
> Adds **`--best-effort`** to restore the prior semantics: warn per failure and still launch the child. **`Ok` responses with no value** (empty/missing payload) now count as failures for selected secrets and URI refs, not silent drops or literal `xv://...` left in the env.
> 
> CLI wiring passes the flag through `commands.rs` → `execute_secret_run_direct` → `execute_secret_run`. **CHANGELOG**, **README**, and **docs/FEATURES.md** document the default and flag. **E2e tests** cover happy path, failing URI with `--inherit-env` (exit 3, child never runs), and `--best-effort` (warning + child runs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862c35013177d7853610a2806226c96013693739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->