### PR TITLE
chore: cache-dir override for tests, enforce AWS name charset locally, multi-backend Cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ name = "crosstache"
 version = "0.18.0"
 edition = "2021"
 authors = ["crosstache Team"]
-description = "A comprehensive command-line tool for managing Azure Key Vaults"
+description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"
 license = "MIT"
 repository = "https://github.com/crosstache/crosstache-rust"
-keywords = ["azure", "keyvault", "cli", "secrets", "vault"]
+keywords = ["secrets", "cli", "azure", "aws", "keyvault"]
 categories = ["command-line-utilities", "authentication"]
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -1191,6 +1191,7 @@ configuration error.
 | `XV_ENV` | Active env from `.xv.toml` (highest priority for env selection) |
 | `XV_NO_PARENT_CONFIG` | `1` disables `.xv.toml` walk-up |
 | `CACHE_TTL` | Cache TTL in seconds |
+| `XV_CACHE_DIR` | Override the on-disk cache root directory (default: OS cache dir + `xv`) |
 | `DEBUG` | `true` / `1` enables debug logging |
 | `NO_COLOR` | Disable colored output (any value; standard [NO_COLOR](https://no-color.org/) convention) |
 | `AZURE_STORAGE_ACCOUNT` / `AZURE_STORAGE_CONTAINER` | Blob storage destination |

--- a/src/backend/aws/encoding.rs
+++ b/src/backend/aws/encoding.rs
@@ -8,6 +8,11 @@
 //! rejected at the `set_secret` boundary.
 
 use crate::backend::error::BackendError;
+use crate::backend::NameCharset;
+
+/// Human-readable description of the allowed AWS Secrets Manager charset,
+/// used in validation error messages.
+const ALLOWED_CHARSET_DESC: &str = "letters, digits, and / _ + = . @ -";
 
 /// The AWS Secrets Manager name length limit.
 pub const MAX_NAME_LEN: usize = 512;
@@ -54,6 +59,16 @@ pub fn validate_secret_name(name: &str) -> Result<(), BackendError> {
         return Err(BackendError::InvalidArgument(format!(
             "secret name too long: {} chars (max {MAX_NAME_LEN})",
             name.len()
+        )));
+    }
+    if !NameCharset::AwsRelaxed.is_valid(name) {
+        let offender = name
+            .chars()
+            .find(|c| !NameCharset::AwsRelaxed.is_valid(&c.to_string()))
+            .expect("is_valid returned false, so at least one char must be invalid");
+        return Err(BackendError::InvalidArgument(format!(
+            "secret name '{name}' contains invalid character '{offender}'; \
+             AWS secret names may only contain {ALLOWED_CHARSET_DESC}"
         )));
     }
     Ok(())
@@ -120,6 +135,20 @@ mod tests {
         assert!(validate_secret_name("db-password").is_ok());
         assert!(validate_secret_name("api/v1/key").is_ok());
         assert!(validate_secret_name("v1.2.3-rc.1").is_ok());
+    }
+
+    #[test]
+    fn validate_secret_name_rejects_disallowed_characters() {
+        let err = validate_secret_name("has space").unwrap_err();
+        assert!(
+            err.to_string().contains('\''),
+            "error should quote the offending character: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_secret_name_accepts_full_charset() {
+        assert!(validate_secret_name("app/db/key-1_v2.@x").is_ok());
     }
 
     #[test]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -102,7 +102,7 @@ pub enum NameCharset {
 
 impl NameCharset {
     /// Returns true if `name` is valid under this charset.
-    #[allow(dead_code)] // public API; currently exercised only by tests
+    #[cfg_attr(not(feature = "aws"), allow(dead_code))] // used by the AWS backend's name validation
     pub fn is_valid(&self, name: &str) -> bool {
         match self {
             Self::AlphanumericHyphen => name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),

--- a/src/cache/manager.rs
+++ b/src/cache/manager.rs
@@ -40,11 +40,31 @@ impl CacheManager {
     }
 
     pub fn from_config(config: &crate::config::Config) -> Self {
-        let cache_dir = dirs::cache_dir()
-            .unwrap_or_else(|| PathBuf::from("/tmp"))
-            .join("xv");
+        Self::from_config_with_dir(config, Self::resolve_cache_dir())
+    }
+
+    /// Create a `CacheManager` from config, rooted at an explicit directory
+    /// rather than the resolved `XV_CACHE_DIR`/`dirs::cache_dir()` location.
+    ///
+    /// Intended for tests that need an isolated cache directory (e.g. a
+    /// `tempfile::TempDir`) without touching the real OS cache path.
+    pub fn from_config_with_dir(config: &crate::config::Config, cache_dir: PathBuf) -> Self {
         let enabled = config.cache_enabled && config.cache_ttl_secs > 0;
         Self::new(cache_dir, enabled, config.cache_ttl_secs)
+    }
+
+    /// Resolve the root cache directory: `XV_CACHE_DIR` env var override
+    /// (if set and non-empty), else the OS cache directory joined with
+    /// `xv`, else `/tmp/xv` as a last resort.
+    fn resolve_cache_dir() -> PathBuf {
+        if let Ok(dir) = std::env::var("XV_CACHE_DIR") {
+            if !dir.is_empty() {
+                return PathBuf::from(dir);
+            }
+        }
+        dirs::cache_dir()
+            .unwrap_or_else(|| PathBuf::from("/tmp"))
+            .join("xv")
     }
 
     // ------------------------------------------------------------------

--- a/src/cache/manager.rs
+++ b/src/cache/manager.rs
@@ -55,7 +55,9 @@ impl CacheManager {
 
     /// Resolve the root cache directory: `XV_CACHE_DIR` env var override
     /// (if set and non-empty), else the OS cache directory joined with
-    /// `xv`, else `/tmp/xv` as a last resort.
+    /// `xv`, else `/tmp/xv` as a last resort. A relative `XV_CACHE_DIR` is
+    /// resolved against the process's current working directory, which can
+    /// shift under `cd`/`chdir` — an absolute path is recommended.
     fn resolve_cache_dir() -> PathBuf {
         if let Ok(dir) = std::env::var("XV_CACHE_DIR") {
             if !dir.is_empty() {

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -3907,6 +3907,17 @@ mod tests {
     use crate::backend::secret::SecretBackend;
     use crate::backend::{Backend, BackendCapabilities, BackendKind, NameCharset};
     use std::process::{Command, Stdio};
+    use std::sync::OnceLock;
+    use tokio::sync::Mutex as AsyncMutex;
+
+    /// Serializes tests that mutate the process-global `XV_CACHE_DIR`
+    /// env var, so parallel test threads don't stomp on each other's
+    /// override while it is set. Async-aware so the guard can be held
+    /// across `.await` points.
+    fn cache_dir_env_lock() -> &'static AsyncMutex<()> {
+        static LOCK: OnceLock<AsyncMutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| AsyncMutex::new(()))
+    }
 
     struct TestBackend {
         kind: BackendKind,
@@ -4800,18 +4811,20 @@ mod tests {
     async fn rename_failure_after_successful_update_invalidates_cache() {
         let registry = BackendRegistry::new(Arc::new(RenameFailBackend));
 
-        // Unique per-process vault name: the cache dir is the real OS cache
-        // dir (`CacheManager::from_config` always resolves `dirs::cache_dir()`),
-        // so this keeps the test from colliding with any other cache entry
-        // and lets us safely clean up exactly the key we touched.
-        let vault_name = format!(
-            "xv-test-rename-cache-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        );
+        // `execute_secret_update_direct` invalidates its cache internally via
+        // `invalidate_trait_secret_cache`, which builds its own `CacheManager`
+        // from `config` (`CacheManager::from_config`). To observe that
+        // invalidation from this test we need our own `CacheManager` to
+        // resolve to the *same* directory, so we point both at an isolated
+        // `tempfile::TempDir` via the `XV_CACHE_DIR` override rather than
+        // touching the real OS cache path. `XV_CACHE_DIR` is a process-global
+        // env var, so mutation is serialized with `cache_dir_env_lock()` to
+        // avoid racing other tests that also set it.
+        let _env_guard = cache_dir_env_lock().lock().await;
+        let temp_cache_dir = tempfile::tempdir().unwrap();
+        std::env::set_var("XV_CACHE_DIR", temp_cache_dir.path());
+
+        let vault_name = "xv-test-rename-cache".to_string();
         let config = Config {
             backend: Some("local".to_string()),
             cache_enabled: true,
@@ -4864,16 +4877,15 @@ mod tests {
         )
         .await;
 
-        // Clean up regardless of assertion outcome so a failing run never
-        // leaves stray state in the real OS cache dir.
-        let cleanup = || cache_manager.invalidate(&cache_key);
-
-        // Observe the cache and clean up BEFORE any assertion, so a failing
-        // assertion can never leave stray state in the real OS cache dir.
+        // Observe the cache before clearing the env override, so both this
+        // test's `cache_manager` and the internal invalidation performed by
+        // `execute_secret_update_direct` are still looking at the same temp
+        // dir. `TempDir` cleans up its directory on drop regardless.
         let cache_still_present = cache_manager
             .get::<Vec<crate::secret::manager::SecretSummary>>(&cache_key)
             .is_some();
-        cleanup();
+        std::env::remove_var("XV_CACHE_DIR");
+        drop(_env_guard);
 
         let err = match result {
             Ok(()) => panic!("rename phase must fail for this backend"),

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -3914,9 +3914,42 @@ mod tests {
     /// env var, so parallel test threads don't stomp on each other's
     /// override while it is set. Async-aware so the guard can be held
     /// across `.await` points.
+    ///
+    /// This only protects callers that opt in by acquiring the lock: any
+    /// future test that *reads* the cache dir (e.g. builds a cache-enabled
+    /// `CacheManager::from_config`) must also acquire this lock for the
+    /// duration it relies on `XV_CACHE_DIR`/the default resolution being
+    /// stable, or it can observe another test's temporary override.
     fn cache_dir_env_lock() -> &'static AsyncMutex<()> {
         static LOCK: OnceLock<AsyncMutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| AsyncMutex::new(()))
+    }
+
+    /// RAII guard that sets an env var for its lifetime and restores the
+    /// previous value (or removes it, if previously unset) on drop — including
+    /// during a panic unwind, since `tokio::sync::Mutex` does not poison.
+    /// Callers must hold `cache_dir_env_lock()` for the guard's lifetime when
+    /// mutating `XV_CACHE_DIR`.
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
     }
 
     struct TestBackend {
@@ -4819,10 +4852,13 @@ mod tests {
         // `tempfile::TempDir` via the `XV_CACHE_DIR` override rather than
         // touching the real OS cache path. `XV_CACHE_DIR` is a process-global
         // env var, so mutation is serialized with `cache_dir_env_lock()` to
-        // avoid racing other tests that also set it.
+        // avoid racing other tests that also set it, and `EnvVarGuard`
+        // restores the previous value on drop — including on panic unwind,
+        // so a failing assertion below can never leak the override pointing
+        // at an already-deleted `TempDir` for the rest of the test binary.
         let _env_guard = cache_dir_env_lock().lock().await;
         let temp_cache_dir = tempfile::tempdir().unwrap();
-        std::env::set_var("XV_CACHE_DIR", temp_cache_dir.path());
+        let _cache_dir_guard = EnvVarGuard::set("XV_CACHE_DIR", temp_cache_dir.path());
 
         let vault_name = "xv-test-rename-cache".to_string();
         let config = Config {
@@ -4877,15 +4913,16 @@ mod tests {
         )
         .await;
 
-        // Observe the cache before clearing the env override, so both this
-        // test's `cache_manager` and the internal invalidation performed by
-        // `execute_secret_update_direct` are still looking at the same temp
-        // dir. `TempDir` cleans up its directory on drop regardless.
+        // Observe the cache while the env override is still active, so both
+        // this test's `cache_manager` and the internal invalidation performed
+        // by `execute_secret_update_direct` are still looking at the same
+        // temp dir. `_cache_dir_guard` and `_env_guard` are dropped at the
+        // end of the function (in reverse declaration order — guard, then
+        // mutex), restoring `XV_CACHE_DIR` before the lock is released even
+        // if an assertion below panics.
         let cache_still_present = cache_manager
             .get::<Vec<crate::secret::manager::SecretSummary>>(&cache_key)
             .is_some();
-        std::env::remove_var("XV_CACHE_DIR");
-        drop(_env_guard);
 
         let err = match result {
             Ok(()) => panic!("rename phase must fail for this backend"),


### PR DESCRIPTION
Fixes #311 — findings 8, 11, 12 from the 2026-07-03 repo review. Three independent cleanups.

## Cache test isolation (finding 8)

The `rename_failure_after_successful_update_invalidates_cache` unit test seeded the real OS cache path (`dirs::cache_dir()/xv`), which fails wherever that directory is unwritable, and tests shouldn't touch user cache regardless.

- New `XV_CACHE_DIR` env override (documented in README) and a `from_config_with_dir` constructor; `from_config` delegates through a shared `resolve_cache_dir` (env var → OS cache dir → `/tmp/xv`, empty values ignored, relative paths documented as discouraged).
- The test now uses a `TempDir` via the override, serialized by an env lock, with an unwind-safe RAII `EnvVarGuard` so a panic can't leak the variable process-wide.

## AWS name charset enforced locally (finding 11)

The AWS backend advertised charset `[a-zA-Z0-9/_+=.@-]` (`NameCharset::AwsRelaxed`) but never enforced it — invalid names like `has space` passed local validation and failed later with a remote `ValidationException`. `validate_secret_name` now rejects them with a clear message naming the offending character and the allowed set.

- Placed on the write boundary only: `get`/`delete`/`list` are untouched, so nothing strands (and since the charset equals AWS's own, no "legacy invalid" secrets can exist remotely anyway).
- Reserved `.xv-*` check still runs before the charset check; folder-style names (`app/db/key-1_v2.@x`) pass, `has space` is rejected — both pinned by tests.

## Multi-backend Cargo metadata (finding 12)

`Cargo.toml` still described crosstache as "a comprehensive command-line tool for managing Azure Key Vaults" with Azure-only keywords. Description now mirrors the CLI about string (Azure Key Vault, AWS Secrets Manager, local age-encrypted storage); keywords are `secrets, cli, azure, aws, keyvault`. No Cargo.lock churn.

## Verification

`cargo test --features aws --workspace`: all suites green (the one exception is the known pre-existing clipboard timing flake, which passes in isolation). `cargo clippy --all-targets` clean both with and without the `aws` feature. Separate code-review pass performed (approve); its unwind-safety follow-ups are in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are test isolation, stricter local AWS name validation, optional cache-dir override, and package metadata—no auth or data-path behavior changes for normal CLI use.
> 
> **Overview**
> Adds **`XV_CACHE_DIR`** so the on-disk cache root can be overridden (documented in README); `CacheManager::from_config` now resolves via env → OS cache → `/tmp/xv`, with **`from_config_with_dir`** for explicit test roots.
> 
> The rename-after-update cache invalidation test no longer touches the real OS cache: it uses a **`tempfile`** dir under `XV_CACHE_DIR`, serialized with an async env lock and an RAII **`EnvVarGuard`** so overrides are restored on panic.
> 
> **AWS** `validate_secret_name` now enforces **`NameCharset::AwsRelaxed`** at the write boundary with a clear error quoting the bad character; new unit tests cover rejection and full charset acceptance. **`Cargo.toml`** description and keywords are updated to reflect Azure, AWS, and local backends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18f848bbf8bb7a395cc8921aed016320cabf2481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->