### PR TITLE
fix: xfunction derives JWT issuer from OIDC discovery; installer passes secret via stdin

### DIFF
--- a/xfunction/function_app.py
+++ b/xfunction/function_app.py
@@ -18,7 +18,7 @@ from config import OWNER_ROLE_ID, KEY_VAULT_ADMINISTRATOR_ROLE_ID
 # Azure AD JWT validation helpers
 # ---------------------------------------------------------------------------
 
-# Module-level JWKS cache: { "keys": [...], "fetched_at": <epoch>, "jwks_uri": <str> }
+# Module-level JWKS cache: { "keys": [...], "fetched_at": <epoch>, "jwks_uri": <str>, "issuer": <str> }
 _jwks_cache: Dict[str, Any] = {}
 _JWKS_CACHE_TTL_SECONDS = 3600  # 1 hour
 
@@ -29,11 +29,19 @@ def _get_tenant_id() -> Optional[str]:
 
 
 def _get_expected_issuer(tenant_id: Optional[str]) -> Optional[str]:
-    """Return the expected token issuer.
+    """Return the fallback expected token issuer (v1 endpoint).
+
+    This is used only when the OIDC discovery document's own "issuer" field
+    is unavailable (e.g. the metadata endpoint could not be reached). Azure
+    AD v1 tokens use the `sts.windows.net` issuer form; v2 tokens use
+    `login.microsoftonline.com/{tenant}/v2.0`. Since discovery normally
+    supplies the concrete (and correct) issuer for whichever token version
+    is actually presented, this v1 constant is only a best-effort offline
+    fallback and does not by itself support v2 tokens.
 
     Priority:
     1. AZURE_AD_ISSUER env var (explicit override)
-    2. Constructed from AZURE_TENANT_ID (v2 endpoint)
+    2. Constructed from AZURE_TENANT_ID (v1 endpoint, offline fallback)
     """
     explicit = os.environ.get("AZURE_AD_ISSUER")
     if explicit:
@@ -49,12 +57,27 @@ def _get_openid_config_url(tenant_id: Optional[str]) -> str:
     return f"https://login.microsoftonline.com/{tid}/v2.0/.well-known/openid-configuration"
 
 
-def _fetch_jwks_uri(tenant_id: Optional[str]) -> str:
-    """Fetch the JWKS URI from the OpenID Connect metadata endpoint."""
+def _fetch_oidc_metadata(tenant_id: Optional[str]) -> Dict[str, Any]:
+    """Fetch the OpenID Connect discovery document for the tenant."""
     url = _get_openid_config_url(tenant_id)
     resp = http_requests.get(url, timeout=10)
     resp.raise_for_status()
-    return resp.json()["jwks_uri"]
+    return resp.json()
+
+
+def _resolve_issuer(issuer: Optional[str], tenant_id: Optional[str]) -> Optional[str]:
+    """Resolve a discovery-document issuer, substituting any {tenantid} template.
+
+    The `common`/`organizations` discovery endpoints return a templated
+    issuer such as `https://login.microsoftonline.com/{tenantid}/v2.0`; the
+    tenant-specific endpoint returns a concrete issuer already. Substitute
+    the template when present so both cases yield a usable value.
+    """
+    if not issuer:
+        return None
+    if "{tenantid}" in issuer and tenant_id:
+        return issuer.replace("{tenantid}", tenant_id)
+    return issuer
 
 
 def _fetch_signing_keys(jwks_uri: str) -> Dict[str, Any]:
@@ -64,10 +87,15 @@ def _fetch_signing_keys(jwks_uri: str) -> Dict[str, Any]:
     return resp.json()
 
 
-def _get_signing_keys(force_refresh: bool = False) -> Tuple[Dict[str, Any], str]:
-    """Return cached signing keys, refreshing if stale or forced.
+def _get_signing_keys(force_refresh: bool = False) -> Tuple[Dict[str, Any], str, Optional[str]]:
+    """Return cached signing keys and discovery issuer, refreshing if stale or forced.
 
-    Returns (jwks_dict, jwks_uri).
+    The OIDC discovery document is fetched once alongside the JWKS URI (same
+    cache, same TTL) so the issuer used for token validation always reflects
+    metadata that was retrieved together, and discovery is not re-fetched
+    per request any more than the JWKS themselves are.
+
+    Returns (jwks_dict, jwks_uri, issuer).
     """
     global _jwks_cache
 
