### PR TITLE
fix: xv inject aborts on secret resolution failures by default; add --best-effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - **Breaking: `xv run` now aborts before launching the child when any selected secret or `xv://` reference fails to fetch; use `--best-effort` for the old behavior** (#306). Previously a per-secret fetch failure only printed a warning and the command ran anyway, which could silently launch a process missing an env var (e.g. after a transient backend error or a permission problem). All failures across both the selected-secret list and `xv://` reference resolution are now collected and reported together before the exit.
+- **Breaking: `xv inject` now aborts before writing/printing the rendered output when any `{{ secret:name }}` or `xv://` reference fails to resolve; use `--best-effort` for the old behavior** (#313). Previously a per-reference resolution failure only printed a warning and rendering continued, which could silently write a config file (e.g. `.env`) with unresolved `{{ secret:name }}` / `xv://` placeholders left in place while `xv inject` exited 0. An unparseable `xv://` reference in a template (e.g. a malformed backend prefix) is now also treated as a failure rather than silently skipped, since — unlike `xv run`'s scan of arbitrary parent-environment values, which can incidentally contain `xv://`-shaped substrings — every reference in a template the user wrote for `xv inject` is unambiguously intentional.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -675,9 +675,17 @@ Render config files with `{{ secret:NAME }}` references resolved:
 
 xv inject --template template.yml --out app.config
 cat template.yml | xv inject > resolved.yml          # also reads stdin
+xv inject --template template.yml --out app.config --best-effort  # render even if some references fail
 
 # Cross-vault references (xv://vault-name/secret-name) work without context switching.
 ```
+
+By default, `xv inject` aborts **before** writing the output (or printing to
+stdout) if any `{{ secret:name }}` or `xv://` reference fails to resolve
+(missing secret, transient backend error, malformed URI, etc.) — every
+failure is printed, and no partially-rendered output is ever written. Pass
+`--best-effort` to restore the previous behavior: warn on each failure and
+render anyway, leaving unresolved references in the output.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -95,7 +95,7 @@ a two-decimal string, `folder`/`groups` default to empty strings.
 | Command | Description |
 |---------|-------------|
 | `xv run -- <command>` | Run a process with secrets as env vars (`--group`, `--include`, `--exclude`, `--no-masking`, `--best-effort`) |
-| `xv inject` | Render templates with `{{ secret:name }}` and `xv://vault/secret` refs |
+| `xv inject` | Render templates with `{{ secret:name }}` and `xv://vault/secret` refs (`--group`, `--best-effort`) |
 
 Advanced workflows (`run`, `inject`, default `rotate`, `scan`, `env pull`, and
 `env push`) route through the active backend trait. They work with Azure, AWS,
@@ -117,6 +117,12 @@ By default, `xv run` also aborts before spawning the child if any selected
 secret or `xv://` reference fails to fetch — every failure is reported before
 the non-zero exit. Pass `--best-effort` to fall back to the previous
 warn-and-continue behavior.
+
+By default, `xv inject` also aborts before writing/printing the rendered
+output if any `{{ secret:name }}` or `xv://` reference fails to resolve —
+every failure is reported before the non-zero exit, and no
+partially-resolved output is ever written. Pass `--best-effort` to fall back
+to the previous warn-and-continue behavior.
 
 ---
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -651,6 +651,9 @@ pub enum Commands {
         /// Filter secrets by group (can be specified multiple times)
         #[arg(short, long)]
         group: Vec<String>,
+        /// Continue and render/write the template even if some references fail to resolve (previous default)
+        #[arg(long)]
+        best_effort: bool,
     },
     /// Update secret properties in the current vault context
     Update {
@@ -1666,9 +1669,15 @@ impl Cli {
                 template,
                 out,
                 group,
+                best_effort,
             } => {
                 crate::cli::secret_ops::execute_secret_inject_direct(
-                    template, out, group, config, registry,
+                    template,
+                    out,
+                    group,
+                    best_effort,
+                    config,
+                    registry,
                 )
                 .await
             }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -1440,6 +1440,7 @@ pub(crate) async fn execute_secret_inject_direct(
     template: Option<String>,
     out: Option<String>,
     group: Vec<String>,
+    best_effort: bool,
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
@@ -1451,7 +1452,7 @@ pub(crate) async fn execute_secret_inject_direct(
         )
     })?;
 
-    execute_secret_inject(reg, None, template, out, group, &config).await
+    execute_secret_inject(reg, None, template, out, group, best_effort, &config).await
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3192,12 +3193,14 @@ fn clean_split(window: &[u8], secrets: &[Zeroizing<String>], mut split: usize) -
     split
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn execute_secret_inject(
     reg: &BackendRegistry,
     vault: Option<String>,
     template_file: Option<String>,
     output_file: Option<String>,
     groups: Vec<String>,
+    best_effort: bool,
     config: &Config,
 ) -> Result<()> {
     use crate::config::ContextManager;
@@ -3236,6 +3239,20 @@ async fn execute_secret_inject(
     let mut required_secrets: Vec<String> = Vec::new();
     let mut cross_vault_refs: Vec<(String, BackendRef)> = Vec::new(); // (original_uri, parsed_ref)
 
+    // Failures collected across template parsing and secret fetching. By
+    // default any failure aborts rendering (and the output write) before it
+    // happens; `--best-effort` restores the old warn-and-continue behavior
+    // (matching `xv run`'s fetch_failures pattern, #314).
+    //
+    // Unlike `xv run`'s scan of arbitrary parent-environment values (which
+    // can incidentally contain `xv://`-shaped substrings unrelated to secret
+    // references — a genuine "lookalike"), every reference here comes from a
+    // template the user authored specifically for `xv inject`. Both
+    // `{{ secret:name }}` and `xv://vault/secret` are unambiguously
+    // intentional in that context, so an unparseable `xv://` reference is
+    // treated as a failure too, not silently skipped.
+    let mut fetch_failures: Vec<String> = Vec::new();
+
     // Find {{ secret:name }} references (current vault)
     for captures in secret_regex.captures_iter(&template_content) {
         if let Some(secret_name) = captures.get(1) {
@@ -3256,7 +3273,11 @@ async fn execute_secret_inject(
         }
         match BackendRef::parse(&format!("{vault_part}/{secret_part}")) {
             Ok(r) => cross_vault_refs.push((uri_key, r)),
-            Err(e) => output::warn(&format!("Skipping invalid URI '{uri_key}': {e}")),
+            Err(e) => {
+                let msg = format!("Invalid URI '{uri_key}': {e}");
+                output::warn(&msg);
+                fetch_failures.push(msg);
+            }
         }
     }
 
@@ -3336,7 +3357,6 @@ async fn execute_secret_inject(
     // Build a map of secret names/URIs to values
     let mut secret_values: HashMap<String, Zeroizing<String>> = HashMap::new();
     let mut cross_vault_values: HashMap<String, Zeroizing<String>> = HashMap::new(); // URI -> value
-    let mut missing_secrets: Vec<String> = Vec::new();
 
     // Fetch secrets from current vault
     for secret_name in &required_secrets {
@@ -3353,19 +3373,24 @@ async fn execute_secret_inject(
                     if let Some(value) = secret_props.value {
                         secret_values.insert(secret_name.clone(), value);
                     } else {
-                        missing_secrets.push(secret_name.clone());
+                        let msg = format!("Secret '{secret_name}' resolved but has no value");
+                        output::warn(&msg);
+                        fetch_failures.push(msg);
                     }
                 }
                 Err(e) => {
-                    output::warn(&format!(
+                    let msg = format!(
                         "Failed to get value for secret '{}' from vault '{}': {}",
                         secret_name, vault_name, e
-                    ));
-                    missing_secrets.push(secret_name.clone());
+                    );
+                    output::warn(&msg);
+                    fetch_failures.push(msg);
                 }
             }
         } else {
-            missing_secrets.push(secret_name.clone());
+            let msg = format!("Secret '{secret_name}' not found in vault '{vault_name}'");
+            output::warn(&msg);
+            fetch_failures.push(msg);
         }
     }
 
@@ -3383,8 +3408,9 @@ async fn execute_secret_inject(
             let secret_name = match &backend_ref.secret {
                 Some(s) => s.clone(),
                 None => {
-                    output::warn(&format!("URI '{uri}' has no secret segment — skipping"));
-                    missing_secrets.push(uri.clone());
+                    let msg = format!("URI '{uri}' has no secret segment — skipping");
+                    output::warn(&msg);
+                    fetch_failures.push(msg);
                     continue;
                 }
             };
@@ -3404,22 +3430,35 @@ async fn execute_secret_inject(
                     if let Some(value) = secret_props.value {
                         cross_vault_values.insert(uri.clone(), value);
                     } else {
-                        output::warn(&format!("URI '{uri}' resolved but has no value"));
-                        missing_secrets.push(uri.clone());
+                        let msg = format!("URI '{uri}' resolved but has no value");
+                        output::warn(&msg);
+                        fetch_failures.push(msg);
                     }
                 }
                 Err(e) => {
-                    output::warn(&format!("Failed to resolve URI '{uri}': {e}"));
-                    missing_secrets.push(uri.clone());
+                    let msg = format!("Failed to resolve URI '{uri}': {e}");
+                    output::warn(&msg);
+                    fetch_failures.push(msg);
                 }
             }
         }
     }
 
-    if !missing_secrets.is_empty() {
+    // Abort before rendering/writing if any reference failed to resolve,
+    // unless --best-effort was requested (the previous default:
+    // warn-and-continue, leaving unresolved placeholders in the output).
+    if !fetch_failures.is_empty() && !best_effort {
+        output::error(&format!(
+            "Aborting: {} secret(s)/reference(s) failed to resolve. Use --best-effort to render anyway.",
+            fetch_failures.len()
+        ));
+        for failure in &fetch_failures {
+            output::error(&format!("  - {failure}"));
+        }
         return Err(CrosstacheError::config(format!(
-            "Missing secrets: {}",
-            missing_secrets.join(", ")
+            "xv inject aborted: {} secret(s)/reference(s) failed to resolve: {}",
+            fetch_failures.len(),
+            fetch_failures.join("; ")
         )));
     }
 

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -3281,7 +3281,7 @@ async fn execute_secret_inject(
         }
     }
 
-    if required_secrets.is_empty() && cross_vault_refs.is_empty() {
+    if required_secrets.is_empty() && cross_vault_refs.is_empty() && fetch_failures.is_empty() {
         output::warn("No secret references found in template");
         println!("    Use {{ secret:name }} syntax or xv://[backend:]vault/secret URIs");
 

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -1851,6 +1851,99 @@ fn inject_aborts_on_invalid_uri_reference() {
     );
 }
 
+// Regression test for a bug found in code review of the fix above: the
+// "no secret references found in template" early-return only checked
+// `required_secrets.is_empty() && cross_vault_refs.is_empty()`. An invalid
+// `xv://` URI is pushed into `fetch_failures` but NOT into `cross_vault_refs`
+// (it never becomes a resolvable reference), so when the invalid URI is the
+// template's ONLY reference, both vectors are empty and the early-return
+// fired BEFORE the abort gate — silently warning, writing the template
+// verbatim, and exiting 0. This test targets that exact path (no other
+// reference present) and fails against the code prior to this follow-up fix.
+#[test]
+fn inject_aborts_when_only_reference_is_invalid_uri() {
+    let env = TestEnv::new();
+
+    let template_path = env.tmp_path().join("only_invalid_uri_template.yml");
+    std::fs::write(
+        &template_path,
+        "bad: \"xv://notabackend:somevault/somesecret\"\n",
+    )
+    .expect("write template");
+    let out_path = env.tmp_path().join("only_invalid_uri_out.yml");
+
+    let output = env
+        .xv()
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("execute xv inject");
+
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "xv inject should fail with the config-error exit code (3) when the template's only reference is an unparseable xv:// URI:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("notabackend"),
+        "stderr should name the invalid backend/URI: {stderr}"
+    );
+    assert!(
+        !out_path.exists(),
+        "output file must NOT be created when the only reference fails to parse (fail-fast default)"
+    );
+}
+
+#[test]
+fn inject_best_effort_writes_verbatim_when_only_reference_is_invalid_uri() {
+    let env = TestEnv::new();
+
+    let template_path = env
+        .tmp_path()
+        .join("only_invalid_uri_best_effort_template.yml");
+    let template_content = "bad: \"xv://notabackend:somevault/somesecret\"\n";
+    std::fs::write(&template_path, template_content).expect("write template");
+    let out_path = env.tmp_path().join("only_invalid_uri_best_effort_out.yml");
+
+    let output = env
+        .xv()
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+            "--best-effort",
+        ])
+        .output()
+        .expect("execute xv inject");
+
+    assert!(
+        output.status.success(),
+        "--best-effort should write the template verbatim and exit 0 despite the invalid URI:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("notabackend"),
+        "a warning should still be emitted for the invalid URI: {stderr}"
+    );
+    let rendered = std::fs::read_to_string(&out_path).expect("read rendered output");
+    assert_eq!(
+        rendered, template_content,
+        "under --best-effort the template should be written back verbatim: {rendered}"
+    );
+}
+
 #[test]
 fn inject_best_effort_renders_output_despite_missing_secret_reference() {
     let env = TestEnv::new();

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -1706,6 +1706,200 @@ fn run_best_effort_launches_child_despite_failing_uri_reference() {
 }
 
 // ===========================================================================
+// xv inject — fail-fast on secret resolution failures (#313)
+// ===========================================================================
+
+#[test]
+fn inject_happy_path_renders_output() {
+    let env = TestEnv::new();
+    env.set_secret("DB_PASSWORD", "hunter2");
+    env.set_secret("API_KEY", "sk-live-abc123");
+
+    let template_path = env.tmp_path().join("happy_template.yml");
+    std::fs::write(
+        &template_path,
+        "db_password: \"{{ secret:DB_PASSWORD }}\"\napi_key: \"{{ secret:API_KEY }}\"\n",
+    )
+    .expect("write template");
+    let out_path = env.tmp_path().join("happy_out.yml");
+
+    let output = env
+        .xv()
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("execute xv inject");
+
+    assert!(
+        output.status.success(),
+        "xv inject should succeed when all references resolve:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let rendered = std::fs::read_to_string(&out_path).expect("read rendered output");
+    assert!(
+        rendered.contains("hunter2") && rendered.contains("sk-live-abc123"),
+        "rendered output should contain both resolved secret values: {rendered}"
+    );
+    assert!(
+        !rendered.contains("{{ secret:"),
+        "rendered output should not contain any unresolved placeholders: {rendered}"
+    );
+}
+
+#[test]
+fn inject_aborts_on_missing_secret_reference() {
+    let env = TestEnv::new();
+    env.set_secret("PRESENT", "present-value");
+
+    let template_path = env.tmp_path().join("missing_template.yml");
+    std::fs::write(
+        &template_path,
+        "present: \"{{ secret:PRESENT }}\"\nmissing: \"{{ secret:DOES_NOT_EXIST }}\"\n",
+    )
+    .expect("write template");
+    let out_path = env.tmp_path().join("missing_out.yml");
+
+    let output = env
+        .xv()
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("execute xv inject");
+
+    // Pin the exact exit code (3 == CrosstacheError::Config, see src/error.rs)
+    // so an accidental change of error variant is caught, not just "any
+    // non-zero exit" — matches the convention set by the `xv run` fail-fast
+    // tests (#314).
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "xv inject should fail with the config-error exit code (3) when a referenced secret cannot be resolved:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("DOES_NOT_EXIST"),
+        "stderr should name the missing reference: {stderr}"
+    );
+    assert!(
+        !out_path.exists(),
+        "output file must NOT be created when a reference fails to resolve (fail-fast default)"
+    );
+}
+
+// Note: the `{{ secret:name }}` abort path above was already correct before
+// this fix — `execute_secret_inject` already collected unresolved
+// `{{ secret:name }}` references and returned an error before writing. The
+// actual regression this issue (#313) fixes is (a) the lack of a
+// `--best-effort` escape hatch (covered below) and (b) a malformed
+// `xv://backend:vault/secret` URI in the template being silently skipped
+// with only a warning instead of being treated as a failure — covered by
+// `inject_aborts_on_invalid_uri_reference` below, which does fail against
+// unpatched code (verified via `git stash` during development).
+#[test]
+fn inject_aborts_on_invalid_uri_reference() {
+    let env = TestEnv::new();
+    env.set_secret("PRESENT", "present-value");
+
+    let template_path = env.tmp_path().join("invalid_uri_template.yml");
+    std::fs::write(
+        &template_path,
+        "present: \"{{ secret:PRESENT }}\"\nbad: \"xv://notabackend:somevault/somesecret\"\n",
+    )
+    .expect("write template");
+    let out_path = env.tmp_path().join("invalid_uri_out.yml");
+
+    let output = env
+        .xv()
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("execute xv inject");
+
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "xv inject should fail with the config-error exit code (3) when a template contains an unparseable xv:// URI:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("notabackend"),
+        "stderr should name the invalid backend/URI: {stderr}"
+    );
+    assert!(
+        !out_path.exists(),
+        "output file must NOT be created when a URI fails to parse (fail-fast default)"
+    );
+}
+
+#[test]
+fn inject_best_effort_renders_output_despite_missing_secret_reference() {
+    let env = TestEnv::new();
+    env.set_secret("PRESENT", "present-value");
+
+    let template_path = env.tmp_path().join("missing_best_effort_template.yml");
+    std::fs::write(
+        &template_path,
+        "present: \"{{ secret:PRESENT }}\"\nmissing: \"{{ secret:DOES_NOT_EXIST }}\"\n",
+    )
+    .expect("write template");
+    let out_path = env.tmp_path().join("missing_best_effort_out.yml");
+
+    let output = env
+        .xv()
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+            "--best-effort",
+        ])
+        .output()
+        .expect("execute xv inject");
+
+    assert!(
+        output.status.success(),
+        "--best-effort should render and write the output despite the failing reference:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("DOES_NOT_EXIST"),
+        "a warning should still be emitted for the failing reference: {stderr}"
+    );
+    let rendered = std::fs::read_to_string(&out_path).expect("read rendered output");
+    assert!(
+        rendered.contains("present-value"),
+        "the resolved reference should still be substituted: {rendered}"
+    );
+    assert!(
+        rendered.contains("{{ secret:DOES_NOT_EXIST }}"),
+        "the unresolved reference should be left in place under --best-effort: {rendered}"
+    );
+}
+
+// ===========================================================================
 // Cross-vault move / copy (issue #307)
 // ===========================================================================
 


