### PR TITLE
feat: record types core — typed secrets with structured fields (#321 Phase A)

### DIFF
--- a/docs/superpowers/plans/2026-07-03-record-types-plan.md
+++ b/docs/superpowers/plans/2026-07-03-record-types-plan.md
@@ -1,0 +1,302 @@
+# Record Types Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Typed secret records (built-in + custom types) with per-field metadata/secret storage, per the approved spec `docs/superpowers/specs/2026-07-03-record-types-design.md`.
+
+**Architecture:** A new `src/records/` module owns type definitions, resolution (built-in → global config → project config), and the JSON envelope codec. Secret fields ride the existing secret value as a JSON document marked by `content_type = application/vnd.xv.record`; metadata fields ride tags prefixed `f.`; the type name rides the reserved tag `xv-type`. CLI verbs (`set`, `get`, `update`, `ls`, `type`) consume the module; no backend trait changes except two new capability fields for tag limits.
+
+**Tech Stack:** Rust, serde_json (already a dependency), clap derive, existing e2e harnesses (`tests/e2e_local_backend.rs::TestEnv`, `tests/common/mod.rs`).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-03-record-types-design.md` — read it before starting any task.
+- Untyped secrets must be byte-identical in behavior on every code path (`get`/`run`/`inject`/`ls`).
+- The content-type marker `application/vnd.xv.record` — never JSON sniffing — decides record-ness.
+- Reserved tag `xv-type`; metadata-field tag prefix `f.`.
+- Exactly one `primary` field per type; `primary` implies `kind = secret` and `required = true`.
+- Fail before write: every validation error (required field, tag cap, tag value length) must abort before any backend call.
+- All e2e tests hermetic (isolated config/env — reuse `TestEnv` / `xv_isolated_local*`; NEVER depend on host config; simulate CI with a scrubbed env before declaring done).
+- NEVER use `git stash` (shared refs/stash across concurrent worktrees); use `cp` backups + `git checkout HEAD -- <file>` for fail-first proofs.
+- Verification gate per task: `cargo fmt`, `cargo clippy --all-targets --features aws` (0 warnings), `cargo test --features aws` (the pre-existing `test_detached_clear_process_clears_clipboard` timing flake is acceptable iff it passes in isolation).
+- Commit messages end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+## Phase → PR mapping
+
+- **Phase A (Tasks 1–7):** core model + `set`/`get`/`type` — PR "feat: record types core (#<issue>)".
+- **Phase B (Tasks 8–11):** `update`/convert/`ls`/TUI — PR "feat: record editing, conversion, and listing".
+- **Phase C (Tasks 12–13):** `inject` field syntax + docs — PR "feat: inject field access for records + docs".
+
+Each phase lands via the session-standard flow: executor implements on a branch from origin/main → independent code-review pass → push → PR → Bugbot/CI watch.
+
+---
+
+### Task 1: Records module — types, built-ins, validation
+
+**Files:**
+- Create: `src/records/mod.rs` (`pub mod types; pub mod envelope;` + re-exports)
+- Create: `src/records/types.rs`
+- Modify: `src/lib.rs` (add `pub mod records;`)
+- Test: unit tests inside `src/records/types.rs`
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub enum FieldKind { Metadata, Secret }
+  pub struct FieldDef { pub name: String, pub kind: FieldKind, pub required: bool, pub primary: bool }
+  pub enum TypeSource { Builtin, Global, Project }
+  pub struct RecordType { pub name: String, pub fields: Vec<FieldDef>, pub source: TypeSource }
+  impl RecordType {
+      pub fn primary(&self) -> &FieldDef;                    // the single primary field
+      pub fn field(&self, name: &str) -> Option<&FieldDef>;
+      pub fn validate(&self) -> Result<()>;                  // one primary; primary is secret+required; kebab-case names
+  }
+  pub fn builtin_types() -> Vec<RecordType>;                 // login, api-key, database per spec table
+  ```
+- Consumes: `CrosstacheError::config` for validation errors; kebab-case check mirrors `validate_folder_path`'s charset idiom (`src/utils/helpers.rs`).
+
+- [ ] **Step 1: Write failing unit tests** — `builtin_types_are_valid` (every built-in passes `validate()`, `login` primary is `password`, `database` has optional secret `connection-string`), `validate_rejects_zero_primaries`, `validate_rejects_two_primaries`, `validate_rejects_non_secret_primary`, `validate_rejects_bad_field_name` (`"Bad Name"` fails, `"totp-seed"` passes).
+- [ ] **Step 2: Run** `cargo test --lib records::types` — expect compile failure / test failures.
+- [ ] **Step 3: Implement** the structs, `validate()`, and `builtin_types()` exactly per the spec's built-in table (login: username required metadata, url metadata, password primary; api-key: url + account metadata, key primary; database: host/port/database/username metadata, password primary, connection-string optional secret).
+- [ ] **Step 4: Run** `cargo test --lib records::types` — expect PASS.
+- [ ] **Step 5: Commit** `feat: records module with built-in types and validation`
+
+### Task 2: Envelope codec + reserved-tag constants
+
+**Files:**
+- Create: `src/records/envelope.rs`
+- Test: unit tests inside `src/records/envelope.rs`
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub const RECORD_CONTENT_TYPE: &str = "application/vnd.xv.record";
+  pub const TYPE_TAG: &str = "xv-type";
+  pub const FIELD_TAG_PREFIX: &str = "f.";
+  pub fn encode_envelope(fields: &BTreeMap<String, String>) -> Result<String>;   // deterministic key order
+  pub fn parse_envelope(value: &str) -> Result<BTreeMap<String, String>>;        // strict: JSON object of strings only
+  pub fn is_record(content_type: &str) -> bool;                                  // exact match on RECORD_CONTENT_TYPE
+  ```
+
+- [ ] **Step 1: Failing tests** — `roundtrip_preserves_fields`, `parse_rejects_non_object` (`"[1,2]"`, `"\"str\""`), `parse_rejects_non_string_values` (`{"a":1}`), `is_record_matches_exactly` (`"application/vnd.xv.record"` true; `"application/json"`, `""`, `"text/plain"` false), `encode_is_deterministic` (two BTreeMaps with same entries produce identical strings).
+- [ ] **Step 2: Run** `cargo test --lib records::envelope` — FAIL.
+- [ ] **Step 3: Implement** with `serde_json::Map` → `BTreeMap<String,String>`; parse errors wrap `CrosstacheError::config` naming the failure ("record envelope is not a JSON object of strings").
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit** `feat: record envelope codec and reserved tag constants`
+
+### Task 3: Type config parsing + resolution/shadowing
+
+**Files:**
+- Modify: `src/config/settings.rs` (global `[types.<name>]` blocks in `xv.conf`; add `pub types: HashMap<String, RecordTypeConfig>` to `Config`, parsed in `load_from_file`)
+- Modify: `src/config/project.rs` (same block in `.xv.toml`'s `ProjectConfig`)
+- Modify: `src/records/types.rs` (resolution)
+- Test: unit tests in `src/config/project.rs` + `src/records/types.rs`
+
+**Interfaces:**
+- Produces:
+  ```rust
+  // serde shape shared by both config layers (define once in records::types, re-use via serde):
+  #[derive(Deserialize)] pub struct RecordTypeConfig { pub fields: Vec<FieldDefConfig> }
+  #[derive(Deserialize)] pub struct FieldDefConfig {
+      pub name: String,
+      #[serde(default)] pub kind: Option<String>,      // "metadata" (default) | "secret"
+      #[serde(default)] pub required: bool,
+      #[serde(default)] pub primary: bool,
+  }
+  pub fn resolve_types(
+      global: &HashMap<String, RecordTypeConfig>,
+      project: &HashMap<String, RecordTypeConfig>,
+  ) -> Result<Vec<RecordType>>;
+  // precedence: project > global > builtin, matched by name; shadowing a builtin emits
+  // output::warn("type '<name>' shadows a built-in type"); every resolved type passes validate().
+  pub fn find_type<'a>(types: &'a [RecordType], name: &str) -> Option<&'a RecordType>;
+  ```
+- Consumes: Task 1's `RecordType`/`validate()`; existing TOML parsing paths in both config files (mirror how `[scan]`/`[local]` blocks are declared).
+
+- [ ] **Step 1: Failing tests** — `parse_types_block_from_project_toml` (the spec's `[types.smtp]` example parses; `kind` omitted → Metadata), `resolve_project_shadows_global`, `resolve_custom_shadows_builtin_with_warning` (assert resolution result; warning is stderr, assert via the existing capture idiom if one exists, else assert resolution only and note it), `resolve_rejects_invalid_custom_type` (two primaries → Err naming the type).
+- [ ] **Step 2: Run** targeted tests — FAIL.
+- [ ] **Step 3: Implement** parsing in both config layers + `resolve_types`/`find_type`.
+- [ ] **Step 4: Run** — PASS. Also `cargo test --lib config` to catch regressions in existing config tests.
+- [ ] **Step 5: Commit** `feat: parse [types.*] config blocks and resolve with shadowing`
+
+### Task 4: `xv type list` / `xv type show`
+
+**Files:**
+- Modify: `src/cli/commands.rs` (new `Type { List, Show { name } }` subcommand with `ls` alias on `list`, matching every other subcommand's alias convention from PR #299)
+- Create: `src/cli/type_ops.rs` (execution; register in `src/cli/mod.rs`)
+- Modify: `src/main.rs` (`needs_backend` excludes `Type` — it is config-only)
+- Test: `tests/e2e_record_types.rs` (new file, harness: `tests/common/mod.rs::xv_isolated_local_with_profile` for the project-type case, `xv_isolated_local` otherwise)
+
+**Interfaces:**
+- Consumes: `resolve_types`, `Config::types`, project config discovery (same walk as `resolve_group` in `src/config/settings.rs`).
+- Produces: `pub async fn execute_type_list(config: Config, format: OutputFormat) -> Result<()>`, `pub async fn execute_type_show(config: Config, name: String, format: OutputFormat) -> Result<()>`. Table output: `NAME  SOURCE  FIELDS` (fields rendered `username*` for required, `[password]` for secret, `[password]•` for primary); json output serializes the resolved `RecordType`.
+
+- [ ] **Step 1: Failing e2e tests** — `type_list_shows_builtins` (`xv type list` contains `login`, `api-key`, `database`, source `built-in`), `type_show_login_fields`, `type_list_includes_project_custom_type` (`.xv.toml` with `[types.smtp]` → listed with source `project`), `type_show_unknown_errors` (exit 3, message lists known type names).
+- [ ] **Step 2: Run** `cargo test --features aws --test e2e_record_types` — FAIL (unknown subcommand).
+- [ ] **Step 3: Implement** subcommand + ops file.
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit** `feat: xv type list/show`
+
+### Task 5: Tag-limit capabilities + pre-write budget check
+
+**Files:**
+- Modify: `src/backend/mod.rs` (`BackendCapabilities`: add `pub max_tags: Option<usize>` and `pub max_tag_value_len: Option<usize>`; `Default` → both `None`)
+- Modify: `src/backend/azure/mod.rs` (`max_tags: Some(15)`, `max_tag_value_len: Some(256)`), `src/backend/aws/mod.rs` (`max_tags: Some(50)`, `max_tag_value_len: Some(256)`), `src/backend/local/mod.rs` (both `None`)
+- Create: tag-budget helper in `src/records/mod.rs`
+- Test: unit tests in `src/records/mod.rs`
+
+**Interfaces:**
+- Produces:
+  ```rust
+  /// Count = reserved tags actually present (xv-type, groups, note, folder,
+  /// original_name, created_by) + f.* field tags + user tags.
+  pub fn check_tag_budget(
+      caps: &BackendCapabilities,
+      reserved_count: usize,
+      field_tags: &BTreeMap<String, String>,
+      user_tag_count: usize,
+  ) -> Result<()>;   // Err(config) with per-category breakdown when over max_tags;
+                     // Err(config) naming the field + suggesting kind="secret" when a value exceeds max_tag_value_len
+  ```
+
+- [ ] **Step 1: Failing tests** — `budget_ok_under_cap`, `budget_errors_over_cap_with_breakdown` (msg contains "reserved", "fields", "user"), `budget_errors_on_long_tag_value` (msg contains the field name and `kind = "secret"`), `no_caps_never_errors`.
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement**; update the three backends' capability constructors.
+- [ ] **Step 4: Run** unit tests + `cargo test --features aws --lib backend` — PASS.
+- [ ] **Step 5: Commit** `feat: tag-limit capabilities and record tag-budget check`
+
+### Task 6: `xv set --type` (non-interactive + interactive)
+
+**Files:**
+- Modify: `src/cli/commands.rs` (`SecretWriteArgs` unchanged; `Set` gains `#[arg(long)] r#type: Option<String>`, `#[arg(long = "field", value_parser = parse_key_val)] fields: Vec<(String, String)>`, `#[arg(long = "field-secret")] secret_fields: Vec<(String, String)>` — reuse/add the `key=value` parser near the existing tag parser)
+- Modify: `src/cli/secret_ops.rs` (`execute_secret_set_direct`: record path builds envelope value + `f.*`/`xv-type` tags + content type before the existing request construction; primary value comes from `--value`/`--stdin`/prompt exactly like today)
+- Modify: `src/utils/interactive.rs` consumers only (reuse `input_text` for metadata fields, the existing masked secret prompt for secret fields — find it via the current `set` prompt path)
+- Test: `tests/e2e_record_types.rs`
+
+**Interfaces:**
+- Consumes: Tasks 1–3 (find_type, FieldKind), Task 2 (encode_envelope, constants), Task 5 (check_tag_budget), existing `SecretRequest`.
+- Produces: record write behavior other tasks rely on — a `login` record set as
+  `xv set cred --type login --field username=bob --field url=https://ex.com --value hunter2`
+  stores value `{"password":"hunter2"}`, content type `application/vnd.xv.record`, tags `xv-type=login`, `f.username=bob`, `f.url=https://ex.com`.
+
+Rules (all fail-before-write):
+- unknown type → error listing known types;
+- required field missing (non-interactive) → error listing every absent required field;
+- `--field` names not in the type are accepted as ad-hoc metadata; `--field-secret` ad-hoc goes into the envelope;
+- interactive mode (no `--field`s, no `--value`/`--stdin`, TTY): prompt per declared field in order, metadata via `input_text` (empty allowed unless required), secret masked, primary last;
+- tag budget checked via Task 5 before the backend call.
+
+- [ ] **Step 1: Failing e2e tests** — `set_typed_record_stores_envelope_and_tags` (create, then `get --format json` on the raw secret via `ls --format json` asserts `xv-type` and `f.username` present; value assertions come in Task 7), `set_typed_missing_required_field_fails_before_write` (exit 3, names `username`, and `ls` shows no secret created), `set_unknown_type_errors_listing_types`, `set_adhoc_field_allowed`, `set_field_secret_goes_to_envelope` (assert NOT present as a tag).
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement** non-interactive path first, then the interactive prompt loop.
+- [ ] **Step 4: Run** e2e + full `cargo test --features aws` — PASS (interactive loop is not e2e-testable without a TTY; unit-test the field-ordering plan function you extract for it: `fn prompt_plan(t: &RecordType, provided: &BTreeMap<String,String>) -> Vec<&FieldDef>`).
+- [ ] **Step 5: Commit** `feat: xv set --type creates typed records`
+
+### Task 7: `xv get` — primary, `--field`, `--record`, failure modes
+
+**Files:**
+- Modify: `src/cli/commands.rs` (`Get` gains `#[arg(long)] field: Option<String>`, `#[arg(long)] record: bool`, mutually exclusive)
+- Modify: `src/cli/secret_ops.rs` (`execute_secret_get_direct`: when `is_record(content_type)` → parse envelope; plain → primary field's value through the existing output path (clipboard/raw semantics unchanged); `--field` → envelope value or `f.*` tag value; `--record` → merged view of all fields in the requested format)
+- Test: `tests/e2e_record_types.rs`
+
+**Interfaces:**
+- Consumes: Task 6's stored shape; `parse_envelope`, `find_type`.
+- Produces: the compatibility contract — plain `get` on a typed record returns the primary field's bare value with today's exit codes/output paths.
+
+Failure modes (per spec §6): corrupt envelope → exit 3 naming secret + content type, never printing raw JSON as the value; `--field` unknown → exit 3 listing the record's actual field names (envelope keys ∪ `f.*` tags); record whose `xv-type` resolves to no known type → plain `get` exits 3 telling the user to use `--field`/`--record` (primary unknowable), `--field`/`--record` still work; `--field`/`--record` on an untyped secret → exit 3 ("not a record").
+
+- [ ] **Step 1: Failing e2e tests** — `get_typed_record_returns_primary_bare`, `get_field_metadata_and_secret`, `get_record_json_includes_all_fields`, `get_unknown_field_lists_fields`, `get_corrupt_envelope_fails_loud` (write a record, then overwrite its value with `not-json` via a plain `xv set` keeping the content type — if the CLI can't produce that state, drive the local store file directly and document why), `get_unknown_type_degrades` (record with `xv-type=nosuch` → plain get exit 3, `--field` works), `get_field_on_untyped_errors`.
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run** e2e + full suite; also run `tests/e2e_local_backend.rs` untouched-behavior spot checks (`get` on plain secrets unchanged).
+- [ ] **Step 5: Commit** `feat: xv get primary/--field/--record for typed records`
+- [ ] **Step 6: Phase A gate** — full verification (Global Constraints), independent code-review pass, push branch, PR referencing the tracking issue, Bugbot/CI watch.
+
+---
+
+### Task 8: `xv update --field`
+
+**Files:**
+- Modify: `src/cli/commands.rs` (`Update` gains the same `--field` args as `Set`)
+- Modify: `src/cli/secret_ops.rs` (`execute_secret_update_direct`: metadata-field change → tag-only update path; secret-field change → fetch envelope, merge, re-encode, new version via the existing value-update path; both re-run `check_tag_budget`)
+- Test: `tests/e2e_record_types.rs`
+
+**Interfaces:**
+- Consumes: Tasks 2/5/6/7 shapes.
+- Produces: `xv update cred --field username=alice` (tag-only), `xv update cred --field-secret totp-seed=XYZ` (new version, envelope gains key).
+
+- [ ] **Step 1: Failing e2e tests** — `update_metadata_field_is_tag_only` (version count unchanged if backend exposes it via `ls --format json`; else assert value unchanged + tag changed), `update_secret_field_writes_new_envelope`, `update_field_on_untyped_errors`.
+- [ ] **Step 2: Run** — FAIL. **Step 3: Implement.** **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit** `feat: xv update --field edits record fields`
+
+### Task 9: Conversion — `--type` and `--untype`
+
+**Files:**
+- Modify: `src/cli/commands.rs` (`Update` gains `r#type: Option<String>` and `untype: bool`, mutually exclusive with each other and with `--field`)
+- Modify: `src/cli/secret_ops.rs`
+- Test: `tests/e2e_record_types.rs`
+
+**Interfaces:**
+- Produces: `xv update name --type login` — bare secret's value becomes `{"password":"<old value>"}` + content type + `xv-type` tag (existing tags/groups/note/folder untouched; error if already a record); `xv update name --untype` — value becomes the primary field's bare value, content type cleared, `xv-type` and all `f.*` tags removed; if non-primary **secret** fields exist, interactive confirm listing what will be dropped (`--yes` bypasses; non-TTY without `--yes` → exit 3, mirroring `mv`'s bulk-confirm convention).
+
+- [ ] **Step 1: Failing e2e tests** — `type_conversion_roundtrip` (bare → `--type login` → `get` still returns old value → `--untype --yes` → bare again, tags gone), `untype_with_extra_secret_fields_requires_yes` (non-TTY: exit 3 without `--yes`, succeeds with it, dropped field named in output), `type_on_existing_record_errors`.
+- [ ] **Step 2–4:** standard TDD cycle, full-suite run.
+- [ ] **Step 5: Commit** `feat: explicit record conversion with --type/--untype`
+
+### Task 10: `ls` — type column, `f.*` fields in JSON, `--type` filter
+
+**Files:**
+- Modify: `src/cli/commands.rs` (`List` gains `#[arg(long = "type")] type_filter: Option<String>`)
+- Modify: `src/cli/secret_ops.rs` (list path: filter on `xv-type` tag; table gains `TYPE` column only when at least one listed secret is typed — avoids churn for untyped-only vaults; json output already carries tags, additionally lift `f.*` into a `fields` map and `xv-type` into `record_type`)
+- Modify: `src/secret/models.rs` if the list summary struct needs the two new serialized fields
+- Test: `tests/e2e_record_types.rs`
+
+- [ ] **Step 1: Failing e2e tests** — `ls_shows_type_column_when_typed_present`, `ls_json_lifts_fields_and_type`, `ls_type_filter`, `ls_untyped_only_output_unchanged` (byte-compare table header against a pre-recorded expected string).
+- [ ] **Step 2–4:** TDD cycle + full suite.
+- [ ] **Step 5: Commit** `feat: ls type column, field lifting, --type filter`
+
+### Task 11: TUI record detail
+
+**Files:**
+- Modify: `src/tui/view.rs` (detail pane: when the selected secret has `record_type`, render a `Fields` section — metadata fields plain, secret field names shown with masked values, fetched only on the existing detail-fetch path)
+- Test: existing TUI test approach (`rg "cfg(test)" src/tui/` — follow it; if the TUI has no render tests, add a pure-function test for the field-section formatter you extract: `fn record_field_lines(record_type: &str, fields: &BTreeMap<String,String>, secret_names: &[String]) -> Vec<String>`)
+
+- [ ] **Step 1–4:** TDD on the extracted formatter; manual TUI smoke via `cargo run -- tui` against a local-backend store with one typed record (document the smoke result in the commit body).
+- [ ] **Step 5: Commit** `feat: TUI shows record fields`
+- [ ] **Step 6: Phase B gate** — verification, review pass, push, PR, watch.
+
+---
+
+### Task 12: `inject` field syntax
+
+**Files:**
+- Modify: `src/cli/secret_ops.rs` (`execute_secret_inject`: template grammar `{{ secret:name.field }}` — split on the LAST `.` only when the base name resolves to a record and the suffix matches a field, so existing secrets with dots in names keep working: try exact-name match FIRST, fall back to name.field split; URI grammar `xv://vault/name#field` — fragment split is unambiguous since `#` is invalid in names on every backend)
+- Modify: `src/cli/secret_ops.rs` run path: NO changes (spec: primary only) — add a guard test proving `xv run` on a typed record injects the primary.
+- Test: `tests/e2e_record_types.rs`
+
+**Interfaces:**
+- Consumes: Task 7's field-read logic (extract a shared `fn record_field_value(props: &SecretProperties, field: &str, types: &[RecordType]) -> Result<String>` if not already shared).
+- Failure semantics inherit #313/#319: unresolved field references collect into `fetch_failures` and abort before write unless `--best-effort`.
+
+- [ ] **Step 1: Failing e2e tests** — `inject_field_syntax_renders`, `inject_bare_name_renders_primary`, `inject_dot_name_exact_match_wins` (create untyped secret literally named `a.b`; `{{ secret:a.b }}` resolves it, not field `b` of record `a`), `inject_unknown_field_aborts` (exit 3, no output file), `inject_uri_fragment_field`, `run_typed_record_injects_primary`.
+- [ ] **Step 2–4:** TDD cycle + full suite.
+- [ ] **Step 5: Commit** `feat: inject {{ secret:name.field }} and xv://vault/name#field`
+
+### Task 13: Docs + CHANGELOG
+
+**Files:**
+- Modify: `README.md` (record types section: built-ins table, custom `[types.*]` example, per-field sensitivity note, external-consumer JSON note + explicit-conversion rule), `docs/FEATURES.md` (same, shorter), `docs/env-profiles.md` (no change unless types interact — they don't; verify), `CHANGELOG.md` (Unreleased/Added entry; NOT breaking — say so explicitly and why: only explicitly-created/converted records change shape)
+- Test: none (docs) — but re-run the full suite as the phase gate.
+
+- [ ] **Step 1: Write docs** matching implemented behavior exactly (copy flag names from `--help` output, not from memory).
+- [ ] **Step 2:** `cargo test --features aws` full suite green.
+- [ ] **Step 3: Commit** `docs: record types`
+- [ ] **Step 4: Phase C gate** — verification, review pass, push, PR, watch.
+
+---
+
+## Self-review (done at write time)
+
+- **Spec coverage:** decisions 1–5 → Tasks 1–7; spec §4 CLI → Tasks 4/6/7/8/9/10; §5 integrations → Tasks 11/12 (run: guard test only, per spec); §6 limits/errors → Tasks 5/7; §7 compat → untouched-behavior tests in Tasks 7/10 + non-breaking CHANGELOG in Task 13; §8 testing → per-task tests + hermetic constraint; §9 out-of-scope respected (no run expansion, no vault registry, no value validation).
+- **Placeholders:** none — every step names its tests and exact behavior; code blocks give exact signatures/constants; two deliberate implementation-freedom points (TUI test idiom discovery, corrupt-envelope state setup) instruct discovery rather than leaving gaps.
+- **Type consistency:** `RecordType`/`FieldDef`/`find_type`/`check_tag_budget`/`encode_envelope`/`parse_envelope`/`RECORD_CONTENT_TYPE`/`TYPE_TAG`/`FIELD_TAG_PREFIX` used identically across Tasks 1–12.

--- a/docs/superpowers/specs/2026-07-03-record-types-design.md
+++ b/docs/superpowers/specs/2026-07-03-record-types-design.md
@@ -1,0 +1,199 @@
+# Record Types: Structured Secrets with Typed Fields
+
+**Date:** 2026-07-03
+**Status:** Approved design, not yet implemented
+**Depends on:** metadata-preserving copy/move (PR #315, merged); profile write defaults (PR #320, merged)
+
+## Motivation
+
+Other secret managers (1Password, Bitwarden, Vault) support typed records:
+a "login" carries a username and URL alongside the password, a "database"
+carries host/port/connection details. xv secrets today are one opaque value
+plus a handful of bookkeeping tags. Users who want to record which account
+a password belongs to must abuse the `note` tag or maintain sidecar secrets.
+
+This design adds **record types** — built-in and user-defined — that attach
+structured fields (username, URL, connection-string, …) to a secret, with
+per-field control over whether a field is listable metadata or encrypted
+secret material, without breaking any existing secret or consumer.
+
+## Decisions (settled during brainstorm)
+
+1. **Per-field sensitivity, with type-supplied defaults.** Each field is
+   `metadata` (listable without fetching the secret) or `secret`
+   (encrypted in the value). Built-ins ship sensible defaults (username/url
+   metadata; password/key/token secret).
+2. **Primary-field `get` compatibility.** Every type declares exactly one
+   `primary` secret field. Plain `xv get <name>` returns it, byte-identical
+   to today's behavior, so `get`/`run`/`inject` never break when a secret
+   gains a type.
+3. **Custom types live in config files.** `[types.<name>]` blocks in global
+   `xv.conf`, overridable per-project in `.xv.toml` — same hierarchy as all
+   other config. No vault-stored registry in v1.
+4. **Templates, not schemas.** A type prompts for its declared fields and
+   enforces `required` ones; ad-hoc extra fields are always allowed.
+5. **Encoding: JSON envelope + field tags (Approach A).** Secret fields
+   live in a JSON document in the secret value, marked by content type;
+   metadata fields and the type name live in reserved/prefixed tags.
+   Single backend object per record; rejected alternatives were companion
+   secrets (two-object atomicity/verb complexity) and envelope-only-when-
+   needed (dual representation in every reader/writer).
+
+## Data model
+
+```
+RecordType { name: String, fields: Vec<FieldDef> }
+FieldDef   { name: String, kind: Metadata | Secret, required: bool, primary: bool }
+```
+
+- Exactly one field per type is `primary`; `primary` implies
+  `kind = Secret` and `required = true`. Type resolution rejects types with
+  zero or multiple primaries.
+- Field names are kebab-case, validated with the same charset rules as
+  secret names.
+- A **record** is a secret whose reserved `xv-type` tag names a type.
+  Any secret without that tag is an untyped secret with today's exact
+  semantics.
+
+### Storage mapping (identical across Azure / AWS / local)
+
+| Piece | Where | Details |
+|---|---|---|
+| Secret fields | secret value | JSON object `{"<field>": "<value>", …}`; `content_type = application/vnd.xv.record` |
+| Metadata fields | tags | prefixed `f.` (`f.username`, `f.url`), beside existing `groups`/`note`/`folder` lifting |
+| Type name | tag | reserved `xv-type` |
+
+The **content-type marker**, not JSON sniffing, is what makes a secret a
+record. A user who stores a JSON document as a plain secret value is never
+misinterpreted as a record.
+
+## Built-in types
+
+Deliberately small; custom types cover the rest.
+
+| Type | Metadata fields | Secret fields |
+|---|---|---|
+| `login` | username (required), url | **password** (primary) |
+| `api-key` | url, account | **key** (primary) |
+| `database` | host, port, database, username | **password** (primary), connection-string (optional) |
+
+There is no `note` type — the existing `note` tag already covers free-text
+annotation on any secret.
+
+## Custom types
+
+```toml
+# xv.conf (global) or .xv.toml (project override)
+[types.smtp]
+fields = [
+  { name = "host" },                          # metadata by default
+  { name = "port" },
+  { name = "username", required = true },
+  { name = "password", kind = "secret", primary = true },
+]
+```
+
+- Project type shadows a global type of the same name; shadowing a
+  built-in emits a warning but works.
+- `xv type list` shows resolved types with their source
+  (built-in / global / project); `xv type show <name>` prints the field
+  table.
+
+## CLI surface
+
+### Create
+
+- `xv set mail-cred --type smtp` — interactive: prompts for each declared
+  field in order, secret fields masked, primary last. Missing required
+  field → error listing what is absent (fail before any write).
+- Non-interactive: `--field name=value` (repeatable) for metadata and
+  non-primary secret fields; the primary value arrives via the existing
+  `--value` / `--stdin`. Ad-hoc `--field` names not in the type are
+  accepted (decision 4) and default to metadata kind; `--field-secret`
+  variant marks an ad-hoc field secret.
+
+### Read
+
+- `xv get name` → primary field only. Unchanged behavior and output for
+  untyped secrets and typed records alike.
+- `xv get name --field username` → that field's value (either kind).
+  Unknown field → error listing the record's actual fields.
+- `xv get name --record` → the full record (secret fields included) in the
+  requested `--format` (json/yaml/table).
+
+### Update / convert
+
+- `xv update name --field username=new` — edits one field. A secret-field
+  change writes a new secret version (envelope rewritten); a metadata-field
+  change is tag-only.
+- `xv update name --type login` — **explicit** conversion of a bare secret:
+  current value becomes the primary field, envelope + tags written.
+  Conversion never happens implicitly.
+- `xv update name --untype` — flattens a record back to a bare secret
+  holding the primary field's value; non-primary secret fields are
+  **dropped with an interactive confirmation** (or `--yes`), metadata
+  fields removed from tags.
+
+### List / TUI
+
+- `xv ls`: type column in table output; `f.*` fields included in
+  `--format json` output; `ls --type login` filters by type.
+- TUI detail view lists fields, secret ones masked.
+
+## Integrations
+
+- **`xv inject`**: `{{ secret:name.username }}` selects a field; bare
+  `{{ secret:name }}` remains the primary. `xv://` URIs use a fragment:
+  `xv://vault/name#username` (`#` cannot appear in secret names on any
+  backend, so the grammar is unambiguous).
+- **`xv run`**: injects the primary under the record's name, unchanged.
+  Per-field env expansion is out of scope for v1.
+- **`mv` / `copy` / `move`**: no changes — the envelope is the value and
+  fields are tags, both already preserved end-to-end (guaranteed since
+  PR #315's metadata-fidelity work).
+
+## Limits and error handling
+
+- **Azure 15-tag cap**: `set`/`update` counts reserved tags + `f.*` fields
+  + user tags and fails with a per-category breakdown *before writing* when
+  the cap would be exceeded. AWS (50 tags) and local (unbounded) get the
+  same check with their own caps.
+- **Azure 256-char tag values**: a metadata field value exceeding the cap
+  errors with a suggestion to declare that field `kind = "secret"`.
+- **Corrupt envelope**: a record-marked secret whose value fails JSON
+  parsing makes `get` fail loudly (naming the secret and content type);
+  xv never silently returns raw JSON as if it were the primary value.
+- **Type not found** (record's `xv-type` names no resolvable type):
+  degrade gracefully — `get` still works via the envelope's contents
+  (primary unknown → require `--field` or `--record`), `ls` shows the type
+  name with a marker; a warning explains how to define the missing type.
+
+## Compatibility and migration
+
+- Untyped secrets are untouched in every code path: no envelope, no new
+  tags, `get`/`run`/`inject` byte-identical.
+- Older xv versions reading a typed record `get` the raw envelope JSON.
+  CHANGELOG note, not a breaking change — only explicitly-converted or
+  newly-created records are affected.
+- External consumers (Azure portal, raw SDKs) see JSON values for typed
+  records. Documented in README with the explicit-conversion rule.
+
+## Testing
+
+- Hermetic e2e on the local backend (isolated harness per the #317
+  lesson): create/get/update per built-in type; primary-field
+  compatibility; `--field` reads; conversion round-trip
+  (`--type` → `--untype`); required-field enforcement; ad-hoc fields;
+  tag-cap failure; `inject` field syntax; `ls --type` filter; corrupt
+  envelope failure; unknown-type degradation.
+- Unit tests: type resolution/shadowing (built-in vs global vs project),
+  envelope encode/parse, FieldDef validation (one primary, kebab names).
+- AWS tag-encoding parity via the existing LocalStack suite.
+
+## Out of scope (v1)
+
+- Vault-stored shared type registry (config-only for now; revisit if teams
+  need vault-attached types).
+- `xv run` per-field env expansion.
+- Typed value validation (URL/port formats).
+- TOTP generation, attachment fields.

--- a/src/backend/aws/mod.rs
+++ b/src/backend/aws/mod.rs
@@ -100,6 +100,8 @@ impl Backend for AwsBackend {
             max_secret_size: Some(65_536),
             max_name_length: Some(encoding::MAX_NAME_LEN),
             name_charset: NameCharset::AwsRelaxed,
+            max_tags: Some(50),
+            max_tag_value_len: Some(256),
         }
     }
 

--- a/src/backend/azure/mod.rs
+++ b/src/backend/azure/mod.rs
@@ -203,6 +203,8 @@ impl Backend for AzureBackend {
             max_secret_size: Some(25 * 1024), // 25 KiB Azure limit
             max_name_length: Some(127),       // Azure Key Vault name limit
             name_charset: NameCharset::AlphanumericHyphen,
+            max_tags: Some(15),
+            max_tag_value_len: Some(256),
         }
     }
 

--- a/src/backend/azure/secrets.rs
+++ b/src/backend/azure/secrets.rs
@@ -115,8 +115,14 @@ fn build_patched_tags(
         }
     };
 
-    tags.insert("original_name".to_string(), request.name.clone());
-    tags.insert("created_by".to_string(), "crosstache".to_string());
+    tags.insert(
+        crate::backend::TAG_ORIGINAL_NAME.to_string(),
+        request.name.clone(),
+    );
+    tags.insert(
+        crate::backend::TAG_CREATED_BY.to_string(),
+        "crosstache".to_string(),
+    );
 
     // Handle groups: remove first, then conditionally insert.
     tags.remove("groups");

--- a/src/backend/local/mod.rs
+++ b/src/backend/local/mod.rs
@@ -228,6 +228,8 @@ impl Backend for LocalBackend {
             max_secret_size: None,
             max_name_length: Some(255),
             name_charset: NameCharset::Unrestricted,
+            max_tags: None,
+            max_tag_value_len: None,
         }
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -28,6 +28,23 @@ pub mod registry;
 pub mod secret;
 pub mod vault;
 
+/// Reserved tag name for a secret's user-facing original name (before
+/// backend-specific sanitization).
+pub const TAG_ORIGINAL_NAME: &str = "original_name";
+
+/// Reserved tag name recording that crosstache wrote a secret.
+pub const TAG_CREATED_BY: &str = "created_by";
+
+/// Bookkeeping tags written unconditionally on every Azure secret write —
+/// `SecretManager::prepare_secret_request` (create, `src/secret/manager.rs`)
+/// and `azure::secrets::build_patched_tags` (attribute-only update,
+/// `src/backend/azure/secrets.rs`) — one tag slot each, always consumed
+/// regardless of what the caller requests. `records::check_tag_budget`'s
+/// pre-check must count these so it can't under-count relative to what the
+/// backend actually writes; both call sites reference this constant
+/// instead of repeating the literal strings, so the two can't drift apart.
+pub const ALWAYS_WRITTEN_TAGS: [&str; 2] = [TAG_ORIGINAL_NAME, TAG_CREATED_BY];
+
 // Re-exports for convenience.
 pub use addressing::BackendRef;
 pub use audit::{AuditBackend, AuditEvent};

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -151,6 +151,14 @@ pub struct BackendCapabilities {
     pub max_name_length: Option<usize>,
     /// Valid character set for secret names.
     pub name_charset: NameCharset,
+    /// Maximum number of tags per secret (None = unlimited). Used by
+    /// `records::check_tag_budget` to fail record writes before they
+    /// exceed the backend's tag cap.
+    pub max_tags: Option<usize>,
+    /// Maximum length of a single tag value (None = unlimited). Used by
+    /// `records::check_tag_budget` to fail record writes whose metadata
+    /// field value is too long for a tag.
+    pub max_tag_value_len: Option<usize>,
 }
 
 impl Default for BackendCapabilities {
@@ -171,6 +179,8 @@ impl Default for BackendCapabilities {
             max_secret_size: None,
             max_name_length: None,
             name_charset: NameCharset::Unrestricted,
+            max_tags: None,
+            max_tag_value_len: None,
         }
     }
 }

--- a/src/backend/secret.rs
+++ b/src/backend/secret.rs
@@ -213,8 +213,8 @@ pub(crate) fn rename_request_from_properties(
         .filter(|g| !g.is_empty());
     let note = tags.remove("note");
     let folder = tags.remove("folder");
-    tags.remove("original_name");
-    tags.remove("created_by");
+    tags.remove(super::TAG_ORIGINAL_NAME);
+    tags.remove(super::TAG_CREATED_BY);
 
     Ok(SecretRequest {
         name: new_name.to_string(),

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -449,6 +449,14 @@ pub enum Commands {
         /// Get a specific version of the secret
         #[arg(long)]
         version: Option<String>,
+        /// Read a single field from a typed record (metadata or secret).
+        /// Errors if the secret is untyped. Mutually exclusive with --record.
+        #[arg(long, conflicts_with = "record")]
+        field: Option<String>,
+        /// Print the full record (all fields) in the requested --format.
+        /// Errors if the secret is untyped. Mutually exclusive with --field.
+        #[arg(long, conflicts_with = "field")]
+        record: bool,
     },
     /// Ranked fuzzy search over secrets (alias: search). Non-interactive;
     /// pipe the output through fzf or similar for an interactive picker.
@@ -1572,9 +1580,22 @@ impl Cli {
                 )
                 .await
             }
-            Commands::Get { name, raw, version } => {
+            Commands::Get {
+                name,
+                raw,
+                version,
+                field,
+                record,
+            } => {
                 crate::cli::secret_ops::execute_secret_get_direct(
-                    &name, raw, version, config, registry,
+                    &name,
+                    raw,
+                    version,
+                    field,
+                    record,
+                    self.format,
+                    config,
+                    registry,
                 )
                 .await
             }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -894,6 +894,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: LocalCommands,
     },
+    /// Record type management (built-in + custom `[types.*]` config blocks).
+    /// Config-only: never talks to a secrets backend.
+    Type {
+        #[command(subcommand)]
+        command: TypeCommands,
+    },
     /// Quick file upload (alias for file upload)
     #[cfg(feature = "file-ops")]
     #[command(alias = "up")]
@@ -1297,6 +1303,20 @@ pub enum LocalCommands {
         /// Print the rename plan without touching anything on disk.
         #[arg(long)]
         dry_run: bool,
+    },
+}
+
+/// Record-type subcommands (`xv type ...`).
+#[derive(Subcommand)]
+pub enum TypeCommands {
+    /// List resolved record types (built-in + global + project), with
+    /// their source (alias: ls)
+    #[command(alias = "ls")]
+    List,
+    /// Show a single resolved record type's field table
+    Show {
+        /// Type name
+        name: String,
     },
 }
 
@@ -1862,6 +1882,9 @@ impl Cli {
             }
             Commands::Local { command } => {
                 crate::cli::local_ops::execute_local_command(command, config).await
+            }
+            Commands::Type { command } => {
+                crate::cli::type_ops::execute_type_command(command, config).await
             }
             #[cfg(feature = "file-ops")]
             Commands::Upload {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -422,6 +422,19 @@ pub enum Commands {
         /// secret name; mutually exclusive with --stdin.
         #[arg(long, conflicts_with = "stdin")]
         value: Option<String>,
+        /// Create a typed record of this type (built-in or custom `[types.*]`).
+        /// Only valid for a single secret. See `xv type list`/`xv type show`.
+        #[arg(long = "type")]
+        r#type: Option<String>,
+        /// Set a metadata (or type-declared non-primary secret) field
+        /// value, `name=value` (repeatable). Fields not declared by the
+        /// type are accepted as ad-hoc metadata. Requires --type.
+        #[arg(long = "field", value_name = "NAME=VALUE", value_parser = parse_key_val::<String, String>, requires = "type")]
+        fields: Vec<(String, String)>,
+        /// Set an ad-hoc secret field value, `name=value` (repeatable) —
+        /// stored in the record envelope rather than as a tag. Requires --type.
+        #[arg(long = "field-secret", value_name = "NAME=VALUE", value_parser = parse_key_val::<String, String>, requires = "type")]
+        secret_fields: Vec<(String, String)>,
         /// Write-time metadata (group/note/folder/expires/not-before)
         #[command(flatten)]
         meta: SecretWriteArgs,
@@ -1540,10 +1553,22 @@ impl Cli {
                 stdin,
                 trim,
                 value,
+                r#type,
+                fields,
+                secret_fields,
                 meta,
             } => {
                 crate::cli::secret_ops::execute_secret_set_direct(
-                    args, stdin, trim, value, meta, config, registry,
+                    args,
+                    stdin,
+                    trim,
+                    value,
+                    r#type,
+                    fields,
+                    secret_fields,
+                    meta,
+                    config,
+                    registry,
                 )
                 .await
             }

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -1321,6 +1321,7 @@ async fn execute_context_init(
         default_env: Some(env_name.clone()),
         envs,
         scan: None,
+        types: std::collections::HashMap::new(),
     };
 
     let body = toml::to_string_pretty(&cfg)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod mv_ops;
 pub(crate) mod scan_ops;
 pub(crate) mod secret_ops;
 pub(crate) mod system_ops;
+pub(crate) mod type_ops;
 pub(crate) mod upgrade_ops;
 pub(crate) mod vault_ops;
 

--- a/src/cli/mv_ops.rs
+++ b/src/cli/mv_ops.rs
@@ -715,6 +715,8 @@ mod tests {
                 max_secret_size: None,
                 max_name_length: None,
                 name_charset: NameCharset::Unrestricted,
+                max_tags: None,
+                max_tag_value_len: None,
             }
         }
 

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -132,8 +132,30 @@ fn route_fields(
     Ok((metadata, secret))
 }
 
+/// True when `name` is present in `metadata` or `secret` with a
+/// non-blank value. Only meaningful for required fields: a non-required
+/// field is free to keep an explicit empty value (an explicit empty is a
+/// legitimate user choice there — mirrors how env-profile defaults treat
+/// blank-as-absent per #320, applied here only to the required-ness
+/// check, not to whether the field gets stored), but a required field
+/// supplied as `--field name=` or `--field name=" "` isn't meaningfully
+/// "set" and must be treated as missing — matching the interactive
+/// prompt path, which already rejects a blank answer for a required
+/// field.
+fn has_non_blank_value(
+    name: &str,
+    metadata: &BTreeMap<String, String>,
+    secret: &BTreeMap<String, String>,
+) -> bool {
+    metadata
+        .get(name)
+        .or_else(|| secret.get(name))
+        .is_some_and(|v| !v.trim().is_empty())
+}
+
 /// Every required field (except the primary, which is always required and
-/// supplied separately) that is missing from both maps, in declared order.
+/// supplied separately) that is missing — absent, or present with an
+/// empty/whitespace-only value — from both maps, in declared order.
 fn missing_required_fields<'a>(
     record_type: &'a RecordType,
     metadata: &BTreeMap<String, String>,
@@ -143,7 +165,7 @@ fn missing_required_fields<'a>(
         .fields
         .iter()
         .filter(|f| f.required && !f.primary)
-        .filter(|f| !metadata.contains_key(&f.name) && !secret.contains_key(&f.name))
+        .filter(|f| !has_non_blank_value(&f.name, metadata, secret))
         .collect()
 }
 
@@ -5835,6 +5857,52 @@ mod tests {
         let missing = missing_required_fields(&t, &BTreeMap::new(), &BTreeMap::new());
         let names: Vec<&str> = missing.iter().map(|f| f.name.as_str()).collect();
         assert_eq!(names, vec!["username"]);
+    }
+
+    // ── Empty required fields (Bugbot round 3 follow-up) ────────────────
+
+    #[test]
+    fn missing_required_fields_treats_empty_value_as_missing() {
+        let t = login_type();
+        let mut metadata = BTreeMap::new();
+        metadata.insert("username".to_string(), String::new());
+        let missing = missing_required_fields(&t, &metadata, &BTreeMap::new());
+        let names: Vec<&str> = missing.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["username"], "empty value must count as missing");
+    }
+
+    #[test]
+    fn missing_required_fields_treats_whitespace_only_value_as_missing() {
+        let t = login_type();
+        let mut metadata = BTreeMap::new();
+        metadata.insert("username".to_string(), "   ".to_string());
+        let missing = missing_required_fields(&t, &metadata, &BTreeMap::new());
+        let names: Vec<&str> = missing.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["username"],
+            "whitespace-only value must count as missing"
+        );
+    }
+
+    #[test]
+    fn missing_required_fields_non_required_field_may_stay_empty() {
+        // `url` on `login` is optional metadata; an explicit empty value is
+        // a legitimate user choice and must not affect required-field
+        // reporting (only `username`, the required field, is missing).
+        let t = login_type();
+        let mut metadata = BTreeMap::new();
+        metadata.insert("url".to_string(), String::new());
+        let missing = missing_required_fields(&t, &metadata, &BTreeMap::new());
+        let names: Vec<&str> = missing.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["username"]);
+    }
+
+    #[test]
+    fn has_non_blank_value_true_for_real_value() {
+        let mut metadata = BTreeMap::new();
+        metadata.insert("username".to_string(), "bob".to_string());
+        assert!(has_non_blank_value("username", &metadata, &BTreeMap::new()));
     }
 
     // ── `xv get --field` clipboard auto-clear (code review follow-up) ──

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -234,6 +234,30 @@ async fn build_record_set_request(
         )));
     };
 
