### PR TITLE
fix: honor [scan] config (min_value_length, patterns, excludes) and XV_SCAN_DISABLE across all scan modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - AWS: `list_deleted_secrets` now exposes the `xv:original_name` tag in its summaries (matching `list_secrets`), so `xv ls --deleted` no longer loses the user-facing name on AWS (#301).
+- **`xv scan` now honors every `[scan]` knob it already documented (#309).** `[scan].min_value_length` and `[scan].patterns` were parsed but silently ignored — the engine always used the hard-coded default minimum length, and every scan mode enabled all built-in patterns regardless of the allowlist. `XV_SCAN_DISABLE=1` (or `=true`) was documented as an escape hatch but read nowhere. All three now work, uniformly, across `xv scan [PATH]...`, `--staged`, and `--all`. An `[scan].patterns` allowlist that resolves to zero known pattern names (e.g. a typo) is now a hard config error listing the valid names, rather than a silent all-patterns-disabled scan that still exits 0. **Behavior change:** `xv scan --staged` (and therefore the installed pre-commit hook) now applies the same default excludes and `[scan].exclude` globs that `scan .` and `scan --all` already applied — previously it scanned every staged file regardless of excludes.
 
 ## v0.18.0 — Filesystem verbs: xv mv, ls aliases everywhere, and reliable rename (2026-07-02)
 

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -118,4 +118,4 @@ gitleaks protect --staged && xv scan --staged --hook
 Scanner is in-memory and re-fetches values per process. Expect 1–3 s on a 50-secret vault for `--staged`. To speed up:
 
 - `[scan].min_value_length = 12` — skip short values.
-- `XV_SCAN_DISABLE=1` (or `=true`, case-insensitive) — bypass entirely (escape hatch for emergencies).
+- `XV_SCAN_DISABLE=1` (or `=true`, case-insensitive) — bypass entirely (escape hatch for emergencies). The check runs *after* global config is loaded and validated, so a broken or missing config (e.g. no Azure subscription/tenant ID configured) still fails before this escape hatch applies — it is not a general "xv is broken" bypass.

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -27,7 +27,7 @@ xv scan uninstall           # remove the managed hook
 | Mode | Reads from | Typical use | Notes |
 |------|------------|-------------|-------|
 | `xv scan [PATH]...` | Working tree files under the requested paths | Local checks before staging | Honors default excludes, `.xvignore`, and `[scan].exclude`; prints skipped-file warnings outside hook mode. |
-| `xv scan --staged` | Git index via `git diff --cached` + `git show :PATH` | Pre-commit hooks | Scans exactly what would be committed, not unstaged edits. |
+| `xv scan --staged` | Git index via `git diff --cached` + `git show :PATH` | Pre-commit hooks | Scans exactly what would be committed, not unstaged edits; honors the same default and `[scan].exclude` globs as path scans (this is a behavior change from earlier releases, which scanned every staged file regardless of excludes). |
 | `xv scan --all` | Committed `HEAD` tree via `git ls-tree HEAD` + `git show HEAD:PATH` | CI sweeps of the current revision | Ignores unstaged and staged-but-uncommitted edits; honors the same default and `[scan].exclude` globs as path scans. |
 
 `--staged` and `--all` are mutually exclusive. Use a path scan for working-tree
@@ -67,8 +67,16 @@ on stderr and the command continues.
 [scan]
 exclude = ["dist/**", "*.lock"]
 min_value_length = 12
-patterns = ["aws", "github", "stripe"]
+patterns = ["aws-access-key-id", "github-token", "stripe-secret-key"]
 ```
+
+`patterns` is an allowlist matched against the built-in pattern names
+exactly: `aws-access-key-id`, `github-token`, `stripe-secret-key`,
+`slack-token`, `jwt`, `ssh-private-key`, `low-confidence-high-entropy`.
+Leave it empty (or omit it) to enable all built-ins. If it is non-empty but
+none of the names match a known pattern, `xv scan` fails with a config error
+listing the valid names — this is deliberate: a typo'd allowlist must never
+silently disable the whole built-in safety net.
 
 ## `.xvignore`
 
@@ -110,4 +118,4 @@ gitleaks protect --staged && xv scan --staged --hook
 Scanner is in-memory and re-fetches values per process. Expect 1–3 s on a 50-secret vault for `--staged`. To speed up:
 
 - `[scan].min_value_length = 12` — skip short values.
-- `XV_SCAN_DISABLE=1` — bypass entirely (escape hatch for emergencies).
+- `XV_SCAN_DISABLE=1` (or `=true`, case-insensitive) — bypass entirely (escape hatch for emergencies).

--- a/src/cli/scan_ops.rs
+++ b/src/cli/scan_ops.rs
@@ -63,16 +63,29 @@ async fn load_scan_config() -> Result<Option<ScanConfig>> {
     let cwd = std::env::current_dir()?;
     match crate::config::project::find_project_config(&cwd).await {
         Ok(Some((_, project))) => Ok(project.scan),
-        _ => Ok(None),
+        Ok(None) => Ok(None),
+        Err(e) => {
+            // A typo'd .xv.toml must not silently disable [scan] settings
+            // (excludes, min_value_length, patterns) without the user
+            // noticing. Warn and fall back to scanner defaults — scanning
+            // *more* (all built-ins, default excludes) is the safe
+            // direction to fail in for a leak scanner.
+            eprintln!(
+                "xv scan: warning: failed to parse .xv.toml, using default [scan] settings: {e}"
+            );
+            Ok(None)
+        }
     }
 }
 
 /// Resolve the effective minimum secret-value length from `[scan].min_value_length`,
-/// falling back to [`DEFAULT_MIN_VALUE_LENGTH`] when unset.
+/// falling back to [`DEFAULT_MIN_VALUE_LENGTH`] when unset. Clamped to a floor of 1
+/// so a configured `0` can't produce a zero-length Aho-Corasick needle.
 fn effective_min_value_length(scan_cfg: Option<&ScanConfig>) -> usize {
     scan_cfg
         .and_then(|s| s.min_value_length)
         .unwrap_or(DEFAULT_MIN_VALUE_LENGTH)
+        .max(1)
 }
 
 /// Resolve the effective exclude globs from `[scan].exclude` (empty when unset).
@@ -83,11 +96,17 @@ fn effective_excludes(scan_cfg: Option<&ScanConfig>) -> Vec<String> {
 /// Filter `builtin_patterns()` by `[scan].patterns` allowlist. An empty
 /// allowlist enables all built-ins (per `docs/scan.md`). Unknown names in
 /// the allowlist are warned about on stderr rather than silently ignored.
-fn effective_patterns(scan_cfg: Option<&ScanConfig>) -> Vec<BuiltinPattern> {
+///
+/// If the allowlist is non-empty but resolves to zero known patterns (e.g.
+/// every name is a typo, like the pre-#309 docs example `["aws", "github",
+/// "stripe"]` instead of `["aws-access-key-id", ...]`), this is a hard
+/// error rather than a silent all-patterns-disabled scan: a leak scanner
+/// must never fail open without the user noticing.
+fn effective_patterns(scan_cfg: Option<&ScanConfig>) -> Result<Vec<BuiltinPattern>> {
     let all = builtin_patterns();
     let allowlist = match scan_cfg {
         Some(s) if !s.patterns.is_empty() => &s.patterns,
-        _ => return all,
+        _ => return Ok(all),
     };
     let known: std::collections::HashSet<&str> = all.iter().map(|p| p.name).collect();
     for name in allowlist {
@@ -97,9 +116,22 @@ fn effective_patterns(scan_cfg: Option<&ScanConfig>) -> Vec<BuiltinPattern> {
             );
         }
     }
-    all.into_iter()
+    let filtered: Vec<BuiltinPattern> = all
+        .into_iter()
         .filter(|p| allowlist.iter().any(|a| a == p.name))
-        .collect()
+        .collect();
+
+    if filtered.is_empty() {
+        let mut valid_names: Vec<&str> = known.into_iter().collect();
+        valid_names.sort_unstable();
+        return Err(CrosstacheError::config(format!(
+            "[scan].patterns = {allowlist:?} matched none of the built-in pattern names; \
+             valid names are: {}. Leave [scan].patterns empty to enable all built-ins.",
+            valid_names.join(", ")
+        )));
+    }
+
+    Ok(filtered)
 }
 
 /// Resolve the active backend and the set of vaults to scan, then fetch every
@@ -159,7 +191,7 @@ async fn execute_scan_paths(
     let secrets = fetch_scan_secrets(all_vaults, config, registry).await?;
 
     let scan_cfg = load_scan_config().await?;
-    let patterns = effective_patterns(scan_cfg.as_ref());
+    let patterns = effective_patterns(scan_cfg.as_ref())?;
     let min_value_length = effective_min_value_length(scan_cfg.as_ref());
     let engine = MatchEngine::new(&secrets, &patterns, min_value_length);
 
@@ -204,7 +236,7 @@ async fn execute_scan_staged(
     let secrets = fetch_scan_secrets(all_vaults, config, registry).await?;
 
     let scan_cfg = load_scan_config().await?;
-    let patterns = effective_patterns(scan_cfg.as_ref());
+    let patterns = effective_patterns(scan_cfg.as_ref())?;
     let min_value_length = effective_min_value_length(scan_cfg.as_ref());
     let engine = MatchEngine::new(&secrets, &patterns, min_value_length);
 
@@ -235,7 +267,7 @@ async fn execute_scan_head(
     // committed paths that `scan .` would skip.
     let excludes = build_exclude_set(&effective_excludes(scan_cfg.as_ref()))?;
 
-    let patterns = effective_patterns(scan_cfg.as_ref());
+    let patterns = effective_patterns(scan_cfg.as_ref())?;
     let min_value_length = effective_min_value_length(scan_cfg.as_ref());
     let engine = MatchEngine::new(&secrets, &patterns, min_value_length);
     let findings = scan_head(&engine, &excludes)?;
@@ -380,9 +412,21 @@ mod tests {
     }
 
     #[test]
+    fn effective_min_value_length_clamps_zero_to_floor_of_one() {
+        // Review follow-up on #309: [scan].min_value_length = 0 must not
+        // reach MatchEngine::new as 0 (which combined with a would-be
+        // empty secret value could produce a zero-length needle).
+        let cfg = ScanConfig {
+            min_value_length: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(effective_min_value_length(Some(&cfg)), 1);
+    }
+
+    #[test]
     fn effective_patterns_empty_allowlist_enables_all_builtins() {
         let cfg = ScanConfig::default();
-        let patterns = effective_patterns(Some(&cfg));
+        let patterns = effective_patterns(Some(&cfg)).expect("empty allowlist must not error");
         assert_eq!(patterns.len(), builtin_patterns().len());
     }
 
@@ -395,7 +439,8 @@ mod tests {
             patterns: vec!["aws-access-key-id".to_string()],
             ..Default::default()
         };
-        let patterns = effective_patterns(Some(&cfg));
+        let patterns =
+            effective_patterns(Some(&cfg)).expect("a valid allowlisted name must not error");
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "aws-access-key-id");
 
@@ -420,19 +465,48 @@ mod tests {
     }
 
     #[test]
-    fn effective_patterns_unknown_name_is_dropped_not_matched() {
-        // Unknown pattern names in the allowlist are warned about (stderr)
-        // rather than silently ignored, but must not cause a panic and must
-        // not match anything themselves.
+    fn effective_patterns_all_unknown_names_is_a_hard_error() {
+        // Issue #309 review follow-up: an allowlist that resolves to zero
+        // known patterns (every name is a typo) must be a hard config
+        // error, not a silent all-patterns-disabled scan that still exits
+        // 0. Bugbot example: docs used to say `["aws", "github", "stripe"]`
+        // instead of the real names — that must fail loud, not scan nothing.
         let cfg = ScanConfig {
             patterns: vec!["not-a-real-pattern".to_string()],
             ..Default::default()
         };
-        let patterns = effective_patterns(Some(&cfg));
+        let result = effective_patterns(Some(&cfg));
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("an allowlist matching zero known patterns must error"),
+        };
+        let msg = err.to_string();
         assert!(
-            patterns.is_empty(),
-            "unknown allowlisted name must not resolve to any built-in pattern"
+            msg.contains("not-a-real-pattern"),
+            "error should name the bad value; got: {msg}"
         );
+        assert!(
+            msg.contains("aws-access-key-id"),
+            "error should list the valid pattern names; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn effective_patterns_mixed_known_and_unknown_keeps_known_and_warns() {
+        // A mix of one valid + one unknown name must keep the valid pattern
+        // (not error) — only an allowlist resolving to zero known patterns
+        // is a hard error.
+        let cfg = ScanConfig {
+            patterns: vec![
+                "aws-access-key-id".to_string(),
+                "not-a-real-pattern".to_string(),
+            ],
+            ..Default::default()
+        };
+        let patterns = effective_patterns(Some(&cfg))
+            .expect("at least one valid name in the allowlist must not error");
+        assert_eq!(patterns.len(), 1);
+        assert_eq!(patterns[0].name, "aws-access-key-id");
     }
 
     #[test]

--- a/src/cli/scan_ops.rs
+++ b/src/cli/scan_ops.rs
@@ -1,13 +1,14 @@
 //! CLI executors for `xv scan` and its subcommands.
 
 use crate::cli::commands::ScanCommands;
+use crate::config::project::ScanConfig;
 use crate::config::Config;
 use crate::error::{CrosstacheError, Result};
-use crate::scan::engine::MatchEngine;
+use crate::scan::engine::{MatchEngine, DEFAULT_MIN_VALUE_LENGTH};
 use crate::scan::finding::Finding;
 use crate::scan::orchestrator::{fetch_secret_values, scan_paths};
-use crate::scan::patterns::builtin_patterns;
-use crate::scan::walker::{walk, WalkConfig};
+use crate::scan::patterns::{builtin_patterns, BuiltinPattern};
+use crate::scan::walker::{build_exclude_set, walk, WalkConfig};
 use std::path::PathBuf;
 
 #[allow(clippy::too_many_arguments)]
@@ -28,6 +29,12 @@ pub(crate) async fn execute_scan_command(
             ScanCommands::Uninstall => execute_scan_uninstall(&config).await,
         };
     }
+
+    if scan_disabled_via_env() {
+        eprintln!("xv scan: disabled via XV_SCAN_DISABLE; skipping scan.");
+        return Ok(());
+    }
+
     if staged {
         return execute_scan_staged(hook, all_vaults, format, &config, registry).await;
     }
@@ -35,6 +42,64 @@ pub(crate) async fn execute_scan_command(
         return execute_scan_head(hook, all_vaults, format, &config, registry).await;
     }
     execute_scan_paths(paths, hook, all_vaults, format, &config, registry).await
+}
+
+/// `XV_SCAN_DISABLE=1` (or `true`, case-insensitive) bypasses scanning
+/// entirely — an escape hatch for emergencies, documented in `docs/scan.md`.
+/// Checked once, uniformly, across every scan mode (paths, `--staged`,
+/// `--all`) so the pre-commit hook and local scans agree.
+fn scan_disabled_via_env() -> bool {
+    std::env::var("XV_SCAN_DISABLE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Load the effective `[scan]` block from the nearest `.xv.toml`, if any.
+///
+/// Shared by all three scan entry points (paths, `--staged`, `--all`) so
+/// excludes, `min_value_length`, and the `patterns` allowlist are resolved
+/// identically regardless of scan mode.
+async fn load_scan_config() -> Result<Option<ScanConfig>> {
+    let cwd = std::env::current_dir()?;
+    match crate::config::project::find_project_config(&cwd).await {
+        Ok(Some((_, project))) => Ok(project.scan),
+        _ => Ok(None),
+    }
+}
+
+/// Resolve the effective minimum secret-value length from `[scan].min_value_length`,
+/// falling back to [`DEFAULT_MIN_VALUE_LENGTH`] when unset.
+fn effective_min_value_length(scan_cfg: Option<&ScanConfig>) -> usize {
+    scan_cfg
+        .and_then(|s| s.min_value_length)
+        .unwrap_or(DEFAULT_MIN_VALUE_LENGTH)
+}
+
+/// Resolve the effective exclude globs from `[scan].exclude` (empty when unset).
+fn effective_excludes(scan_cfg: Option<&ScanConfig>) -> Vec<String> {
+    scan_cfg.map(|s| s.exclude.clone()).unwrap_or_default()
+}
+
+/// Filter `builtin_patterns()` by `[scan].patterns` allowlist. An empty
+/// allowlist enables all built-ins (per `docs/scan.md`). Unknown names in
+/// the allowlist are warned about on stderr rather than silently ignored.
+fn effective_patterns(scan_cfg: Option<&ScanConfig>) -> Vec<BuiltinPattern> {
+    let all = builtin_patterns();
+    let allowlist = match scan_cfg {
+        Some(s) if !s.patterns.is_empty() => &s.patterns,
+        _ => return all,
+    };
+    let known: std::collections::HashSet<&str> = all.iter().map(|p| p.name).collect();
+    for name in allowlist {
+        if !known.contains(name.as_str()) {
+            eprintln!(
+                "xv scan: warning: unknown pattern name '{name}' in [scan].patterns (ignored)"
+            );
+        }
+    }
+    all.into_iter()
+        .filter(|p| allowlist.iter().any(|a| a == p.name))
+        .collect()
 }
 
 /// Resolve the active backend and the set of vaults to scan, then fetch every
@@ -93,18 +158,15 @@ async fn execute_scan_paths(
 ) -> Result<()> {
     let secrets = fetch_scan_secrets(all_vaults, config, registry).await?;
 
-    let patterns = builtin_patterns();
-    let engine = MatchEngine::new(&secrets, &patterns);
+    let scan_cfg = load_scan_config().await?;
+    let patterns = effective_patterns(scan_cfg.as_ref());
+    let min_value_length = effective_min_value_length(scan_cfg.as_ref());
+    let engine = MatchEngine::new(&secrets, &patterns, min_value_length);
 
     // Build the path list. Apply [scan].exclude from .xv.toml if found.
-    let mut walk_cfg = WalkConfig::default();
-    if let Ok(Some((_, project))) =
-        crate::config::project::find_project_config(&std::env::current_dir()?).await
-    {
-        if let Some(scan) = &project.scan {
-            walk_cfg.extra_excludes = scan.exclude.clone();
-        }
-    }
+    let walk_cfg = WalkConfig {
+        extra_excludes: effective_excludes(scan_cfg.as_ref()),
+    };
     let path_refs: Vec<&std::path::Path> = paths.iter().map(|p| p.as_path()).collect();
     let walked = walk(&path_refs, &walk_cfg)?;
     let outcome = scan_paths(&walked, &engine)?;
@@ -141,9 +203,16 @@ async fn execute_scan_staged(
 
     let secrets = fetch_scan_secrets(all_vaults, config, registry).await?;
 
-    let patterns = builtin_patterns();
-    let engine = MatchEngine::new(&secrets, &patterns);
-    let findings = scan_staged(&engine)?;
+    let scan_cfg = load_scan_config().await?;
+    let patterns = effective_patterns(scan_cfg.as_ref());
+    let min_value_length = effective_min_value_length(scan_cfg.as_ref());
+    let engine = MatchEngine::new(&secrets, &patterns, min_value_length);
+
+    // Apply the same [scan].exclude + default globs the filesystem walk and
+    // `--all` head scan use, so the pre-commit hook (`scan --staged --hook`)
+    // doesn't scan target/, node_modules/, or user-excluded staged paths.
+    let excludes = build_exclude_set(&effective_excludes(scan_cfg.as_ref()))?;
+    let findings = scan_staged(&engine, &excludes)?;
 
     render_findings(&findings, hook, format)
 }
@@ -159,21 +228,16 @@ async fn execute_scan_head(
 
     let secrets = fetch_scan_secrets(all_vaults, config, registry).await?;
 
+    let scan_cfg = load_scan_config().await?;
+
     // Apply the same [scan].exclude + default globs the filesystem walk uses,
     // so `scan --all` doesn't scan target/, node_modules/, or user-excluded
     // committed paths that `scan .` would skip.
-    let mut extra_excludes: Vec<String> = Vec::new();
-    if let Ok(Some((_, project))) =
-        crate::config::project::find_project_config(&std::env::current_dir()?).await
-    {
-        if let Some(scan) = &project.scan {
-            extra_excludes = scan.exclude.clone();
-        }
-    }
-    let excludes = crate::scan::walker::build_exclude_set(&extra_excludes)?;
+    let excludes = build_exclude_set(&effective_excludes(scan_cfg.as_ref()))?;
 
-    let patterns = builtin_patterns();
-    let engine = MatchEngine::new(&secrets, &patterns);
+    let patterns = effective_patterns(scan_cfg.as_ref());
+    let min_value_length = effective_min_value_length(scan_cfg.as_ref());
+    let engine = MatchEngine::new(&secrets, &patterns, min_value_length);
     let findings = scan_head(&engine, &excludes)?;
 
     render_findings(&findings, hook, format)
@@ -261,6 +325,12 @@ mod tests {
     use super::*;
     use crate::scan::finding::{FindingKind, Severity};
     use crate::utils::format::OutputFormat;
+    use std::sync::Mutex;
+
+    /// Guards tests that mutate `XV_SCAN_DISABLE` so they don't race each
+    /// other under cargo's default parallel test runner (mirrors the
+    /// XV_ENV_LOCK pattern in `config/project.rs`).
+    static SCAN_DISABLE_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn render_no_findings_returns_ok() {
@@ -286,5 +356,111 @@ mod tests {
             }
             other => panic!("expected ScanLeakDetected, got {other:?}"),
         }
+    }
+
+    // --- Issue #309 Finding 6: [scan].min_value_length / patterns / XV_SCAN_DISABLE ---
+
+    #[test]
+    fn effective_min_value_length_falls_back_to_default_when_unset() {
+        assert_eq!(effective_min_value_length(None), DEFAULT_MIN_VALUE_LENGTH);
+        let cfg = ScanConfig::default();
+        assert_eq!(
+            effective_min_value_length(Some(&cfg)),
+            DEFAULT_MIN_VALUE_LENGTH
+        );
+    }
+
+    #[test]
+    fn effective_min_value_length_uses_configured_value() {
+        let cfg = ScanConfig {
+            min_value_length: Some(4),
+            ..Default::default()
+        };
+        assert_eq!(effective_min_value_length(Some(&cfg)), 4);
+    }
+
+    #[test]
+    fn effective_patterns_empty_allowlist_enables_all_builtins() {
+        let cfg = ScanConfig::default();
+        let patterns = effective_patterns(Some(&cfg));
+        assert_eq!(patterns.len(), builtin_patterns().len());
+    }
+
+    #[test]
+    fn effective_patterns_allowlist_filters_to_named_patterns_only() {
+        // [scan].patterns = ["aws-access-key-id"] must enable only that
+        // pattern; every other built-in (github, stripe, slack, jwt, ...)
+        // must not fire.
+        let cfg = ScanConfig {
+            patterns: vec!["aws-access-key-id".to_string()],
+            ..Default::default()
+        };
+        let patterns = effective_patterns(Some(&cfg));
+        assert_eq!(patterns.len(), 1);
+        assert_eq!(patterns[0].name, "aws-access-key-id");
+
+        let secrets: Vec<crate::scan::engine::SecretRef> = vec![];
+        let engine = MatchEngine::new(&secrets, &patterns, DEFAULT_MIN_VALUE_LENGTH);
+
+        // The enabled pattern still fires.
+        let aws_findings =
+            engine.scan_text(std::path::Path::new("x"), "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n");
+        assert_eq!(aws_findings.len(), 1);
+
+        // A different built-in (github token) must NOT fire — it was
+        // filtered out of the allowlist.
+        let github_findings = engine.scan_text(
+            std::path::Path::new("x"),
+            "token=ghp_1234567890abcdefghijklmnopqrstuvwxyz\n",
+        );
+        assert!(
+            github_findings.is_empty(),
+            "github-token pattern must not fire when only aws-access-key-id is allowlisted"
+        );
+    }
+
+    #[test]
+    fn effective_patterns_unknown_name_is_dropped_not_matched() {
+        // Unknown pattern names in the allowlist are warned about (stderr)
+        // rather than silently ignored, but must not cause a panic and must
+        // not match anything themselves.
+        let cfg = ScanConfig {
+            patterns: vec!["not-a-real-pattern".to_string()],
+            ..Default::default()
+        };
+        let patterns = effective_patterns(Some(&cfg));
+        assert!(
+            patterns.is_empty(),
+            "unknown allowlisted name must not resolve to any built-in pattern"
+        );
+    }
+
+    #[test]
+    fn scan_disabled_via_env_true_for_one() {
+        let _guard = SCAN_DISABLE_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("XV_SCAN_DISABLE", "1");
+        assert!(scan_disabled_via_env());
+        std::env::remove_var("XV_SCAN_DISABLE");
+    }
+
+    #[test]
+    fn scan_disabled_via_env_false_when_unset() {
+        let _guard = SCAN_DISABLE_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("XV_SCAN_DISABLE");
+        assert!(!scan_disabled_via_env());
+    }
+
+    #[test]
+    fn scan_disabled_via_env_false_for_other_values() {
+        let _guard = SCAN_DISABLE_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("XV_SCAN_DISABLE", "0");
+        assert!(!scan_disabled_via_env());
+        std::env::remove_var("XV_SCAN_DISABLE");
     }
 }

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -778,7 +778,7 @@ resource_group = "rg"
 [scan]
 exclude = ["dist/**", "*.lock"]
 min_value_length = 12
-patterns = ["aws", "github"]
+patterns = ["aws-access-key-id", "github-token"]
 
 [env.dev]
 vault = "v"
@@ -788,6 +788,6 @@ resource_group = "rg"
         let scan = cfg.scan.as_ref().expect("must have [scan]");
         assert_eq!(scan.exclude, vec!["dist/**", "*.lock"]);
         assert_eq!(scan.min_value_length, Some(12));
-        assert_eq!(scan.patterns, vec!["aws", "github"]);
+        assert_eq!(scan.patterns, vec!["aws-access-key-id", "github-token"]);
     }
 }

--- a/src/scan/engine.rs
+++ b/src/scan/engine.rs
@@ -67,9 +67,14 @@ impl MatchEngine {
         patterns: &[BuiltinPattern],
         min_value_length: usize,
     ) -> Self {
+        // `!s.value.is_empty()` is a defensive floor independent of
+        // `min_value_length`: an empty-string needle handed to the
+        // Aho-Corasick builder is a degenerate input we never want to
+        // build against, regardless of what the caller passed as the
+        // configured minimum (e.g. an unclamped `min_value_length = 0`).
         let mut filtered: Vec<&SecretRef> = secrets
             .iter()
-            .filter(|s| s.value.len() >= min_value_length)
+            .filter(|s| !s.value.is_empty() && s.value.len() >= min_value_length)
             .collect();
         // Sort by descending value length so longest-leftmost matching
         // produces the longest match when two secrets share a prefix.
@@ -251,6 +256,34 @@ mod tests {
             1,
             "5-char value must be caught when min_value_length is configured to 4"
         );
+    }
+
+    #[test]
+    fn min_value_length_zero_does_not_panic_on_empty_secret_value() {
+        // Review follow-up on #309: min_value_length is clamped to a floor
+        // of 1 in scan_ops::effective_min_value_length, but the engine
+        // itself must not trust that — an empty secret value (`value.len()
+        // == 0`) combined with an unclamped `min_value_length = 0` must
+        // never reach the Aho-Corasick builder as a zero-length needle.
+        let secrets = vec![
+            SecretRef {
+                name: "EMPTY".to_string(),
+                vault: "v".to_string(),
+                value: Zeroizing::new(String::new()),
+            },
+            SecretRef {
+                name: "NONEMPTY".to_string(),
+                vault: "v".to_string(),
+                value: Zeroizing::new("x".to_string()),
+            },
+        ];
+        // Must not panic.
+        let engine = MatchEngine::new(&secrets, &[], 0);
+        let findings = engine.scan_text(Path::new("x"), "some content with x in it");
+        // The 1-char secret is still short but non-empty, so it is a valid
+        // (if noisy) needle at min_value_length = 0; the point of this test
+        // is the absence of a panic, not a specific finding count.
+        let _ = findings;
     }
 
     #[test]

--- a/src/scan/engine.rs
+++ b/src/scan/engine.rs
@@ -58,12 +58,18 @@ struct NeedlessPattern {
 }
 
 impl MatchEngine {
-    /// Build the engine. `secrets` whose `value.len() < DEFAULT_MIN_VALUE_LENGTH`
-    /// are skipped to avoid trivially-matched short strings.
-    pub fn new(secrets: &[SecretRef], patterns: &[BuiltinPattern]) -> Self {
+    /// Build the engine. `secrets` whose `value.len() < min_value_length`
+    /// are skipped to avoid trivially-matched short strings. Callers pass
+    /// the effective `[scan].min_value_length` (falling back to
+    /// [`DEFAULT_MIN_VALUE_LENGTH`] when unset).
+    pub fn new(
+        secrets: &[SecretRef],
+        patterns: &[BuiltinPattern],
+        min_value_length: usize,
+    ) -> Self {
         let mut filtered: Vec<&SecretRef> = secrets
             .iter()
-            .filter(|s| s.value.len() >= DEFAULT_MIN_VALUE_LENGTH)
+            .filter(|s| s.value.len() >= min_value_length)
             .collect();
         // Sort by descending value length so longest-leftmost matching
         // produces the longest match when two secrets share a prefix.
@@ -190,7 +196,7 @@ mod tests {
             vault: "dev-kv".to_string(),
             value: Zeroizing::new("hunter2-very-long-password".to_string()),
         }];
-        let engine = MatchEngine::new(&secrets, &[]);
+        let engine = MatchEngine::new(&secrets, &[], DEFAULT_MIN_VALUE_LENGTH);
         let findings = engine.scan_text(
             Path::new("src/config.rs"),
             "let db_pw = \"hunter2-very-long-password\";\n",
@@ -214,16 +220,44 @@ mod tests {
             vault: "v".to_string(),
             value: Zeroizing::new("abc".to_string()),
         }];
-        let engine = MatchEngine::new(&secrets, &[]);
+        let engine = MatchEngine::new(&secrets, &[], DEFAULT_MIN_VALUE_LENGTH);
         let findings = engine.scan_text(Path::new("x"), "abc abc abc abc");
         assert!(findings.is_empty(), "short secret values must be skipped");
+    }
+
+    #[test]
+    fn custom_min_value_length_catches_shorter_values() {
+        // Issue #309 Finding 6: [scan].min_value_length was parsed but never
+        // threaded into the engine, which always used the hard-coded default
+        // of 8. A 5-char secret value must be caught when the configured
+        // min_value_length is 4, and must NOT be caught at the default of 8.
+        let secrets = vec![SecretRef {
+            name: "PIN".to_string(),
+            vault: "v".to_string(),
+            value: Zeroizing::new("ab123".to_string()),
+        }];
+
+        let default_engine = MatchEngine::new(&secrets, &[], DEFAULT_MIN_VALUE_LENGTH);
+        let default_findings = default_engine.scan_text(Path::new("x"), "code=ab123 done");
+        assert!(
+            default_findings.is_empty(),
+            "5-char value must be skipped at the default min length of 8"
+        );
+
+        let custom_engine = MatchEngine::new(&secrets, &[], 4);
+        let custom_findings = custom_engine.scan_text(Path::new("x"), "code=ab123 done");
+        assert_eq!(
+            custom_findings.len(),
+            1,
+            "5-char value must be caught when min_value_length is configured to 4"
+        );
     }
 
     #[test]
     fn matches_aws_key_pattern_when_no_secret_overlaps() {
         let secrets: Vec<SecretRef> = vec![];
         let patterns = builtin_patterns();
-        let engine = MatchEngine::new(&secrets, &patterns);
+        let engine = MatchEngine::new(&secrets, &patterns, DEFAULT_MIN_VALUE_LENGTH);
         let findings = engine.scan_text(Path::new("creds.txt"), "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n");
         assert_eq!(findings.len(), 1);
         let f = &findings[0];
@@ -242,7 +276,7 @@ mod tests {
             value: Zeroizing::new("AKIAIOSFODNN7EXAMPLE".to_string()),
         }];
         let patterns = builtin_patterns();
-        let engine = MatchEngine::new(&secrets, &patterns);
+        let engine = MatchEngine::new(&secrets, &patterns, DEFAULT_MIN_VALUE_LENGTH);
         let findings = engine.scan_text(Path::new("x"), "key = \"AKIAIOSFODNN7EXAMPLE\";");
         assert!(!findings.is_empty());
         let f = &findings[0];
@@ -257,7 +291,7 @@ mod tests {
             vault: "v".to_string(),
             value: Zeroizing::new("needle12345".to_string()),
         }];
-        let engine = MatchEngine::new(&secrets, &[]);
+        let engine = MatchEngine::new(&secrets, &[], DEFAULT_MIN_VALUE_LENGTH);
         let content = "line1\nline2 needle12345 line2 cont\nline3";
         let findings = engine.scan_text(Path::new("x"), content);
         assert_eq!(findings.len(), 1);

--- a/src/scan/orchestrator.rs
+++ b/src/scan/orchestrator.rs
@@ -176,7 +176,11 @@ mod tests {
             value: Zeroizing::new("hunter2-very-long-password".to_string()),
         }];
         let patterns = builtin_patterns();
-        let engine = MatchEngine::new(&secrets, &patterns);
+        let engine = MatchEngine::new(
+            &secrets,
+            &patterns,
+            crate::scan::engine::DEFAULT_MIN_VALUE_LENGTH,
+        );
         let paths = walk(&[temp.path()], &WalkConfig::default()).unwrap();
         let outcome = scan_paths(&paths, &engine).unwrap();
         assert_eq!(outcome.findings.len(), 1);
@@ -210,7 +214,11 @@ mod tests {
             value: Zeroizing::new(secret.to_string()),
         }];
         let patterns = builtin_patterns();
-        let engine = MatchEngine::new(&secrets, &patterns);
+        let engine = MatchEngine::new(
+            &secrets,
+            &patterns,
+            crate::scan::engine::DEFAULT_MIN_VALUE_LENGTH,
+        );
         let outcome = scan_paths(std::slice::from_ref(&big), &engine).unwrap();
         assert!(
             outcome.findings.is_empty(),

--- a/src/scan/staged.rs
+++ b/src/scan/staged.rs
@@ -109,8 +109,16 @@ where
 /// Scan all staged files. Each file's content comes from `git show :PATH`
 /// (the index, not the working tree) so the scan reflects exactly what
 /// will be committed.
-pub fn scan_staged(engine: &MatchEngine) -> Result<Vec<Finding>> {
-    let files = list_staged_files()?;
+///
+/// `excludes` carries the same default + `[scan].exclude` globs the filesystem
+/// walker and `scan_head` apply (see `walker::build_exclude_set`), so
+/// `--staged` (and therefore the installed pre-commit hook) doesn't scan
+/// `target/`, `node_modules/`, or user-excluded paths that `scan .` skips.
+pub fn scan_staged(engine: &MatchEngine, excludes: &globset::GlobSet) -> Result<Vec<Finding>> {
+    let files: Vec<String> = list_staged_files()?
+        .into_iter()
+        .filter(|f| !excludes.is_match(f))
+        .collect();
     Ok(scan_git_paths(&files, read_staged_file, engine))
 }
 
@@ -127,4 +135,79 @@ pub fn scan_head(engine: &MatchEngine, excludes: &globset::GlobSet) -> Result<Ve
         .filter(|f| !excludes.is_match(f))
         .collect();
     Ok(scan_git_paths(&files, read_head_file, engine))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan::engine::{MatchEngine, SecretRef, DEFAULT_MIN_VALUE_LENGTH};
+    use crate::scan::patterns::builtin_patterns;
+    use crate::scan::walker::build_exclude_set;
+    use std::sync::Mutex;
+    use tempfile::tempdir;
+
+    /// `list_staged_files`/`read_staged_file` shell out to `git` using the
+    /// process's current working directory (mirroring the installed
+    /// pre-commit hook, which always runs with cwd = repo root). Tests that
+    /// exercise `scan_staged` against a real git fixture must therefore
+    /// change the process-global cwd; this lock serializes them against each
+    /// other. No other test in this binary changes cwd (see installer.rs's
+    /// tests, which deliberately avoid cwd-dependent code paths).
+    static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+    fn git(dir: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .expect("git command must spawn");
+        assert!(status.success(), "git {args:?} failed in {}", dir.display());
+    }
+
+    fn init_repo(dir: &Path) {
+        git(dir, &["init", "-q"]);
+        git(dir, &["config", "user.email", "test@example.invalid"]);
+        git(dir, &["config", "user.name", "test"]);
+    }
+
+    /// Issue #309 Finding 7: `scan --staged` (and therefore the installed
+    /// pre-commit hook) must honor `[scan].exclude`, exactly like `scan .`
+    /// and `scan --all` already do.
+    #[test]
+    fn scan_staged_honors_excludes() {
+        let _guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let temp = tempdir().unwrap();
+        let dir = temp.path();
+        init_repo(dir);
+
+        // A staged file whose content matches the built-in AWS key pattern.
+        std::fs::write(dir.join("leak.env"), "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n").unwrap();
+        git(dir, &["add", "leak.env"]);
+
+        let secrets: Vec<SecretRef> = vec![];
+        let patterns = builtin_patterns();
+        let engine = MatchEngine::new(&secrets, &patterns, DEFAULT_MIN_VALUE_LENGTH);
+
+        let original_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir).unwrap();
+
+        // Sanity check: without excludes, the staged leak is found.
+        let no_excludes = build_exclude_set(&[]).unwrap();
+        let unfiltered = scan_staged(&engine, &no_excludes).unwrap();
+
+        // With [scan].exclude = ["*.env"], the same staged file is skipped.
+        let with_excludes = build_exclude_set(&["*.env".to_string()]).unwrap();
+        let filtered = scan_staged(&engine, &with_excludes).unwrap();
+
+        std::env::set_current_dir(&original_cwd).unwrap();
+
+        assert!(
+            !unfiltered.is_empty(),
+            "sanity check: staged leak.env should produce a finding without excludes"
+        );
+        assert!(
+            filtered.is_empty(),
+            "excluded staged file must not produce findings via scan_staged"
+        );
+    }
 }

--- a/src/scan/staged.rs
+++ b/src/scan/staged.rs
@@ -155,6 +155,31 @@ mod tests {
     /// tests, which deliberately avoid cwd-dependent code paths).
     static CWD_LOCK: Mutex<()> = Mutex::new(());
 
+    /// Restores the process cwd to the path captured at construction time
+    /// when dropped — including on an early return via `?`/panic/unwrap
+    /// between the `set_current_dir` call and the end of the test. Without
+    /// this, a panicking `unwrap()` in the guarded region would leave the
+    /// whole test binary's cwd pointed at a tempdir that gets deleted when
+    /// `TempDir` drops, breaking every subsequently-run test that touches
+    /// the process cwd.
+    struct CwdGuard {
+        original: std::path::PathBuf,
+    }
+
+    impl CwdGuard {
+        fn change_to(dir: &Path) -> Self {
+            let original = std::env::current_dir().expect("must read current cwd");
+            std::env::set_current_dir(dir).expect("must change cwd");
+            Self { original }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original);
+        }
+    }
+
     fn git(dir: &Path, args: &[&str]) {
         let status = Command::new("git")
             .args(args)
@@ -188,18 +213,21 @@ mod tests {
         let patterns = builtin_patterns();
         let engine = MatchEngine::new(&secrets, &patterns, DEFAULT_MIN_VALUE_LENGTH);
 
-        let original_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(dir).unwrap();
+        let (unfiltered, filtered) = {
+            let _cwd_guard = CwdGuard::change_to(dir);
 
-        // Sanity check: without excludes, the staged leak is found.
-        let no_excludes = build_exclude_set(&[]).unwrap();
-        let unfiltered = scan_staged(&engine, &no_excludes).unwrap();
+            // Sanity check: without excludes, the staged leak is found.
+            let no_excludes = build_exclude_set(&[]).unwrap();
+            let unfiltered = scan_staged(&engine, &no_excludes).unwrap();
 
-        // With [scan].exclude = ["*.env"], the same staged file is skipped.
-        let with_excludes = build_exclude_set(&["*.env".to_string()]).unwrap();
-        let filtered = scan_staged(&engine, &with_excludes).unwrap();
+            // With [scan].exclude = ["*.env"], the same staged file is skipped.
+            let with_excludes = build_exclude_set(&["*.env".to_string()]).unwrap();
+            let filtered = scan_staged(&engine, &with_excludes).unwrap();
 
-        std::env::set_current_dir(&original_cwd).unwrap();
+            (unfiltered, filtered)
+            // _cwd_guard drops here, restoring cwd even if one of the
+            // unwraps above had panicked.
+        };
 
         assert!(
             !unfiltered.is_empty(),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -49,6 +49,63 @@ pub fn xv_isolated() -> (Command, TempDir) {
     (cmd, temp)
 }
 
+/// Build an isolated `xv` command backed by the **local** (age-encrypted
+/// file) backend, with a valid `xv.conf` written up front — so commands
+/// that need a working backend (not just filesystem/config-parse checks)
+/// can run fully offline, deterministically, with no Azure credentials or
+/// network access. Mirrors the harness in `e2e_local_backend.rs::TestEnv`.
+///
+/// Returns `(command, tempdir)`; hold the tempdir alive for the test
+/// duration (it cleans up on drop). The `--backend local` selection happens
+/// via `XV_BACKEND=local` (read directly by config loading, unlike a CLI
+/// `--backend` flag which is resolved too late to affect the early
+/// `Config::validate()` pass) plus `backend = "local"` in `xv.conf` as a
+/// belt-and-suspenders match.
+pub fn xv_isolated_local() -> (Command, TempDir) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config_dir = temp.path().join(".config");
+    let store_dir = temp.path().join("store");
+    let key_file = temp.path().join("key.txt");
+    let xv_dir = config_dir.join("xv");
+    std::fs::create_dir_all(&xv_dir).expect("create config dir");
+    std::fs::create_dir_all(&store_dir).expect("create store dir");
+
+    let config_content = format!(
+        r#"backend = "local"
+debug = false
+subscription_id = ""
+default_vault = "default"
+default_resource_group = ""
+default_location = ""
+tenant_id = ""
+output_json = false
+no_color = true
+cache_enabled = false
+cache_ttl_secs = 0
+clipboard_timeout = 0
+
+[local]
+store_path = "{store}"
+key_file = "{key}"
+default_vault = "default"
+"#,
+        store = store_dir.display(),
+        key = key_file.display(),
+    );
+    std::fs::write(xv_dir.join("xv.conf"), config_content).expect("write config");
+
+    let mut cmd = xv();
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", temp.path())
+        .env("XDG_CONFIG_HOME", &config_dir)
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "local")
+        .env("NO_COLOR", "1")
+        .current_dir(temp.path());
+    (cmd, temp)
+}
+
 /// Init a minimal git repo at `path`. Used by scan-install tests.
 pub fn init_git_repo(path: &Path) {
     let status = Command::new("git")

--- a/tests/scan_tests.rs
+++ b/tests/scan_tests.rs
@@ -49,28 +49,61 @@ fn scan_with_aws_key_exits_50() {
 /// Issue #309 Finding 6: `XV_SCAN_DISABLE=1` was documented but read
 /// nowhere. It must now bypass the scan entirely — exit 0 with no
 /// findings — even against a file that would otherwise trip a built-in
-/// pattern. This is deterministic (unlike `scan_with_aws_key_exits_50`)
-/// because the disable check happens before any vault/secret fetch.
+/// pattern.
+///
+/// Uses `common::xv_isolated_local()` (local age-encrypted backend, fully
+/// offline, valid `xv.conf`) rather than the bare host environment: a plain
+/// `xv scan` with no config at all fails `Config::validate()` (missing
+/// Azure subscription/tenant ID) before `execute_scan_command` ever reaches
+/// the `XV_SCAN_DISABLE` check, which is exactly the false-pass this test
+/// hit in CI (exit 3, not the disable path) when it relied on ambient host
+/// config. The local backend needs no credentials, so the *second* run
+/// below (without the disable var) deterministically reaches real content
+/// scanning and finds the leak — proving the first run's exit 0 came from
+/// the disable check, not from the scan failing to run at all.
 #[test]
 fn scan_disabled_via_env_skips_scan_even_with_leak() {
-    let temp = tempfile::tempdir().unwrap();
-    std::fs::write(temp.path().join("leak.txt"), "aws=AKIAIOSFODNN7EXAMPLE\n").unwrap();
-    let out = common::xv()
+    // Run 1: XV_SCAN_DISABLE=1 must skip the scan entirely (exit 0), even
+    // though leak.txt contains a value that trips a built-in pattern.
+    let (mut cmd_disabled, temp_disabled) = common::xv_isolated_local();
+    std::fs::write(
+        temp_disabled.path().join("leak.txt"),
+        "aws=AKIAIOSFODNN7EXAMPLE\n",
+    )
+    .unwrap();
+    let out_disabled = cmd_disabled
         .args(["scan"])
-        .current_dir(temp.path())
         .env("XV_SCAN_DISABLE", "1")
         .output()
         .unwrap();
     assert_eq!(
-        out.status.code(),
+        out_disabled.status.code(),
         Some(0),
         "stderr: {}",
-        common::stderr_str(&out)
+        common::stderr_str(&out_disabled)
     );
-    let stderr = common::stderr_str(&out);
+    let stderr_disabled = common::stderr_str(&out_disabled);
     assert!(
-        stderr.contains("XV_SCAN_DISABLE"),
-        "must print a notice that the scan was skipped: {stderr}"
+        stderr_disabled.contains("XV_SCAN_DISABLE"),
+        "must print a notice that the scan was skipped: {stderr_disabled}"
+    );
+
+    // Run 2: same fixture, same isolated local backend, no disable var —
+    // the scan must actually run and find the leak (exit 50). This is the
+    // control that proves run 1's exit 0 came from the disable check, not
+    // from the scan silently failing to run for some unrelated reason.
+    let (mut cmd_enabled, temp_enabled) = common::xv_isolated_local();
+    std::fs::write(
+        temp_enabled.path().join("leak.txt"),
+        "aws=AKIAIOSFODNN7EXAMPLE\n",
+    )
+    .unwrap();
+    let out_enabled = cmd_enabled.args(["scan"]).output().unwrap();
+    assert_eq!(
+        out_enabled.status.code(),
+        Some(50),
+        "without XV_SCAN_DISABLE the scan must run and detect the leak; stderr: {}",
+        common::stderr_str(&out_enabled)
     );
 }
 

--- a/tests/scan_tests.rs
+++ b/tests/scan_tests.rs
@@ -46,6 +46,34 @@ fn scan_with_aws_key_exits_50() {
     }
 }
 
+/// Issue #309 Finding 6: `XV_SCAN_DISABLE=1` was documented but read
+/// nowhere. It must now bypass the scan entirely — exit 0 with no
+/// findings — even against a file that would otherwise trip a built-in
+/// pattern. This is deterministic (unlike `scan_with_aws_key_exits_50`)
+/// because the disable check happens before any vault/secret fetch.
+#[test]
+fn scan_disabled_via_env_skips_scan_even_with_leak() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("leak.txt"), "aws=AKIAIOSFODNN7EXAMPLE\n").unwrap();
+    let out = common::xv()
+        .args(["scan"])
+        .current_dir(temp.path())
+        .env("XV_SCAN_DISABLE", "1")
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(
+        stderr.contains("XV_SCAN_DISABLE"),
+        "must print a notice that the scan was skipped: {stderr}"
+    );
+}
+
 #[test]
 fn scan_install_outside_git_repo_errors() {
     let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Fixes #309 — findings 6 and 7 (P2) from the 2026-07-03 repo review.

## Problem

Three documented scanner knobs did nothing, and the pre-commit hook path ignored project excludes:

- `[scan].min_value_length` was parsed but the engine hard-coded an 8-char minimum
- `[scan].patterns` was parsed but every entry point unconditionally used all built-in patterns
- `XV_SCAN_DISABLE=1` was documented but read nowhere
- `xv scan --staged` (the installed pre-commit hook) never loaded `[scan].exclude`, so the hook behaved differently from `xv scan .` / `--all`

## Changes

- `MatchEngine::new` takes the effective min-value-length; `[scan].min_value_length` is honored (clamped to a floor of 1, and empty secret values can never reach the Aho-Corasick build).
- `[scan].patterns` filters built-ins by name; unknown names warn, and an allowlist that resolves to **zero** known patterns is a hard error listing the valid names — a security scanner must not silently check nothing and exit 0.
- `XV_SCAN_DISABLE=1` (or `=true`) short-circuits all scan modes with a stderr notice and exit 0; `scan install`/`uninstall` still work while disabled.
- `scan_staged` filters staged files through the same exclude GlobSet as head scans; all three entry points share one config-loading path. **Behavior note:** staged scans now also apply the default excludes (`dist/**`, `*.lock`, `*.min.*`, …) for parity — documented in docs/scan.md and CHANGELOG.
- A malformed `.xv.toml` now warns to stderr before falling back to defaults instead of silently reverting scan settings.
- docs/scan.md's `[scan].patterns` example used pattern names that don't exist (`"aws"`, `"github"`) — copying it would have disabled every built-in pattern with only stderr warnings (caught in review). Example corrected to real names; full valid-names list documented.

## Tests

Unit + integration coverage: custom min-length catches shorter values, allowlist keeps only named patterns, all-unknown allowlist hard-errors, min_value_length=0 doesn't panic, `XV_SCAN_DISABLE` skips a scan that would otherwise find a leak (fails on main with exit 50), and staged scans honor excludes via a real git-repo fixture (cwd protected by an RAII guard).

`cargo test --features aws --workspace`: all green, 756 lib tests + all integration binaries. `cargo clippy --all-targets --features aws`: 0 warnings. Separate code-review pass performed; all its findings (including the docs pattern-name trap) are fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-commit and CI leak-detection behavior (staged excludes, pattern allowlist failures) in security-sensitive paths; intentional hardening but teams relying on old staged-scan semantics may see different hook results.
> 
> **Overview**
> **`xv scan` now applies documented `[scan]` settings and `XV_SCAN_DISABLE` on every entry path** (path scan, `--staged`, `--all`), via shared config loading in `scan_ops` instead of ad hoc logic per mode.
> 
> **`[scan].min_value_length`** is passed into `MatchEngine::new` (with a floor of 1 and empty values never becoming needles). **`[scan].patterns`** filters built-in detectors by exact name; unknown names warn, and a non-empty allowlist that matches nothing is a **hard config error** (no silent “scan nothing, exit 0”). **`XV_SCAN_DISABLE=1`/`true`** skips scanning with a stderr notice after normal config validation (install/uninstall unaffected).
> 
> **Behavior change:** `xv scan --staged` (including the pre-commit hook) now filters staged paths through the same default + `[scan].exclude` globs as path/`--all` scans. Unparseable `.xv.toml` warns and falls back to scanner defaults (scan more, not less). Docs fix pattern name examples; tests add local-backend E2E for disable and a git fixture for staged excludes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434bb9e3323deda0f3406a12dc23fee0d04e8e62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->