### PR DESCRIPTION
Fixes #313 — the follow-up to #314, discovered during its code review.

## Problem

`xv inject` had the same defect class #314 fixed for `xv run`: secret resolution failures (fetch errors, references resolving without a value, unparseable `xv://` URIs) only warned, and the rendered output — possibly a `.env` or config file written to disk — could silently contain unresolved placeholders while the command exited 0.

## Changes (breaking)

- **Resolution failures now abort by default.** All failures are collected and reported together; `xv inject` exits with code 3 (same as `xv run`'s abort) **before** any output is written. Rendering is buffered, so a failed run never creates or truncates the output file.
- **`--best-effort`** restores the previous warn-and-render behavior, mirroring `xv run`'s flag.
- **Unparseable `xv://` references in templates are hard failures** (unlike `xv run`'s env-value scan, which stays warn-only): template content is authored intent, while env values can contain incidental `xv://`-shaped strings. The asymmetry rationale is documented inline.
- Review caught a bypass in the first cut: a template whose *only* reference was an invalid URI slipped through the "no references found" early-return, wrote the template verbatim, and exited 0 (runtime-reproduced). The early-return now respects collected failures — fixed in the second commit with dedicated regression tests.
- README, docs/FEATURES.md, and CHANGELOG (breaking, in #314's entry style) updated.

## Tests

Six `inject_*` e2e tests in `tests/e2e_local_backend.rs` (real binary, local backend, hermetic): missing-secret abort (exit 3, no output file), invalid-URI abort, sole-invalid-URI abort (fails against the first cut: exit 0 + file written), `--best-effort` variants, and the happy path.

`cargo test --features aws`: full suite green (known clipboard timing flake passes in isolation); `e2e_local_backend` at 85 passed. `cargo clippy --all-targets --features aws`: 0 warnings. Separate code-review pass performed, including runtime probes; its MAJOR finding is fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking CLI default for config generation workflows; behavior is intentional and aligned with `xv run`, with `--best-effort` as escape hatch—risk is mainly surprise for scripts that relied on partial output exiting 0.
> 
> **Overview**
> **Breaking:** `xv inject` now mirrors `xv run` (#314): any failed `{{ secret:name }}` or `xv://` resolution is collected, reported, and causes exit **3** **before** the output file is written or stdout is printed—no partially rendered configs with leftover placeholders.
> 
> Adds **`--best-effort`** on `Inject` to restore warn-and-continue rendering. Unparseable **`xv://`** references in templates are **failures** (not skipped with a warning), since template refs are intentional unlike incidental `xv://` substrings in env values for `xv run`.
> 
> Fixes a review regression: when the **only** reference was an invalid URI, the “no references found” path could write the template verbatim and exit 0—the early-return now also requires `fetch_failures` to be empty.
> 
> README, `docs/FEATURES.md`, and CHANGELOG updated; six local-backend e2e tests cover happy path, missing secret, invalid URI, sole-invalid URI, and `--best-effort` variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff9147be2480287a6098c5a9c7a8af86a0fd8ae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->