+    // Reject any user `--tag` that collides with a reserved record tag
+    // name, before any prompting or backend call. Applying `--tag` after
+    // xv-type/f.* would silently overwrite the record's own bookkeeping
+    // (e.g. `--tag xv-type=other` desyncs the type marker from the
+    // envelope, breaking type resolution and plain `get`); rejecting is at
+    // least as strict as the untyped `set` path, which already loses a
+    // user-supplied `original_name`/`created_by` tag to the backend's own
+    // unconditional overwrite (see `crate::backend::ALWAYS_WRITTEN_TAGS`).
+    for key in meta.tag.iter().map(|(k, _)| k.as_str()) {
+        let collides = key == TYPE_TAG
+            || key.starts_with(FIELD_TAG_PREFIX)
+            || key == crate::backend::TAG_ORIGINAL_NAME
+            || key == crate::backend::TAG_CREATED_BY;
+        if collides {
+            return Err(CrosstacheError::config(format!(
+                "--tag '{key}' collides with a reserved record tag name ({}, {FIELD_TAG_PREFIX}*, \
+                 {}, {}); rename it",
+                TYPE_TAG,
+                crate::backend::TAG_ORIGINAL_NAME,
+                crate::backend::TAG_CREATED_BY
+            )));
+        }
+    }
+
     let (metadata, mut secret_map, primary_value) =
         if fields.is_empty() && secret_fields.is_empty() && value.is_none() && !stdin {
             if std::io::stdin().is_terminal() {
@@ -304,7 +328,8 @@ async fn build_record_set_request(
         .iter()
         .map(|(k, v)| (format!("{FIELD_TAG_PREFIX}{k}"), v.clone()))
         .collect();
-    crate::records::check_tag_budget(&caps, reserved_count, &field_tags, meta.tag.len())?;
+    let user_tags: BTreeMap<String, String> = meta.tag.iter().cloned().collect();
+    crate::records::check_tag_budget(&caps, reserved_count, &field_tags, &user_tags)?;
 
     // Build the envelope: secret fields + primary.
     secret_map.insert(record_type.primary().name.clone(), primary_value);
@@ -316,7 +341,7 @@ async fn build_record_set_request(
     for (k, v) in &field_tags {
         tags.insert(k.clone(), v.clone());
     }
-    for (k, v) in &meta.tag {
+    for (k, v) in &user_tags {
         tags.insert(k.clone(), v.clone());
     }
     let _ = metadata; // folded into field_tags above; kept for clarity at the call site
@@ -629,9 +654,10 @@ pub(crate) async fn execute_secret_get_direct(
         if record {
             if !is_rec {
                 return Err(CrosstacheError::config(format!(
-                    "secret '{name}' is not a record (has no {} tag); --record only applies to \
-                     typed records",
-                    crate::records::TYPE_TAG
+                    "secret '{name}' is not a typed record (value is not marked {}); \
+                     --record only applies to typed records. Use 'xv update {name} --type <type>' \
+                     to convert it.",
+                    crate::records::RECORD_CONTENT_TYPE
                 )));
             }
             let value = secret.value.as_deref().map(|s| s.as_str()).unwrap_or("");
@@ -676,9 +702,10 @@ pub(crate) async fn execute_secret_get_direct(
         if let Some(field_name) = field {
             if !is_rec {
                 return Err(CrosstacheError::config(format!(
-                    "secret '{name}' is not a record (has no {} tag); --field only applies to \
-                     typed records",
-                    crate::records::TYPE_TAG
+                    "secret '{name}' is not a typed record (value is not marked {}); \
+                     --field only applies to typed records. Use 'xv update {name} --type <type>' \
+                     to convert it.",
+                    crate::records::RECORD_CONTENT_TYPE
                 )));
             }
             let value = secret.value.as_deref().map(|s| s.as_str()).unwrap_or("");

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -247,6 +247,18 @@ async fn build_record_set_request(
             }
         } else {
             let (metadata, secret_map) = route_fields(record_type, fields, secret_fields)?;
+            // Fail before prompting for the primary value: a user
+            // shouldn't be asked for a (possibly masked, hard-to-retype)
+            // secret and only afterward be told a required metadata field
+            // was missing.
+            let missing = missing_required_fields(record_type, &metadata, &secret_map);
+            if !missing.is_empty() {
+                let names: Vec<&str> = missing.iter().map(|f| f.name.as_str()).collect();
+                return Err(CrosstacheError::config(format!(
+                    "type '{type_name}' is missing required field(s): {}",
+                    names.join(", ")
+                )));
+            }
             let primary_value = if let Some(v) = value {
                 v
             } else if stdin {
@@ -275,18 +287,19 @@ async fn build_record_set_request(
         )));
     }
 
-    // Tag budget: reserved (xv-type, plus whatever SecretWriteArgs sets —
-    // groups/note/folder) + f.* metadata fields + user --tag count.
-    let mut reserved_count = 1; // xv-type
-    if !meta.group.is_empty() {
-        reserved_count += 1;
-    }
-    if meta.note.is_some() {
-        reserved_count += 1;
-    }
-    if meta.folder.is_some() {
-        reserved_count += 1;
-    }
+    // Tag budget: reserved (xv-type + the two backend-always-written
+    // bookkeeping tags + whatever SecretWriteArgs sets — groups/note/folder)
+    // + f.* metadata fields + user --tag count. `reserved_tag_count`
+    // includes `original_name`/`created_by` because every backend's
+    // `set_secret` stamps those unconditionally regardless of this
+    // pre-check — see its doc comment for why omitting them under-counts
+    // relative to what the real write attaches.
+    let reserved_count = crate::records::reserved_tag_count(
+        true, // xv-type: always present on a record write
+        !meta.group.is_empty(),
+        meta.note.is_some(),
+        meta.folder.is_some(),
+    );
     let field_tags: BTreeMap<String, String> = metadata
         .iter()
         .map(|(k, v)| (format!("{FIELD_TAG_PREFIX}{k}"), v.clone()))
@@ -552,6 +565,36 @@ fn lookup_record_field<'a>(
         .map(|s| s.as_str())
 }
 
+/// Decides the clipboard success message and whether to schedule an
+/// auto-clear for `xv get --field`, mirroring plain `get`'s clipboard
+/// handling for secret-kind fields exactly (same message shape, same
+/// `schedule_clipboard_clear` call when `timeout > 0`). Metadata-kind
+/// fields intentionally never schedule a clear: they're listable without
+/// fetching the secret at all (e.g. via `--record`, or a future `ls` field
+/// lift), so treating a clipboard copy of one as equally sensitive as a
+/// secret buys nothing. Extracted as a pure function so this branching is
+/// unit-testable without a real clipboard.
+fn field_clipboard_outcome(
+    name: &str,
+    field_name: &str,
+    is_secret_field: bool,
+    clipboard_timeout: u64,
+) -> (String, bool) {
+    if is_secret_field && clipboard_timeout > 0 {
+        (
+            format!(
+                "Field '{field_name}' of '{name}' copied to clipboard (auto-clears in {clipboard_timeout}s)"
+            ),
+            true,
+        )
+    } else {
+        (
+            format!("Field '{field_name}' of '{name}' copied to clipboard"),
+            false,
+        )
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_secret_get_direct(
     name: &str,
@@ -648,13 +691,27 @@ pub(crate) async fn execute_secret_get_direct(
                     known.join(", ")
                 )));
             };
+            // A field found in the envelope is secret-kind; one found only
+            // via the f.<name> tag is metadata-kind (listable without
+            // fetching the secret in the first place).
+            let is_secret_field = envelope.contains_key(&field_name);
+
             if raw {
                 print!("{field_value}");
             } else {
                 match copy_to_clipboard(field_value) {
-                    Ok(()) => output::success(&format!(
-                        "Field '{field_name}' of '{name}' copied to clipboard"
-                    )),
+                    Ok(()) => {
+                        let (message, schedule_clear) = field_clipboard_outcome(
+                            name,
+                            &field_name,
+                            is_secret_field,
+                            config.clipboard_timeout,
+                        );
+                        output::success(&message);
+                        if schedule_clear {
+                            schedule_clipboard_clear(config.clipboard_timeout);
+                        }
+                    }
                     Err(e) => {
                         output::warn(&format!("Failed to copy to clipboard: {e}"));
                         eprintln!(
@@ -5694,5 +5751,38 @@ mod tests {
         let missing = missing_required_fields(&t, &BTreeMap::new(), &BTreeMap::new());
         let names: Vec<&str> = missing.iter().map(|f| f.name.as_str()).collect();
         assert_eq!(names, vec!["username"]);
+    }
+
+    // ── `xv get --field` clipboard auto-clear (code review follow-up) ──
+
+    #[test]
+    fn field_clipboard_outcome_secret_field_schedules_clear_like_plain_get() {
+        let (message, schedule_clear) = field_clipboard_outcome("cred", "password", true, 30);
+        assert!(schedule_clear, "secret-kind fields must schedule a clear");
+        assert!(message.contains("auto-clears in 30s"), "{message}");
+        assert!(message.contains("password"), "{message}");
+        assert!(message.contains("cred"), "{message}");
+    }
+
+    #[test]
+    fn field_clipboard_outcome_secret_field_no_clear_when_timeout_disabled() {
+        let (message, schedule_clear) = field_clipboard_outcome("cred", "password", true, 0);
+        assert!(!schedule_clear, "timeout=0 must never schedule a clear");
+        assert!(
+            !message.contains("auto-clears"),
+            "no affordance text when disabled: {message}"
+        );
+    }
+
+    #[test]
+    fn field_clipboard_outcome_metadata_field_never_schedules_clear() {
+        // Even with a non-zero timeout, a metadata-kind field (listable
+        // without fetching the secret) intentionally skips the auto-clear.
+        let (message, schedule_clear) = field_clipboard_outcome("cred", "username", false, 30);
+        assert!(
+            !schedule_clear,
+            "metadata-kind fields must not schedule a clear"
+        );
+        assert!(!message.contains("auto-clears"), "{message}");
     }
 }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -282,15 +282,32 @@ async fn build_record_set_request(
     // least as strict as the untyped `set` path, which already loses a
     // user-supplied `original_name`/`created_by` tag to the backend's own
     // unconditional overwrite (see `crate::backend::ALWAYS_WRITTEN_TAGS`).
+    //
+    // Also reject `groups`/`note`/`folder` — on the untyped `set` path
+    // these keys don't error either, but they're not silently ignored:
+    // `SecretManager::prepare_secret_request` (Azure's real write path)
+    // copies `request.tags` (which would include a user `--tag note=y`)
+    // into the tag map FIRST, then unconditionally re-inserts
+    // `groups`/`note`/`folder` from the dedicated `--group`/`--note`/
+    // `--folder` flags when those flags were passed — so `--note x --tag
+    // note=y` deterministically keeps `x` (the dedicated flag always wins
+    // over the same-named `--tag`), never `y`, and never errors. That
+    // silent "last write wins" merge is exactly the desync class round 1
+    // already rejected for xv-type/f.*/original_name/created_by, so the
+    // record path is intentionally stricter here than the untyped path:
+    // fail loud instead of silently picking a winner.
     for key in meta.tag.iter().map(|(k, _)| k.as_str()) {
         let collides = key == TYPE_TAG
             || key.starts_with(FIELD_TAG_PREFIX)
             || key == crate::backend::TAG_ORIGINAL_NAME
-            || key == crate::backend::TAG_CREATED_BY;
+            || key == crate::backend::TAG_CREATED_BY
+            || key == "groups"
+            || key == "note"
+            || key == "folder";
         if collides {
             return Err(CrosstacheError::config(format!(
                 "--tag '{key}' collides with a reserved record tag name ({}, {FIELD_TAG_PREFIX}*, \
-                 {}, {}); rename it",
+                 {}, {}, groups, note, folder); rename it or use --group/--note/--folder instead",
                 TYPE_TAG,
                 crate::backend::TAG_ORIGINAL_NAME,
                 crate::backend::TAG_CREATED_BY
@@ -362,25 +379,23 @@ async fn build_record_set_request(
         )));
     }
 
-    // Tag budget: reserved (xv-type + the two backend-always-written
-    // bookkeeping tags + whatever SecretWriteArgs sets — groups/note/folder)
-    // + backend-specific extras (AWS's xv:content_type/xv:expires_at tags)
-    // + f.* metadata fields + user --tag count. `reserved_tag_count`
-    // includes `original_name`/`created_by` because every backend's
-    // `set_secret` stamps those unconditionally regardless of this
-    // pre-check — see its doc comment for why omitting them under-counts
-    // relative to what the real write attaches. `backend_extra_reserved_tags`
-    // covers AWS's additional always/conditionally-written tags that the
-    // universal (Azure-shaped) count above doesn't know about — without
-    // it, a record could pass this pre-check and still blow AWS's 50-tag
-    // cap at the API.
-    let reserved_count =
-        crate::records::reserved_tag_count(
-            true, // xv-type: always present on a record write
-            !meta.group.is_empty(),
-            meta.note.is_some(),
-            meta.folder.is_some(),
-        ) + crate::records::backend_extra_reserved_tags(backend_kind, meta.expires.is_some());
+    // Tag budget: reserved (backend-specific bookkeeping tags this write
+    // will actually cause the active backend's `set_secret` to attach) +
+    // f.* metadata fields + user --tag count. `predicted_reserved_tag_count`
+    // is derived per-backend from what each backend's `set_secret` really
+    // puts on the wire (see its doc comment) — a single universal count
+    // would either under-count (missing a backend-specific tag, letting a
+    // write pass this pre-check and still blow the real cap) or
+    // over-count (assuming a tag every backend doesn't actually write,
+    // falsely rejecting a write that would have succeeded).
+    let reserved_count = crate::records::predicted_reserved_tag_count(
+        backend_kind,
+        true, // xv-type: always present on a record write
+        !meta.group.is_empty(),
+        meta.note.is_some(),
+        meta.folder.is_some(),
+        meta.expires.is_some(),
+    );
     let field_tags: BTreeMap<String, String> = metadata
         .iter()
         .map(|(k, v)| (format!("{FIELD_TAG_PREFIX}{k}"), v.clone()))

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -76,6 +76,23 @@ fn route_fields(
     fields: &[(String, String)],
     secret_fields: &[(String, String)],
 ) -> Result<(BTreeMap<String, String>, BTreeMap<String, String>)> {
+    // Reject the same field name appearing more than once across
+    // --field/--field-secret (or repeated within one flag) before doing
+    // anything else. Two values for one field would otherwise silently
+    // pick a winner depending on kind/insertion order — e.g. `--field
+    // a=1 --field-secret a=2` would store `a` as both an f.* tag AND an
+    // envelope entry, and `get --field a` would only ever see the
+    // envelope one, silently ignoring the tag.
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for (name, _) in fields.iter().chain(secret_fields.iter()) {
+        if !seen.insert(name.as_str()) {
+            return Err(CrosstacheError::config(format!(
+                "field '{name}' was supplied more than once across --field/--field-secret; \
+                 each field may only be set once"
+            )));
+        }
+    }
+
     let mut metadata: BTreeMap<String, String> = BTreeMap::new();
     let mut secret: BTreeMap<String, String> = BTreeMap::new();
 
@@ -223,6 +240,7 @@ async fn build_record_set_request(
     meta: &SecretWriteArgs,
     config: &Config,
     caps: BackendCapabilities,
+    backend_kind: crate::backend::BackendKind,
 ) -> Result<crate::secret::manager::SecretRequest> {
     let types = config.resolve_record_types().await?;
     let Some(record_type) = find_type(&types, type_name) else {
@@ -287,11 +305,22 @@ async fn build_record_set_request(
                 v
             } else if stdin {
                 read_secret_value_from_stdin(trim)?
-            } else {
+            } else if std::io::stdin().is_terminal() {
                 rpassword::prompt_password(format!(
                     "Enter value for '{}' (primary field of '{type_name}'): ",
                     record_type.primary().name
                 ))?
+            } else {
+                // No TTY to prompt on: don't hang scripts/CI waiting on
+                // stdin that will never produce input. Fail before write
+                // with a clear, actionable message instead of an opaque
+                // "empty primary" error further down.
+                return Err(CrosstacheError::config(format!(
+                    "type '{type_name}' requires a value for its primary field \
+                     ('{}'), and no TTY is available to prompt for one; pass \
+                     --value or --stdin",
+                    record_type.primary().name
+                )));
             };
             (metadata, secret_map, primary_value)
         };
@@ -313,17 +342,23 @@ async fn build_record_set_request(
 
     // Tag budget: reserved (xv-type + the two backend-always-written
     // bookkeeping tags + whatever SecretWriteArgs sets — groups/note/folder)
+    // + backend-specific extras (AWS's xv:content_type/xv:expires_at tags)
     // + f.* metadata fields + user --tag count. `reserved_tag_count`
     // includes `original_name`/`created_by` because every backend's
     // `set_secret` stamps those unconditionally regardless of this
     // pre-check — see its doc comment for why omitting them under-counts
-    // relative to what the real write attaches.
-    let reserved_count = crate::records::reserved_tag_count(
-        true, // xv-type: always present on a record write
-        !meta.group.is_empty(),
-        meta.note.is_some(),
-        meta.folder.is_some(),
-    );
+    // relative to what the real write attaches. `backend_extra_reserved_tags`
+    // covers AWS's additional always/conditionally-written tags that the
+    // universal (Azure-shaped) count above doesn't know about — without
+    // it, a record could pass this pre-check and still blow AWS's 50-tag
+    // cap at the API.
+    let reserved_count =
+        crate::records::reserved_tag_count(
+            true, // xv-type: always present on a record write
+            !meta.group.is_empty(),
+            meta.note.is_some(),
+            meta.folder.is_some(),
+        ) + crate::records::backend_extra_reserved_tags(backend_kind, meta.expires.is_some());
     let field_tags: BTreeMap<String, String> = metadata
         .iter()
         .map(|(k, v)| (format!("{FIELD_TAG_PREFIX}{k}"), v.clone()))
@@ -431,6 +466,7 @@ pub(crate) async fn execute_secret_set_direct(
                 &meta,
                 &config,
                 reg.active().capabilities(),
+                reg.active().kind(),
             )
             .await?;
             let props = reg
@@ -5770,6 +5806,27 @@ mod tests {
         let (metadata, secret) = route_fields(&t, &[], &secret_fields).unwrap();
         assert!(metadata.is_empty());
         assert_eq!(secret.get("totp"), Some(&"x".to_string()));
+    }
+
+    #[test]
+    fn route_fields_rejects_duplicate_across_field_and_field_secret() {
+        // Bugbot follow-up: `--field a=1 --field-secret a=2` must not
+        // silently store `a` as both an f.* tag and an envelope entry.
+        let t = login_type();
+        let fields = vec![("custom".to_string(), "1".to_string())];
+        let secret_fields = vec![("custom".to_string(), "2".to_string())];
+        let err = route_fields(&t, &fields, &secret_fields).unwrap_err();
+        assert!(err.to_string().contains("custom"), "{err}");
+    }
+
+    #[test]
+    fn route_fields_rejects_duplicate_within_field_alone() {
+        let t = login_type();
+        let fields = vec![
+            ("custom".to_string(), "1".to_string()),
+            ("custom".to_string(), "2".to_string()),
+        ];
+        assert!(route_fields(&t, &fields, &[]).is_err());
     }
 
     #[test]

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -1,5 +1,6 @@
 //! Secret command execution handlers.
 
+use crate::backend::BackendCapabilities;
 use crate::backend::{BackendKind, BackendRef, BackendRegistry};
 use crate::cli::commands::{CharsetType, SecretWriteArgs, ShareCommands};
 use crate::cli::helpers::{
@@ -9,10 +10,16 @@ use crate::cli::helpers::{
 };
 use crate::config::Config;
 use crate::error::{CrosstacheError, Result};
+use crate::records::{
+    encode_envelope, find_type, FieldDef, FieldKind, RecordType, FIELD_TAG_PREFIX,
+    RECORD_CONTENT_TYPE, TYPE_TAG,
+};
 use crate::secret::manager::SecretManager;
 use crate::utils::format::OutputFormat;
 use crate::utils::output;
 use crate::utils::pagination::Pagination;
+use std::collections::BTreeMap;
+use std::io::IsTerminal;
 use std::sync::Arc;
 use zeroize::Zeroizing;
 
@@ -56,12 +63,284 @@ pub(crate) async fn apply_profile_write_defaults(
     Ok(())
 }
 
+/// Routes user-supplied `--field`/`--field-secret` pairs into metadata-tag
+/// and envelope (secret) maps, per record-types plan Task 6:
+/// - `--field name=value`: uses the type's declared kind when `name` is a
+///   declared field; ad-hoc names default to metadata.
+/// - `--field-secret name=value`: always routes to the envelope
+///   (secret), overriding the type's declared kind if any.
+/// - Either flag targeting the type's primary field is an error — the
+///   primary value only ever arrives via `--value`/`--stdin`/prompt.
+fn route_fields(
+    record_type: &RecordType,
+    fields: &[(String, String)],
+    secret_fields: &[(String, String)],
+) -> Result<(BTreeMap<String, String>, BTreeMap<String, String>)> {
+    let mut metadata: BTreeMap<String, String> = BTreeMap::new();
+    let mut secret: BTreeMap<String, String> = BTreeMap::new();
+
+    for (name, val) in fields {
+        if let Some(def) = record_type.field(name) {
+            if def.primary {
+                return Err(CrosstacheError::invalid_argument(format!(
+                    "field '{name}' is the primary field of type '{}'; set it via --value/--stdin, not --field",
+                    record_type.name
+                )));
+            }
+            match def.kind {
+                FieldKind::Metadata => {
+                    metadata.insert(name.clone(), val.clone());
+                }
+                FieldKind::Secret => {
+                    secret.insert(name.clone(), val.clone());
+                }
+            }
+        } else {
+            metadata.insert(name.clone(), val.clone());
+        }
+    }
+
+    for (name, val) in secret_fields {
+        if let Some(def) = record_type.field(name) {
+            if def.primary {
+                return Err(CrosstacheError::invalid_argument(format!(
+                    "field '{name}' is the primary field of type '{}'; set it via --value/--stdin, not --field-secret",
+                    record_type.name
+                )));
+            }
+        }
+        secret.insert(name.clone(), val.clone());
+    }
+
+    Ok((metadata, secret))
+}
+
+/// Every required field (except the primary, which is always required and
+/// supplied separately) that is missing from both maps, in declared order.
+fn missing_required_fields<'a>(
+    record_type: &'a RecordType,
+    metadata: &BTreeMap<String, String>,
+    secret: &BTreeMap<String, String>,
+) -> Vec<&'a FieldDef> {
+    record_type
+        .fields
+        .iter()
+        .filter(|f| f.required && !f.primary)
+        .filter(|f| !metadata.contains_key(&f.name) && !secret.contains_key(&f.name))
+        .collect()
+}
+
+/// Ordered list of fields still needing a value, primary last. Extracted as
+/// a pure function so the field-ordering rule (primary prompted last) is
+/// unit-testable without a TTY.
+fn prompt_plan<'a>(
+    record_type: &'a RecordType,
+    provided: &BTreeMap<String, String>,
+) -> Vec<&'a FieldDef> {
+    let mut non_primary: Vec<&FieldDef> = record_type
+        .fields
+        .iter()
+        .filter(|f| !f.primary && !provided.contains_key(&f.name))
+        .collect();
+    if let Some(primary) = record_type.fields.iter().find(|f| f.primary) {
+        non_primary.push(primary);
+    }
+    non_primary
+}
+
+/// Interactively prompts for every field in `prompt_plan`, splitting the
+/// results into (metadata, secret, primary_value). Metadata fields accept
+/// an empty answer unless required; secret fields are masked via
+/// `rpassword`. Called only when the caller supplied no `--field`s and no
+/// `--value`/`--stdin` on an interactive TTY.
+/// (metadata fields, secret fields, primary field value)
+type RecordFieldPlan = (BTreeMap<String, String>, BTreeMap<String, String>, String);
+
+fn interactive_prompt_record_fields(
+    record_type: &RecordType,
+    already_provided: &BTreeMap<String, String>,
+) -> Result<RecordFieldPlan> {
+    use crate::utils::interactive::InteractivePrompt;
+
+    let prompt = InteractivePrompt::new();
+    let mut metadata = BTreeMap::new();
+    let mut secret = BTreeMap::new();
+    let mut primary_value = String::new();
+
+    for field in prompt_plan(record_type, already_provided) {
+        match field.kind {
+            FieldKind::Metadata => {
+                let label = if field.required {
+                    format!("{} (required)", field.name)
+                } else {
+                    field.name.clone()
+                };
+                let answer = prompt.input_text(&label, None)?;
+                if field.required && answer.trim().is_empty() {
+                    return Err(CrosstacheError::config(format!(
+                        "field '{}' is required for type '{}'",
+                        field.name, record_type.name
+                    )));
+                }
+                if !answer.is_empty() {
+                    metadata.insert(field.name.clone(), answer);
+                }
+            }
+            FieldKind::Secret => {
+                let answer = rpassword::prompt_password(format!("{}: ", field.name))?;
+                if field.required && answer.is_empty() {
+                    return Err(CrosstacheError::config(format!(
+                        "field '{}' is required for type '{}'",
+                        field.name, record_type.name
+                    )));
+                }
+                if field.primary {
+                    primary_value = answer;
+                } else if !answer.is_empty() {
+                    secret.insert(field.name.clone(), answer);
+                }
+            }
+        }
+    }
+
+    Ok((metadata, secret, primary_value))
+}
+
+/// Builds the `SecretRequest` for `xv set <name> --type <type>`: resolves
+/// the type, routes `--field`/`--field-secret` (or runs the interactive
+/// prompt when none were given and no `--value`/`--stdin`), enforces
+/// required fields, checks the tag budget, and encodes the envelope. Fails
+/// before any backend call on every validation error.
+#[allow(clippy::too_many_arguments)]
+async fn build_record_set_request(
+    name: &str,
+    value: Option<String>,
+    stdin: bool,
+    trim: bool,
+    type_name: &str,
+    fields: &[(String, String)],
+    secret_fields: &[(String, String)],
+    meta: &SecretWriteArgs,
+    config: &Config,
+    caps: BackendCapabilities,
+) -> Result<crate::secret::manager::SecretRequest> {
+    let types = config.resolve_record_types().await?;
+    let Some(record_type) = find_type(&types, type_name) else {
+        let mut known: Vec<&str> = types.iter().map(|t| t.name.as_str()).collect();
+        known.sort_unstable();
+        return Err(CrosstacheError::config(format!(
+            "unknown type '{type_name}'. Known types: {}",
+            known.join(", ")
+        )));
+    };
+
+    let (metadata, mut secret_map, primary_value) =
+        if fields.is_empty() && secret_fields.is_empty() && value.is_none() && !stdin {
+            if std::io::stdin().is_terminal() {
+                interactive_prompt_record_fields(record_type, &BTreeMap::new())?
+            } else {
+                return Err(CrosstacheError::config(format!(
+                    "type '{type_name}' requires field values; pass --value/--stdin for the \
+                     primary field and --field/--field-secret for the rest (no TTY available \
+                     for interactive prompts)"
+                )));
+            }
+        } else {
+            let (metadata, secret_map) = route_fields(record_type, fields, secret_fields)?;
+            let primary_value = if let Some(v) = value {
+                v
+            } else if stdin {
+                read_secret_value_from_stdin(trim)?
+            } else {
+                rpassword::prompt_password(format!(
+                    "Enter value for '{}' (primary field of '{type_name}'): ",
+                    record_type.primary().name
+                ))?
+            };
+            (metadata, secret_map, primary_value)
+        };
+
+    if primary_value.is_empty() {
+        return Err(CrosstacheError::config(
+            "primary field value cannot be empty",
+        ));
+    }
+
+    let missing = missing_required_fields(record_type, &metadata, &secret_map);
+    if !missing.is_empty() {
+        let names: Vec<&str> = missing.iter().map(|f| f.name.as_str()).collect();
+        return Err(CrosstacheError::config(format!(
+            "type '{type_name}' is missing required field(s): {}",
+            names.join(", ")
+        )));
+    }
+
+    // Tag budget: reserved (xv-type, plus whatever SecretWriteArgs sets —
+    // groups/note/folder) + f.* metadata fields + user --tag count.
+    let mut reserved_count = 1; // xv-type
+    if !meta.group.is_empty() {
+        reserved_count += 1;
+    }
+    if meta.note.is_some() {
+        reserved_count += 1;
+    }
+    if meta.folder.is_some() {
+        reserved_count += 1;
+    }
+    let field_tags: BTreeMap<String, String> = metadata
+        .iter()
+        .map(|(k, v)| (format!("{FIELD_TAG_PREFIX}{k}"), v.clone()))
+        .collect();
+    crate::records::check_tag_budget(&caps, reserved_count, &field_tags, meta.tag.len())?;
+
+    // Build the envelope: secret fields + primary.
+    secret_map.insert(record_type.primary().name.clone(), primary_value);
+    let envelope_value = encode_envelope(&secret_map)?;
+
+    // Tags: xv-type + f.* metadata fields + user --tag.
+    let mut tags: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    tags.insert(TYPE_TAG.to_string(), record_type.name.clone());
+    for (k, v) in &field_tags {
+        tags.insert(k.clone(), v.clone());
+    }
+    for (k, v) in &meta.tag {
+        tags.insert(k.clone(), v.clone());
+    }
+    let _ = metadata; // folded into field_tags above; kept for clarity at the call site
+
+    use crate::utils::datetime::parse_datetime_or_duration;
+    let expires_on = match meta.expires.as_deref() {
+        Some(s) => Some(parse_datetime_or_duration(s)?),
+        None => None,
+    };
+    let not_before_on = match meta.not_before.as_deref() {
+        Some(s) => Some(parse_datetime_or_duration(s)?),
+        None => None,
+    };
+
+    Ok(crate::secret::manager::SecretRequest {
+        name: name.to_string(),
+        value: Zeroizing::new(envelope_value),
+        content_type: Some(RECORD_CONTENT_TYPE.to_string()),
+        enabled: Some(true),
+        expires_on,
+        not_before: not_before_on,
+        tags: Some(tags),
+        groups: meta.groups_opt(),
+        note: meta.note.clone(),
+        folder: meta.folder.clone(),
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_secret_set_direct(
     args: Vec<String>,
     stdin: bool,
     trim: bool,
     value: Option<String>,
+    type_name: Option<String>,
+    fields: Vec<(String, String)>,
+    secret_fields: Vec<(String, String)>,
     meta: SecretWriteArgs,
     config: Config,
     registry: Option<&BackendRegistry>,
@@ -83,6 +362,11 @@ pub(crate) async fn execute_secret_set_direct(
             "--value can only be used when setting a single secret (not with KEY=value bulk args)",
         ));
     }
+    if type_name.is_some() && is_bulk {
+        return Err(CrosstacheError::invalid_argument(
+            "--type can only be used when setting a single secret (not with KEY=value bulk args)",
+        ));
+    }
 
     // ── Trait-based path (non-Azure backends) ──────────────────────────
     if use_trait_path(registry) {
@@ -95,7 +379,36 @@ pub(crate) async fn execute_secret_set_direct(
         let mut meta = meta;
         apply_profile_write_defaults(&mut meta, &config).await?;
 
-        if args.len() == 1 && !args[0].contains('=') {
+        if args.len() == 1 && !args[0].contains('=') && type_name.is_some() {
+            // Typed record single-secret set.
+            let name = &args[0];
+            let request = build_record_set_request(
+                name,
+                value.clone(),
+                stdin,
+                trim,
+                type_name.as_deref().expect("checked Some above"),
+                &fields,
+                &secret_fields,
+                &meta,
+                &config,
+                reg.active().capabilities(),
+            )
+            .await?;
+            let props = reg
+                .active()
+                .secrets()
+                .set_secret(&vault_name, request)
+                .await?;
+            output::success(&format!(
+                "Successfully set record '{}' (type: {})",
+                props.original_name,
+                type_name.as_deref().unwrap_or("")
+            ));
+            println!("   Vault: {vault_name}");
+            println!("   Version: {}", props.version);
+            output::hint(&format!("Verify with 'xv get {}'", props.original_name));
+        } else if args.len() == 1 && !args[0].contains('=') {
             // Single secret set
             let name = &args[0];
             let secret_value = if let Some(v) = value.clone() {
@@ -5153,5 +5466,70 @@ mod tests {
             "cache must be invalidated once the in-place update applied, \
              even though the following rename failed"
         );
+    }
+
+    // ── Record-types Task 6 helpers ─────────────────────────────────────
+
+    fn login_type() -> crate::records::RecordType {
+        crate::records::builtin_types()
+            .into_iter()
+            .find(|t| t.name == "login")
+            .unwrap()
+    }
+
+    #[test]
+    fn prompt_plan_orders_non_primary_then_primary_last() {
+        let t = login_type();
+        let plan = prompt_plan(&t, &BTreeMap::new());
+        let names: Vec<&str> = plan.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["username", "url", "password"]);
+        assert!(plan.last().unwrap().primary);
+    }
+
+    #[test]
+    fn prompt_plan_skips_already_provided_fields() {
+        let t = login_type();
+        let mut provided = BTreeMap::new();
+        provided.insert("username".to_string(), "bob".to_string());
+        let plan = prompt_plan(&t, &provided);
+        let names: Vec<&str> = plan.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["url", "password"]);
+    }
+
+    #[test]
+    fn route_fields_declared_metadata_and_adhoc() {
+        let t = login_type();
+        let fields = vec![
+            ("username".to_string(), "bob".to_string()),
+            ("custom".to_string(), "x".to_string()),
+        ];
+        let (metadata, secret) = route_fields(&t, &fields, &[]).unwrap();
+        assert_eq!(metadata.get("username"), Some(&"bob".to_string()));
+        assert_eq!(metadata.get("custom"), Some(&"x".to_string()));
+        assert!(secret.is_empty());
+    }
+
+    #[test]
+    fn route_fields_rejects_primary_via_field() {
+        let t = login_type();
+        let fields = vec![("password".to_string(), "x".to_string())];
+        assert!(route_fields(&t, &fields, &[]).is_err());
+    }
+
+    #[test]
+    fn route_fields_secret_flag_always_goes_to_envelope() {
+        let t = login_type();
+        let secret_fields = vec![("totp".to_string(), "x".to_string())];
+        let (metadata, secret) = route_fields(&t, &[], &secret_fields).unwrap();
+        assert!(metadata.is_empty());
+        assert_eq!(secret.get("totp"), Some(&"x".to_string()));
+    }
+
+    #[test]
+    fn missing_required_fields_reports_absent_username() {
+        let t = login_type();
+        let missing = missing_required_fields(&t, &BTreeMap::new(), &BTreeMap::new());
+        let names: Vec<&str> = missing.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["username"]);
     }
 }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -4284,6 +4284,8 @@ mod tests {
                 max_secret_size: None,
                 max_name_length: None,
                 name_charset: NameCharset::Unrestricted,
+                max_tags: None,
+                max_tag_value_len: None,
             }
         }
 
@@ -5025,6 +5027,8 @@ mod tests {
                 max_secret_size: None,
                 max_name_length: None,
                 name_charset: NameCharset::Unrestricted,
+                max_tags: None,
+                max_tag_value_len: None,
             }
         }
 

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -505,10 +505,61 @@ pub(crate) async fn execute_secret_set_direct(
     ))
 }
 
+/// Parses a record's envelope, failing loud (never returning raw JSON as if
+/// it were a value) when the content type says "record" but the value
+/// isn't a valid envelope.
+fn parse_record_envelope_or_fail(
+    name: &str,
+    content_type: &str,
+    value: &str,
+) -> Result<BTreeMap<String, String>> {
+    crate::records::parse_envelope(value).map_err(|e| {
+        CrosstacheError::config(format!(
+            "secret '{name}' is marked as a record (content-type: {content_type}) but its \
+             value is not a valid record envelope: {e}"
+        ))
+    })
+}
+
+/// All field names a record exposes: envelope keys (secret fields) union
+/// `f.*` tag names (metadata fields), for "unknown field" error messages.
+fn record_field_names(
+    envelope: &BTreeMap<String, String>,
+    tags: &std::collections::HashMap<String, String>,
+) -> Vec<String> {
+    let mut names: Vec<String> = envelope.keys().cloned().collect();
+    for key in tags.keys() {
+        if let Some(field) = key.strip_prefix(FIELD_TAG_PREFIX) {
+            names.push(field.to_string());
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// Looks up one field's value: envelope (secret fields) first, then the
+/// `f.<name>` tag (metadata fields).
+fn lookup_record_field<'a>(
+    field: &str,
+    envelope: &'a BTreeMap<String, String>,
+    tags: &'a std::collections::HashMap<String, String>,
+) -> Option<&'a str> {
+    if let Some(v) = envelope.get(field) {
+        return Some(v.as_str());
+    }
+    tags.get(&format!("{FIELD_TAG_PREFIX}{field}"))
+        .map(|s| s.as_str())
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_secret_get_direct(
     name: &str,
     raw: bool,
     version: Option<String>,
+    field: Option<String>,
+    record: bool,
+    format: OutputFormat,
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
@@ -529,11 +580,123 @@ pub(crate) async fn execute_secret_get_direct(
                 .await?
         };
 
+        let is_rec = crate::records::is_record(&secret.content_type);
+
+        // ── `--record`: full record view, all fields, requested format ──
+        if record {
+            if !is_rec {
+                return Err(CrosstacheError::config(format!(
+                    "secret '{name}' is not a record (has no {} tag); --record only applies to \
+                     typed records",
+                    crate::records::TYPE_TAG
+                )));
+            }
+            let value = secret.value.as_deref().map(|s| s.as_str()).unwrap_or("");
+            let envelope = parse_record_envelope_or_fail(name, &secret.content_type, value)?;
+            let mut all_fields: std::collections::BTreeMap<String, String> = envelope.clone();
+            for (k, v) in &secret.tags {
+                if let Some(f) = k.strip_prefix(FIELD_TAG_PREFIX) {
+                    all_fields.insert(f.to_string(), v.clone());
+                }
+            }
+            let type_name = secret.tags.get(TYPE_TAG).cloned().unwrap_or_default();
+            let resolved = format.resolve_for_stdout();
+            let body = serde_json::json!({
+                "name": name,
+                "type": type_name,
+                "fields": all_fields,
+            });
+            match resolved {
+                OutputFormat::Json => println!(
+                    "{}",
+                    serde_json::to_string_pretty(&body).map_err(|e| {
+                        CrosstacheError::serialization(format!("JSON serialization failed: {e}"))
+                    })?
+                ),
+                OutputFormat::Yaml => println!(
+                    "{}",
+                    serde_yaml::to_string(&body).map_err(|e| {
+                        CrosstacheError::serialization(format!("YAML serialization failed: {e}"))
+                    })?
+                ),
+                _ => {
+                    println!("{name}  (type: {type_name})");
+                    for (k, v) in &all_fields {
+                        println!("  {k}: {v}");
+                    }
+                }
+            }
+            return Ok(());
+        }
+
+        // ── `--field NAME`: one field, either kind ──
+        if let Some(field_name) = field {
+            if !is_rec {
+                return Err(CrosstacheError::config(format!(
+                    "secret '{name}' is not a record (has no {} tag); --field only applies to \
+                     typed records",
+                    crate::records::TYPE_TAG
+                )));
+            }
+            let value = secret.value.as_deref().map(|s| s.as_str()).unwrap_or("");
+            let envelope = parse_record_envelope_or_fail(name, &secret.content_type, value)?;
+            let Some(field_value) = lookup_record_field(&field_name, &envelope, &secret.tags)
+            else {
+                let known = record_field_names(&envelope, &secret.tags);
+                return Err(CrosstacheError::config(format!(
+                    "secret '{name}' has no field '{field_name}'. Known fields: {}",
+                    known.join(", ")
+                )));
+            };
+            if raw {
+                print!("{field_value}");
+            } else {
+                match copy_to_clipboard(field_value) {
+                    Ok(()) => output::success(&format!(
+                        "Field '{field_name}' of '{name}' copied to clipboard"
+                    )),
+                    Err(e) => {
+                        output::warn(&format!("Failed to copy to clipboard: {e}"));
+                        eprintln!(
+                            "Use 'xv get {name} --field {field_name} --raw' to print the value to stdout instead."
+                        );
+                    }
+                }
+            }
+            return Ok(());
+        }
+
+        // ── Plain `get`: primary field for records, untouched for untyped ──
+        let effective_value: Option<Zeroizing<String>> = if is_rec {
+            let value = secret.value.as_deref().map(|s| s.as_str()).unwrap_or("");
+            let envelope = parse_record_envelope_or_fail(name, &secret.content_type, value)?;
+
+            let type_name = secret.tags.get(TYPE_TAG).cloned().unwrap_or_default();
+            let types = config.resolve_record_types().await?;
+            let Some(record_type) = crate::records::find_type(&types, &type_name) else {
+                return Err(CrosstacheError::config(format!(
+                    "secret '{name}' has type '{type_name}', which has no resolvable type \
+                     definition (check your [types.*] config). Its primary field can't be \
+                     determined; use --field or --record to access this record's raw fields."
+                )));
+            };
+            let primary_name = &record_type.primary().name;
+            let Some(primary_value) = envelope.get(primary_name) else {
+                return Err(CrosstacheError::config(format!(
+                    "secret '{name}' is missing its primary field '{primary_name}' in the record \
+                     envelope"
+                )));
+            };
+            Some(Zeroizing::new(primary_value.clone()))
+        } else {
+            secret.value
+        };
+
         if raw {
-            if let Some(value) = secret.value {
+            if let Some(value) = effective_value {
                 print!("{}", value.as_str());
             }
-        } else if let Some(ref value) = secret.value {
+        } else if let Some(ref value) = effective_value {
             match copy_to_clipboard(value) {
                 Ok(()) => {
                     let timeout = config.clipboard_timeout;

--- a/src/cli/type_ops.rs
+++ b/src/cli/type_ops.rs
@@ -1,0 +1,156 @@
+//! Record-type command handlers (`xv type ...`). Config-only: never talks
+//! to a secrets backend.
+
+use crate::cli::commands::TypeCommands;
+use crate::config::Config;
+use crate::error::{CrosstacheError, Result};
+use crate::records::RecordType;
+use crate::utils::format::OutputFormat;
+
+pub(crate) async fn execute_type_command(command: TypeCommands, config: Config) -> Result<()> {
+    let format = config.runtime_output_format;
+    match command {
+        TypeCommands::List => execute_type_list(config, format).await,
+        TypeCommands::Show { name } => execute_type_show(config, name, format).await,
+    }
+}
+
+/// Renders one field's compact table cell: `username*` for required,
+/// `[password]` for secret, `[password]•` for primary (secret + required).
+fn render_field(field: &crate::records::FieldDef) -> String {
+    let mut s = String::new();
+    if field.kind == crate::records::FieldKind::Secret {
+        s.push('[');
+        s.push_str(&field.name);
+        s.push(']');
+    } else {
+        s.push_str(&field.name);
+    }
+    if field.required {
+        s.push('*');
+    }
+    if field.primary {
+        s.push('•');
+    }
+    s
+}
+
+fn render_fields(record_type: &RecordType) -> String {
+    record_type
+        .fields
+        .iter()
+        .map(render_field)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[derive(Debug, Clone, serde::Serialize, tabled::Tabled)]
+struct TypeListRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "SOURCE")]
+    source: String,
+    #[tabled(rename = "FIELDS")]
+    fields: String,
+}
+
+pub(crate) async fn execute_type_list(config: Config, format: OutputFormat) -> Result<()> {
+    use crate::utils::format::TableFormatter;
+
+    let mut types = config.resolve_record_types().await?;
+    types.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let resolved = format.resolve_for_stdout();
+    if resolved == OutputFormat::Json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&types).map_err(|e| CrosstacheError::serialization(
+                format!("JSON serialization failed: {e}")
+            ))?
+        );
+        return Ok(());
+    }
+    if resolved == OutputFormat::Yaml {
+        println!(
+            "{}",
+            serde_yaml::to_string(&types).map_err(|e| CrosstacheError::serialization(format!(
+                "YAML serialization failed: {e}"
+            )))?
+        );
+        return Ok(());
+    }
+
+    let rows: Vec<TypeListRow> = types
+        .iter()
+        .map(|t| TypeListRow {
+            name: t.name.clone(),
+            source: t.source.to_string(),
+            fields: render_fields(t),
+        })
+        .collect();
+
+    let formatter = TableFormatter::new(
+        format,
+        config.no_color,
+        config.template.clone(),
+        config.runtime_columns.clone(),
+    );
+    println!("{}", formatter.format_table(&rows)?);
+    Ok(())
+}
+
+pub(crate) async fn execute_type_show(
+    config: Config,
+    name: String,
+    format: OutputFormat,
+) -> Result<()> {
+    let types = config.resolve_record_types().await?;
+    let Some(record_type) = crate::records::find_type(&types, &name) else {
+        let mut known: Vec<&str> = types.iter().map(|t| t.name.as_str()).collect();
+        known.sort_unstable();
+        return Err(CrosstacheError::config(format!(
+            "unknown type '{name}'. Known types: {}",
+            known.join(", ")
+        )));
+    };
+
+    let resolved = format.resolve_for_stdout();
+    if resolved == OutputFormat::Json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(record_type).map_err(|e| {
+                CrosstacheError::serialization(format!("JSON serialization failed: {e}"))
+            })?
+        );
+        return Ok(());
+    }
+    if resolved == OutputFormat::Yaml {
+        println!(
+            "{}",
+            serde_yaml::to_string(record_type).map_err(|e| CrosstacheError::serialization(
+                format!("YAML serialization failed: {e}")
+            ))?
+        );
+        return Ok(());
+    }
+
+    println!("{}  ({})", record_type.name, record_type.source);
+    println!(
+        "{:<20} {:<10} {:<10} {:<10}",
+        "FIELD", "KIND", "REQUIRED", "PRIMARY"
+    );
+    for field in &record_type.fields {
+        let kind = match field.kind {
+            crate::records::FieldKind::Metadata => "metadata",
+            crate::records::FieldKind::Secret => "secret",
+        };
+        println!(
+            "{:<20} {:<10} {:<10} {:<10}",
+            field.name,
+            kind,
+            if field.required { "yes" } else { "no" },
+            if field.primary { "yes" } else { "no" },
+        );
+    }
+    Ok(())
+}

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -243,6 +243,7 @@ impl ConfigInitializer {
             cli_backend: None,
             cli_backend_was_arg: false,
             disk_backend: None,
+            types: std::collections::HashMap::new(),
         };
 
         self.save_config(&config).await?;
@@ -326,6 +327,7 @@ impl ConfigInitializer {
             cli_backend: None,
             cli_backend_was_arg: false,
             disk_backend: None,
+            types: std::collections::HashMap::new(),
         };
 
         self.save_config(&config).await?;
@@ -1088,6 +1090,7 @@ impl ConfigInitializer {
             cli_backend: None,
             cli_backend_was_arg: false,
             disk_backend: None,
+            types: std::collections::HashMap::new(),
         })
     }
 

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -34,6 +34,12 @@ pub struct ProjectConfig {
     /// Optional scanner configuration for leak detection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scan: Option<ScanConfig>,
+
+    /// Custom record types declared as `[types.<name>]` blocks, overriding
+    /// global config / built-in types of the same name. See
+    /// `crate::records::resolve_types`.
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub types: std::collections::HashMap<String, crate::records::RecordTypeConfig>,
 }
 
 /// One environment's defaults. All fields optional; a missing field
@@ -481,6 +487,7 @@ resource_group = "rg"
             default_env: default_env.map(String::from),
             envs: envs_map,
             scan: None,
+            types: std::collections::HashMap::new(),
         }
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -283,6 +283,13 @@ pub struct Config {
     #[serde(skip)]
     #[tabled(skip)]
     pub disk_backend: Option<String>,
+
+    /// Custom record types declared as `[types.<name>]` blocks. Merged with
+    /// built-in types and any `.xv.toml` project-level types via
+    /// `records::resolve_types` (project overrides global overrides builtin).
+    #[tabled(skip)]
+    #[serde(default)]
+    pub types: std::collections::HashMap<String, crate::records::RecordTypeConfig>,
 }
 
 fn default_clipboard_timeout() -> u64 {
@@ -326,6 +333,7 @@ impl Default for Config {
             cli_backend: None,
             cli_backend_was_arg: false,
             disk_backend: None,
+            types: std::collections::HashMap::new(),
         }
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -413,6 +413,24 @@ impl Config {
         self.backend.as_deref().unwrap_or("azure")
     }
 
+    /// Resolve the effective set of record types: built-ins merged with
+    /// this config's `[types.*]` blocks and (if present) the project
+    /// `.xv.toml`'s `[types.*]` blocks, with precedence project > global >
+    /// builtin. Same project-config discovery walk as `resolve_group`.
+    pub async fn resolve_record_types(&self) -> Result<Vec<crate::records::RecordType>> {
+        use crate::config::project;
+
+        let project_types = {
+            let cwd = std::env::current_dir()?;
+            match project::find_project_config(&cwd).await {
+                Ok(Some((_, cfg))) => cfg.types,
+                _ => std::collections::HashMap::new(),
+            }
+        };
+
+        crate::records::resolve_types(&self.types, &project_types)
+    }
+
     /// Resolve vault name with context awareness
     /// Priority: CLI argument > .xv.toml env profile > context > config default
     pub async fn resolve_vault_name(&self, vault_arg: Option<String>) -> Result<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod cache;
 pub mod cli;
 pub mod config;
 pub mod error;
+pub mod records;
 pub mod scan;
 pub mod secret;
 #[cfg(feature = "tui")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,6 +218,7 @@ Rebuild with `cargo build --features aws` or install an AWS-enabled binary.",
             | crate::cli::Commands::Parse { .. }
             | crate::cli::Commands::Cache { .. }
             | crate::cli::Commands::Local { .. }
+            | crate::cli::Commands::Type { .. }
             | crate::cli::Commands::Context { .. }
             // Env subcommands that only read/write `.xv.toml` need no backend.
             // `env pull` / `env push` DO talk to the active backend, so they are

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod cache;
 mod cli;
 mod config;
 mod error;
+mod records;
 mod scan;
 mod secret;
 #[cfg(feature = "tui")]

--- a/src/records/envelope.rs
+++ b/src/records/envelope.rs
@@ -1,0 +1,104 @@
+//! JSON envelope codec for record secret-kind fields, plus the reserved
+//! tag/content-type constants that mark a secret as a record.
+
+use crate::error::{CrosstacheError, Result};
+use std::collections::BTreeMap;
+
+/// Content type marker that decides record-ness. Never inferred by JSON
+/// sniffing — only an exact content-type match makes a secret a record.
+pub const RECORD_CONTENT_TYPE: &str = "application/vnd.xv.record";
+
+/// Reserved tag holding the record's type name.
+pub const TYPE_TAG: &str = "xv-type";
+
+/// Prefix for metadata-field tags, e.g. `f.username`.
+pub const FIELD_TAG_PREFIX: &str = "f.";
+
+/// Encodes secret-kind fields as a deterministic JSON object (sorted keys,
+/// via `BTreeMap`'s iteration order).
+pub fn encode_envelope(fields: &BTreeMap<String, String>) -> Result<String> {
+    serde_json::to_string(fields)
+        .map_err(|e| CrosstacheError::config(format!("failed to encode record envelope: {e}")))
+}
+
+/// Parses a record envelope. Strict: the value must be a JSON object whose
+/// values are all strings.
+pub fn parse_envelope(value: &str) -> Result<BTreeMap<String, String>> {
+    let parsed: serde_json::Value = serde_json::from_str(value).map_err(|e| {
+        CrosstacheError::config(format!(
+            "record envelope is not a JSON object of strings: {e}"
+        ))
+    })?;
+
+    let obj = parsed.as_object().ok_or_else(|| {
+        CrosstacheError::config("record envelope is not a JSON object of strings".to_string())
+    })?;
+
+    let mut fields = BTreeMap::new();
+    for (key, val) in obj {
+        let s = val.as_str().ok_or_else(|| {
+            CrosstacheError::config(format!(
+                "record envelope is not a JSON object of strings: field '{key}' is not a string"
+            ))
+        })?;
+        fields.insert(key.clone(), s.to_string());
+    }
+
+    Ok(fields)
+}
+
+/// Returns true iff `content_type` exactly matches [`RECORD_CONTENT_TYPE`].
+pub fn is_record(content_type: &str) -> bool {
+    content_type == RECORD_CONTENT_TYPE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_preserves_fields() {
+        let mut fields = BTreeMap::new();
+        fields.insert("password".to_string(), "hunter2".to_string());
+        fields.insert(
+            "connection-string".to_string(),
+            "postgres://...".to_string(),
+        );
+
+        let encoded = encode_envelope(&fields).unwrap();
+        let decoded = parse_envelope(&encoded).unwrap();
+        assert_eq!(decoded, fields);
+    }
+
+    #[test]
+    fn parse_rejects_non_object() {
+        assert!(parse_envelope("[1,2]").is_err());
+        assert!(parse_envelope("\"str\"").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_non_string_values() {
+        assert!(parse_envelope(r#"{"a":1}"#).is_err());
+    }
+
+    #[test]
+    fn is_record_matches_exactly() {
+        assert!(is_record("application/vnd.xv.record"));
+        assert!(!is_record("application/json"));
+        assert!(!is_record(""));
+        assert!(!is_record("text/plain"));
+    }
+
+    #[test]
+    fn encode_is_deterministic() {
+        let mut a = BTreeMap::new();
+        a.insert("b".to_string(), "2".to_string());
+        a.insert("a".to_string(), "1".to_string());
+
+        let mut b = BTreeMap::new();
+        b.insert("a".to_string(), "1".to_string());
+        b.insert("b".to_string(), "2".to_string());
+
+        assert_eq!(encode_envelope(&a).unwrap(), encode_envelope(&b).unwrap());
+    }
+}

--- a/src/records/envelope.rs
+++ b/src/records/envelope.rs
@@ -1,5 +1,11 @@
 //! JSON envelope codec for record secret-kind fields, plus the reserved
 //! tag/content-type constants that mark a secret as a record.
+//!
+//! Consumed by the `xv set --type` / `xv get --field`/`--record` CLI
+//! wiring added later in Phase A (record-types plan Tasks 6/7); until
+//! that wiring lands, this module's public API is unused from the `xv`
+//! binary target, hence the crate-wide `#[allow(dead_code)]` below.
+#![allow(dead_code)]
 
 use crate::error::{CrosstacheError, Result};
 use std::collections::BTreeMap;

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -1,0 +1,14 @@
+//! Record types: structured secrets with typed fields.
+//!
+//! See `docs/superpowers/specs/2026-07-03-record-types-design.md` for the
+//! design. This module owns type definitions/resolution (`types`) and the
+//! JSON envelope codec (`envelope`) used to store secret-kind fields in the
+//! backend secret value.
+
+pub mod envelope;
+pub mod types;
+
+pub use envelope::{
+    encode_envelope, is_record, parse_envelope, FIELD_TAG_PREFIX, RECORD_CONTENT_TYPE, TYPE_TAG,
+};
+pub use types::{builtin_types, FieldDef, FieldKind, RecordType, TypeSource};

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -115,6 +115,30 @@ pub fn reserved_tag_count(
     count
 }
 
+/// Extra reserved tag slots consumed by backend-specific bookkeeping that
+/// [`reserved_tag_count`]'s universal (Azure-shaped) count doesn't cover.
+///
+/// AWS's `set_secret` (`src/backend/aws/secrets.rs`) always tags
+/// `xv:content_type` whenever the request carries a content type — which
+/// every record write does (`RECORD_CONTENT_TYPE`) — and additionally
+/// tags `xv:expires_at` whenever an expiry is set. Neither Azure (content
+/// type lives on the secret object, not a tag) nor the local backend
+/// (unbounded tags) spend a slot on these, so this returns `0` for any
+/// `backend_kind` other than `Aws`.
+pub fn backend_extra_reserved_tags(
+    backend_kind: crate::backend::BackendKind,
+    has_expiry: bool,
+) -> usize {
+    match backend_kind {
+        crate::backend::BackendKind::Aws => {
+            // xv:content_type, always present on a record write, + xv:expires_at
+            // when an expiry is set.
+            1 + usize::from(has_expiry)
+        }
+        crate::backend::BackendKind::Azure | crate::backend::BackendKind::Local => 0,
+    }
+}
+
 #[cfg(test)]
 mod tag_budget_tests {
     use super::*;
@@ -247,5 +271,64 @@ mod tag_budget_tests {
         fields_16.insert("field11".to_string(), "v".to_string());
         let err = check_tag_budget(&c, reserved, &fields_16, &BTreeMap::new()).unwrap_err();
         assert!(err.to_string().contains("16"), "{err}");
+    }
+
+    #[test]
+    fn backend_extra_reserved_tags_is_zero_for_azure_and_local() {
+        assert_eq!(
+            backend_extra_reserved_tags(crate::backend::BackendKind::Azure, true),
+            0
+        );
+        assert_eq!(
+            backend_extra_reserved_tags(crate::backend::BackendKind::Local, true),
+            0
+        );
+    }
+
+    #[test]
+    fn backend_extra_reserved_tags_counts_aws_content_type_and_expiry() {
+        // xv:content_type only (no expiry set).
+        assert_eq!(
+            backend_extra_reserved_tags(crate::backend::BackendKind::Aws, false),
+            1
+        );
+        // xv:content_type + xv:expires_at.
+        assert_eq!(
+            backend_extra_reserved_tags(crate::backend::BackendKind::Aws, true),
+            2
+        );
+    }
+
+    /// AWS's real boundary (max_tags = 50): reserved_tag_count() alone
+    /// (Azure-shaped) doesn't know about AWS's always-written
+    /// xv:content_type tag or its conditional xv:expires_at tag, so a
+    /// record write with an expiry set could pass the pre-check and still
+    /// blow AWS's real 50-tag cap at the API without
+    /// backend_extra_reserved_tags folded in. Reproduces that boundary:
+    /// with the extra reserved tags counted, a 50-tag-total record passes
+    /// and a 51-tag-total fails before write.
+    #[test]
+    fn budget_boundary_at_aws_max_tags_counts_content_type_and_expiry() {
+        let c = caps(Some(50), Some(256));
+
+        // Universal reserved: xv-type + original_name + created_by + groups = 4.
+        // AWS extras: xv:content_type (always) + xv:expires_at (expiry set) = 2.
+        let reserved = reserved_tag_count(true, true, false, false)
+            + backend_extra_reserved_tags(crate::backend::BackendKind::Aws, true);
+        assert_eq!(reserved, 6);
+
+        // 6 reserved + 44 f.* fields = 50 total on the wire. Must pass.
+        let mut fields_50 = BTreeMap::new();
+        for i in 0..44 {
+            fields_50.insert(format!("field{i}"), "v".to_string());
+        }
+        assert!(check_tag_budget(&c, reserved, &fields_50, &BTreeMap::new()).is_ok());
+
+        // One more f.* field pushes the real wire total to 51. Must fail
+        // before write.
+        let mut fields_51 = fields_50.clone();
+        fields_51.insert("field44".to_string(), "v".to_string());
+        let err = check_tag_budget(&c, reserved, &fields_51, &BTreeMap::new()).unwrap_err();
+        assert!(err.to_string().contains("51"), "{err}");
     }
 }

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -19,3 +19,120 @@ pub use types::{
     builtin_types, find_type, resolve_types, FieldDef, FieldDefConfig, FieldKind, RecordType,
     RecordTypeConfig, TypeSource,
 };
+
+use crate::backend::BackendCapabilities;
+use crate::error::{CrosstacheError, Result};
+use std::collections::BTreeMap;
+
+/// Checks that a record write stays within the active backend's tag
+/// budget, failing *before* any backend call.
+///
+/// `reserved_count` is the number of reserved bookkeeping tags actually
+/// present on this write (`xv-type`, `groups`, `note`, `folder`,
+/// `original_name`, `created_by`); `field_tags` are the record's `f.*`
+/// metadata-field tags; `user_tag_count` is the count of additional
+/// user-supplied tags. A backend with `max_tags = None` (unbounded) never
+/// errors on count. Each `field_tags` value is also checked against
+/// `max_tag_value_len` (when set) independently of the count check.
+#[allow(dead_code)] // consumed by `xv set --type` / `xv update --field` (Tasks 6/8)
+pub fn check_tag_budget(
+    caps: &BackendCapabilities,
+    reserved_count: usize,
+    field_tags: &BTreeMap<String, String>,
+    user_tag_count: usize,
+) -> Result<()> {
+    if let Some(max_len) = caps.max_tag_value_len {
+        for (field, value) in field_tags {
+            if value.len() > max_len {
+                return Err(CrosstacheError::config(format!(
+                    "field '{field}' value is {} characters, exceeding the backend's {max_len}-character \
+                     tag value limit. Consider declaring it kind = \"secret\" instead of metadata.",
+                    value.len()
+                )));
+            }
+        }
+    }
+
+    if let Some(max_tags) = caps.max_tags {
+        let field_count = field_tags.len();
+        let total = reserved_count + field_count + user_tag_count;
+        if total > max_tags {
+            return Err(CrosstacheError::config(format!(
+                "record would use {total} tags, exceeding the backend's {max_tags}-tag limit \
+                 (reserved: {reserved_count}, fields: {field_count}, user: {user_tag_count}). \
+                 Reduce the number of metadata fields or user tags, or move a field to kind = \"secret\"."
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tag_budget_tests {
+    use super::*;
+    use crate::backend::NameCharset;
+
+    fn caps(max_tags: Option<usize>, max_tag_value_len: Option<usize>) -> BackendCapabilities {
+        BackendCapabilities {
+            has_vaults: true,
+            has_file_storage: false,
+            has_rbac: false,
+            has_audit: false,
+            has_versioning: false,
+            has_soft_delete: false,
+            has_secret_rotation: false,
+            has_groups: true,
+            has_folders: true,
+            has_notes: true,
+            has_expiry: true,
+            max_secret_size: None,
+            max_name_length: None,
+            name_charset: NameCharset::Unrestricted,
+            max_tags,
+            max_tag_value_len,
+        }
+    }
+
+    #[test]
+    fn budget_ok_under_cap() {
+        let c = caps(Some(15), Some(256));
+        let mut fields = BTreeMap::new();
+        fields.insert("username".to_string(), "bob".to_string());
+        assert!(check_tag_budget(&c, 2, &fields, 1).is_ok());
+    }
+
+    #[test]
+    fn budget_errors_over_cap_with_breakdown() {
+        let c = caps(Some(3), Some(256));
+        let mut fields = BTreeMap::new();
+        fields.insert("a".to_string(), "1".to_string());
+        fields.insert("b".to_string(), "2".to_string());
+        let err = check_tag_budget(&c, 2, &fields, 1).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("reserved"), "{msg}");
+        assert!(msg.contains("fields"), "{msg}");
+        assert!(msg.contains("user"), "{msg}");
+    }
+
+    #[test]
+    fn budget_errors_on_long_tag_value() {
+        let c = caps(Some(15), Some(4));
+        let mut fields = BTreeMap::new();
+        fields.insert("username".to_string(), "toolong".to_string());
+        let err = check_tag_budget(&c, 1, &fields, 0).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("username"), "{msg}");
+        assert!(msg.contains("kind = \"secret\""), "{msg}");
+    }
+
+    #[test]
+    fn no_caps_never_errors() {
+        let c = caps(None, None);
+        let mut fields = BTreeMap::new();
+        for i in 0..100 {
+            fields.insert(format!("field{i}"), "x".repeat(10_000));
+        }
+        assert!(check_tag_budget(&c, 100, &fields, 100).is_ok());
+    }
+}

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -68,6 +68,39 @@ pub fn check_tag_budget(
     Ok(())
 }
 
+/// Computes `reserved_count` for [`check_tag_budget`]: the number of
+/// reserved bookkeeping tags a record write actually consumes.
+///
+/// This always includes `crate::backend::ALWAYS_WRITTEN_TAGS` (currently
+/// `original_name` + `created_by`) — every backend `set_secret` write
+/// stamps these unconditionally regardless of what the caller requests, so
+/// a pre-check that omits them can pass here and still be rejected by the
+/// backend as over budget (undercounting defeats fail-before-write right
+/// at the boundary). `has_type` adds one more for the reserved `xv-type`
+/// tag (always present on a record write); `has_groups`/`has_note`/
+/// `has_folder` are conditional on whether this specific write sets them.
+pub fn reserved_tag_count(
+    has_type: bool,
+    has_groups: bool,
+    has_note: bool,
+    has_folder: bool,
+) -> usize {
+    let mut count = crate::backend::ALWAYS_WRITTEN_TAGS.len();
+    if has_type {
+        count += 1;
+    }
+    if has_groups {
+        count += 1;
+    }
+    if has_note {
+        count += 1;
+    }
+    if has_folder {
+        count += 1;
+    }
+    count
+}
+
 #[cfg(test)]
 mod tag_budget_tests {
     use super::*;
@@ -134,5 +167,44 @@ mod tag_budget_tests {
             fields.insert(format!("field{i}"), "x".repeat(10_000));
         }
         assert!(check_tag_budget(&c, 100, &fields, 100).is_ok());
+    }
+
+    #[test]
+    fn reserved_tag_count_includes_always_written_bookkeeping_tags() {
+        // xv-type + original_name + created_by, no groups/note/folder.
+        assert_eq!(reserved_tag_count(true, false, false, false), 3);
+        // All optional bookkeeping tags present too.
+        assert_eq!(reserved_tag_count(true, true, true, true), 6);
+        // Even with has_type = false, the two always-written tags still count.
+        assert_eq!(reserved_tag_count(false, false, false, false), 2);
+    }
+
+    /// Azure's real boundary (max_tags = 15): reserved_tag_count must
+    /// include original_name + created_by so a record that would total
+    /// exactly 15 tags on the wire passes, and one that would total 16
+    /// fails *before* any backend call — reproducing the under-count bug
+    /// where the old ad-hoc `reserved_count` computation (missing
+    /// original_name/created_by) let a request through that Azure's real
+    /// REST call would then reject.
+    #[test]
+    fn budget_boundary_at_azure_max_tags_matches_real_write() {
+        let c = caps(Some(15), Some(256));
+
+        // xv-type + original_name + created_by + groups = 4 reserved,
+        // plus 11 f.* metadata field tags = 15 total on the wire. Must pass.
+        let reserved = reserved_tag_count(true, true, false, false);
+        assert_eq!(reserved, 4);
+        let mut fields_15 = BTreeMap::new();
+        for i in 0..11 {
+            fields_15.insert(format!("field{i}"), "v".to_string());
+        }
+        assert!(check_tag_budget(&c, reserved, &fields_15, 0).is_ok());
+
+        // One more f.* field pushes the real wire total to 16. Must fail
+        // before write.
+        let mut fields_16 = fields_15.clone();
+        fields_16.insert("field11".to_string(), "v".to_string());
+        let err = check_tag_budget(&c, reserved, &fields_16, 0).unwrap_err();
+        assert!(err.to_string().contains("16"), "{err}");
     }
 }

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -30,16 +30,20 @@ use std::collections::BTreeMap;
 /// `reserved_count` is the number of reserved bookkeeping tags actually
 /// present on this write (`xv-type`, `groups`, `note`, `folder`,
 /// `original_name`, `created_by`); `field_tags` are the record's `f.*`
-/// metadata-field tags; `user_tag_count` is the count of additional
-/// user-supplied tags. A backend with `max_tags = None` (unbounded) never
-/// errors on count. Each `field_tags` value is also checked against
-/// `max_tag_value_len` (when set) independently of the count check.
+/// metadata-field tags; `user_tags` are additional user-supplied
+/// (`--tag`) tags. A backend with `max_tags = None` (unbounded) never
+/// errors on count. Both `field_tags` and `user_tags` values are checked
+/// against `max_tag_value_len` (when set) independently of the count
+/// check — a user tag is exactly as capable of exceeding the backend's
+/// per-value limit as a metadata field is, so skipping it here would let
+/// an oversized `--tag` pass this pre-check and fail at the backend,
+/// contradicting fail-before-write.
 #[allow(dead_code)] // consumed by `xv set --type` / `xv update --field` (Tasks 6/8)
 pub fn check_tag_budget(
     caps: &BackendCapabilities,
     reserved_count: usize,
     field_tags: &BTreeMap<String, String>,
-    user_tag_count: usize,
+    user_tags: &BTreeMap<String, String>,
 ) -> Result<()> {
     if let Some(max_len) = caps.max_tag_value_len {
         for (field, value) in field_tags {
@@ -51,10 +55,20 @@ pub fn check_tag_budget(
                 )));
             }
         }
+        for (tag, value) in user_tags {
+            if value.len() > max_len {
+                return Err(CrosstacheError::config(format!(
+                    "--tag '{tag}' value is {} characters, exceeding the backend's {max_len}-character \
+                     tag value limit.",
+                    value.len()
+                )));
+            }
+        }
     }
 
     if let Some(max_tags) = caps.max_tags {
         let field_count = field_tags.len();
+        let user_tag_count = user_tags.len();
         let total = reserved_count + field_count + user_tag_count;
         if total > max_tags {
             return Err(CrosstacheError::config(format!(
@@ -127,12 +141,20 @@ mod tag_budget_tests {
         }
     }
 
+    /// `n` dummy user tags with short values, for tests that only care
+    /// about the *count* toward the tag budget.
+    fn user_tags(n: usize) -> BTreeMap<String, String> {
+        (0..n)
+            .map(|i| (format!("user{i}"), "v".to_string()))
+            .collect()
+    }
+
     #[test]
     fn budget_ok_under_cap() {
         let c = caps(Some(15), Some(256));
         let mut fields = BTreeMap::new();
         fields.insert("username".to_string(), "bob".to_string());
-        assert!(check_tag_budget(&c, 2, &fields, 1).is_ok());
+        assert!(check_tag_budget(&c, 2, &fields, &user_tags(1)).is_ok());
     }
 
     #[test]
@@ -141,7 +163,7 @@ mod tag_budget_tests {
         let mut fields = BTreeMap::new();
         fields.insert("a".to_string(), "1".to_string());
         fields.insert("b".to_string(), "2".to_string());
-        let err = check_tag_budget(&c, 2, &fields, 1).unwrap_err();
+        let err = check_tag_budget(&c, 2, &fields, &user_tags(1)).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("reserved"), "{msg}");
         assert!(msg.contains("fields"), "{msg}");
@@ -153,10 +175,29 @@ mod tag_budget_tests {
         let c = caps(Some(15), Some(4));
         let mut fields = BTreeMap::new();
         fields.insert("username".to_string(), "toolong".to_string());
-        let err = check_tag_budget(&c, 1, &fields, 0).unwrap_err();
+        let err = check_tag_budget(&c, 1, &fields, &BTreeMap::new()).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("username"), "{msg}");
         assert!(msg.contains("kind = \"secret\""), "{msg}");
+    }
+
+    #[test]
+    fn budget_errors_on_long_user_tag_value() {
+        // Azure's real per-value cap (256 chars): a 257-char user --tag
+        // value must fail before write, naming the offending tag key; a
+        // 256-char value must pass.
+        let c = caps(Some(15), Some(256));
+
+        let mut over = BTreeMap::new();
+        over.insert("owner".to_string(), "x".repeat(257));
+        let err = check_tag_budget(&c, 1, &BTreeMap::new(), &over).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("owner"), "{msg}");
+        assert!(msg.contains("257"), "{msg}");
+
+        let mut at_limit = BTreeMap::new();
+        at_limit.insert("owner".to_string(), "x".repeat(256));
+        assert!(check_tag_budget(&c, 1, &BTreeMap::new(), &at_limit).is_ok());
     }
 
     #[test]
@@ -166,7 +207,7 @@ mod tag_budget_tests {
         for i in 0..100 {
             fields.insert(format!("field{i}"), "x".repeat(10_000));
         }
-        assert!(check_tag_budget(&c, 100, &fields, 100).is_ok());
+        assert!(check_tag_budget(&c, 100, &fields, &user_tags(100)).is_ok());
     }
 
     #[test]
@@ -198,13 +239,13 @@ mod tag_budget_tests {
         for i in 0..11 {
             fields_15.insert(format!("field{i}"), "v".to_string());
         }
-        assert!(check_tag_budget(&c, reserved, &fields_15, 0).is_ok());
+        assert!(check_tag_budget(&c, reserved, &fields_15, &BTreeMap::new()).is_ok());
 
         // One more f.* field pushes the real wire total to 16. Must fail
         // before write.
         let mut fields_16 = fields_15.clone();
         fields_16.insert("field11".to_string(), "v".to_string());
-        let err = check_tag_budget(&c, reserved, &fields_16, 0).unwrap_err();
+        let err = check_tag_budget(&c, reserved, &fields_16, &BTreeMap::new()).unwrap_err();
         assert!(err.to_string().contains("16"), "{err}");
     }
 }

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -8,7 +8,14 @@
 pub mod envelope;
 pub mod types;
 
+// Re-exports consumed by CLI wiring added later in Phase A (Tasks 4/6/7);
+// unused from the `xv` binary target until then.
+#[allow(unused_imports)]
 pub use envelope::{
     encode_envelope, is_record, parse_envelope, FIELD_TAG_PREFIX, RECORD_CONTENT_TYPE, TYPE_TAG,
 };
-pub use types::{builtin_types, FieldDef, FieldKind, RecordType, TypeSource};
+#[allow(unused_imports)]
+pub use types::{
+    builtin_types, find_type, resolve_types, FieldDef, FieldDefConfig, FieldKind, RecordType,
+    RecordTypeConfig, TypeSource,
+};

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -83,59 +83,92 @@ pub fn check_tag_budget(
 }
 
 /// Computes `reserved_count` for [`check_tag_budget`]: the number of
-/// reserved bookkeeping tags a record write actually consumes.
+/// reserved bookkeeping tags a record write actually consumes on the wire
+/// for a given backend.
 ///
-/// This always includes `crate::backend::ALWAYS_WRITTEN_TAGS` (currently
-/// `original_name` + `created_by`) — every backend `set_secret` write
-/// stamps these unconditionally regardless of what the caller requests, so
-/// a pre-check that omits them can pass here and still be rejected by the
-/// backend as over budget (undercounting defeats fail-before-write right
-/// at the boundary). `has_type` adds one more for the reserved `xv-type`
-/// tag (always present on a record write); `has_groups`/`has_note`/
-/// `has_folder` are conditional on whether this specific write sets them.
-pub fn reserved_tag_count(
+/// This single, backend-aware predictor replaces two earlier functions
+/// (a universal `reserved_tag_count` plus an AWS-only
+/// `backend_extra_reserved_tags` add-on) that together mis-modeled two
+/// backends at once: the universal count assumed every backend always
+/// writes `created_by` and a `note` tag, which is true for Azure but not
+/// for AWS (see the per-backend derivation below) — so near AWS's 50-tag
+/// cap the old model could *falsely reject* a write that would actually
+/// succeed. Each arm here is derived directly from what that backend's
+/// `set_secret` implementation actually puts on the wire, so it can't
+/// drift the same way again.
+///
+/// - `has_type`: the reserved `xv-type` tag is always present on a record
+///   write, on every backend (it rides in `SecretRequest.tags`, not a
+///   backend-specific field, so it costs the same slot everywhere).
+/// - `has_groups` / `has_note` / `has_folder` / `has_expiry`: whether this
+///   specific write sets `SecretRequest.groups` / `.note` / `.folder` /
+///   `.expires_on`.
+///
+/// ## Per-backend derivation
+///
+/// **Azure** — `SecretManager::prepare_secret_request` (`src/secret/manager.rs`,
+/// the path `xv set`'s full write always takes; `xv update`'s
+/// attributes-only PATCH via `azure::secrets::build_patched_tags` mirrors
+/// the same stamps and isn't reachable from `xv set --type`):
+/// unconditionally inserts `original_name` and `created_by` as tags, then
+/// `groups`/`note`/`folder` as tags only when present. `content_type` and
+/// expiry are secret *attributes* on the Key Vault object, not tags — 0
+/// slots for those.
+///
+/// **AWS** — `AwsSecretBackend::set_secret` (`src/backend/aws/secrets.rs`):
+/// always pushes `xv:original_name`; pushes `xv:groups`/`xv:folder` only
+/// when present; pushes `xv:content_type` whenever the request has a
+/// content type (every record write does — `RECORD_CONTENT_TYPE`), and
+/// `xv:expires_at` whenever an expiry is set. `note` becomes the secret's
+/// `Description` (`create_builder.description(note)`), never a tag — 0
+/// slots. `created_by`: `metadata::TAG_CREATED_BY` exists as a constant
+/// but `set_secret` never writes it (`#[allow(dead_code)]`, "exercised by
+/// the round-trip tests only") — 0 slots.
+///
+/// **Local** — `LocalBackend::set_secret` (`src/backend/local/secrets.rs`):
+/// `SecretMeta.tags` is exactly `request.tags.clone().unwrap_or_default()`
+/// with nothing added; `original_name`/`created_by`/`groups`/`note`/
+/// `folder`/`content_type`/expiry are all separate `SecretMeta` struct
+/// fields, never tags. Only `has_type` (which rides in `request.tags`
+/// itself, same as every backend) contributes here. This arm is moot in
+/// practice — local's `BackendCapabilities.max_tags` is `None`, so
+/// `check_tag_budget` never applies the count check — but is kept
+/// accurate rather than a shortcut, per the same "can't drift" reasoning
+/// as the other two arms.
+pub fn predicted_reserved_tag_count(
+    backend: crate::backend::BackendKind,
     has_type: bool,
     has_groups: bool,
     has_note: bool,
     has_folder: bool,
-) -> usize {
-    let mut count = crate::backend::ALWAYS_WRITTEN_TAGS.len();
-    if has_type {
-        count += 1;
-    }
-    if has_groups {
-        count += 1;
-    }
-    if has_note {
-        count += 1;
-    }
-    if has_folder {
-        count += 1;
-    }
-    count
-}
-
-/// Extra reserved tag slots consumed by backend-specific bookkeeping that
-/// [`reserved_tag_count`]'s universal (Azure-shaped) count doesn't cover.
-///
-/// AWS's `set_secret` (`src/backend/aws/secrets.rs`) always tags
-/// `xv:content_type` whenever the request carries a content type — which
-/// every record write does (`RECORD_CONTENT_TYPE`) — and additionally
-/// tags `xv:expires_at` whenever an expiry is set. Neither Azure (content
-/// type lives on the secret object, not a tag) nor the local backend
-/// (unbounded tags) spend a slot on these, so this returns `0` for any
-/// `backend_kind` other than `Aws`.
-pub fn backend_extra_reserved_tags(
-    backend_kind: crate::backend::BackendKind,
     has_expiry: bool,
 ) -> usize {
-    match backend_kind {
-        crate::backend::BackendKind::Aws => {
-            // xv:content_type, always present on a record write, + xv:expires_at
-            // when an expiry is set.
-            1 + usize::from(has_expiry)
+    let type_tag = usize::from(has_type);
+    match backend {
+        crate::backend::BackendKind::Azure => {
+            type_tag
+                + crate::backend::ALWAYS_WRITTEN_TAGS.len() // original_name + created_by
+                + usize::from(has_groups)
+                + usize::from(has_note)
+                + usize::from(has_folder)
+            // content_type / expiry: secret attributes, not tags — 0.
         }
-        crate::backend::BackendKind::Azure | crate::backend::BackendKind::Local => 0,
+        crate::backend::BackendKind::Aws => {
+            type_tag
+                + 1 // xv:original_name, always
+                + usize::from(has_groups) // xv:groups
+                + usize::from(has_folder) // xv:folder
+                + 1 // xv:content_type, always present on a record write
+                + usize::from(has_expiry) // xv:expires_at
+                                          // note -> Description, not a tag; created_by is never written — 0 each.
+        }
+        crate::backend::BackendKind::Local => {
+            type_tag
+            // original_name/created_by/groups/note/folder/content_type/expiry
+            // are all separate SecretMeta struct fields, never tags — 0 each.
+            // (Moot: local's max_tags is None, so check_tag_budget never
+            // applies the count check regardless.)
+        }
     }
 }
 
@@ -234,30 +267,70 @@ mod tag_budget_tests {
         assert!(check_tag_budget(&c, 100, &fields, &user_tags(100)).is_ok());
     }
 
+    use crate::backend::BackendKind;
+
     #[test]
-    fn reserved_tag_count_includes_always_written_bookkeeping_tags() {
+    fn predicted_reserved_tag_count_azure_matches_prepare_secret_request() {
         // xv-type + original_name + created_by, no groups/note/folder.
-        assert_eq!(reserved_tag_count(true, false, false, false), 3);
-        // All optional bookkeeping tags present too.
-        assert_eq!(reserved_tag_count(true, true, true, true), 6);
+        assert_eq!(
+            predicted_reserved_tag_count(BackendKind::Azure, true, false, false, false, false),
+            3
+        );
+        // All optional bookkeeping tags present too; expiry is a secret
+        // attribute on Azure, not a tag, so it must NOT add a slot.
+        assert_eq!(
+            predicted_reserved_tag_count(BackendKind::Azure, true, true, true, true, true),
+            6
+        );
         // Even with has_type = false, the two always-written tags still count.
-        assert_eq!(reserved_tag_count(false, false, false, false), 2);
+        assert_eq!(
+            predicted_reserved_tag_count(BackendKind::Azure, false, false, false, false, false),
+            2
+        );
     }
 
-    /// Azure's real boundary (max_tags = 15): reserved_tag_count must
-    /// include original_name + created_by so a record that would total
-    /// exactly 15 tags on the wire passes, and one that would total 16
-    /// fails *before* any backend call — reproducing the under-count bug
-    /// where the old ad-hoc `reserved_count` computation (missing
-    /// original_name/created_by) let a request through that Azure's real
-    /// REST call would then reject.
+    #[test]
+    fn predicted_reserved_tag_count_aws_matches_set_secret() {
+        // xv-type + xv:original_name + xv:content_type only: no groups,
+        // no folder, no expiry — and note/created_by must NOT add a slot
+        // (note -> Description, created_by is never written on AWS).
+        assert_eq!(
+            predicted_reserved_tag_count(BackendKind::Aws, true, false, true, false, false),
+            3
+        );
+        // groups + folder + expiry all present.
+        assert_eq!(
+            predicted_reserved_tag_count(BackendKind::Aws, true, true, false, true, true),
+            6
+        );
+    }
+
+    #[test]
+    fn predicted_reserved_tag_count_local_only_counts_the_type_tag() {
+        // original_name/created_by/groups/note/folder/content_type/expiry
+        // are all separate SecretMeta struct fields on local — never tags.
+        assert_eq!(
+            predicted_reserved_tag_count(BackendKind::Local, true, true, true, true, true),
+            1
+        );
+        assert_eq!(
+            predicted_reserved_tag_count(BackendKind::Local, false, true, true, true, true),
+            0
+        );
+    }
+
+    /// Azure's real boundary (max_tags = 15): the predictor must include
+    /// original_name + created_by so a record that would total exactly 15
+    /// tags on the wire passes, and one that would total 16 fails *before*
+    /// any backend call.
     #[test]
     fn budget_boundary_at_azure_max_tags_matches_real_write() {
         let c = caps(Some(15), Some(256));
 
         // xv-type + original_name + created_by + groups = 4 reserved,
         // plus 11 f.* metadata field tags = 15 total on the wire. Must pass.
-        let reserved = reserved_tag_count(true, true, false, false);
+        let reserved =
+            predicted_reserved_tag_count(BackendKind::Azure, true, true, false, false, false);
         assert_eq!(reserved, 4);
         let mut fields_15 = BTreeMap::new();
         for i in 0..11 {
@@ -273,53 +346,31 @@ mod tag_budget_tests {
         assert!(err.to_string().contains("16"), "{err}");
     }
 
+    /// AWS's real boundary (max_tags = 50), WITH an expiry set (so both
+    /// xv:content_type and xv:expires_at are on the wire) but WITHOUT note
+    /// (which costs 0 slots on AWS — the round-2 fix's bug: the old
+    /// universal predictor assumed every backend spends a slot on `note`,
+    /// which is only true for Azure). Reproduces the fix: a record with
+    /// note set that would have been falsely counted as over budget on
+    /// the old model now correctly passes at the real 50-tag boundary,
+    /// and one more field still fails before write.
     #[test]
-    fn backend_extra_reserved_tags_is_zero_for_azure_and_local() {
-        assert_eq!(
-            backend_extra_reserved_tags(crate::backend::BackendKind::Azure, true),
-            0
-        );
-        assert_eq!(
-            backend_extra_reserved_tags(crate::backend::BackendKind::Local, true),
-            0
-        );
-    }
-
-    #[test]
-    fn backend_extra_reserved_tags_counts_aws_content_type_and_expiry() {
-        // xv:content_type only (no expiry set).
-        assert_eq!(
-            backend_extra_reserved_tags(crate::backend::BackendKind::Aws, false),
-            1
-        );
-        // xv:content_type + xv:expires_at.
-        assert_eq!(
-            backend_extra_reserved_tags(crate::backend::BackendKind::Aws, true),
-            2
-        );
-    }
-
-    /// AWS's real boundary (max_tags = 50): reserved_tag_count() alone
-    /// (Azure-shaped) doesn't know about AWS's always-written
-    /// xv:content_type tag or its conditional xv:expires_at tag, so a
-    /// record write with an expiry set could pass the pre-check and still
-    /// blow AWS's real 50-tag cap at the API without
-    /// backend_extra_reserved_tags folded in. Reproduces that boundary:
-    /// with the extra reserved tags counted, a 50-tag-total record passes
-    /// and a 51-tag-total fails before write.
-    #[test]
-    fn budget_boundary_at_aws_max_tags_counts_content_type_and_expiry() {
+    fn budget_boundary_at_aws_max_tags_counts_content_type_and_expiry_not_note() {
         let c = caps(Some(50), Some(256));
 
-        // Universal reserved: xv-type + original_name + created_by + groups = 4.
-        // AWS extras: xv:content_type (always) + xv:expires_at (expiry set) = 2.
-        let reserved = reserved_tag_count(true, true, false, false)
-            + backend_extra_reserved_tags(crate::backend::BackendKind::Aws, true);
-        assert_eq!(reserved, 6);
+        // xv-type + xv:original_name + xv:groups + xv:content_type +
+        // xv:expires_at = 5 reserved (note is set on this write too, but
+        // costs 0 AWS tag slots — it becomes the Description).
+        let reserved =
+            predicted_reserved_tag_count(BackendKind::Aws, true, true, true, false, true);
+        assert_eq!(reserved, 5);
 
-        // 6 reserved + 44 f.* fields = 50 total on the wire. Must pass.
+        // 5 reserved + 45 f.* fields = 50 total on the wire. Must pass —
+        // the old over-counting model (which added a phantom `note` slot
+        // and a phantom `created_by` slot) would have rejected this at
+        // only 43 f.* fields.
         let mut fields_50 = BTreeMap::new();
-        for i in 0..44 {
+        for i in 0..45 {
             fields_50.insert(format!("field{i}"), "v".to_string());
         }
         assert!(check_tag_budget(&c, reserved, &fields_50, &BTreeMap::new()).is_ok());
@@ -327,7 +378,7 @@ mod tag_budget_tests {
         // One more f.* field pushes the real wire total to 51. Must fail
         // before write.
         let mut fields_51 = fields_50.clone();
-        fields_51.insert("field44".to_string(), "v".to_string());
+        fields_51.insert("field45".to_string(), "v".to_string());
         let err = check_tag_budget(&c, reserved, &fields_51, &BTreeMap::new()).unwrap_err();
         assert!(err.to_string().contains("51"), "{err}");
     }

--- a/src/records/types.rs
+++ b/src/records/types.rs
@@ -1,0 +1,237 @@
+//! Record type definitions, built-in types, and validation.
+//!
+//! A `RecordType` describes the fields a typed secret ("record") carries:
+//! which are listable metadata and which are encrypted secret material,
+//! which are required, and which single field is the `primary` value
+//! returned by plain `xv get`.
+
+use crate::error::{CrosstacheError, Result};
+
+/// Whether a field's value lives in tags (metadata) or in the encrypted
+/// secret value (secret).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldKind {
+    Metadata,
+    Secret,
+}
+
+/// A single field declared by a record type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldDef {
+    pub name: String,
+    pub kind: FieldKind,
+    pub required: bool,
+    pub primary: bool,
+}
+
+/// Where a resolved `RecordType` came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeSource {
+    Builtin,
+    Global,
+    Project,
+}
+
+/// A named collection of field definitions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordType {
+    pub name: String,
+    pub fields: Vec<FieldDef>,
+    pub source: TypeSource,
+}
+
+impl RecordType {
+    /// Returns the single primary field of this type.
+    ///
+    /// Panics if `validate()` has not been called successfully first —
+    /// callers must validate a `RecordType` before relying on this.
+    pub fn primary(&self) -> &FieldDef {
+        self.fields
+            .iter()
+            .find(|f| f.primary)
+            .expect("RecordType::primary called on an unvalidated type with no primary field")
+    }
+
+    /// Looks up a field by name.
+    pub fn field(&self, name: &str) -> Option<&FieldDef> {
+        self.fields.iter().find(|f| f.name == name)
+    }
+
+    /// Validates structural invariants:
+    /// - exactly one `primary` field
+    /// - the primary field is `Secret` kind and `required`
+    /// - every field name is kebab-case (matches secret-name charset rules)
+    pub fn validate(&self) -> Result<()> {
+        let primaries: Vec<&FieldDef> = self.fields.iter().filter(|f| f.primary).collect();
+
+        if primaries.is_empty() {
+            return Err(CrosstacheError::config(format!(
+                "record type '{}' has no primary field; exactly one field must be marked primary",
+                self.name
+            )));
+        }
+        if primaries.len() > 1 {
+            return Err(CrosstacheError::config(format!(
+                "record type '{}' has {} primary fields; exactly one field must be marked primary",
+                self.name,
+                primaries.len()
+            )));
+        }
+
+        let primary = primaries[0];
+        if primary.kind != FieldKind::Secret {
+            return Err(CrosstacheError::config(format!(
+                "record type '{}': primary field '{}' must be kind = secret",
+                self.name, primary.name
+            )));
+        }
+        if !primary.required {
+            return Err(CrosstacheError::config(format!(
+                "record type '{}': primary field '{}' must be required",
+                self.name, primary.name
+            )));
+        }
+
+        for field in &self.fields {
+            if !is_kebab_case(&field.name) {
+                return Err(CrosstacheError::config(format!(
+                    "record type '{}': field name '{}' is not valid (kebab-case, lowercase alphanumeric and hyphens only)",
+                    self.name, field.name
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Validates that `name` is kebab-case: lowercase alphanumeric segments
+/// separated by single hyphens, no leading/trailing/consecutive hyphens.
+fn is_kebab_case(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    if name.starts_with('-') || name.ends_with('-') || name.contains("--") {
+        return false;
+    }
+    name.chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+fn field(name: &str, kind: FieldKind, required: bool, primary: bool) -> FieldDef {
+    FieldDef {
+        name: name.to_string(),
+        kind,
+        required,
+        primary,
+    }
+}
+
+/// The built-in record types: `login`, `api-key`, `database`.
+pub fn builtin_types() -> Vec<RecordType> {
+    vec![
+        RecordType {
+            name: "login".to_string(),
+            source: TypeSource::Builtin,
+            fields: vec![
+                field("username", FieldKind::Metadata, true, false),
+                field("url", FieldKind::Metadata, false, false),
+                field("password", FieldKind::Secret, true, true),
+            ],
+        },
+        RecordType {
+            name: "api-key".to_string(),
+            source: TypeSource::Builtin,
+            fields: vec![
+                field("url", FieldKind::Metadata, false, false),
+                field("account", FieldKind::Metadata, false, false),
+                field("key", FieldKind::Secret, true, true),
+            ],
+        },
+        RecordType {
+            name: "database".to_string(),
+            source: TypeSource::Builtin,
+            fields: vec![
+                field("host", FieldKind::Metadata, false, false),
+                field("port", FieldKind::Metadata, false, false),
+                field("database", FieldKind::Metadata, false, false),
+                field("username", FieldKind::Metadata, false, false),
+                field("password", FieldKind::Secret, true, true),
+                field("connection-string", FieldKind::Secret, false, false),
+            ],
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_types_are_valid() {
+        let types = builtin_types();
+        assert_eq!(types.len(), 3);
+        for t in &types {
+            t.validate().unwrap_or_else(|e| panic!("{}: {e}", t.name));
+        }
+
+        let login = types.iter().find(|t| t.name == "login").unwrap();
+        assert_eq!(login.primary().name, "password");
+
+        let database = types.iter().find(|t| t.name == "database").unwrap();
+        let cs = database.field("connection-string").unwrap();
+        assert_eq!(cs.kind, FieldKind::Secret);
+        assert!(!cs.required);
+        assert!(!cs.primary);
+    }
+
+    #[test]
+    fn validate_rejects_zero_primaries() {
+        let t = RecordType {
+            name: "bad".to_string(),
+            source: TypeSource::Builtin,
+            fields: vec![field("username", FieldKind::Metadata, true, false)],
+        };
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_two_primaries() {
+        let t = RecordType {
+            name: "bad".to_string(),
+            source: TypeSource::Builtin,
+            fields: vec![
+                field("password", FieldKind::Secret, true, true),
+                field("key", FieldKind::Secret, true, true),
+            ],
+        };
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_non_secret_primary() {
+        let t = RecordType {
+            name: "bad".to_string(),
+            source: TypeSource::Builtin,
+            fields: vec![field("username", FieldKind::Metadata, true, true)],
+        };
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_bad_field_name() {
+        let t = RecordType {
+            name: "bad".to_string(),
+            source: TypeSource::Builtin,
+            fields: vec![field("Bad Name", FieldKind::Secret, true, true)],
+        };
+        assert!(t.validate().is_err());
+
+        let ok = RecordType {
+            name: "ok".to_string(),
+            source: TypeSource::Builtin,
+            fields: vec![field("totp-seed", FieldKind::Secret, true, true)],
+        };
+        assert!(ok.validate().is_ok());
+    }
+}

--- a/src/records/types.rs
+++ b/src/records/types.rs
@@ -18,14 +18,15 @@ use std::collections::HashMap;
 
 /// Whether a field's value lives in tags (metadata) or in the encrypted
 /// secret value (secret).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum FieldKind {
     Metadata,
     Secret,
 }
 
 /// A single field declared by a record type.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct FieldDef {
     pub name: String,
     pub kind: FieldKind,
@@ -34,15 +35,26 @@ pub struct FieldDef {
 }
 
 /// Where a resolved `RecordType` came from.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum TypeSource {
     Builtin,
     Global,
     Project,
 }
 
+impl std::fmt::Display for TypeSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Builtin => write!(f, "built-in"),
+            Self::Global => write!(f, "global"),
+            Self::Project => write!(f, "project"),
+        }
+    }
+}
+
 /// A named collection of field definitions.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RecordType {
     pub name: String,
     pub fields: Vec<FieldDef>,
@@ -213,10 +225,16 @@ impl RecordTypeConfig {
                     )));
                 }
             };
+            // `primary` implies `kind = secret` and `required = true` (spec
+            // decision — the `[types.smtp]` example in the design doc
+            // marks its primary field `primary = true` without also
+            // repeating `required = true`), so a primary field is always
+            // treated as required regardless of what the config said.
+            let required = f.required || f.primary;
             fields.push(FieldDef {
                 name: f.name,
                 kind,
-                required: f.required,
+                required,
                 primary: f.primary,
             });
         }

--- a/src/records/types.rs
+++ b/src/records/types.rs
@@ -4,8 +4,17 @@
 //! which are listable metadata and which are encrypted secret material,
 //! which are required, and which single field is the `primary` value
 //! returned by plain `xv get`.
+//!
+//! Consumed by the `xv type`/`xv set --type`/`xv get --field` CLI wiring
+//! added later in Phase A (record-types plan Tasks 4/6/7); until that
+//! wiring lands, this module's public API is unused from the `xv` binary
+//! target, hence the crate-wide `#[allow(dead_code)]` below.
+#![allow(dead_code)]
 
 use crate::error::{CrosstacheError, Result};
+use crate::utils::output;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Whether a field's value lives in tags (metadata) or in the encrypted
 /// secret value (secret).
@@ -163,6 +172,112 @@ pub fn builtin_types() -> Vec<RecordType> {
     ]
 }
 
+// ---------------------------------------------------------------------------
+// Config-file parsing and resolution
+// ---------------------------------------------------------------------------
+
+/// On-disk shape of a `[types.<name>]` block, shared by both the global
+/// `xv.conf` and per-project `.xv.toml` config layers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RecordTypeConfig {
+    pub fields: Vec<FieldDefConfig>,
+}
+
+/// On-disk shape of one field within a `[types.<name>]` block.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FieldDefConfig {
+    pub name: String,
+    /// `"metadata"` (default) | `"secret"`.
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub primary: bool,
+}
+
+impl RecordTypeConfig {
+    /// Converts this config-file shape into a `RecordType`, tagging it
+    /// with `source` and `name`. Does not validate — callers must call
+    /// `RecordType::validate()`.
+    fn into_record_type(self, name: &str, source: TypeSource) -> Result<RecordType> {
+        let mut fields = Vec::with_capacity(self.fields.len());
+        for f in self.fields {
+            let kind = match f.kind.as_deref() {
+                None | Some("metadata") => FieldKind::Metadata,
+                Some("secret") => FieldKind::Secret,
+                Some(other) => {
+                    return Err(CrosstacheError::config(format!(
+                        "type '{name}': field '{}' has invalid kind '{other}' (expected 'metadata' or 'secret')",
+                        f.name
+                    )));
+                }
+            };
+            fields.push(FieldDef {
+                name: f.name,
+                kind,
+                required: f.required,
+                primary: f.primary,
+            });
+        }
+        Ok(RecordType {
+            name: name.to_string(),
+            fields,
+            source,
+        })
+    }
+}
+
+/// Resolves the effective set of record types from built-ins, the global
+/// config, and the project config, with precedence project > global >
+/// builtin (matched by name). Shadowing a built-in type emits a warning
+/// but is allowed. Every resolved type is validated.
+pub fn resolve_types(
+    global: &HashMap<String, RecordTypeConfig>,
+    project: &HashMap<String, RecordTypeConfig>,
+) -> Result<Vec<RecordType>> {
+    let mut resolved: HashMap<String, RecordType> = HashMap::new();
+
+    for t in builtin_types() {
+        resolved.insert(t.name.clone(), t);
+    }
+
+    for (name, cfg) in global {
+        let is_shadow_builtin = resolved
+            .get(name)
+            .map(|t| t.source == TypeSource::Builtin)
+            .unwrap_or(false);
+        if is_shadow_builtin {
+            output::warn(&format!("type '{name}' shadows a built-in type"));
+        }
+        let record_type = cfg.clone().into_record_type(name, TypeSource::Global)?;
+        record_type.validate()?;
+        resolved.insert(name.clone(), record_type);
+    }
+
+    for (name, cfg) in project {
+        let is_shadow_builtin = resolved
+            .get(name)
+            .map(|t| t.source == TypeSource::Builtin)
+            .unwrap_or(false);
+        if is_shadow_builtin {
+            output::warn(&format!("type '{name}' shadows a built-in type"));
+        }
+        let record_type = cfg.clone().into_record_type(name, TypeSource::Project)?;
+        record_type.validate()?;
+        resolved.insert(name.clone(), record_type);
+    }
+
+    let mut result: Vec<RecordType> = resolved.into_values().collect();
+    result.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(result)
+}
+
+/// Looks up a resolved type by name.
+pub fn find_type<'a>(types: &'a [RecordType], name: &str) -> Option<&'a RecordType> {
+    types.iter().find(|t| t.name == name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -233,5 +348,105 @@ mod tests {
             fields: vec![field("totp-seed", FieldKind::Secret, true, true)],
         };
         assert!(ok.validate().is_ok());
+    }
+
+    #[test]
+    fn parse_types_block_from_project_toml() {
+        let toml = r#"
+            [types.smtp]
+            fields = [
+              { name = "host" },
+              { name = "port" },
+              { name = "username", required = true },
+              { name = "password", kind = "secret", primary = true },
+            ]
+        "#;
+        #[derive(Deserialize)]
+        struct Wrapper {
+            types: HashMap<String, RecordTypeConfig>,
+        }
+        let parsed: Wrapper = toml::from_str(toml).unwrap();
+        let smtp = parsed.types.get("smtp").unwrap();
+        assert_eq!(smtp.fields.len(), 4);
+        let host = smtp.fields.iter().find(|f| f.name == "host").unwrap();
+        assert_eq!(host.kind, None); // omitted -> None, resolved to Metadata later
+        let password = smtp.fields.iter().find(|f| f.name == "password").unwrap();
+        assert_eq!(password.kind.as_deref(), Some("secret"));
+        assert!(password.primary);
+    }
+
+    fn smtp_config() -> RecordTypeConfig {
+        RecordTypeConfig {
+            fields: vec![
+                FieldDefConfig {
+                    name: "host".to_string(),
+                    kind: None,
+                    required: false,
+                    primary: false,
+                },
+                FieldDefConfig {
+                    name: "password".to_string(),
+                    kind: Some("secret".to_string()),
+                    required: true,
+                    primary: true,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn resolve_project_shadows_global() {
+        let mut global = HashMap::new();
+        global.insert("smtp".to_string(), smtp_config());
+
+        let mut project_cfg = smtp_config();
+        project_cfg.fields[0].name = "hostname".to_string(); // distinguishing tweak
+        let mut project = HashMap::new();
+        project.insert("smtp".to_string(), project_cfg);
+
+        let resolved = resolve_types(&global, &project).unwrap();
+        let smtp = find_type(&resolved, "smtp").unwrap();
+        assert_eq!(smtp.source, TypeSource::Project);
+        assert!(smtp.field("hostname").is_some());
+    }
+
+    #[test]
+    fn resolve_custom_shadows_builtin_with_warning() {
+        let mut global = HashMap::new();
+        global.insert("login".to_string(), smtp_config());
+        let project = HashMap::new();
+
+        let resolved = resolve_types(&global, &project).unwrap();
+        let login = find_type(&resolved, "login").unwrap();
+        assert_eq!(login.source, TypeSource::Global);
+        // Warning goes to stderr; asserting resolution result only per plan note.
+    }
+
+    #[test]
+    fn resolve_rejects_invalid_custom_type() {
+        let mut global = HashMap::new();
+        global.insert(
+            "bad".to_string(),
+            RecordTypeConfig {
+                fields: vec![
+                    FieldDefConfig {
+                        name: "a".to_string(),
+                        kind: Some("secret".to_string()),
+                        required: true,
+                        primary: true,
+                    },
+                    FieldDefConfig {
+                        name: "b".to_string(),
+                        kind: Some("secret".to_string()),
+                        required: true,
+                        primary: true,
+                    },
+                ],
+            },
+        );
+        let project = HashMap::new();
+
+        let err = resolve_types(&global, &project).unwrap_err();
+        assert!(err.to_string().contains("bad"));
     }
 }

--- a/src/secret/manager.rs
+++ b/src/secret/manager.rs
@@ -404,8 +404,14 @@ impl AzureSecretOperations {
         let mut tags = request.tags.clone().unwrap_or_default();
 
         // Store original name in tags for mapping
-        tags.insert("original_name".to_string(), request.name.clone());
-        tags.insert("created_by".to_string(), "crosstache".to_string());
+        tags.insert(
+            crate::backend::TAG_ORIGINAL_NAME.to_string(),
+            request.name.clone(),
+        );
+        tags.insert(
+            crate::backend::TAG_CREATED_BY.to_string(),
+            "crosstache".to_string(),
+        );
 
         // Handle groups from request
         if let Some(ref groups) = request.groups {

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -135,21 +135,12 @@ fn set_typed_record_stores_envelope_and_tags() {
     // The primary field never appears as a tag.
     assert!(meta["tags"].get("f.password").is_none());
 
-    // The stored value is the JSON envelope, not the bare primary — proven
-    // via --raw (Task 7 hasn't landed record-aware `get` yet, so --raw
-    // returns the stored value verbatim). Reuses the same store/env as the
-    // `set` above (can't reuse `cmd`/xv_isolated_local() itself: each
-    // Command is single-use and a fresh xv_isolated_local() call would
-    // create a brand-new, empty store).
-    let out2 = common::xv()
-        .env_clear()
-        .env("PATH", std::env::var("PATH").unwrap_or_default())
-        .env("HOME", temp.path())
-        .env("XDG_CONFIG_HOME", temp.path().join(".config"))
-        .env("XV_NO_PARENT_CONFIG", "1")
-        .env("XV_BACKEND", "local")
-        .env("NO_COLOR", "1")
-        .current_dir(temp.path())
+    // Plain `get --raw` returns the primary field bare (record-aware `get`,
+    // Task 7's compatibility contract) — not the JSON envelope. The
+    // envelope shape itself is asserted directly against the on-disk value
+    // in `set_field_secret_goes_to_envelope` below and via `--record` in
+    // `get_record_json_includes_all_fields`.
+    let out2 = xv_same_env(temp.path())
         .args(["get", "cred", "--raw"])
         .output()
         .unwrap();
@@ -158,10 +149,7 @@ fn set_typed_record_stores_envelope_and_tags() {
         "stderr: {}",
         common::stderr_str(&out2)
     );
-    let stdout2 = common::stdout_str(&out2);
-    let envelope: serde_json::Value = serde_json::from_str(&stdout2).expect("valid json envelope");
-    assert_eq!(envelope["password"], "hunter2");
-    assert_eq!(envelope.as_object().unwrap().len(), 1);
+    assert_eq!(common::stdout_str(&out2), "hunter2");
 }
 
 #[test]
@@ -279,5 +267,378 @@ fn type_show_unknown_errors() {
     assert!(
         stderr.contains("database"),
         "stderr should list known types: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Task 7: `xv get` — primary, --field, --record, failure modes
+// ---------------------------------------------------------------------------
+
+/// Builds a fresh `xv` `Command` bound to the same isolated store/env as an
+/// existing `xv_isolated_local()` tempdir, for a second CLI invocation
+/// against the same store (each `Command` is single-use).
+fn xv_same_env(temp: &std::path::Path) -> std::process::Command {
+    let mut cmd = common::xv();
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", temp)
+        .env("XDG_CONFIG_HOME", temp.join(".config"))
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "local")
+        .env("NO_COLOR", "1")
+        .current_dir(temp);
+    cmd
+}
+
+#[test]
+fn get_typed_record_returns_primary_bare() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let out2 = xv_same_env(temp.path())
+        .args(["get", "cred", "--raw"])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    assert_eq!(common::stdout_str(&out2), "hunter2");
+}
+
+#[test]
+fn get_field_metadata_and_secret() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--field",
+            "url=https://example.com",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    // Metadata field (tag-backed).
+    let out_meta = xv_same_env(temp.path())
+        .args(["get", "cred", "--field", "username", "--raw"])
+        .output()
+        .unwrap();
+    assert!(
+        out_meta.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out_meta)
+    );
+    assert_eq!(common::stdout_str(&out_meta), "bob");
+
+    // Secret field (envelope-backed).
+    let out_secret = xv_same_env(temp.path())
+        .args(["get", "cred", "--field", "password", "--raw"])
+        .output()
+        .unwrap();
+    assert!(
+        out_secret.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out_secret)
+    );
+    assert_eq!(common::stdout_str(&out_secret), "hunter2");
+}
+
+#[test]
+fn get_record_json_includes_all_fields() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let out2 = xv_same_env(temp.path())
+        .args(["get", "cred", "--record", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let stdout = common::stdout_str(&out2);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(parsed["type"], "login");
+    assert_eq!(parsed["fields"]["username"], "bob");
+    assert_eq!(parsed["fields"]["password"], "hunter2");
+}
+
+#[test]
+fn get_unknown_field_lists_fields() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let out2 = xv_same_env(temp.path())
+        .args(["get", "cred", "--field", "nosuchfield"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out2.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let stderr = common::stderr_str(&out2);
+    assert!(stderr.contains("username"), "stderr: {stderr}");
+    assert!(stderr.contains("password"), "stderr: {stderr}");
+}
+
+/// Corrupt-envelope: a record-marked secret whose value fails JSON parsing.
+/// The CLI's plain `xv set` can't produce this state directly — a full
+/// `set_secret` write always replaces `content_type` from the request
+/// (`unwrap_or_default()` in the local backend), so overwriting a record's
+/// value through the CLI's untyped `xv set` path would also clear the
+/// record content-type rather than reproduce "record-tagged, bad JSON".
+/// Instead this drives the local backend library directly (same crate,
+/// same store/key as the CLI run above) to write a bogus value while
+/// keeping `content_type` and tags intact — reproducing the state a
+/// corrupted on-disk write (or manual tampering) would leave behind.
+#[test]
+fn get_corrupt_envelope_fails_loud() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let store_path = temp.path().join("store");
+    let key_file = temp.path().join("key.txt");
+    let local_config = crosstache::config::settings::LocalConfig {
+        store_path: Some(store_path.to_string_lossy().to_string()),
+        key_file: Some(key_file.to_string_lossy().to_string()),
+        default_vault: Some("default".to_string()),
+        encrypt_metadata: None,
+        opaque_filenames: None,
+    };
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        use crosstache::backend::local::LocalBackend;
+        use crosstache::backend::Backend;
+        use crosstache::secret::manager::SecretRequest;
+
+        let backend = LocalBackend::new(Some(&local_config)).expect("open local backend");
+        let existing = backend
+            .secrets()
+            .get_secret("default", "cred", false)
+            .await
+            .expect("get existing record");
+
+        let request = SecretRequest {
+            name: "cred".to_string(),
+            value: zeroize::Zeroizing::new("not-json".to_string()),
+            content_type: Some("application/vnd.xv.record".to_string()),
+            enabled: Some(true),
+            expires_on: None,
+            not_before: None,
+            tags: Some(existing.tags.clone()),
+            groups: None,
+            note: None,
+            folder: None,
+        };
+        backend
+            .secrets()
+            .set_secret("default", request)
+            .await
+            .expect("overwrite with corrupt envelope");
+    });
+
+    let out2 = xv_same_env(temp.path())
+        .args(["get", "cred"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out2.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let stderr = common::stderr_str(&out2);
+    assert!(stderr.contains("cred"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("application/vnd.xv.record"),
+        "stderr: {stderr}"
+    );
+    // Never print the raw JSON value as if it were valid.
+    assert!(!stderr.contains("not-json"), "stderr: {stderr}");
+}
+
+#[test]
+fn get_unknown_type_degrades() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    // Rewrite the xv-type tag to an unresolvable type name via the local
+    // backend library (same rationale as get_corrupt_envelope_fails_loud —
+    // no CLI verb yet edits tags in place; that's Task 8, out of Phase A).
+    let store_path = temp.path().join("store");
+    let key_file = temp.path().join("key.txt");
+    let local_config = crosstache::config::settings::LocalConfig {
+        store_path: Some(store_path.to_string_lossy().to_string()),
+        key_file: Some(key_file.to_string_lossy().to_string()),
+        default_vault: Some("default".to_string()),
+        encrypt_metadata: None,
+        opaque_filenames: None,
+    };
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        use crosstache::backend::local::LocalBackend;
+        use crosstache::backend::Backend;
+        use crosstache::secret::manager::SecretRequest;
+
+        let backend = LocalBackend::new(Some(&local_config)).expect("open local backend");
+        let existing = backend
+            .secrets()
+            .get_secret("default", "cred", true)
+            .await
+            .expect("get existing record");
+        let mut tags = existing.tags.clone();
+        tags.insert("xv-type".to_string(), "nosuch".to_string());
+
+        let request = SecretRequest {
+            name: "cred".to_string(),
+            value: existing.value.clone().unwrap(),
+            content_type: Some("application/vnd.xv.record".to_string()),
+            enabled: Some(true),
+            expires_on: None,
+            not_before: None,
+            tags: Some(tags),
+            groups: None,
+            note: None,
+            folder: None,
+        };
+        backend
+            .secrets()
+            .set_secret("default", request)
+            .await
+            .expect("rewrite with unknown type");
+    });
+
+    // Plain `get` can't determine the primary field: errors.
+    let out_plain = xv_same_env(temp.path())
+        .args(["get", "cred"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out_plain.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out_plain)
+    );
+
+    // `--field` still works via the raw envelope/tags.
+    let out_field = xv_same_env(temp.path())
+        .args(["get", "cred", "--field", "username", "--raw"])
+        .output()
+        .unwrap();
+    assert!(
+        out_field.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out_field)
+    );
+    assert_eq!(common::stdout_str(&out_field), "bob");
+}
+
+#[test]
+fn get_field_on_untyped_errors() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args(["set", "plain", "--value", "just-a-value"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let out2 = xv_same_env(temp.path())
+        .args(["get", "plain", "--field", "whatever"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out2.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+
+    let out3 = xv_same_env(temp.path())
+        .args(["get", "plain", "--record"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out3.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out3)
     );
 }

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -328,6 +328,81 @@ fn set_typed_rejects_tag_colliding_with_field_prefix() {
     assert!(!meta_path.exists(), "nothing must be written on rejection");
 }
 
+/// Bugbot PR #322 re-review: `xv set --type` with `--field` values but no
+/// `--value`/`--stdin` must not hang waiting on a TTY that will never
+/// arrive — the test harness's stdin is not a TTY (it's whatever
+/// std::process::Command inherits/pipes by default in a test process), so
+/// this exercises exactly the non-interactive-without-primary path.
+#[test]
+fn set_typed_missing_value_non_tty_fails_before_write_mentions_stdin() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args(["set", "cred", "--type", "login", "--field", "username=bob"])
+        .stdin(std::process::Stdio::null())
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("--stdin"), "stderr: {stderr}");
+
+    let meta_path = temp
+        .path()
+        .join("store")
+        .join("vaults")
+        .join("default")
+        .join("secrets")
+        .join("cred.meta.json");
+    assert!(!meta_path.exists(), "nothing must be written on rejection");
+}
+
+/// Bugbot PR #322 re-review: `--field a=1 --field-secret a=2` must be
+/// rejected rather than silently storing `a` as both an f.* tag and an
+/// envelope entry (which `get --field a` would then read inconsistently —
+/// envelope first, silently ignoring the tag).
+#[test]
+fn set_typed_rejects_duplicate_field_across_field_and_field_secret() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--field",
+            "a=1",
+            "--field-secret",
+            "a=2",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains('a'), "stderr: {stderr}");
+
+    let meta_path = temp
+        .path()
+        .join("store")
+        .join("vaults")
+        .join("default")
+        .join("secrets")
+        .join("cred.meta.json");
+    assert!(!meta_path.exists(), "nothing must be written on rejection");
+}
+
 #[test]
 fn type_show_unknown_errors() {
     let (mut cmd, _temp) = common::xv_isolated_local();

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -367,6 +367,131 @@ fn set_typed_rejects_tag_colliding_with_field_prefix() {
     assert!(!meta_path.exists(), "nothing must be written on rejection");
 }
 
+/// Bugbot PR #322 round 4: `--note x --tag note=y` must be rejected on a
+/// typed record set rather than silently letting the dedicated `--note`
+/// flag win (which is what the untyped `set` path does deterministically
+/// today — no error, `x` always wins over a same-named `--tag`). The
+/// record path is intentionally stricter: fail loud instead of silently
+/// picking a winner between two conflicting sources for the same tag.
+#[test]
+fn set_typed_rejects_tag_colliding_with_note() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+            "--note",
+            "x",
+            "--tag",
+            "note=y",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("note"), "stderr: {stderr}");
+
+    let meta_path = temp
+        .path()
+        .join("store")
+        .join("vaults")
+        .join("default")
+        .join("secrets")
+        .join("cred.meta.json");
+    assert!(!meta_path.exists(), "nothing must be written on rejection");
+}
+
+/// Same collision class as `note`, for `--group`/`--tag groups=...`.
+#[test]
+fn set_typed_rejects_tag_colliding_with_groups() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+            "--group",
+            "prod",
+            "--tag",
+            "groups=other",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("groups"), "stderr: {stderr}");
+
+    let meta_path = temp
+        .path()
+        .join("store")
+        .join("vaults")
+        .join("default")
+        .join("secrets")
+        .join("cred.meta.json");
+    assert!(!meta_path.exists(), "nothing must be written on rejection");
+}
+
+/// Same collision class as `note`, for `--folder`/`--tag folder=...`.
+#[test]
+fn set_typed_rejects_tag_colliding_with_folder() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+            "--folder",
+            "app",
+            "--tag",
+            "folder=other",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("folder"), "stderr: {stderr}");
+
+    let meta_path = temp
+        .path()
+        .join("store")
+        .join("vaults")
+        .join("default")
+        .join("secrets")
+        .join("cred.meta.json");
+    assert!(!meta_path.exists(), "nothing must be written on rejection");
+}
+
 /// Bugbot PR #322 re-review: `xv set --type` with `--field` values but no
 /// `--value`/`--stdin` must not hang waiting on a TTY that will never
 /// arrive — the test harness's stdin is not a TTY (it's whatever

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -245,6 +245,89 @@ fn set_field_secret_goes_to_envelope() {
     );
 }
 
+/// Bugbot PR #322 follow-up: a user `--tag xv-type=...` on a typed `set`
+/// must be rejected before write, not silently override the record's own
+/// type marker (which would desync tags from the envelope and break type
+/// resolution / plain `get`).
+#[test]
+fn set_typed_rejects_tag_colliding_with_xv_type() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+            "--tag",
+            "xv-type=other",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("xv-type"), "stderr: {stderr}");
+
+    let meta_path = temp
+        .path()
+        .join("store")
+        .join("vaults")
+        .join("default")
+        .join("secrets")
+        .join("cred.meta.json");
+    assert!(!meta_path.exists(), "nothing must be written on rejection");
+}
+
+/// Same as above but for a `--tag f.<name>=...` collision (the `f.*`
+/// metadata-field tag prefix is just as reserved as `xv-type` itself).
+#[test]
+fn set_typed_rejects_tag_colliding_with_field_prefix() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+            "--tag",
+            "f.something=x",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(
+        stderr.contains("f.something") || stderr.contains("f.*"),
+        "stderr: {stderr}"
+    );
+
+    let meta_path = temp
+        .path()
+        .join("store")
+        .join("vaults")
+        .join("default")
+        .join("secrets")
+        .join("cred.meta.json");
+    assert!(!meta_path.exists(), "nothing must be written on rejection");
+}
+
 #[test]
 fn type_show_unknown_errors() {
     let (mut cmd, _temp) = common::xv_isolated_local();

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -1,0 +1,109 @@
+//! End-to-end CLI tests for record types (`xv type`, `xv set --type`,
+//! `xv get --field`/`--record`). Hermetic: every test uses the isolated
+//! local-backend harness from `tests/common/mod.rs` — no Azure credentials
+//! or network access required.
+//!
+//! Run with:
+//!   cargo test --test e2e_record_types
+
+mod common;
+
+// ---------------------------------------------------------------------------
+// Task 4: `xv type list` / `xv type show`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn type_list_shows_builtins() {
+    let (mut cmd, _temp) = common::xv_isolated_local();
+    let out = cmd
+        .args(["type", "list", "--format", "table"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(stdout.contains("login"), "stdout: {stdout}");
+    assert!(stdout.contains("api-key"), "stdout: {stdout}");
+    assert!(stdout.contains("database"), "stdout: {stdout}");
+    assert!(stdout.contains("built-in"), "stdout: {stdout}");
+}
+
+#[test]
+fn type_list_ls_alias_works() {
+    let (mut cmd, _temp) = common::xv_isolated_local();
+    let out = cmd
+        .args(["type", "ls", "--format", "table"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(stdout.contains("login"), "stdout: {stdout}");
+}
+
+#[test]
+fn type_show_login_fields() {
+    let (mut cmd, _temp) = common::xv_isolated_local();
+    let out = cmd.args(["type", "show", "login"]).output().unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(stdout.contains("username"), "stdout: {stdout}");
+    assert!(stdout.contains("url"), "stdout: {stdout}");
+    assert!(stdout.contains("password"), "stdout: {stdout}");
+}
+
+#[test]
+fn type_list_includes_project_custom_type() {
+    let xv_toml = r#"
+default_env = "dev"
+
+[env.dev]
+vault = "default"
+resource_group = "test-rg"
+
+[types.smtp]
+fields = [
+  { name = "host" },
+  { name = "port" },
+  { name = "username", required = true },
+  { name = "password", kind = "secret", primary = true },
+]
+"#;
+    let (mut cmd, _temp) = common::xv_isolated_local_with_profile(xv_toml);
+    let out = cmd
+        .args(["type", "list", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    let types = parsed.as_array().expect("array");
+    let smtp = types
+        .iter()
+        .find(|t| t["name"] == "smtp")
+        .expect("smtp type present");
+    assert_eq!(smtp["source"], "project");
+}
+
+#[test]
+fn type_show_unknown_errors() {
+    let (mut cmd, _temp) = common::xv_isolated_local();
+    let out = cmd.args(["type", "show", "nosuch"]).output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(
+        stderr.contains("login"),
+        "stderr should list known types: {stderr}"
+    );
+    assert!(
+        stderr.contains("api-key"),
+        "stderr should list known types: {stderr}"
+    );
+    assert!(
+        stderr.contains("database"),
+        "stderr should list known types: {stderr}"
+    );
+}

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -83,6 +83,180 @@ fields = [
     assert_eq!(smtp["source"], "project");
 }
 
+// ---------------------------------------------------------------------------
+// Task 6: `xv set --type` (non-interactive)
+// ---------------------------------------------------------------------------
+
+/// Reads the on-disk `.meta.json` for `name` in the `default` vault of the
+/// isolated local-backend store created by `common::xv_isolated_local()`.
+/// There is no CLI surface yet (Phase A stops at Task 7) that exposes a
+/// record's tags directly, so these tests read the store layout the local
+/// backend itself defines (`<store>/vaults/<vault>/secrets/<name>.meta.json`
+/// — un-opaque by default) to assert on tags. This is a deliberate,
+/// documented deviation for Task 6 only; Task 10 (`ls` JSON field lifting,
+/// out of Phase A scope) will give these assertions a CLI path.
+fn read_local_meta(temp_dir: &std::path::Path, vault: &str, name: &str) -> serde_json::Value {
+    let path = temp_dir
+        .join("store")
+        .join("vaults")
+        .join(vault)
+        .join("secrets")
+        .join(format!("{name}.meta.json"));
+    let content =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_json::from_str(&content).expect("valid meta json")
+}
+
+#[test]
+fn set_typed_record_stores_envelope_and_tags() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--field",
+            "url=https://example.com",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let meta = read_local_meta(temp.path(), "default", "cred");
+    assert_eq!(meta["content_type"], "application/vnd.xv.record");
+    assert_eq!(meta["tags"]["xv-type"], "login");
+    assert_eq!(meta["tags"]["f.username"], "bob");
+    assert_eq!(meta["tags"]["f.url"], "https://example.com");
+    // The primary field never appears as a tag.
+    assert!(meta["tags"].get("f.password").is_none());
+
+    // The stored value is the JSON envelope, not the bare primary — proven
+    // via --raw (Task 7 hasn't landed record-aware `get` yet, so --raw
+    // returns the stored value verbatim). Reuses the same store/env as the
+    // `set` above (can't reuse `cmd`/xv_isolated_local() itself: each
+    // Command is single-use and a fresh xv_isolated_local() call would
+    // create a brand-new, empty store).
+    let out2 = common::xv()
+        .env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", temp.path())
+        .env("XDG_CONFIG_HOME", temp.path().join(".config"))
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "local")
+        .env("NO_COLOR", "1")
+        .current_dir(temp.path())
+        .args(["get", "cred", "--raw"])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let stdout2 = common::stdout_str(&out2);
+    let envelope: serde_json::Value = serde_json::from_str(&stdout2).expect("valid json envelope");
+    assert_eq!(envelope["password"], "hunter2");
+    assert_eq!(envelope.as_object().unwrap().len(), 1);
+}
+
+#[test]
+fn set_typed_missing_required_field_fails_before_write() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args(["set", "cred", "--type", "login", "--value", "hunter2"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("username"), "stderr: {stderr}");
+
+    // No secret was created.
+    let meta_path = temp
+        .path()
+        .join("store")
+        .join("vaults")
+        .join("default")
+        .join("secrets")
+        .join("cred.meta.json");
+    assert!(!meta_path.exists());
+}
+
+#[test]
+fn set_unknown_type_errors_listing_types() {
+    let (mut cmd, _temp) = common::xv_isolated_local();
+    let out = cmd
+        .args(["set", "cred", "--type", "nosuch", "--value", "x"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("login"), "stderr: {stderr}");
+}
+
+#[test]
+fn set_adhoc_field_allowed() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--field",
+            "custom-note=hello",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let meta = read_local_meta(temp.path(), "default", "cred");
+    assert_eq!(meta["tags"]["f.custom-note"], "hello");
+}
+
+#[test]
+fn set_field_secret_goes_to_envelope() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--field-secret",
+            "totp-seed=ABCDEF",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let meta = read_local_meta(temp.path(), "default", "cred");
+    assert!(
+        meta["tags"].get("f.totp-seed").is_none(),
+        "secret field must not appear as a tag: {meta}"
+    );
+}
+
 #[test]
 fn type_show_unknown_errors() {
     let (mut cmd, _temp) = common::xv_isolated_local();

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -179,6 +179,45 @@ fn set_typed_missing_required_field_fails_before_write() {
     assert!(!meta_path.exists());
 }
 
+/// Bugbot PR #322 round 3: `--field username= ` (empty/whitespace value)
+/// must not satisfy a required field — non-interactive validation must
+/// match the interactive prompt path, which already rejects a blank
+/// answer for a required field.
+#[test]
+fn set_typed_empty_required_field_fails_before_write() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username= ",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("username"), "stderr: {stderr}");
+
+    let meta_path = temp
+        .path()
+        .join("store")
+        .join("vaults")
+        .join("default")
+        .join("secrets")
+        .join("cred.meta.json");
+    assert!(!meta_path.exists(), "nothing must be written on rejection");
+}
+
 #[test]
 fn set_unknown_type_errors_listing_types() {
     let (mut cmd, _temp) = common::xv_isolated_local();

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -320,6 +320,14 @@ fn get_typed_record_returns_primary_bare() {
     assert_eq!(common::stdout_str(&out2), "hunter2");
 }
 
+/// This test exercises `--field --raw`, not the clipboard path: every
+/// harness in `tests/common/mod.rs` sets `clipboard_timeout = 0` and CI
+/// runners are headless (no real clipboard), so asserting the "auto-clears
+/// in Ns" affordance line end-to-end would be flaky/environment-dependent
+/// here. The clipboard auto-clear-vs-skip decision for secret-kind vs
+/// metadata-kind fields (code review follow-up) is instead unit-tested
+/// directly against the extracted pure function `field_clipboard_outcome`
+/// — see the `field_clipboard_outcome_*` tests in `src/cli/secret_ops.rs`.
 #[test]
 fn get_field_metadata_and_secret() {
     let (mut cmd, temp) = common::xv_isolated_local();


### PR DESCRIPTION
Phase A of #321 — record types core. Spec and plan ride this PR (`docs/superpowers/specs/2026-07-03-record-types-design.md`, `docs/superpowers/plans/2026-07-03-record-types-plan.md`).

## What this adds

Typed secret records with structured fields, per the approved spec:

- **`src/records/` module**: `RecordType`/`FieldDef` model with validation (exactly one primary field; primary ⇒ secret + required), built-in types (`login`, `api-key`, `database`), strict JSON envelope codec, and the reserved constants (`application/vnd.xv.record`, `xv-type` tag, `f.` field-tag prefix).
- **Custom types in config**: `[types.<name>]` blocks in global `xv.conf` and `.xv.toml`, resolved project > global > built-in (shadowing a built-in warns); invalid custom types rejected at resolution.
- **`xv type list` / `xv type show`**: resolved types with source attribution; config-only (excluded from backend validation per the #312 gating pattern).
- **`xv set --type login --field username=bob …`**: non-interactive and interactive record creation. Secret-kind fields go into the JSON envelope in the value; metadata fields become `f.*` tags; required fields enforced and the tag budget checked **before any write**.
- **`xv get`**: plain get returns the primary field — byte-identical behavior for untyped secrets and typed records alike; `--field` reads one field (with clipboard auto-clear for secret-kind values); `--record` returns the whole record. Four failure modes per spec: corrupt envelope fails loud (never prints raw JSON as a value), unknown field lists the record's real fields, unknown type degrades gracefully, `--field`/`--record` on untyped secrets errors.
- **Tag-limit capabilities**: `BackendCapabilities` gains `max_tags`/`max_tag_value_len` (Azure 15/256, AWS 50/256, local unbounded); the budget check counts the always-written bookkeeping tags (`original_name`, `created_by`) via a shared constant used by all write paths, with a boundary test at Azure's real 15-tag cap (caught in review — the first cut under-counted by 2, which would have broken fail-before-write exactly at the boundary).

## Compatibility

Record-ness is decided by the content-type marker, never JSON sniffing — a plain secret whose value happens to be JSON is never misread. Untyped secrets are byte-identical on every touched path (verified in review against the `get` rewrite: clipboard, `--raw`, formats, exit codes).

## Tests

17 hermetic e2e tests in `tests/e2e_record_types.rs` (isolated config/env; also run under a scrubbed `env -i` environment to simulate clean CI) plus unit coverage for type validation, resolution/shadowing, envelope strictness, tag-budget boundaries, and clipboard outcomes. Full workspace: 787 lib tests + all integration suites green; clippy 0 warnings. Independent code-review pass performed; its MAJOR (tag under-count) and MINOR (clipboard auto-clear) findings are fixed in the final commit.

Phases B (update/convert/ls/TUI) and C (inject fields + docs) follow per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `get`/`set` secret paths and storage shape for explicitly typed records; mitigated by content-type gating and tests asserting untyped behavior stays the same, but Azure/AWS tag-cap logic must stay aligned with each backend's write path.
> 
> **Overview**
> **Phase A** adds **record types**: structured secrets with metadata in `f.*` tags, secret fields in a JSON envelope (`application/vnd.xv.record`), and type name in `xv-type`. Record-ness is determined only by content type, not JSON sniffing.
> 
> A new **`src/records/`** module defines built-in types (`login`, `api-key`, `database`), validation, envelope encode/parse, type resolution from **`[types.*]`** in `xv.conf` / `.xv.toml` (project > global > built-in), and **`check_tag_budget`** with backend-specific reserved-tag prediction (Azure/AWS/local).
> 
> **CLI:** config-only **`xv type list` / `show`**; **`xv set --type`** with `--field` / `--field-secret` (fail-before-write for required fields, tag collisions, duplicates, non-TTY primary); **`xv get`** unchanged for untyped secrets, returns primary for records, plus **`--field`** and **`--record`** with corrupt-envelope and unknown-type handling.
> 
> **Backends** gain `max_tags` / `max_tag_value_len` on capabilities; shared **`TAG_ORIGINAL_NAME`** / **`TAG_CREATED_BY`** constants align budget checks with actual writes.
> 
> Hermetic **`tests/e2e_record_types.rs`** and unit tests cover the above; design/plan docs are included for later phases (update, ls, inject).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33196053caf999959f724e566b5890699d26b064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->