### PR TITLE
fix: xv move --force can overwrite; copy/move work on non-Azure backends

### DIFF
--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -1894,7 +1894,9 @@ pub(crate) async fn execute_secret_copy_direct(
         from_vault,
         to_vault,
         new_name,
+        false,
         &config,
+        registry,
     )
     .await?;
 
@@ -1932,6 +1934,7 @@ pub(crate) async fn execute_secret_move_direct(
         new_name,
         force,
         &config,
+        registry,
     )
     .await?;
 
@@ -3510,13 +3513,16 @@ async fn execute_secret_restore(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn execute_secret_copy(
     secret_manager: &crate::secret::manager::SecretManager,
     name: &str,
     from_vault: &str,
     to_vault: &str,
     new_name: Option<String>,
-    _config: &Config,
+    force: bool,
+    config: &Config,
+    registry: Option<&BackendRegistry>,
 ) -> Result<()> {
     use crate::config::ContextManager;
     use crate::secret::manager::SecretRequest;
@@ -3529,6 +3535,65 @@ async fn execute_secret_copy(
         name, from_vault, to_vault, target_name
     );
 
+    // ── Trait-based path (non-Azure backends, e.g. local/AWS) ──────────
+    if use_trait_path(registry) {
+        let reg = registry.expect("use_trait_path guarantees Some");
+        let backend = reg.active().secrets();
+
+        let source_secret = backend.get_secret(from_vault, name, true).await?;
+
+        if backend
+            .get_secret(to_vault, target_name, false)
+            .await
+            .is_ok()
+        {
+            if !force {
+                return Err(CrosstacheError::config(format!(
+                    "Secret '{}' already exists in vault '{}'. Use 'xv move' with --force or delete the target secret first.",
+                    target_name, to_vault
+                )));
+            }
+            output::warn(&format!(
+                "Overwriting existing secret '{}' in vault '{}'",
+                target_name, to_vault
+            ));
+        }
+
+        let secret_request = SecretRequest {
+            name: target_name.to_string(),
+            value: source_secret.value.unwrap_or_default(),
+            content_type: Some(source_secret.content_type),
+            enabled: Some(source_secret.enabled),
+            expires_on: source_secret.expires_on,
+            not_before: source_secret.not_before,
+            tags: Some(source_secret.tags),
+            groups: None,
+            note: None,
+            folder: None,
+        };
+
+        let copied_secret = backend.set_secret(to_vault, secret_request).await?;
+        invalidate_trait_secret_cache(config, to_vault);
+
+        output::success(&format!(
+            "Successfully copied secret '{}' to vault '{}'",
+            copied_secret.original_name, to_vault
+        ));
+        println!("   Source: {}/{}", from_vault, name);
+        println!("   Target: {}/{}", to_vault, target_name);
+        println!("   Version: {}", copied_secret.version);
+        println!("   Enabled: {}", copied_secret.enabled);
+
+        if let Some(expires_on) = copied_secret.expires_on {
+            use crate::utils::datetime::format_datetime;
+            println!("   Expires: {}", format_datetime(Some(expires_on)));
+        }
+
+        return Ok(());
+    }
+
+    // ── Legacy Azure REST path (no registry available) ─────────────────
+
     // Get the source secret with all its metadata
     let source_secret = secret_manager
         .get_secret_safe(from_vault, name, true, true)
@@ -3540,10 +3605,16 @@ async fn execute_secret_copy(
         .await
         .is_ok()
     {
-        return Err(CrosstacheError::config(format!(
-            "Secret '{}' already exists in vault '{}'. Use 'xv move' with --force or delete the target secret first.",
+        if !force {
+            return Err(CrosstacheError::config(format!(
+                "Secret '{}' already exists in vault '{}'. Use 'xv move' with --force or delete the target secret first.",
+                target_name, to_vault
+            )));
+        }
+        output::warn(&format!(
+            "Overwriting existing secret '{}' in vault '{}'",
             target_name, to_vault
-        )));
+        ));
     }
 
     // Create the request for the target vault preserving all metadata
@@ -3587,6 +3658,7 @@ async fn execute_secret_copy(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn execute_secret_move(
     secret_manager: &crate::secret::manager::SecretManager,
     name: &str,
@@ -3595,6 +3667,7 @@ async fn execute_secret_move(
     new_name: Option<String>,
     force: bool,
     config: &Config,
+    registry: Option<&BackendRegistry>,
 ) -> Result<()> {
     use crate::utils::interactive::InteractivePrompt;
 
@@ -3605,6 +3678,31 @@ async fn execute_secret_move(
         "Moving secret '{}' from vault '{}' to vault '{}' as '{}'...",
         name, from_vault, to_vault, target_name
     );
+
+    // Check if target secret already exists and fail fast with a move-specific
+    // message when not forced, *before* prompting for confirmation — there is
+    // no point asking the user to confirm an operation that is guaranteed to
+    // fail. When forced, `execute_secret_copy` below emits its own
+    // "Overwriting existing secret" warning and performs the overwrite.
+    let target_exists = if use_trait_path(registry) {
+        let reg = registry.expect("use_trait_path guarantees Some");
+        reg.active()
+            .secrets()
+            .get_secret(to_vault, target_name, false)
+            .await
+            .is_ok()
+    } else {
+        secret_manager
+            .get_secret_safe(to_vault, target_name, false, true)
+            .await
+            .is_ok()
+    };
+    if !force && target_exists {
+        return Err(CrosstacheError::config(format!(
+            "Secret '{}' already exists in vault '{}'. Use --force to overwrite.",
+            target_name, to_vault
+        )));
+    }
 
     // Confirmation prompt if not forced
     if !force {
@@ -3619,33 +3717,16 @@ async fn execute_secret_move(
         }
     }
 
-    // Check if target secret already exists and handle accordingly
-    if secret_manager
-        .get_secret_safe(to_vault, target_name, false, true)
-        .await
-        .is_ok()
-    {
-        if !force {
-            return Err(CrosstacheError::config(format!(
-                "Secret '{}' already exists in vault '{}'. Use --force to overwrite.",
-                target_name, to_vault
-            )));
-        } else {
-            output::warn(&format!(
-                "Overwriting existing secret '{}' in vault '{}'",
-                target_name, to_vault
-            ));
-        }
-    }
-
-    // First copy the secret
+    // First copy the secret (source is only deleted after this succeeds)
     execute_secret_copy(
         secret_manager,
         name,
         from_vault,
         to_vault,
         new_name.clone(),
+        force,
         config,
+        registry,
     )
     .await?;
 
@@ -3654,9 +3735,18 @@ async fn execute_secret_move(
         "Deleting source secret '{}' from vault '{}'...",
         name, from_vault
     );
-    secret_manager
-        .delete_secret_safe(from_vault, name, true)
-        .await?;
+    if use_trait_path(registry) {
+        let reg = registry.expect("use_trait_path guarantees Some");
+        reg.active()
+            .secrets()
+            .delete_secret(from_vault, name)
+            .await?;
+        invalidate_trait_secret_cache(config, from_vault);
+    } else {
+        secret_manager
+            .delete_secret_safe(from_vault, name, true)
+            .await?;
+    }
 
     output::success(&format!(
         "Successfully moved secret '{}' from '{}' to '{}'",

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -3524,6 +3524,7 @@ async fn execute_secret_copy(
     config: &Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
+    use crate::backend::secret::rename_request_from_properties;
     use crate::config::ContextManager;
     use crate::secret::manager::SecretRequest;
 
@@ -3559,18 +3560,13 @@ async fn execute_secret_copy(
             ));
         }
 
-        let secret_request = SecretRequest {
-            name: target_name.to_string(),
-            value: source_secret.value.unwrap_or_default(),
-            content_type: Some(source_secret.content_type),
-            enabled: Some(source_secret.enabled),
-            expires_on: source_secret.expires_on,
-            not_before: source_secret.not_before,
-            tags: Some(source_secret.tags),
-            groups: None,
-            note: None,
-            folder: None,
-        };
+        // Lift groups/note/folder out of the canonical tag encoding into the
+        // dedicated `SecretRequest` fields so every backend (local, AWS, ...)
+        // re-encodes them the way its own reader expects — the local and AWS
+        // backends only read those attributes from the dedicated fields, not
+        // from raw tags, so building the request by hand here previously
+        // silently dropped group membership, folder, and note on copy/move.
+        let secret_request = rename_request_from_properties(target_name, &source_secret)?;
 
         let copied_secret = backend.set_secret(to_vault, secret_request).await?;
         invalidate_trait_secret_cache(config, to_vault);

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -1671,3 +1671,65 @@ fn copy_refuses_to_overwrite_existing_target_even_semantics_unchanged() {
     assert_eq!(env.get_raw("copy-dst"), "copy-dst-original");
     env.xv_ok(&["context", "use", "default", "--global"]);
 }
+
+#[test]
+fn move_preserves_group_folder_and_note_metadata() {
+    let env = TestEnv::new();
+    env.xv_ok(&["vault", "create", "dest3"]);
+
+    env.set_secret_with_args(
+        "meta-src",
+        "meta-value",
+        &[
+            "--group",
+            "backend",
+            "--folder",
+            "prod",
+            "--note",
+            "something",
+        ],
+    );
+
+    env.xv_ok(&[
+        "move",
+        "meta-src",
+        "--from",
+        "default",
+        "--to",
+        "dest3",
+        "--new-name",
+        "meta-dst",
+        "--force",
+    ]);
+
+    // Value moved.
+    env.xv_ok(&["context", "use", "dest3", "--global"]);
+    assert_eq!(env.get_raw("meta-dst"), "meta-value");
+
+    // Group/folder/note metadata rode along to the destination vault; the
+    // local backend's `set_secret` only reads these from the dedicated
+    // `SecretRequest` fields (not raw tags), so hand-building the request
+    // without lifting them out of `tags` silently drops them.
+    let json = env.xv_ok(&["ls", "--format", "json"]);
+    assert!(
+        json.contains("meta-dst")
+            && json.contains("backend")
+            && json.contains("prod")
+            && json.contains("something"),
+        "group/folder/note metadata missing after move:\n{json}"
+    );
+
+    let group_list = env.xv_ok(&["group", "list", "--format", "json"]);
+    assert!(
+        group_list.contains("backend"),
+        "moved secret's group not visible to 'group list':\n{group_list}"
+    );
+
+    let folder_ls = env.xv_ok(&["ls", "prod", "--format", "json"]);
+    assert!(
+        folder_ls.contains("meta-dst"),
+        "moved secret not visible under its folder via 'ls prod':\n{folder_ls}"
+    );
+
+    env.xv_ok(&["context", "use", "default", "--global"]);
+}

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -1567,3 +1567,107 @@ fn mv_folder_to_root() {
     assert!(!json.contains("\"app\""), "{json}");
     assert!(json.contains("\"db\""), "remainder folder lost: {json}");
 }
+
+// ===========================================================================
+// Cross-vault move / copy (issue #307)
+// ===========================================================================
+
+#[test]
+fn move_without_force_refuses_to_overwrite_existing_target() {
+    let env = TestEnv::new();
+    env.xv_ok(&["vault", "create", "dest"]);
+
+    env.set_secret("src-secret", "src-value");
+    // Set a target secret directly in the destination vault.
+    env.xv_ok(&["context", "use", "dest", "--global"]);
+    env.set_secret("dst-secret", "dst-original-value");
+    env.xv_ok(&["context", "use", "default", "--global"]);
+
+    let (_stdout, stderr) = env.xv_fail(&[
+        "move",
+        "src-secret",
+        "--from",
+        "default",
+        "--to",
+        "dest",
+        "--new-name",
+        "dst-secret",
+    ]);
+    assert!(
+        stderr.contains("already exists"),
+        "expected 'already exists' error, got:\n{stderr}"
+    );
+
+    // Both secrets are unchanged.
+    assert_eq!(env.get_raw("src-secret"), "src-value");
+    env.xv_ok(&["context", "use", "dest", "--global"]);
+    assert_eq!(env.get_raw("dst-secret"), "dst-original-value");
+    env.xv_ok(&["context", "use", "default", "--global"]);
+}
+
+#[test]
+fn move_with_force_overwrites_existing_target_and_deletes_source() {
+    let env = TestEnv::new();
+    env.xv_ok(&["vault", "create", "dest"]);
+
+    env.set_secret("src-secret2", "src-value2");
+    env.xv_ok(&["context", "use", "dest", "--global"]);
+    env.set_secret("dst-secret2", "dst-original-value2");
+    env.xv_ok(&["context", "use", "default", "--global"]);
+
+    env.xv_ok(&[
+        "move",
+        "src-secret2",
+        "--from",
+        "default",
+        "--to",
+        "dest",
+        "--new-name",
+        "dst-secret2",
+        "--force",
+    ]);
+
+    // Destination now holds the source's value.
+    env.xv_ok(&["context", "use", "dest", "--global"]);
+    assert_eq!(env.get_raw("dst-secret2"), "src-value2");
+    env.xv_ok(&["context", "use", "default", "--global"]);
+
+    // Source is gone.
+    let (_, stderr) = env.xv_fail(&["get", "src-secret2", "--raw"]);
+    assert!(
+        stderr.to_lowercase().contains("not found"),
+        "source secret should be gone after forced move:\n{stderr}"
+    );
+}
+
+#[test]
+fn copy_refuses_to_overwrite_existing_target_even_semantics_unchanged() {
+    let env = TestEnv::new();
+    env.xv_ok(&["vault", "create", "dest2"]);
+
+    env.set_secret("copy-src", "copy-src-value");
+    env.xv_ok(&["context", "use", "dest2", "--global"]);
+    env.set_secret("copy-dst", "copy-dst-original");
+    env.xv_ok(&["context", "use", "default", "--global"]);
+
+    let (_stdout, stderr) = env.xv_fail(&[
+        "copy",
+        "copy-src",
+        "--from",
+        "default",
+        "--to",
+        "dest2",
+        "--new-name",
+        "copy-dst",
+    ]);
+    assert!(
+        stderr.contains("already exists"),
+        "expected 'already exists' error, got:\n{stderr}"
+    );
+
+    // Both secrets are unchanged; copy has no --force flag to override this.
+    assert_eq!(env.get_raw("copy-src"), "copy-src-value");
+    env.xv_ok(&["context", "use", "dest2", "--global"]);
+    assert_eq!(env.get_raw("copy-dst"), "copy-dst-original");
+    env.xv_ok(&["context", "use", "default", "--global"]);
+}


### PR DESCRIPTION
Fixes #307 — P1 finding from the 2026-07-03 repo review.

## Problem

`xv move --force` could never overwrite an existing target: `execute_secret_move` detected the target, warned "Overwriting existing secret", then delegated to `execute_secret_copy` — which unconditionally errored on an existing target, with a message that ironically told the user to use `xv move --force`. The copy aborted before the source was deleted, making `--force` a dead flag.

## Changes

- **`force` is threaded into `execute_secret_copy`**: with force, the target-exists guard becomes the warning and the overwrite proceeds. The standalone `xv copy` passes `false` — its refuse-to-overwrite semantics are unchanged and pinned by a test.
- **Existence check now runs before the interactive confirmation prompt** in `execute_secret_move`: previously a non-interactive `xv move` without `--force` died with "not a terminal" before the informative "already exists" error could ever surface. No confirmation is skipped in any case that previously required one.
- **`xv copy`/`xv move` now work on non-Azure backends**: they unconditionally built an Azure `SecretManager` regardless of `--backend`, so they were Azure-only. They now use the same `use_trait_path(registry)` dispatch as get/set/delete/list. Metadata is preserved via the canonical `rename_request_from_properties` helper, so `groups`/`folder`/`note` survive the copy on local and AWS (caught in review: the first cut dropped them into orphaned raw tags, unrecoverable after move deletes the source).
- Source deletion still happens strictly after a successful copy on both paths; a failed overwrite never touches the source. `xv mv` (`mv_ops.rs`) untouched.

## Tests

New e2e tests in `tests/e2e_local_backend.rs` (real binary, local backend):

- move onto existing target without `--force` → fails with "already exists", both secrets unchanged
- move onto existing target with `--force` → destination has source's value, source gone (fails on main: dead flag)
- `xv copy` onto existing target → still refuses (semantics pinned)
- move preserves `--group` / `--folder` / `--note` metadata (fails against the pre-review commit: all three came back null)

`cargo test --features aws -- --test-threads=1`: all 27 test binaries green (e2e_local_backend: 76 passed). `cargo clippy --all-targets --features aws`: 0 warnings. Separate code-review pass performed; its MAJOR metadata-loss finding is fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-vault secret write/delete and overwrite semantics; mistakes could lose metadata or delete sources incorrectly, though copy-then-delete ordering and new e2e tests mitigate that.
> 
> **Overview**
> Fixes broken **`xv move --force`** when the destination secret already exists: copy now honors a **`force`** flag (warn + overwrite) instead of always erroring after move had already promised an overwrite. Standalone **`xv copy`** still passes **`force: false`**, so refuse-to-overwrite behavior is unchanged.
> 
> **`execute_secret_copy`** and **`execute_secret_move`** gain a **`BackendRegistry`** and branch on **`use_trait_path`**, routing local/AWS (and other trait backends) through **`get_secret` / `set_secret` / `delete_secret`** instead of Azure-only **`SecretManager`**. Metadata on copy/move uses **`rename_request_from_properties`** so **group, folder, and note** land in **`SecretRequest`** fields backends actually read—not orphaned tags.
> 
> **Move** checks target existence **before** the interactive confirm (move-specific error when not forced). Source deletion stays **after** a successful copy on both paths, with trait-path cache invalidation on destination and source vaults.
> 
> New **e2e** coverage in **`tests/e2e_local_backend.rs`** for overwrite refusal, forced move, copy semantics, and metadata preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b908932cf54992f8224bed44dd717f3b3ca2196c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->