@@ -79,18 +107,21 @@ def _get_signing_keys(force_refresh: bool = False) -> Tuple[Dict[str, Any], str]
     )
 
     if cache_valid:
-        return _jwks_cache["keys"], _jwks_cache["jwks_uri"]
+        return _jwks_cache["keys"], _jwks_cache["jwks_uri"], _jwks_cache.get("issuer")
 
     tenant_id = _get_tenant_id()
-    jwks_uri = _fetch_jwks_uri(tenant_id)
+    metadata = _fetch_oidc_metadata(tenant_id)
+    jwks_uri = metadata["jwks_uri"]
+    issuer = _resolve_issuer(metadata.get("issuer"), tenant_id)
     jwks_data = _fetch_signing_keys(jwks_uri)
 
     _jwks_cache = {
         "keys": jwks_data,
         "fetched_at": now,
         "jwks_uri": jwks_uri,
+        "issuer": issuer,
     }
-    return jwks_data, jwks_uri
+    return jwks_data, jwks_uri, issuer
 
 
 def _find_key_by_kid(jwks_data: Dict[str, Any], kid: str) -> Optional[Dict[str, Any]]:
@@ -108,7 +139,7 @@ def _validate_jwt(token: str) -> Dict[str, Any]:
     Raises jwt.PyJWTError (or subclass) on any validation failure.
     """
     tenant_id = _get_tenant_id()
-    expected_issuer = _get_expected_issuer(tenant_id)
+    explicit_issuer = os.environ.get("AZURE_AD_ISSUER")
     expected_audience = os.environ.get("EXPECTED_AUDIENCE")
 
     # Fail closed on missing validation configuration: a token minted for any
@@ -119,7 +150,7 @@ def _validate_jwt(token: str) -> Dict[str, Any]:
             "Server misconfiguration: EXPECTED_AUDIENCE is not set; "
             "refusing to validate tokens without audience verification"
         )
-    if not expected_issuer:
+    if not explicit_issuer and not tenant_id:
         raise jwt.InvalidTokenError(
             "Server misconfiguration: AZURE_TENANT_ID / AZURE_AD_ISSUER is not set; "
             "refusing to validate tokens without issuer verification"
@@ -133,19 +164,32 @@ def _validate_jwt(token: str) -> Dict[str, Any]:
     if not kid:
         raise jwt.InvalidTokenError("Token header missing 'kid' claim")
 
-    # Fetch signing keys (from cache if available)
-    jwks_data, _jwks_uri = _get_signing_keys()
+    # Fetch signing keys (from cache if available). The OIDC discovery
+    # document's "issuer" field is fetched and cached alongside the JWKS URI
+    # so the expected issuer tracks whichever token version (v1 or v2) the
+    # tenant's discovery endpoint actually reports.
+    jwks_data, _jwks_uri, discovery_issuer = _get_signing_keys()
 
     key_data = _find_key_by_kid(jwks_data, kid)
 
     # If kid not found, force-refresh keys (handle key rotation)
     if key_data is None:
         logging.info(f"Key ID '{kid}' not found in cached JWKS, refreshing keys")
-        jwks_data, _jwks_uri = _get_signing_keys(force_refresh=True)
+        jwks_data, _jwks_uri, discovery_issuer = _get_signing_keys(force_refresh=True)
         key_data = _find_key_by_kid(jwks_data, kid)
 
     if key_data is None:
         raise jwt.InvalidTokenError(f"Unable to find signing key with kid '{kid}'")
+
+    # Prefer an explicit override, then the issuer reported by discovery,
+    # then fall back to the constructed v1 issuer if discovery didn't
+    # provide one (e.g. metadata unavailable or missing the field).
+    expected_issuer = explicit_issuer or discovery_issuer or _get_expected_issuer(tenant_id)
+    if not expected_issuer:
+        raise jwt.InvalidTokenError(
+            "Server misconfiguration: unable to determine expected token issuer; "
+            "refusing to validate tokens without issuer verification"
+        )
 
     # Build the public key from JWK
     public_key = jwt.algorithms.RSAAlgorithm.from_jwk(key_data)

--- a/xfunction/installer/cli.py
+++ b/xfunction/installer/cli.py
@@ -263,16 +263,21 @@ def _offer_xv_storage(config: InstallerConfig, app_reg_data: dict, prereq_data: 
     secrets = [("azure-tenant-id", tenant_id), ("azure-client-id", client_id), ("function-app-url", url)]
     if client_secret:
         secrets.append(("azure-client-secret", client_secret))
+    all_succeeded = True
     for name, value in secrets:
         if value:
-            subprocess.run(
+            result = subprocess.run(
                 ["xv", "set", name, "--stdin", "--group", "xfunction"],
                 input=value,
                 text=True,
                 capture_output=True,
                 timeout=10,
             )
-    success("Credentials stored in xv (group: xfunction)")
+            if result.returncode != 0:
+                all_succeeded = False
+                warning(f"Failed to store '{name}' in xv: {result.stderr.strip()}")
+    if all_succeeded:
+        success("Credentials stored in xv (group: xfunction)")
 
 def run_uninstall(config: InstallerConfig) -> int:
     az = AzCli(verbose=config.verbose)

--- a/xfunction/installer/cli.py
+++ b/xfunction/installer/cli.py
@@ -265,7 +265,13 @@ def _offer_xv_storage(config: InstallerConfig, app_reg_data: dict, prereq_data: 
         secrets.append(("azure-client-secret", client_secret))
     for name, value in secrets:
         if value:
-            subprocess.run(["xv", "set", name, "--value", value, "--group", "xfunction"], capture_output=True, timeout=10)
+            subprocess.run(
+                ["xv", "set", name, "--stdin", "--group", "xfunction"],
+                input=value,
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
     success("Credentials stored in xv (group: xfunction)")
 
 def run_uninstall(config: InstallerConfig) -> int:

--- a/xfunction/tests/test_installer_cli.py
+++ b/xfunction/tests/test_installer_cli.py
@@ -2,10 +2,12 @@
 import unittest
 import sys
 import os
+from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from installer.cli import parse_args
+from installer.cli import parse_args, _offer_xv_storage
+from installer.config import InstallerConfig
 
 class TestParseArgs(unittest.TestCase):
 
@@ -43,6 +45,65 @@ class TestParseArgs(unittest.TestCase):
     def test_verify_command(self):
         args = parse_args(["verify"])
         self.assertEqual(args.command, "verify")
+
+class TestOfferXvStorage(unittest.TestCase):
+    """_offer_xv_storage must pass secret values via stdin, never argv."""
+
+    def _config(self):
+        return InstallerConfig(function_app_name="fa-xfunction", non_interactive=False)
+
+    @patch("installer.cli.subprocess.run")
+    @patch("installer.cli.confirm", return_value=True)
+    @patch("installer.cli.shutil.which", return_value="/usr/local/bin/xv")
+    def test_stores_secrets_via_stdin_not_argv(self, mock_which, mock_confirm, mock_run):
+        app_reg_data = {"app_id": "client-123", "client_secret": "s3cr3t-value"}
+        prereq_data = {"tenant_id": "tenant-abc"}
+
+        _offer_xv_storage(self._config(), app_reg_data, prereq_data)
+
+        self.assertTrue(mock_run.called)
+        for call in mock_run.call_args_list:
+            argv = call.args[0]
+            kwargs = call.kwargs
+            # The secret value must never appear as a bare CLI argument.
+            self.assertNotIn("--value", argv)
+            self.assertIn("--stdin", argv)
+            self.assertNotIn("s3cr3t-value", argv)
+            self.assertNotIn("client-123", argv)
+            self.assertNotIn("tenant-abc", argv)
+            # The value must be supplied verbatim via stdin instead.
+            self.assertIn("input", kwargs)
+            self.assertTrue(kwargs.get("text"))
+
+    @patch("installer.cli.subprocess.run")
+    @patch("installer.cli.confirm", return_value=True)
+    @patch("installer.cli.shutil.which", return_value="/usr/local/bin/xv")
+    def test_client_secret_value_passed_verbatim_via_stdin(self, mock_which, mock_confirm, mock_run):
+        app_reg_data = {"app_id": "client-123", "client_secret": "s3cr3t-value"}
+        prereq_data = {"tenant_id": "tenant-abc"}
+
+        _offer_xv_storage(self._config(), app_reg_data, prereq_data)
+
+        secret_calls = [
+            call for call in mock_run.call_args_list
+            if call.args[0][1] == "set" and call.args[0][2] == "azure-client-secret"
+        ]
+        self.assertEqual(len(secret_calls), 1)
+        self.assertEqual(secret_calls[0].kwargs["input"], "s3cr3t-value")
+
+    @patch("installer.cli.subprocess.run")
+    @patch("installer.cli.shutil.which", return_value=None)
+    def test_skips_when_xv_not_installed(self, mock_which, mock_run):
+        _offer_xv_storage(self._config(), {"app_id": "x"}, {"tenant_id": "t"})
+        mock_run.assert_not_called()
+
+    @patch("installer.cli.subprocess.run")
+    @patch("installer.cli.shutil.which", return_value="/usr/local/bin/xv")
+    def test_skips_when_non_interactive(self, mock_which, mock_run):
+        config = InstallerConfig(function_app_name="fa-xfunction", non_interactive=True)
+        _offer_xv_storage(config, {"app_id": "x"}, {"tenant_id": "t"})
+        mock_run.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/xfunction/tests/test_installer_cli.py
+++ b/xfunction/tests/test_installer_cli.py
@@ -52,10 +52,18 @@ class TestOfferXvStorage(unittest.TestCase):
     def _config(self):
         return InstallerConfig(function_app_name="fa-xfunction", non_interactive=False)
 
+    @staticmethod
+    def _ok_result():
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        return result
+
     @patch("installer.cli.subprocess.run")
     @patch("installer.cli.confirm", return_value=True)
     @patch("installer.cli.shutil.which", return_value="/usr/local/bin/xv")
     def test_stores_secrets_via_stdin_not_argv(self, mock_which, mock_confirm, mock_run):
+        mock_run.return_value = self._ok_result()
         app_reg_data = {"app_id": "client-123", "client_secret": "s3cr3t-value"}
         prereq_data = {"tenant_id": "tenant-abc"}
 
@@ -79,6 +87,7 @@ class TestOfferXvStorage(unittest.TestCase):
     @patch("installer.cli.confirm", return_value=True)
     @patch("installer.cli.shutil.which", return_value="/usr/local/bin/xv")
     def test_client_secret_value_passed_verbatim_via_stdin(self, mock_which, mock_confirm, mock_run):
+        mock_run.return_value = self._ok_result()
         app_reg_data = {"app_id": "client-123", "client_secret": "s3cr3t-value"}
         prereq_data = {"tenant_id": "tenant-abc"}
 
@@ -103,6 +112,85 @@ class TestOfferXvStorage(unittest.TestCase):
         config = InstallerConfig(function_app_name="fa-xfunction", non_interactive=True)
         _offer_xv_storage(config, {"app_id": "x"}, {"tenant_id": "t"})
         mock_run.assert_not_called()
+
+    @patch("installer.cli.warning")
+    @patch("installer.cli.success")
+    @patch("installer.cli.subprocess.run")
+    @patch("installer.cli.confirm", return_value=True)
+    @patch("installer.cli.shutil.which", return_value="/usr/local/bin/xv")
+    def test_failed_store_reports_warning_not_success(
+        self, mock_which, mock_confirm, mock_run, mock_success, mock_warning
+    ):
+        """A non-zero `xv set` returncode (bad vault, auth error, etc.) must
+        surface a warning naming the failed secret and must NOT be reported
+        as success. The secret value must never appear in the warning or in
+        any other captured output."""
+        failed_result = MagicMock()
+        failed_result.returncode = 1
+        failed_result.stderr = "Error: vault 'bad-vault' not found"
+        mock_run.return_value = failed_result
+
+        app_reg_data = {"app_id": "client-123", "client_secret": "s3cr3t-value"}
+        prereq_data = {"tenant_id": "tenant-abc"}
+
+        _offer_xv_storage(self._config(), app_reg_data, prereq_data)
+
+        # Success must never be reported when any store failed.
+        mock_success.assert_not_called()
+
+        # A warning must be emitted per failed secret, naming the secret and
+        # including the stderr output.
+        self.assertTrue(mock_warning.called)
+        warned_messages = [call.args[0] for call in mock_warning.call_args_list]
+        self.assertTrue(any("azure-tenant-id" in msg for msg in warned_messages))
+        self.assertTrue(any("vault 'bad-vault' not found" in msg for msg in warned_messages))
+
+        # The secret value must never leak into any warning/success message.
+        for msg in warned_messages:
+            self.assertNotIn("s3cr3t-value", msg)
+            self.assertNotIn("client-123", msg)
+            self.assertNotIn("tenant-abc", msg)
+
+    @patch("installer.cli.warning")
+    @patch("installer.cli.success")
+    @patch("installer.cli.subprocess.run")
+    @patch("installer.cli.confirm", return_value=True)
+    @patch("installer.cli.shutil.which", return_value="/usr/local/bin/xv")
+    def test_partial_failure_still_suppresses_success(
+        self, mock_which, mock_confirm, mock_run, mock_success, mock_warning
+    ):
+        """If only one of several `xv set` calls fails, success must still
+        be suppressed overall."""
+        ok_result = self._ok_result()
+        failed_result = MagicMock()
+        failed_result.returncode = 1
+        failed_result.stderr = "Error: unauthorized"
+        mock_run.side_effect = [ok_result, ok_result, failed_result, ok_result]
+
+        app_reg_data = {"app_id": "client-123", "client_secret": "s3cr3t-value"}
+        prereq_data = {"tenant_id": "tenant-abc"}
+
+        _offer_xv_storage(self._config(), app_reg_data, prereq_data)
+
+        mock_success.assert_not_called()
+        self.assertTrue(mock_warning.called)
+
+    @patch("installer.cli.warning")
+    @patch("installer.cli.success")
+    @patch("installer.cli.subprocess.run")
+    @patch("installer.cli.confirm", return_value=True)
+    @patch("installer.cli.shutil.which", return_value="/usr/local/bin/xv")
+    def test_all_succeed_reports_success_and_no_warning(
+        self, mock_which, mock_confirm, mock_run, mock_success, mock_warning
+    ):
+        mock_run.return_value = self._ok_result()
+        app_reg_data = {"app_id": "client-123", "client_secret": "s3cr3t-value"}
+        prereq_data = {"tenant_id": "tenant-abc"}
+
+        _offer_xv_storage(self._config(), app_reg_data, prereq_data)
+
+        mock_warning.assert_not_called()
+        mock_success.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/xfunction/tests/test_jwt_issuer_validation.py
+++ b/xfunction/tests/test_jwt_issuer_validation.py
@@ -1,0 +1,185 @@
+"""Tests exercising the REAL `_validate_jwt` issuer verification path.
+
+Unlike test_direct_rbac_processor.py (which mocks `_validate_jwt` entirely),
+these tests only mock the HTTP calls used to fetch the OIDC discovery
+document and JWKS, sign real JWTs with a generated RSA key, and let the
+actual signature/issuer/audience validation in `_validate_jwt` run.
+"""
+import copy
+import os
+import sys
+import time
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch, MagicMock
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import function_app
+
+
+TENANT_ID = "test-tenant-id"
+AUDIENCE = "test-client-id"
+KID = "test-key-id"
+
+
+def _generate_rsa_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _jwk_for(private_key, kid):
+    alg = jwt.algorithms.RSAAlgorithm(jwt.algorithms.RSAAlgorithm.SHA256)
+    jwk = alg.to_jwk(private_key.public_key(), as_dict=True)
+    jwk["kid"] = kid
+    jwk["kty"] = "RSA"
+    jwk["use"] = "sig"
+    return jwk
+
+
+def _make_token(private_key, issuer, kid=KID, audience=AUDIENCE, expired=False):
+    now = datetime.now(timezone.utc)
+    exp = now - timedelta(minutes=5) if expired else now + timedelta(hours=1)
+    payload = {
+        "oid": "test-user-id",
+        "iss": issuer,
+        "aud": audience,
+        "exp": int(exp.timestamp()),
+        "iat": int(now.timestamp()),
+    }
+    return jwt.encode(payload, private_key, algorithm="RS256", headers={"kid": kid})
+
+
+def _mock_response(json_data):
+    resp = MagicMock()
+    resp.json.return_value = json_data
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+class JwtIssuerValidationTestBase(unittest.TestCase):
+    def setUp(self):
+        self.private_key = _generate_rsa_key()
+        self.jwks = {"keys": [_jwk_for(self.private_key, KID)]}
+        self.env_patcher = patch.dict(
+            os.environ,
+            {
+                "AZURE_TENANT_ID": TENANT_ID,
+                "EXPECTED_AUDIENCE": AUDIENCE,
+            },
+            clear=False,
+        )
+        self.env_patcher.start()
+        os.environ.pop("AZURE_AD_ISSUER", None)
+        # Ensure each test starts with a clean, unpopulated JWKS cache.
+        function_app._jwks_cache = {}
+
+    def tearDown(self):
+        self.env_patcher.stop()
+        function_app._jwks_cache = {}
+
+    def _mock_http_get(self, discovery_doc):
+        """Return a side_effect for http_requests.get: discovery doc, then JWKS."""
+        def _get(url, timeout=10):
+            if url.endswith("/.well-known/openid-configuration"):
+                return _mock_response(discovery_doc)
+            if url == discovery_doc.get("jwks_uri"):
+                return _mock_response(self.jwks)
+            raise AssertionError(f"Unexpected URL fetched: {url}")
+        return _get
+
+
+class TestV2IssuerAccepted(JwtIssuerValidationTestBase):
+    def test_v2_token_accepted_when_discovery_issuer_is_v2(self):
+        v2_issuer = f"https://login.microsoftonline.com/{TENANT_ID}/v2.0"
+        discovery_doc = {
+            "issuer": v2_issuer,
+            "jwks_uri": "https://login.microsoftonline.com/test-tenant-id/discovery/v2.0/keys",
+        }
+        token = _make_token(self.private_key, issuer=v2_issuer)
+
+        with patch.object(
+            function_app.http_requests, "get", side_effect=self._mock_http_get(discovery_doc)
+        ):
+            claims = function_app._validate_jwt(token)
+
+        self.assertEqual(claims["oid"], "test-user-id")
+        self.assertEqual(claims["iss"], v2_issuer)
+
+
+class TestWrongIssuerRejected(JwtIssuerValidationTestBase):
+    def test_token_with_wrong_issuer_rejected(self):
+        v2_issuer = f"https://login.microsoftonline.com/{TENANT_ID}/v2.0"
+        discovery_doc = {
+            "issuer": v2_issuer,
+            "jwks_uri": "https://login.microsoftonline.com/test-tenant-id/discovery/v2.0/keys",
+        }
+        # Token signed with an issuer that does NOT match discovery's issuer.
+        token = _make_token(self.private_key, issuer="https://evil.example.com/not-azure/")
+
+        with patch.object(
+            function_app.http_requests, "get", side_effect=self._mock_http_get(discovery_doc)
+        ):
+            with self.assertRaises(jwt.InvalidIssuerError):
+                function_app._validate_jwt(token)
+
+
+class TestDiscoveryUnavailableFallback(JwtIssuerValidationTestBase):
+    def test_fallback_still_validates_v1_tokens_when_discovery_issuer_missing(self):
+        """If the discovery document has no "issuer" field (unavailable /
+        unparseable), _validate_jwt must fall back to the constructed v1
+        issuer and still accept a genuine v1 token."""
+        v1_issuer = f"https://sts.windows.net/{TENANT_ID}/"
+        discovery_doc = {
+            # No "issuer" field present.
+            "jwks_uri": "https://login.microsoftonline.com/test-tenant-id/discovery/v2.0/keys",
+        }
+        token = _make_token(self.private_key, issuer=v1_issuer)
+
+        with patch.object(
+            function_app.http_requests, "get", side_effect=self._mock_http_get(discovery_doc)
+        ):
+            claims = function_app._validate_jwt(token)
+
+        self.assertEqual(claims["oid"], "test-user-id")
+        self.assertEqual(claims["iss"], v1_issuer)
+
+    def test_fallback_rejects_v2_token_when_discovery_issuer_missing(self):
+        """Sanity check: the v1 fallback issuer does NOT accept v2 tokens,
+        confirming the fallback is genuinely v1-only (matches Finding 9's
+        documented nuance)."""
+        v2_issuer = f"https://login.microsoftonline.com/{TENANT_ID}/v2.0"
+        discovery_doc = {
+            "jwks_uri": "https://login.microsoftonline.com/test-tenant-id/discovery/v2.0/keys",
+        }
+        token = _make_token(self.private_key, issuer=v2_issuer)
+
+        with patch.object(
+            function_app.http_requests, "get", side_effect=self._mock_http_get(discovery_doc)
+        ):
+            with self.assertRaises(jwt.InvalidIssuerError):
+                function_app._validate_jwt(token)
+
+
+class TestExplicitIssuerOverride(JwtIssuerValidationTestBase):
+    def test_explicit_issuer_env_var_overrides_discovery(self):
+        override_issuer = "https://custom-issuer.example.com/"
+        discovery_doc = {
+            "issuer": f"https://login.microsoftonline.com/{TENANT_ID}/v2.0",
+            "jwks_uri": "https://login.microsoftonline.com/test-tenant-id/discovery/v2.0/keys",
+        }
+        token = _make_token(self.private_key, issuer=override_issuer)
+
+        with patch.dict(os.environ, {"AZURE_AD_ISSUER": override_issuer}):
+            with patch.object(
+                function_app.http_requests, "get", side_effect=self._mock_http_get(discovery_doc)
+            ):
+                claims = function_app._validate_jwt(token)
+
+        self.assertEqual(claims["iss"], override_issuer)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #310 — findings 9 (P2) and 10 (P3) from the 2026-07-03 repo review. All changes under `xfunction/`.

## JWT issuer from OIDC discovery (finding 9)

`_get_expected_issuer` hard-coded the v1 `sts.windows.net` issuer (while its docstring claimed v2), and discovery only ever read `jwks_uri` — so genuine v2 tokens were always rejected. Default installer deployments issue v1 tokens, so this only broke v2 callers.

- `_fetch_jwks_uri` → `_fetch_oidc_metadata`: fetches the full discovery document once (same cache + TTL as JWKS, no extra per-request fetch) and caches the `issuer` alongside the keys, so the expected issuer always reflects metadata retrieved atomically with the signing keys.
- Expected issuer resolution: explicit `AZURE_AD_ISSUER` env var → discovery `issuer` (with `{tenantid}` template substitution) → v1 constant fallback (docstring corrected).
- Fail-closed preserved: discovery failure → exception → 401; failed fetches don't write the cache (no poisoning); a `None` issuer raises before `jwt.decode` (PyJWT silently skips issuer checks on `None` — guarded).
- Note: with discovery reachable, the expected issuer is the concrete v2 issuer, so v1-only callers would need `AZURE_AD_ISSUER` — intended per #310; mixed fleets can use the override.

## Installer secret via stdin (finding 10)

`_offer_xv_storage` passed the client secret as `xv set --value <secret>` — visible in process listings. Now `xv set <name> --stdin` with `input=value` (verbatim: verified against the Rust source that `--stdin` preserves bytes exactly unless `--trim` is passed). Also fixed while there: per-secret `returncode` is checked, failures warn with the secret name + stderr (never the value), and "Credentials stored" only prints when every store succeeded.

## Tests

- New `test_jwt_issuer_validation.py` (5 tests) exercises the **real** `_validate_jwt`: real RSA keys, real RS256 signatures, only HTTP mocked. Covers v2-accepted-via-discovery (fails on main with `InvalidIssuerError`), wrong-issuer rejected, v1 fallback when discovery omits `issuer`, and `AZURE_AD_ISSUER` override.
- `TestOfferXvStorage` (7 tests): asserts secrets never appear in argv, stdin carries the exact value, and the failure/partial-failure paths warn without claiming success.

Full xfunction suite: **100 passed, 1 skipped**. Separate security-focused code-review pass performed — it verified fail-closed behavior with live mutation probes (bad signature / wrong audience / expired / failed discovery all rejected) and approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication issuer logic on a role-granting HTTP endpoint; behavior shifts for v1 vs v2 tokens unless `AZURE_AD_ISSUER` is set, though fail-closed guards remain.
> 
> **Overview**
> **JWT validation** on the privileged `assign-roles` endpoint now derives the expected issuer from the cached OIDC discovery document (same fetch/TTL as JWKS), with `{tenantid}` template resolution, then `AZURE_AD_ISSUER`, then a documented v1 `sts.windows.net` offline fallback. That fixes rejection of genuine v2 tokens when discovery reports a v2 issuer; v1-only callers may need `AZURE_AD_ISSUER` when discovery is healthy. Issuer verification still fails closed if no issuer can be resolved.
> 
> **Installer** `_offer_xv_storage` writes credentials via `xv set --stdin` instead of `--value` so secrets are not exposed on the process command line. It checks each `xv` exit code, warns with secret name and stderr (never the value), and only prints overall success when every store succeeds.
> 
> New tests cover real `_validate_jwt` issuer paths (HTTP mocked only) and xv stdin / failure handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed4560dd8953b1a697b17155b308c8a67aa4900d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->