### PR TITLE
feat: record editing, conversion, and listing (#321 Phase B)

### DIFF
--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -695,7 +695,9 @@ impl SecretBackend for AwsSecretBackend {
         request: SecretUpdateRequest,
     ) -> Result<SecretProperties, BackendError> {
         use crate::backend::aws::encoding::aws_name;
-        use crate::backend::aws::metadata::{TAG_EXPIRES_AT, TAG_FOLDER, TAG_GROUPS};
+        use crate::backend::aws::metadata::{
+            TAG_CONTENT_TYPE, TAG_EXPIRES_AT, TAG_FOLDER, TAG_GROUPS,
+        };
         use aws_sdk_secretsmanager::types::Tag;
 
         // AWS Secrets Manager has no enable/disable concept — fail loudly
@@ -707,6 +709,23 @@ impl SecretBackend for AwsSecretBackend {
         }
 
         let aws_full_name = aws_name(vault, name);
+
+        // Write a new secret version when the caller supplied a new value —
+        // mirrors `set_secret`'s (via `update_existing_secret`) Step 1.
+        // Bugbot review on the first cut of the record-types edit paths:
+        // this backend previously applied only note/tag/folder/expiry
+        // deltas and NEVER wrote a value, so `xv update --field-secret`
+        // silently discarded the new envelope on AWS while reporting
+        // success.
+        if let Some(ref new_value) = request.value {
+            self.client
+                .put_secret_value()
+                .secret_id(&aws_full_name)
+                .secret_string(new_value.as_str().to_string())
+                .send()
+                .await
+                .map_err(|e| super::errors::from_put_value(name, e))?;
+        }
 
         // Update description (note): Set writes the new text, Clear empties it.
         match &request.note {
@@ -765,12 +784,62 @@ impl SecretBackend for AwsSecretBackend {
             FieldUpdate::Clear => keys_to_remove.push(TAG_EXPIRES_AT.into()),
             FieldUpdate::Unchanged => {}
         }
+        // Content type: `Some("")` (used by `xv update --untype` to clear a
+        // record's content-type marker) removes the tag; `Some(nonempty)`
+        // (used by a secret-field edit / `--type` conversion to (re)stamp
+        // `application/vnd.xv.record`) sets it. `None` leaves it untouched
+        // — mirrors `set_secret`'s handling of `TAG_CONTENT_TYPE`. Bugbot
+        // review: this backend previously never looked at
+        // `request.content_type` at all, so a record's content-type marker
+        // was never written/cleared here.
+        if let Some(ref ct) = request.content_type {
+            if ct.is_empty() {
+                keys_to_remove.push(TAG_CONTENT_TYPE.into());
+            } else {
+                tags_to_set.push(Tag::builder().key(TAG_CONTENT_TYPE).value(ct).build());
+            }
+        }
         if let Some(ref user_tags) = request.tags {
             for (k, v) in user_tags {
                 if v.is_empty() {
                     keys_to_remove.push(k.clone());
                 } else if preserves_request_tag(k) {
                     tags_to_set.push(Tag::builder().key(k).value(v).build());
+                }
+            }
+
+            // `replace_tags`: the loop above is a per-key DELTA (only keys
+            // present in `user_tags` are touched; a key silently absent
+            // from the map is left alone). Record-types plan Tasks 8/9
+            // build a FULL desired tag map and set `replace_tags: true`
+            // expecting "this map IS the whole picture" semantics — e.g.
+            // `xv update --untype` drops `xv-type`/`f.*` by omitting them
+            // from the map entirely, not by sending them with an empty
+            // value. Without this branch that omission was silently a
+            // no-op on AWS (Bugbot review: "untype no-ops ... xv-type tag
+            // survives since absent-from-map != removed"). Only plain
+            // (non "xv:"-prefixed) existing tags participate: the "xv:"
+            // namespace (original_name/groups/folder/content_type/
+            // expires_at/migration markers) is always managed by its own
+            // dedicated request field above, never by this generic diff.
+            if request.replace_tags {
+                let describe = self
+                    .client
+                    .describe_secret()
+                    .secret_id(&aws_full_name)
+                    .send()
+                    .await
+                    .map_err(|e| super::errors::from_describe(name, e))?;
+                let desired_keys: std::collections::HashSet<&str> =
+                    user_tags.keys().map(String::as_str).collect();
+                for tag in describe.tags() {
+                    let Some(key) = tag.key() else { continue };
+                    if key.starts_with("xv:") {
+                        continue;
+                    }
+                    if !desired_keys.contains(key) && !keys_to_remove.iter().any(|k| k == key) {
+                        keys_to_remove.push(key.to_string());
+                    }
                 }
             }
         }

--- a/src/backend/aws/secrets.rs
+++ b/src/backend/aws/secrets.rs
@@ -642,6 +642,17 @@ impl SecretBackend for AwsSecretBackend {
                     .map(String::from)
                     .filter(|n| !n.is_empty());
 
+                // Full tag map (record-types plan Task 10): xv-type/f.*
+                // fields ride as plain user tags (see `request.tags` in
+                // `set_secret`), unprefixed — unlike the "xv:*" bookkeeping
+                // tags above, so they're captured verbatim here.
+                let tags_val: std::collections::HashMap<String, String> = entry
+                    .tags()
+                    .iter()
+                    .filter_map(|t| t.key().zip(t.value()))
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect();
+
                 summaries.push(SecretSummary {
                     name: secret_name,
                     original_name: original_name_val,
@@ -651,6 +662,7 @@ impl SecretBackend for AwsSecretBackend {
                     updated_on: String::new(),
                     enabled: true,
                     content_type: String::new(),
+                    tags: tags_val,
                 });
             }
 

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -341,6 +341,7 @@ fn meta_to_summary(meta: &SecretMeta) -> SecretSummary {
         updated_on: meta.updated_at.format("%Y-%m-%d %H:%M").to_string(),
         enabled: meta.enabled,
         content_type: meta.content_type.clone(),
+        tags: meta.tags.clone(),
     }
 }
 

--- a/src/backend/secret.rs
+++ b/src/backend/secret.rs
@@ -5,6 +5,7 @@
 //! methods have default implementations that return [`BackendError::Unsupported`].
 
 use async_trait::async_trait;
+use std::collections::HashMap;
 
 use crate::secret::manager::{
     DeletedSecretSummary, SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest,
@@ -184,6 +185,45 @@ pub trait SecretBackend: Send + Sync {
     }
 }
 
+/// Extracts the denormalized `groups`/`note`/`folder` tags out of `tags`
+/// (in place) and returns them, and strips the bookkeeping tags
+/// (`original_name`, `created_by`) that a fresh write regenerates.
+///
+/// Every backend's `get_secret` folds groups/note/folder into plain tag
+/// keys on `SecretProperties.tags` for display convenience — Azure stores
+/// them as literal tags natively (so this "just works" there), while AWS's
+/// `props_from_describe` explicitly lifts `xv:groups`/the description
+/// field/`xv:folder` into the same plain `"groups"`/`"note"`/`"folder"`
+/// keys. Any caller that reads a secret's properties and later writes a
+/// tags map back (`SecretRequest.tags` / `SecretUpdateRequest.tags`) MUST
+/// run it through this first: handing the denormalized map back verbatim
+/// would create extra plain `groups`/`note`/`folder` *user* tags on AWS
+/// (duplicating the real `xv:groups`/description/`xv:folder`) or persist
+/// them into the wrong storage location on the local backend
+/// (`SecretMeta.tags` instead of the dedicated `.groups`/`.note`/`.folder`
+/// fields) — the exact bug class the #315 copy/move review caught, and
+/// later reproduced by the record-types update/conversion paths (Bugbot
+/// review, record-types plan). This is the single source of truth for
+/// that key list; do not hand-roll it elsewhere.
+pub(crate) fn split_denormalized_tags(
+    tags: &mut HashMap<String, String>,
+) -> (Option<Vec<String>>, Option<String>, Option<String>) {
+    let groups = tags
+        .remove("groups")
+        .map(|g| {
+            g.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .filter(|g| !g.is_empty());
+    let note = tags.remove("note");
+    let folder = tags.remove("folder");
+    tags.remove(super::TAG_ORIGINAL_NAME);
+    tags.remove(super::TAG_CREATED_BY);
+    (groups, note, folder)
+}
+
 /// Build the create-under-the-new-name request for a rename from the source
 /// secret's properties. Groups/note/folder live under canonical tag keys in
 /// `SecretProperties.tags` on every backend; lift them into the first-class
@@ -202,19 +242,7 @@ pub(crate) fn rename_request_from_properties(
     })?;
 
     let mut tags = current.tags.clone();
-    let groups = tags
-        .remove("groups")
-        .map(|g| {
-            g.split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect::<Vec<_>>()
-        })
-        .filter(|g| !g.is_empty());
-    let note = tags.remove("note");
-    let folder = tags.remove("folder");
-    tags.remove(super::TAG_ORIGINAL_NAME);
-    tags.remove(super::TAG_CREATED_BY);
+    let (groups, note, folder) = split_denormalized_tags(&mut tags);
 
     Ok(SecretRequest {
         name: new_name.to_string(),

--- a/src/cache/manager.rs
+++ b/src/cache/manager.rs
@@ -440,6 +440,62 @@ mod tests {
         assert_eq!(retrieved, Some(data));
     }
 
+    /// Bugbot MEDIUM review (record-types plan): `SecretSummary` gained a
+    /// `tags` field with `#[serde(default)]`, so a v1-schema secrets-list
+    /// cache entry written before that change would deserialize
+    /// successfully but with an empty `tags` map — silently hiding every
+    /// typed secret's `xv-type`/`f.*` tags from `ls --type`/the TYPE column
+    /// until TTL expiry. The fix renames the on-disk filename
+    /// (`secrets-list.json` -> `secrets-list-v2.json`, see
+    /// `SECRETS_LIST_FILENAME` in `cache::models`) so a pre-existing v1
+    /// entry simply misses instead of silently deserializing into
+    /// incomplete data. This test writes a legacy-shaped entry at the OLD
+    /// path directly (bypassing `CacheManager::set`, which only ever
+    /// writes the current path) and asserts `get` treats it as absent.
+    #[test]
+    fn test_get_misses_legacy_pre_v2_secrets_list_cache_file() {
+        let dir = tempdir().unwrap();
+        let mgr = make_manager(dir.path(), true, 300);
+        let key = CacheKey::SecretsList {
+            vault_name: "myvault".to_string(),
+        };
+
+        // Simulate a cache entry written by a pre-Task-10 binary: same
+        // vault directory, but the OLD filename and a payload shaped like
+        // the OLD (tags-less) SecretSummary.
+        let legacy_dir = dir.path().join("myvault");
+        std::fs::create_dir_all(&legacy_dir).unwrap();
+        let legacy_path = legacy_dir.join("secrets-list.json");
+        let legacy_json = serde_json::json!({
+            "created_at": chrono::Utc::now().to_rfc3339(),
+            "ttl_secs": 300,
+            "vault_name": "myvault",
+            "entry_type": "SecretsList",
+            "data": [{"name": "cred", "note": null, "folder": null, "groups": null, "updated_on": "", "original_name": "cred"}]
+        });
+        std::fs::write(&legacy_path, legacy_json.to_string()).unwrap();
+
+        // The new code path never looks at the old filename — a cache
+        // miss, not a hit with an empty `tags` map masking a typed secret.
+        let result: Option<Vec<crate::secret::manager::SecretSummary>> = mgr.get(&key);
+        assert!(
+            result.is_none(),
+            "legacy pre-v2 cache entry must miss, not silently deserialize: {result:?}"
+        );
+
+        // The current writer never touches the legacy path either.
+        let data = vec![];
+        mgr.set::<Vec<crate::secret::manager::SecretSummary>>(&key, &data);
+        assert!(
+            legacy_path.exists(),
+            "set() must not overwrite/consume the legacy file"
+        );
+        assert!(
+            key.to_path(dir.path()).ends_with("secrets-list-v2.json"),
+            "current schema must resolve to the v2 filename"
+        );
+    }
+
     #[test]
     fn test_get_returns_none_for_expired_entry() {
         // TTL = 0 means every entry is immediately expired.

--- a/src/cache/models.rs
+++ b/src/cache/models.rs
@@ -27,6 +27,23 @@ pub enum CacheEntryType {
     FileList,
 }
 
+/// On-disk filename for the secrets-list cache entry, versioned in the name
+/// itself so a schema change to the cached payload (`SecretSummary`) makes
+/// old entries simply miss instead of deserializing into wrong/incomplete
+/// data.
+///
+/// Bumped v1 -> v2 for the record-types plan (Task 10): `SecretSummary`
+/// gained a `tags` field with `#[serde(default)]`, so a pre-existing v1
+/// cache entry written before that change would deserialize successfully
+/// but with an EMPTY `tags` map — silently hiding every typed secret's
+/// `xv-type`/`f.*` tags from `ls --type` and the `ls` TYPE column until the
+/// entry's TTL expired (Bugbot review: "a cache hit hides typed secrets").
+/// Renaming the file (rather than trying to detect "empty tags" as stale)
+/// is deliberate: legitimately untagged secrets exist, so an empty map is
+/// not itself evidence of staleness. Bump this suffix again on any future
+/// change to `SecretSummary`'s shape.
+const SECRETS_LIST_FILENAME: &str = "secrets-list-v2.json";
+
 /// Identifies a cache entry and determines its file path.
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
@@ -96,13 +113,13 @@ impl CacheKey {
                     Ok(()) => vault_name.clone(),
                     Err(_) => safe_fallback_dir(vault_name),
                 };
-                let candidate = cache_dir.join(&dir_name).join("secrets-list.json");
+                let candidate = cache_dir.join(&dir_name).join(SECRETS_LIST_FILENAME);
                 if ensure_cache_child_path(cache_dir, &candidate) {
                     candidate
                 } else {
                     cache_dir
                         .join(safe_fallback_dir(vault_name))
-                        .join("secrets-list.json")
+                        .join(SECRETS_LIST_FILENAME)
                 }
             }
             CacheKey::VaultList => cache_dir.join("vaults-list.json"),
@@ -332,7 +349,7 @@ mod tests {
         };
         assert_eq!(
             key.to_path(&base),
-            PathBuf::from("/cache/myvault/secrets-list.json")
+            PathBuf::from("/cache/myvault/secrets-list-v2.json")
         );
 
         let key = CacheKey::VaultList;

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -552,10 +552,12 @@ pub enum Commands {
         /// secrets (backend must support soft delete)
         #[arg(
             long,
-            conflicts_with_all = ["path", "recursive", "group", "all", "expiring", "expired"]
+            conflicts_with_all = ["path", "recursive", "group", "all", "expiring", "expired", "type_filter"]
         )]
         deleted: bool,
-        /// Filter by record type (built-in or custom `[types.*]`, e.g. `login`)
+        /// Filter by record type (built-in or custom `[types.*]`, e.g. `login`).
+        /// Not supported with --deleted: deleted-secret summaries don't carry
+        /// tags on any backend, so there's no `xv-type` to filter on.
         #[arg(long = "type")]
         type_filter: Option<String>,
     },

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -731,6 +731,33 @@ pub enum Commands {
         /// Enable or disable the secret (true/false)
         #[arg(long)]
         enabled: Option<bool>,
+        /// Edit one metadata (or type-declared non-primary secret) field of
+        /// a typed record, `name=value` (repeatable). A metadata-field edit
+        /// is tag-only; a secret-field edit rewrites the record envelope as
+        /// a new version. Errors if the secret is untyped. Mutually
+        /// exclusive with --type/--untype.
+        #[arg(long = "field", value_name = "NAME=VALUE", value_parser = parse_key_val::<String, String>, conflicts_with_all = ["type", "untype"])]
+        fields: Vec<(String, String)>,
+        /// Edit an ad-hoc secret field of a typed record, `name=value`
+        /// (repeatable) — stored in the record envelope. Mutually
+        /// exclusive with --type/--untype.
+        #[arg(long = "field-secret", value_name = "NAME=VALUE", value_parser = parse_key_val::<String, String>, conflicts_with_all = ["type", "untype"])]
+        secret_fields: Vec<(String, String)>,
+        /// Explicitly convert a bare secret into a typed record: its
+        /// current value becomes the primary field. Errors if the secret
+        /// is already a record. Mutually exclusive with --untype/--field/--field-secret.
+        #[arg(long = "type", conflicts_with_all = ["untype", "fields", "secret_fields"])]
+        r#type: Option<String>,
+        /// Flatten a typed record back to a bare secret holding the
+        /// primary field's value. Dropping non-primary secret fields
+        /// prompts for confirmation unless --yes is given. Mutually
+        /// exclusive with --type/--field/--field-secret.
+        #[arg(long, conflicts_with_all = ["type", "fields", "secret_fields"])]
+        untype: bool,
+        /// Skip the confirmation prompt when --untype would drop
+        /// non-primary secret fields.
+        #[arg(long, short = 'y')]
+        yes: bool,
     },
     /// Move or rename a secret, or re-folder a whole folder (trailing / = folder)
     Mv {
@@ -1766,6 +1793,11 @@ impl Cli {
                 clear_note,
                 clear_folder,
                 enabled,
+                fields,
+                secret_fields,
+                r#type,
+                untype,
+                yes,
             } => {
                 crate::cli::secret_ops::execute_secret_update_direct(
                     &name,
@@ -1786,6 +1818,11 @@ impl Cli {
                     clear_note,
                     clear_folder,
                     enabled,
+                    fields,
+                    secret_fields,
+                    r#type,
+                    untype,
+                    yes,
                     config,
                     registry,
                 )

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -555,6 +555,9 @@ pub enum Commands {
             conflicts_with_all = ["path", "recursive", "group", "all", "expiring", "expired"]
         )]
         deleted: bool,
+        /// Filter by record type (built-in or custom `[types.*]`, e.g. `login`)
+        #[arg(long = "type")]
+        type_filter: Option<String>,
     },
     /// Delete a secret from the current vault context (alias: rm)
     #[command(alias = "rm")]
@@ -1664,6 +1667,7 @@ impl Cli {
                 names_only,
                 sort,
                 deleted,
+                type_filter,
             } => {
                 let pagination = crate::utils::pagination::Pagination::from_args(page, page_size)?;
                 let pager = pager.map(PagerWhen::wants_pager).unwrap_or(false);
@@ -1684,8 +1688,21 @@ impl Cli {
                         None => String::new(),
                     };
                     crate::cli::secret_ops::execute_secret_list_direct(
-                        path, group, all, expiring, expired, no_cache, pagination, pager,
-                        names_only, long, recursive, sort, config, registry,
+                        path,
+                        group,
+                        all,
+                        expiring,
+                        expired,
+                        no_cache,
+                        pagination,
+                        pager,
+                        names_only,
+                        long,
+                        recursive,
+                        sort,
+                        type_filter,
+                        config,
+                        registry,
                     )
                     .await
                 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -738,24 +738,55 @@ pub enum Commands {
         /// a typed record, `name=value` (repeatable). A metadata-field edit
         /// is tag-only; a secret-field edit rewrites the record envelope as
         /// a new version. Errors if the secret is untyped. Mutually
-        /// exclusive with --type/--untype.
-        #[arg(long = "field", value_name = "NAME=VALUE", value_parser = parse_key_val::<String, String>, conflicts_with_all = ["type", "untype"])]
+        /// exclusive with --type/--untype and with every classic update
+        /// flag (--value/--stdin/--note/--tags/--folder/etc.) — a record
+        /// field edit is a standalone operation in v1; compound edits are
+        /// two commands (e.g. `xv update x --note n` then
+        /// `xv update x --field a=b`).
+        #[arg(long = "field", value_name = "NAME=VALUE", value_parser = parse_key_val::<String, String>, conflicts_with_all = [
+            "type", "untype",
+            "value", "stdin", "trim", "tags", "group", "rename", "note", "folder",
+            "replace_tags", "replace_groups", "expires", "not_before",
+            "clear_expires", "clear_not_before", "clear_note", "clear_folder", "enabled",
+        ])]
         fields: Vec<(String, String)>,
         /// Edit an ad-hoc secret field of a typed record, `name=value`
         /// (repeatable) — stored in the record envelope. Mutually
-        /// exclusive with --type/--untype.
-        #[arg(long = "field-secret", value_name = "NAME=VALUE", value_parser = parse_key_val::<String, String>, conflicts_with_all = ["type", "untype"])]
+        /// exclusive with --type/--untype and with every classic update
+        /// flag; see --field's note.
+        #[arg(long = "field-secret", value_name = "NAME=VALUE", value_parser = parse_key_val::<String, String>, conflicts_with_all = [
+            "type", "untype",
+            "value", "stdin", "trim", "tags", "group", "rename", "note", "folder",
+            "replace_tags", "replace_groups", "expires", "not_before",
+            "clear_expires", "clear_not_before", "clear_note", "clear_folder", "enabled",
+        ])]
         secret_fields: Vec<(String, String)>,
         /// Explicitly convert a bare secret into a typed record: its
         /// current value becomes the primary field. Errors if the secret
-        /// is already a record. Mutually exclusive with --untype/--field/--field-secret.
-        #[arg(long = "type", conflicts_with_all = ["untype", "fields", "secret_fields"])]
+        /// is already a record. Mutually exclusive with --untype/--field/
+        /// --field-secret and with every classic update flag, INCLUDING
+        /// --value/--stdin: converting and replacing the primary value in
+        /// one step is not supported in v1 — convert first (this command,
+        /// no --value/--stdin), then set the primary via
+        /// `xv update <name> --field-secret <primary-field>=<value>`.
+        #[arg(long = "type", conflicts_with_all = [
+            "untype", "fields", "secret_fields",
+            "value", "stdin", "trim", "tags", "group", "rename", "note", "folder",
+            "replace_tags", "replace_groups", "expires", "not_before",
+            "clear_expires", "clear_not_before", "clear_note", "clear_folder", "enabled",
+        ])]
         r#type: Option<String>,
         /// Flatten a typed record back to a bare secret holding the
         /// primary field's value. Dropping non-primary secret fields
         /// prompts for confirmation unless --yes is given. Mutually
-        /// exclusive with --type/--field/--field-secret.
-        #[arg(long, conflicts_with_all = ["type", "fields", "secret_fields"])]
+        /// exclusive with --type/--field/--field-secret and with every
+        /// classic update flag; see --field's note.
+        #[arg(long, conflicts_with_all = [
+            "type", "fields", "secret_fields",
+            "value", "stdin", "trim", "tags", "group", "rename", "note", "folder",
+            "replace_tags", "replace_groups", "expires", "not_before",
+            "clear_expires", "clear_not_before", "clear_note", "clear_folder", "enabled",
+        ])]
         untype: bool,
         /// Skip the confirmation prompt when --untype would drop
         /// non-primary secret fields.

--- a/src/cli/ls_view.rs
+++ b/src/cli/ls_view.rs
@@ -391,6 +391,7 @@ pub(crate) fn render_name_grid(names: &[String], width: usize) -> String {
                 updated_on: String::new(),
                 enabled: true,
                 content_type: String::new(),
+                tags: std::collections::HashMap::new(),
             })
         })
         .collect();
@@ -468,6 +469,7 @@ mod tests {
             updated_on: "2026-05-17 01:19:00 UTC".to_string(),
             enabled: true,
             content_type: "text/plain".to_string(),
+            tags: std::collections::HashMap::new(),
         }
     }
 

--- a/src/cli/mv_ops.rs
+++ b/src/cli/mv_ops.rs
@@ -539,6 +539,7 @@ mod tests {
             updated_on: String::new(),
             enabled: true,
             content_type: String::new(),
+            tags: std::collections::HashMap::new(),
         }
     }
 
@@ -601,6 +602,7 @@ mod tests {
             updated_on: String::new(),
             enabled: true,
             content_type: String::new(),
+            tags: std::collections::HashMap::new(),
         }
     }
 

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2332,7 +2332,8 @@ async fn execute_record_field_update(
         new_value = Some(Zeroizing::new(encode_envelope(&envelope)?));
     }
 
-    // Tags + content type + replace_tags. Two distinct write shapes:
+    // Tags + content type + replace_tags/replace_groups + groups/note/
+    // folder. Two distinct write shapes:
     //
     // - Secret-field edit (`new_value.is_some()`): this forces the full-PUT
     //   path on Azure's `update_secret` (it only takes the lighter
@@ -2344,42 +2345,84 @@ async fn execute_record_field_update(
     //   "no content type" / "rebuild tags from empty" respectively. Relying
     //   on backend merge-on-`None` semantics here silently destroyed the
     //   record's content-type marker and dropped xv-type/f.*/groups/etc.
-    //   (Bugbot review on the first cut of this function). So whenever a
-    //   secret-field edit is in play we build the COMPLETE desired tag map
-    //   ourselves (existing tags + the metadata overlay) and set
-    //   `replace_tags: true`, exactly like `execute_record_type_conversion`/
-    //   `execute_record_untype` already do — never a partial delta.
+    //   (Bugbot review, round 1). So whenever a secret-field edit is in
+    //   play we build the COMPLETE desired tag map ourselves (existing tags
+    //   + the metadata overlay) and set `replace_tags: true`, exactly like
+    //   `execute_record_type_conversion`/`execute_record_untype` already do
+    //   — never a partial delta.
+    //
+    //   That full-PUT path ALSO does not treat `groups: None` as
+    //   "unchanged": Azure's `prepare_secret_request` (src/secret/manager.rs)
+    //   only re-adds the `groups` tag when `SecretRequest.groups` is `Some`,
+    //   so sending `None` after stripping the denormalized `groups` key out
+    //   of the tags map above silently ERASED group membership on Azure —
+    //   `note`/`folder` happened to survive only because they ride
+    //   `FieldUpdate::Unchanged`, which Azure's translation layer explicitly
+    //   re-fetches and carries forward before reaching `prepare_secret_
+    //   request`; `groups` has no such tri-state fallback (Bugbot review,
+    //   round 3). Fix: use the tuple `split_denormalized_tags` returns —
+    //   `groups` goes into the request's dedicated field as `Some(vec)`
+    //   with `replace_groups: true` (exact carry-forward, mirrors
+    //   `rename_request_from_properties`'s use of the same tuple); `note`/
+    //   `folder` switch from `Unchanged` to `Set`-when-known so they no
+    //   longer rely on any backend's "Unchanged re-fetches current"
+    //   behavior specifically — they're asserted directly from the same
+    //   `secret` this function already fetched.
     // - Metadata-only edit (`new_value.is_none()`): stays on Azure's
     //   attributes-only PATCH, which already merges a partial tag delta
-    //   against the current tags itself (`build_patched_tags`), so a
-    //   partial map + `replace_tags: false` is correct and cheaper (no new
-    //   version).
-    let (new_tags, content_type, replace_tags) = if !secret_updates.is_empty() {
-        let mut full = secret.tags.clone();
-        for (k, v) in &metadata_updates {
-            full.insert(format!("{FIELD_TAG_PREFIX}{k}"), v.clone());
-        }
-        // `secret.tags` is DENORMALIZED for display (groups/note/folder
-        // folded into plain keys by every backend's get_secret) — strip
-        // them before this map becomes a literal `replace_tags: true`
-        // write, or they'd land as extra plain user tags on AWS / the
-        // wrong SecretMeta field on local (Bugbot review; same helper
-        // `rename_request_from_properties` already relies on). The
-        // request's own `groups: None`/`note`/`folder: Unchanged` below
-        // already preserves their real values via each backend's normal
-        // "leave unchanged" handling — this call only needs to run for
-        // its stripping side effect.
-        let _ = crate::backend::secret::split_denormalized_tags(&mut full);
-        (Some(full), Some(RECORD_CONTENT_TYPE.to_string()), true)
-    } else if !metadata_updates.is_empty() {
-        let mut t = std::collections::HashMap::new();
-        for (k, v) in &metadata_updates {
-            t.insert(format!("{FIELD_TAG_PREFIX}{k}"), v.clone());
-        }
-        (Some(t), None, false)
-    } else {
-        (None, None, false)
-    };
+    //   against the current tags itself (`build_patched_tags`) and already
+    //   correctly leaves groups/note/folder alone when their request fields
+    //   are None/Unchanged — untouched, still correct.
+    let (new_tags, content_type, replace_tags, groups, note, folder, replace_groups) =
+        if !secret_updates.is_empty() {
+            let mut full = secret.tags.clone();
+            for (k, v) in &metadata_updates {
+                full.insert(format!("{FIELD_TAG_PREFIX}{k}"), v.clone());
+            }
+            // `secret.tags` is DENORMALIZED for display (groups/note/folder
+            // folded into plain keys by every backend's get_secret) — strip
+            // them before this map becomes a literal `replace_tags: true`
+            // write, or they'd land as extra plain user tags on AWS / the
+            // wrong SecretMeta field on local (Bugbot review, round 2; same
+            // helper `rename_request_from_properties` already relies on).
+            let (groups, note, folder) = crate::backend::secret::split_denormalized_tags(&mut full);
+            (
+                Some(full),
+                Some(RECORD_CONTENT_TYPE.to_string()),
+                true,
+                groups,
+                note.map(crate::secret::manager::FieldUpdate::Set)
+                    .unwrap_or(crate::secret::manager::FieldUpdate::Unchanged),
+                folder
+                    .map(crate::secret::manager::FieldUpdate::Set)
+                    .unwrap_or(crate::secret::manager::FieldUpdate::Unchanged),
+                true,
+            )
+        } else if !metadata_updates.is_empty() {
+            let mut t = std::collections::HashMap::new();
+            for (k, v) in &metadata_updates {
+                t.insert(format!("{FIELD_TAG_PREFIX}{k}"), v.clone());
+            }
+            (
+                Some(t),
+                None,
+                false,
+                None,
+                crate::secret::manager::FieldUpdate::Unchanged,
+                crate::secret::manager::FieldUpdate::Unchanged,
+                false,
+            )
+        } else {
+            (
+                None,
+                None,
+                false,
+                None,
+                crate::secret::manager::FieldUpdate::Unchanged,
+                crate::secret::manager::FieldUpdate::Unchanged,
+                false,
+            )
+        };
 
     // Re-run the tag budget: projected f.* tags (existing, minus any this
     // write overwrites, plus the new values) + existing user tags. This
@@ -2420,11 +2463,11 @@ async fn execute_record_field_update(
         expires_on: crate::secret::manager::FieldUpdate::Unchanged,
         not_before: crate::secret::manager::FieldUpdate::Unchanged,
         tags: new_tags,
-        groups: None,
-        note: crate::secret::manager::FieldUpdate::Unchanged,
-        folder: crate::secret::manager::FieldUpdate::Unchanged,
+        groups,
+        note,
+        folder,
         replace_tags,
-        replace_groups: false,
+        replace_groups,
     };
     let props = reg
         .active()
@@ -2509,9 +2552,16 @@ async fn execute_record_type_conversion(
     let mut new_tags = secret.tags.clone();
     // Strip denormalized groups/note/folder (see
     // `split_denormalized_tags`'s doc comment) before this becomes a
-    // `replace_tags: true` write — their real values are preserved via
-    // `groups: None`/`note`/`folder: Unchanged` below, not this map.
-    let _ = crate::backend::secret::split_denormalized_tags(&mut new_tags);
+    // `replace_tags: true` write, and USE the extracted values via the
+    // request's dedicated fields (`groups: Some(vec)` +
+    // `replace_groups: true`, `note`/`folder` as `Set`-when-known) rather
+    // than `None`/`Unchanged` — a value-changing update takes Azure's
+    // full-PUT path, which does not treat `groups: None` as "leave
+    // unchanged" the way local/AWS's delta model does: `prepare_secret_
+    // request` only re-adds the `groups` tag when the request field is
+    // `Some`, so `None` here previously erased group membership on Azure
+    // (Bugbot review, round 3).
+    let (groups, note, folder) = crate::backend::secret::split_denormalized_tags(&mut new_tags);
     new_tags.insert(TYPE_TAG.to_string(), record_type.name.clone());
 
     let request = crate::secret::manager::SecretUpdateRequest {
@@ -2522,11 +2572,15 @@ async fn execute_record_type_conversion(
         expires_on: crate::secret::manager::FieldUpdate::Unchanged,
         not_before: crate::secret::manager::FieldUpdate::Unchanged,
         tags: Some(new_tags),
-        groups: None,
-        note: crate::secret::manager::FieldUpdate::Unchanged,
-        folder: crate::secret::manager::FieldUpdate::Unchanged,
+        groups,
+        note: note
+            .map(crate::secret::manager::FieldUpdate::Set)
+            .unwrap_or(crate::secret::manager::FieldUpdate::Unchanged),
+        folder: folder
+            .map(crate::secret::manager::FieldUpdate::Set)
+            .unwrap_or(crate::secret::manager::FieldUpdate::Unchanged),
         replace_tags: true,
-        replace_groups: false,
+        replace_groups: true,
     };
     let props = reg
         .active()
@@ -2609,10 +2663,14 @@ async fn execute_record_untype(
     new_tags.remove(TYPE_TAG);
     new_tags.retain(|k, _| !k.starts_with(FIELD_TAG_PREFIX));
     // Strip denormalized groups/note/folder — see
-    // `split_denormalized_tags`'s doc comment. Untyping doesn't touch
-    // groups/note/folder either; `groups: None`/`note`/`folder: Unchanged`
-    // below preserve their real values.
-    let _ = crate::backend::secret::split_denormalized_tags(&mut new_tags);
+    // `split_denormalized_tags`'s doc comment — and USE the extracted
+    // values via the request's dedicated fields. Untyping is a
+    // value-changing update (Azure's full-PUT path), which does not treat
+    // `groups: None` as "leave unchanged": `prepare_secret_request` only
+    // re-adds the `groups` tag when the request field is `Some`, so
+    // `None` here previously erased group membership on Azure (Bugbot
+    // review, round 3).
+    let (groups, note, folder) = crate::backend::secret::split_denormalized_tags(&mut new_tags);
 
     let request = crate::secret::manager::SecretUpdateRequest {
         name: name.to_string(),
@@ -2622,11 +2680,15 @@ async fn execute_record_untype(
         expires_on: crate::secret::manager::FieldUpdate::Unchanged,
         not_before: crate::secret::manager::FieldUpdate::Unchanged,
         tags: Some(new_tags),
-        groups: None,
-        note: crate::secret::manager::FieldUpdate::Unchanged,
-        folder: crate::secret::manager::FieldUpdate::Unchanged,
+        groups,
+        note: note
+            .map(crate::secret::manager::FieldUpdate::Set)
+            .unwrap_or(crate::secret::manager::FieldUpdate::Unchanged),
+        folder: folder
+            .map(crate::secret::manager::FieldUpdate::Set)
+            .unwrap_or(crate::secret::manager::FieldUpdate::Unchanged),
         replace_tags: true,
-        replace_groups: false,
+        replace_groups: true,
     };
     let props = reg
         .active()

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2322,15 +2322,6 @@ async fn execute_record_field_update(
         }
     }
 
-    let mut new_tags: Option<std::collections::HashMap<String, String>> = None;
-    if !metadata_updates.is_empty() {
-        let mut t = std::collections::HashMap::new();
-        for (k, v) in &metadata_updates {
-            t.insert(format!("{FIELD_TAG_PREFIX}{k}"), v.clone());
-        }
-        new_tags = Some(t);
-    }
-
     let mut new_value: Option<Zeroizing<String>> = None;
     if !secret_updates.is_empty() {
         let raw = secret.value.as_deref().map(|s| s.as_str()).unwrap_or("");
@@ -2340,6 +2331,44 @@ async fn execute_record_field_update(
         }
         new_value = Some(Zeroizing::new(encode_envelope(&envelope)?));
     }
+
+    // Tags + content type + replace_tags. Two distinct write shapes:
+    //
+    // - Secret-field edit (`new_value.is_some()`): this forces the full-PUT
+    //   path on Azure's `update_secret` (it only takes the lighter
+    //   attributes-only PATCH when `request.value.is_none()` — see
+    //   `AzureSecretBackendCompat::update_secret`, src/backend/azure/secrets.rs
+    //   ~L214-265). The full-PUT branch writes `content_type`/`tags` from the
+    //   request EXACTLY as given — `None` there does not mean "leave
+    //   unchanged" the way it does on the attributes-only PATCH; it means
+    //   "no content type" / "rebuild tags from empty" respectively. Relying
+    //   on backend merge-on-`None` semantics here silently destroyed the
+    //   record's content-type marker and dropped xv-type/f.*/groups/etc.
+    //   (Bugbot review on the first cut of this function). So whenever a
+    //   secret-field edit is in play we build the COMPLETE desired tag map
+    //   ourselves (existing tags + the metadata overlay) and set
+    //   `replace_tags: true`, exactly like `execute_record_type_conversion`/
+    //   `execute_record_untype` already do — never a partial delta.
+    // - Metadata-only edit (`new_value.is_none()`): stays on Azure's
+    //   attributes-only PATCH, which already merges a partial tag delta
+    //   against the current tags itself (`build_patched_tags`), so a
+    //   partial map + `replace_tags: false` is correct and cheaper (no new
+    //   version).
+    let (new_tags, content_type, replace_tags) = if !secret_updates.is_empty() {
+        let mut full = secret.tags.clone();
+        for (k, v) in &metadata_updates {
+            full.insert(format!("{FIELD_TAG_PREFIX}{k}"), v.clone());
+        }
+        (Some(full), Some(RECORD_CONTENT_TYPE.to_string()), true)
+    } else if !metadata_updates.is_empty() {
+        let mut t = std::collections::HashMap::new();
+        for (k, v) in &metadata_updates {
+            t.insert(format!("{FIELD_TAG_PREFIX}{k}"), v.clone());
+        }
+        (Some(t), None, false)
+    } else {
+        (None, None, false)
+    };
 
     // Re-run the tag budget: projected f.* tags (existing, minus any this
     // write overwrites, plus the new values) + existing user tags. This
@@ -2375,7 +2404,7 @@ async fn execute_record_field_update(
     let request = crate::secret::manager::SecretUpdateRequest {
         name: name.to_string(),
         value: new_value,
-        content_type: None,
+        content_type,
         enabled: None,
         expires_on: crate::secret::manager::FieldUpdate::Unchanged,
         not_before: crate::secret::manager::FieldUpdate::Unchanged,
@@ -2383,7 +2412,7 @@ async fn execute_record_field_update(
         groups: None,
         note: crate::secret::manager::FieldUpdate::Unchanged,
         folder: crate::secret::manager::FieldUpdate::Unchanged,
-        replace_tags: false,
+        replace_tags,
         replace_groups: false,
     };
     let props = reg

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2359,6 +2359,17 @@ async fn execute_record_field_update(
         for (k, v) in &metadata_updates {
             full.insert(format!("{FIELD_TAG_PREFIX}{k}"), v.clone());
         }
+        // `secret.tags` is DENORMALIZED for display (groups/note/folder
+        // folded into plain keys by every backend's get_secret) — strip
+        // them before this map becomes a literal `replace_tags: true`
+        // write, or they'd land as extra plain user tags on AWS / the
+        // wrong SecretMeta field on local (Bugbot review; same helper
+        // `rename_request_from_properties` already relies on). The
+        // request's own `groups: None`/`note`/`folder: Unchanged` below
+        // already preserves their real values via each backend's normal
+        // "leave unchanged" handling — this call only needs to run for
+        // its stripping side effect.
+        let _ = crate::backend::secret::split_denormalized_tags(&mut full);
         (Some(full), Some(RECORD_CONTENT_TYPE.to_string()), true)
     } else if !metadata_updates.is_empty() {
         let mut t = std::collections::HashMap::new();
@@ -2496,6 +2507,11 @@ async fn execute_record_type_conversion(
     )?;
 
     let mut new_tags = secret.tags.clone();
+    // Strip denormalized groups/note/folder (see
+    // `split_denormalized_tags`'s doc comment) before this becomes a
+    // `replace_tags: true` write — their real values are preserved via
+    // `groups: None`/`note`/`folder: Unchanged` below, not this map.
+    let _ = crate::backend::secret::split_denormalized_tags(&mut new_tags);
     new_tags.insert(TYPE_TAG.to_string(), record_type.name.clone());
 
     let request = crate::secret::manager::SecretUpdateRequest {
@@ -2592,6 +2608,11 @@ async fn execute_record_untype(
     let mut new_tags = secret.tags.clone();
     new_tags.remove(TYPE_TAG);
     new_tags.retain(|k, _| !k.starts_with(FIELD_TAG_PREFIX));
+    // Strip denormalized groups/note/folder — see
+    // `split_denormalized_tags`'s doc comment. Untyping doesn't touch
+    // groups/note/folder either; `groups: None`/`note`/`folder: Unchanged`
+    // below preserve their real values.
+    let _ = crate::backend::secret::split_denormalized_tags(&mut new_tags);
 
     let request = crate::secret::manager::SecretUpdateRequest {
         name: name.to_string(),

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -1057,6 +1057,27 @@ struct GroupListRow {
     secrets: usize,
 }
 
+/// Table row shape used only when at least one listed secret is a typed
+/// record (record-types plan Task 10) — adds a `Type` column. Kept as a
+/// separate struct (rather than always adding the column to
+/// `SecretListDisplayRow`) so an untyped-only listing's table output stays
+/// byte-identical to pre-Task-10 behavior.
+#[derive(Debug, Clone, serde::Serialize, tabled::Tabled)]
+struct SecretListDisplayRowTyped {
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Type")]
+    record_type: String,
+    #[tabled(rename = "Note")]
+    note: String,
+    #[tabled(rename = "Folder")]
+    folder: String,
+    #[tabled(rename = "Groups")]
+    groups: String,
+    #[tabled(rename = "Updated")]
+    updated_on: String,
+}
+
 fn format_secret_list_rows_for_human(
     secrets: &[crate::secret::manager::SecretSummary],
 ) -> Vec<SecretListDisplayRow> {
@@ -1074,6 +1095,72 @@ fn format_secret_list_rows_for_human(
             updated_on: crate::cli::ls_view::date_portion_for_display(&secret.updated_on),
         })
         .collect()
+}
+
+fn format_secret_list_rows_for_human_typed(
+    secrets: &[crate::secret::manager::SecretSummary],
+) -> Vec<SecretListDisplayRowTyped> {
+    secrets
+        .iter()
+        .map(|secret| SecretListDisplayRowTyped {
+            name: secret.name.clone(),
+            record_type: secret.tags.get(TYPE_TAG).cloned().unwrap_or_default(),
+            note: secret
+                .note
+                .as_deref()
+                .map(|note| wrap_text_to_width(note, SECRET_LIST_NOTE_WRAP_WIDTH))
+                .unwrap_or_default(),
+            folder: secret.folder.clone().unwrap_or_default(),
+            groups: secret.groups.clone().unwrap_or_default(),
+            updated_on: crate::cli::ls_view::date_portion_for_display(&secret.updated_on),
+        })
+        .collect()
+}
+
+/// True when any secret in `secrets` carries the reserved `xv-type` tag —
+/// decides whether the table view gains a `Type` column.
+fn any_secret_typed(secrets: &[crate::secret::manager::SecretSummary]) -> bool {
+    secrets.iter().any(|s| s.tags.contains_key(TYPE_TAG))
+}
+
+/// Filters `secrets` down to those whose `xv-type` tag matches `type_name`
+/// (record-types plan Task 10's `ls --type` filter).
+fn filter_secrets_by_type(
+    mut secrets: Vec<crate::secret::manager::SecretSummary>,
+    type_name: Option<&str>,
+) -> Vec<crate::secret::manager::SecretSummary> {
+    if let Some(t) = type_name {
+        secrets.retain(|s| s.tags.get(TYPE_TAG).map(String::as_str) == Some(t));
+    }
+    secrets
+}
+
+/// Lifts a `SecretSummary`'s `f.*` tags into a `fields` map and its
+/// `xv-type` tag into `record_type`, for `ls --format json` (record-types
+/// plan Task 10). Other keys match `SecretSummary`'s existing JSON shape
+/// exactly (same field names, no `tags` key) so untyped-secret JSON output
+/// is unaffected beyond the two new keys.
+fn secret_summary_to_json_with_fields(
+    s: &crate::secret::manager::SecretSummary,
+) -> serde_json::Value {
+    let mut fields = serde_json::Map::new();
+    for (k, v) in &s.tags {
+        if let Some(f) = k.strip_prefix(FIELD_TAG_PREFIX) {
+            fields.insert(f.to_string(), serde_json::Value::String(v.clone()));
+        }
+    }
+    serde_json::json!({
+        "name": s.name,
+        "original_name": s.original_name,
+        "note": s.note,
+        "folder": s.folder,
+        "groups": s.groups,
+        "updated_on": s.updated_on,
+        "enabled": s.enabled,
+        "content_type": s.content_type,
+        "record_type": s.tags.get(TYPE_TAG),
+        "fields": fields,
+    })
 }
 
 fn wrap_text_to_width(input: &str, width: usize) -> String {
@@ -1158,6 +1245,7 @@ pub(crate) fn display_cached_secret_list(
     vault_name: &str,
     config: &Config,
     names_only: bool,
+    type_filter: Option<&str>,
 ) -> Result<()> {
     use crate::cli::ls_view::{self, LsEntry};
     use crate::utils::format::TableFormatter;
@@ -1165,6 +1253,7 @@ pub(crate) fn display_cached_secret_list(
     use std::fmt::Write as _;
 
     let filtered = filter_secret_summaries_for_display(secrets, group.as_deref(), all);
+    let filtered = filter_secrets_by_type(filtered, type_filter);
     let mut scoped = ls_view::scope_secrets(filtered, path);
     if sort == crate::cli::commands::LsSort::Updated {
         ls_view::sort_secrets_by_updated_desc(&mut scoped.secrets);
@@ -1195,6 +1284,20 @@ pub(crate) fn display_cached_secret_list(
             crate::utils::output::warn("--long is ignored for machine-readable formats");
         }
         let page = paginate_slice(&scoped.subtree, pagination);
+        if fmt == OutputFormat::Json {
+            // JSON output lifts `f.*` tags into a `fields` map and
+            // `xv-type` into `record_type` (record-types plan Task 10).
+            let body: Vec<serde_json::Value> = page
+                .items
+                .iter()
+                .map(secret_summary_to_json_with_fields)
+                .collect();
+            let output = serde_json::to_string_pretty(&body).map_err(|e| {
+                CrosstacheError::serialization(format!("JSON serialization failed: {e}"))
+            })?;
+            crate::utils::pager::print_output(&output, pager)?;
+            return Ok(());
+        }
         let formatter = TableFormatter::new(
             fmt,
             config.no_color,
@@ -1275,8 +1378,16 @@ pub(crate) fn display_cached_secret_list(
             config.template.clone(),
             config.runtime_columns.clone(),
         );
-        let display_rows = format_secret_list_rows_for_human(&page.items);
-        output.push_str(&formatter.format_table(&display_rows)?);
+        // TYPE column only when at least one listed secret is typed, so an
+        // untyped-only listing's table output stays byte-identical to
+        // pre-Task-10 behavior (record-types plan Task 10).
+        if any_secret_typed(&page.items) {
+            let display_rows = format_secret_list_rows_for_human_typed(&page.items);
+            output.push_str(&formatter.format_table(&display_rows)?);
+        } else {
+            let display_rows = format_secret_list_rows_for_human(&page.items);
+            output.push_str(&formatter.format_table(&display_rows)?);
+        }
         output.push('\n');
         let _ = writeln!(
             output,
@@ -1593,6 +1704,7 @@ pub(crate) async fn execute_secret_list_direct(
     long: bool,
     recursive: bool,
     sort: crate::cli::commands::LsSort,
+    type_filter: Option<String>,
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
@@ -1624,6 +1736,7 @@ pub(crate) async fn execute_secret_list_direct(
                     &vault_name,
                     &config,
                     names_only,
+                    type_filter.as_deref(),
                 );
             }
         }
@@ -1709,6 +1822,7 @@ pub(crate) async fn execute_secret_list_direct(
             &vault_name,
             &config,
             names_only,
+            type_filter.as_deref(),
         );
     }
 

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2117,6 +2117,366 @@ pub(crate) async fn execute_secret_inject_direct(
     execute_secret_inject(reg, None, template, out, group, best_effort, &config).await
 }
 
+/// Like [`crate::cli::helpers::confirm_proceed`], but exits with code 3
+/// (`CrosstacheError::config`) instead of 2 — record-types plan Task 9
+/// requires `xv update --untype` (when it would drop non-primary secret
+/// fields) to exit 3 without `--yes` on a non-interactive session,
+/// consistent with every other record-types validation failure, even
+/// though it mirrors `mv`'s bulk-confirm *behavior* (prompt unless `--yes`,
+/// hard-fail without a TTY).
+fn confirm_record_action(yes: bool, prompt: &str) -> Result<bool> {
+    use std::io::IsTerminal;
+
+    if yes {
+        return Ok(true);
+    }
+    if !std::io::stdin().is_terminal() {
+        return Err(CrosstacheError::config(format!(
+            "Refusing to proceed without confirmation in a non-interactive session ({prompt}). \
+             Re-run with --yes to confirm."
+        )));
+    }
+    crate::utils::interactive::InteractivePrompt::new().confirm(prompt, false)
+}
+
+/// Non-reserved, non-`f.*` user tag entries of `tags` — the same "everything
+/// else" set the tag-budget check counts as `user_tags` on `xv set --type`.
+fn user_tags_of(tags: &std::collections::HashMap<String, String>) -> BTreeMap<String, String> {
+    tags.iter()
+        .filter(|(k, _)| {
+            let k = k.as_str();
+            k != TYPE_TAG
+                && !k.starts_with(FIELD_TAG_PREFIX)
+                && k != crate::backend::TAG_ORIGINAL_NAME
+                && k != crate::backend::TAG_CREATED_BY
+                && k != "groups"
+                && k != "note"
+                && k != "folder"
+        })
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
+}
+
+/// `xv update <name> --field NAME=VALUE [--field-secret NAME=VALUE ...]`
+/// (record-types plan Task 8). A metadata-field change is tag-only
+/// (no new version); a secret-field change fetches the envelope, merges,
+/// re-encodes, and writes a new version. Both re-run the tag budget with
+/// the same collision/required-field rules as `xv set --type`.
+async fn execute_record_field_update(
+    name: &str,
+    fields: &[(String, String)],
+    secret_fields: &[(String, String)],
+    vault_name: &str,
+    config: &Config,
+    reg: &BackendRegistry,
+) -> Result<()> {
+    let secret = reg
+        .active()
+        .secrets()
+        .get_secret(vault_name, name, true)
+        .await?;
+    if !crate::records::is_record(&secret.content_type) {
+        return Err(CrosstacheError::config(format!(
+            "secret '{name}' is not a typed record (value is not marked {}); --field/--field-secret \
+             only apply to typed records. Use 'xv update {name} --type <type>' to convert it.",
+            crate::records::RECORD_CONTENT_TYPE
+        )));
+    }
+
+    let type_name = secret.tags.get(TYPE_TAG).cloned().unwrap_or_default();
+    let types = config.resolve_record_types().await?;
+    let Some(record_type) = find_type(&types, &type_name) else {
+        return Err(CrosstacheError::config(format!(
+            "secret '{name}' has type '{type_name}', which has no resolvable type definition \
+             (check your [types.*] config); --field/--field-secret can't be validated against it."
+        )));
+    };
+
+    let (metadata_updates, secret_updates) = route_fields(record_type, fields, secret_fields)?;
+
+    // Required-field-emptying guard, matching `xv set --type`'s
+    // has_non_blank_value rule: an explicit empty/whitespace value on a
+    // required field isn't meaningfully "set".
+    for (field_name, value) in metadata_updates.iter().chain(secret_updates.iter()) {
+        if let Some(def) = record_type.field(field_name) {
+            if def.required && value.trim().is_empty() {
+                return Err(CrosstacheError::config(format!(
+                    "field '{field_name}' is required for type '{type_name}' and cannot be set to \
+                     an empty value"
+                )));
+            }
+        }
+    }
+
+    let mut new_tags: Option<std::collections::HashMap<String, String>> = None;
+    if !metadata_updates.is_empty() {
+        let mut t = std::collections::HashMap::new();
+        for (k, v) in &metadata_updates {
+            t.insert(format!("{FIELD_TAG_PREFIX}{k}"), v.clone());
+        }
+        new_tags = Some(t);
+    }
+
+    let mut new_value: Option<Zeroizing<String>> = None;
+    if !secret_updates.is_empty() {
+        let raw = secret.value.as_deref().map(|s| s.as_str()).unwrap_or("");
+        let mut envelope = parse_record_envelope_or_fail(name, &secret.content_type, raw)?;
+        for (k, v) in &secret_updates {
+            envelope.insert(k.clone(), v.clone());
+        }
+        new_value = Some(Zeroizing::new(encode_envelope(&envelope)?));
+    }
+
+    // Re-run the tag budget: projected f.* tags (existing, minus any this
+    // write overwrites, plus the new values) + existing user tags. This
+    // write never adds a *new* user tag, but a field update can still push
+    // an existing f.* tag over the backend's per-value length cap.
+    let mut projected_field_tags: BTreeMap<String, String> = secret
+        .tags
+        .iter()
+        .filter_map(|(k, v)| {
+            k.strip_prefix(FIELD_TAG_PREFIX)
+                .map(|f| (f.to_string(), v.clone()))
+        })
+        .collect();
+    for (k, v) in &metadata_updates {
+        projected_field_tags.insert(k.clone(), v.clone());
+    }
+    let user_tags = user_tags_of(&secret.tags);
+    let reserved_count = crate::records::predicted_reserved_tag_count(
+        reg.active().kind(),
+        true,
+        secret.tags.contains_key("groups"),
+        secret.tags.contains_key("note"),
+        secret.tags.contains_key("folder"),
+        secret.expires_on.is_some(),
+    );
+    crate::records::check_tag_budget(
+        &reg.active().capabilities(),
+        reserved_count,
+        &projected_field_tags,
+        &user_tags,
+    )?;
+
+    let request = crate::secret::manager::SecretUpdateRequest {
+        name: name.to_string(),
+        value: new_value,
+        content_type: None,
+        enabled: None,
+        expires_on: crate::secret::manager::FieldUpdate::Unchanged,
+        not_before: crate::secret::manager::FieldUpdate::Unchanged,
+        tags: new_tags,
+        groups: None,
+        note: crate::secret::manager::FieldUpdate::Unchanged,
+        folder: crate::secret::manager::FieldUpdate::Unchanged,
+        replace_tags: false,
+        replace_groups: false,
+    };
+    let props = reg
+        .active()
+        .secrets()
+        .update_secret(vault_name, name, request)
+        .await?;
+    output::success(&format!(
+        "Successfully updated field(s) on record '{}'",
+        props.original_name
+    ));
+    invalidate_trait_secret_cache(config, vault_name);
+    Ok(())
+}
+
+/// `xv update <name> --type <type>` (record-types plan Task 9): explicit
+/// conversion of a bare secret into a typed record. The current value
+/// becomes the primary field; existing groups/note/folder/user tags are
+/// untouched. Errors if the secret is already a record.
+async fn execute_record_type_conversion(
+    name: &str,
+    type_name: &str,
+    vault_name: &str,
+    config: &Config,
+    reg: &BackendRegistry,
+) -> Result<()> {
+    let secret = reg
+        .active()
+        .secrets()
+        .get_secret(vault_name, name, true)
+        .await?;
+    if crate::records::is_record(&secret.content_type) {
+        return Err(CrosstacheError::config(format!(
+            "secret '{name}' is already a typed record (type: {}); use --field/--field-secret to \
+             edit it, or --untype first to convert it back to a bare secret.",
+            secret.tags.get(TYPE_TAG).cloned().unwrap_or_default()
+        )));
+    }
+
+    let types = config.resolve_record_types().await?;
+    let Some(record_type) = find_type(&types, type_name) else {
+        let mut known: Vec<&str> = types.iter().map(|t| t.name.as_str()).collect();
+        known.sort_unstable();
+        return Err(CrosstacheError::config(format!(
+            "unknown type '{type_name}'. Known types: {}",
+            known.join(", ")
+        )));
+    };
+
+    let current_value = secret.value.clone().unwrap_or_default();
+    if current_value.is_empty() {
+        return Err(CrosstacheError::config(format!(
+            "secret '{name}' has no value to convert"
+        )));
+    }
+
+    let mut envelope = BTreeMap::new();
+    envelope.insert(
+        record_type.primary().name.clone(),
+        current_value.as_str().to_string(),
+    );
+    let envelope_value = encode_envelope(&envelope)?;
+
+    // Tag budget: existing tags (unchanged) + the new xv-type tag. No f.*
+    // fields are added by a bare `--type` conversion (only the primary is
+    // set, and the primary never gets an f.* tag).
+    let user_tags = user_tags_of(&secret.tags);
+    let reserved_count = crate::records::predicted_reserved_tag_count(
+        reg.active().kind(),
+        true,
+        secret.tags.contains_key("groups"),
+        secret.tags.contains_key("note"),
+        secret.tags.contains_key("folder"),
+        secret.expires_on.is_some(),
+    );
+    crate::records::check_tag_budget(
+        &reg.active().capabilities(),
+        reserved_count,
+        &BTreeMap::new(),
+        &user_tags,
+    )?;
+
+    let mut new_tags = secret.tags.clone();
+    new_tags.insert(TYPE_TAG.to_string(), record_type.name.clone());
+
+    let request = crate::secret::manager::SecretUpdateRequest {
+        name: name.to_string(),
+        value: Some(Zeroizing::new(envelope_value)),
+        content_type: Some(RECORD_CONTENT_TYPE.to_string()),
+        enabled: None,
+        expires_on: crate::secret::manager::FieldUpdate::Unchanged,
+        not_before: crate::secret::manager::FieldUpdate::Unchanged,
+        tags: Some(new_tags),
+        groups: None,
+        note: crate::secret::manager::FieldUpdate::Unchanged,
+        folder: crate::secret::manager::FieldUpdate::Unchanged,
+        replace_tags: true,
+        replace_groups: false,
+    };
+    let props = reg
+        .active()
+        .secrets()
+        .update_secret(vault_name, name, request)
+        .await?;
+    output::success(&format!(
+        "Successfully converted '{}' to type '{}'",
+        props.original_name, record_type.name
+    ));
+    invalidate_trait_secret_cache(config, vault_name);
+    Ok(())
+}
+
+/// `xv update <name> --untype` (record-types plan Task 9): flattens a
+/// typed record back to a bare secret holding the primary field's value.
+/// Non-primary secret fields are dropped with an interactive confirmation
+/// (or `--yes`); metadata fields are removed from tags. Non-TTY without
+/// `--yes` when fields would be dropped exits 3.
+async fn execute_record_untype(
+    name: &str,
+    yes: bool,
+    vault_name: &str,
+    config: &Config,
+    reg: &BackendRegistry,
+) -> Result<()> {
+    let secret = reg
+        .active()
+        .secrets()
+        .get_secret(vault_name, name, true)
+        .await?;
+    if !crate::records::is_record(&secret.content_type) {
+        return Err(CrosstacheError::config(format!(
+            "secret '{name}' is not a typed record; nothing to untype."
+        )));
+    }
+
+    let type_name = secret.tags.get(TYPE_TAG).cloned().unwrap_or_default();
+    let raw = secret.value.as_deref().map(|s| s.as_str()).unwrap_or("");
+    let envelope = parse_record_envelope_or_fail(name, &secret.content_type, raw)?;
+
+    let types = config.resolve_record_types().await?;
+    let Some(record_type) = find_type(&types, &type_name) else {
+        return Err(CrosstacheError::config(format!(
+            "secret '{name}' has type '{type_name}', which has no resolvable type definition \
+             (check your [types.*] config); its primary field can't be determined, so it can't be \
+             untyped automatically. Use 'xv get {name} --record' to inspect its raw fields."
+        )));
+    };
+
+    let primary_name = &record_type.primary().name;
+    let Some(primary_value) = envelope.get(primary_name) else {
+        return Err(CrosstacheError::config(format!(
+            "secret '{name}' is missing its primary field '{primary_name}' in the record envelope"
+        )));
+    };
+    let primary_value = primary_value.clone();
+
+    let mut dropped: Vec<String> = envelope
+        .keys()
+        .filter(|k| *k != primary_name)
+        .cloned()
+        .collect();
+    dropped.sort();
+
+    if !dropped.is_empty() {
+        let prompt = format!(
+            "Untyping '{name}' will permanently drop {} non-primary secret field(s): {}. Continue?",
+            dropped.len(),
+            dropped.join(", ")
+        );
+        if !confirm_record_action(yes, &prompt)? {
+            output::info("Aborted; secret not untyped.");
+            return Ok(());
+        }
+        output::warn(&format!("Dropped field(s): {}", dropped.join(", ")));
+    }
+
+    let mut new_tags = secret.tags.clone();
+    new_tags.remove(TYPE_TAG);
+    new_tags.retain(|k, _| !k.starts_with(FIELD_TAG_PREFIX));
+
+    let request = crate::secret::manager::SecretUpdateRequest {
+        name: name.to_string(),
+        value: Some(Zeroizing::new(primary_value)),
+        content_type: Some(String::new()),
+        enabled: None,
+        expires_on: crate::secret::manager::FieldUpdate::Unchanged,
+        not_before: crate::secret::manager::FieldUpdate::Unchanged,
+        tags: Some(new_tags),
+        groups: None,
+        note: crate::secret::manager::FieldUpdate::Unchanged,
+        folder: crate::secret::manager::FieldUpdate::Unchanged,
+        replace_tags: true,
+        replace_groups: false,
+    };
+    let props = reg
+        .active()
+        .secrets()
+        .update_secret(vault_name, name, request)
+        .await?;
+    output::success(&format!(
+        "Successfully untyped '{}' (was type '{type_name}')",
+        props.original_name
+    ));
+    invalidate_trait_secret_cache(config, vault_name);
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_secret_update_direct(
     name: &str,
@@ -2137,6 +2497,11 @@ pub(crate) async fn execute_secret_update_direct(
     clear_note: bool,
     clear_folder: bool,
     enabled: Option<bool>,
+    fields: Vec<(String, String)>,
+    secret_fields: Vec<(String, String)>,
+    type_name: Option<String>,
+    untype: bool,
+    yes: bool,
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
@@ -2144,6 +2509,32 @@ pub(crate) async fn execute_secret_update_direct(
     if use_trait_path(registry) {
         use crate::secret::manager::FieldUpdate;
         use crate::utils::datetime::parse_datetime_or_duration;
+
+        // Record-types edit/conversion paths (record-types plan Tasks 8/9)
+        // take over completely — clap's `conflicts_with_all` on --type/
+        // --untype/--field/--field-secret already guarantees at most one
+        // of these fires alongside the classic metadata-update flags below.
+        if let Some(reg) = registry {
+            let vault_name = resolve_vault_for_trait(&config, registry).await?;
+            if let Some(type_name) = type_name {
+                return execute_record_type_conversion(name, &type_name, &vault_name, &config, reg)
+                    .await;
+            }
+            if untype {
+                return execute_record_untype(name, yes, &vault_name, &config, reg).await;
+            }
+            if !fields.is_empty() || !secret_fields.is_empty() {
+                return execute_record_field_update(
+                    name,
+                    &fields,
+                    &secret_fields,
+                    &vault_name,
+                    &config,
+                    reg,
+                )
+                .await;
+            }
+        }
 
         let reg = registry.expect("use_trait_path guarantees Some");
         let vault_name = resolve_vault_for_trait(&config, registry).await?;
@@ -5000,6 +5391,7 @@ mod tests {
             updated_on: "2026-04-28".to_string(),
             enabled,
             content_type: String::new(),
+            tags: std::collections::HashMap::new(),
         }
     }
 
@@ -5271,6 +5663,7 @@ mod tests {
                 updated_on: String::new(),
                 enabled: true,
                 content_type: String::new(),
+                tags: std::collections::HashMap::new(),
             }
         }
         let rows = derive_group_rows(&[
@@ -5524,6 +5917,7 @@ mod tests {
                 updated_on: String::new(),
                 enabled: true,
                 content_type: String::new(),
+                tags: std::collections::HashMap::new(),
             }
         }
         let paths = folder_completion_paths(&[
@@ -5756,6 +6150,11 @@ mod tests {
             false,
             false,
             None,
+            Vec::new(),
+            Vec::new(),
+            None,
+            false,
+            false,
             config.clone(),
             Some(&registry),
         )

--- a/src/secret/manager.rs
+++ b/src/secret/manager.rs
@@ -180,6 +180,14 @@ pub struct SecretSummary {
     pub enabled: bool,
     #[tabled(skip)]
     pub content_type: String,
+    /// Full tag map, used to derive record-types metadata (`xv-type`,
+    /// `f.*` fields) for `ls --type` filtering and JSON field lifting
+    /// (record-types plan Task 10). `#[serde(default)]` so summaries
+    /// deserialized from an older cache entry (written before this field
+    /// existed) still parse.
+    #[tabled(skip)]
+    #[serde(default)]
+    pub tags: HashMap<String, String>,
 }
 
 /// Summary of a soft-deleted secret awaiting purge.
@@ -1083,6 +1091,7 @@ impl SecretOperations for AzureSecretOperations {
                                 updated_on: updated,
                                 enabled,
                                 content_type: secret_details.content_type,
+                                tags: secret_details.tags,
                             }
                         }
                         Err(e) => {
@@ -1098,6 +1107,7 @@ impl SecretOperations for AzureSecretOperations {
                                 updated_on: updated,
                                 enabled,
                                 content_type: "text/plain".to_string(),
+                                tags: HashMap::new(),
                             }
                         }
                     }

--- a/src/secret/manager.rs
+++ b/src/secret/manager.rs
@@ -2272,6 +2272,69 @@ mod tests {
         ))
     }
 
+    /// Bugbot HIGH review, round 3: `prepare_secret_request` is the exact
+    /// function the record write-back paths (execute_record_field_update's
+    /// secret-field-edit branch, execute_record_type_conversion,
+    /// execute_record_untype — all value-changing, so Azure's full-PUT
+    /// path) run through. It only re-adds groups/note/folder tags when the
+    /// corresponding `SecretRequest` field is `Some` — there is no "carry
+    /// forward the existing tag" fallback here, unlike the tri-state
+    /// `FieldUpdate` used elsewhere. This pins the positive case: all three
+    /// present and correctly encoded.
+    #[test]
+    fn prepare_secret_request_emits_groups_note_folder_when_present() {
+        let ops = test_ops();
+        let request = SecretRequest {
+            name: "cred".to_string(),
+            value: Zeroizing::new("v".to_string()),
+            content_type: None,
+            enabled: Some(true),
+            expires_on: None,
+            not_before: None,
+            tags: None,
+            groups: Some(vec!["prod".to_string(), "team-a".to_string()]),
+            note: Some("rotate monthly".to_string()),
+            folder: Some("app/db".to_string()),
+        };
+        let (_, tags) = ops.prepare_secret_request(&request).unwrap();
+        assert_eq!(tags.get("groups").map(String::as_str), Some("prod,team-a"));
+        assert_eq!(tags.get("note").map(String::as_str), Some("rotate monthly"));
+        assert_eq!(tags.get("folder").map(String::as_str), Some("app/db"));
+    }
+
+    /// Companion negative test, documenting the exact PUT semantics that
+    /// bit the record write-back paths (Bugbot review, round 3): a
+    /// value-changing `SecretRequest` (this is the full-PUT path, not the
+    /// attributes-only PATCH) with `groups: None` must NOT emit a `groups`
+    /// tag — `prepare_secret_request` has no "None means leave the
+    /// existing tag alone" fallback the way `FieldUpdate::Unchanged` does
+    /// for note/folder elsewhere in the update flow. A caller that
+    /// forgets this (as the record write-back paths did before the fix)
+    /// silently erases group membership on Azure, even though the same
+    /// `groups: None` is a safe no-op on the delta-based local/AWS
+    /// backends.
+    #[test]
+    fn prepare_secret_request_omits_groups_tag_when_groups_is_none_even_with_a_value() {
+        let ops = test_ops();
+        let request = SecretRequest {
+            name: "cred".to_string(),
+            value: Zeroizing::new("v".to_string()),
+            content_type: None,
+            enabled: Some(true),
+            expires_on: None,
+            not_before: None,
+            tags: None,
+            groups: None,
+            note: None,
+            folder: None,
+        };
+        let (_, tags) = ops.prepare_secret_request(&request).unwrap();
+        assert!(
+            !tags.contains_key("groups"),
+            "groups tag must not appear when SecretRequest.groups is None: {tags:?}"
+        );
+    }
+
     #[test]
     fn test_deleted_backup_restore_url_construction() {
         let ops = test_ops();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -43,6 +43,14 @@ pub struct App {
     pub secrets_loading: bool,
 
     pub values: HashMap<(String, String), Zeroizing<String>>,
+    /// Content type of the fetched value in `values`, keyed the same way.
+    /// Populated alongside `values` from `Message::ValueLoaded`. Lets the
+    /// detail pane gate value-line masking on the actual content-type
+    /// marker at reveal time (`crate::records::is_record`), not just the
+    /// list-summary's `xv-type` tag, which can be absent/stripped while
+    /// the secret is still a record (record-types plan, Bugbot LOW
+    /// review).
+    pub value_content_types: HashMap<(String, String), String>,
     pub value_revealed: bool,
     pub value_loading: bool,
     /// (vault, name, ticks_left) — when ticks_left hits 0, fire LoadValue.
@@ -71,6 +79,7 @@ impl App {
             secret_filter_active: false,
             secrets_loading: false,
             values: HashMap::new(),
+            value_content_types: HashMap::new(),
             value_revealed: false,
             value_loading: false,
             value_debounce: None,

--- a/src/tui/data.rs
+++ b/src/tui/data.rs
@@ -110,16 +110,20 @@ pub fn spawn_load_value(
                 .await
                 .map_err(CrosstacheError::from);
             let msg = match result {
-                Ok(props) => match props.value {
-                    Some(v) => Message::ValueLoaded {
-                        vault,
-                        name,
-                        value: zeroize::Zeroizing::new(v.as_str().to_string()),
-                    },
-                    None => Message::Error(CrosstacheError::config(format!(
-                        "secret {name} has no value"
-                    ))),
-                },
+                Ok(props) => {
+                    let content_type = props.content_type.clone();
+                    match props.value {
+                        Some(v) => Message::ValueLoaded {
+                            vault,
+                            name,
+                            value: zeroize::Zeroizing::new(v.as_str().to_string()),
+                            content_type,
+                        },
+                        None => Message::Error(CrosstacheError::config(format!(
+                            "secret {name} has no value"
+                        ))),
+                    }
+                }
                 Err(e) => Message::Error(e),
             };
             let _ = tx.send(msg).await;
@@ -139,16 +143,20 @@ pub fn spawn_load_value(
             }
             .await;
             let msg = match result {
-                Ok(props) => match props.value {
-                    Some(v) => Message::ValueLoaded {
-                        vault,
-                        name,
-                        value: zeroize::Zeroizing::new(v.as_str().to_string()),
-                    },
-                    None => Message::Error(CrosstacheError::config(format!(
-                        "secret {name} has no value"
-                    ))),
-                },
+                Ok(props) => {
+                    let content_type = props.content_type.clone();
+                    match props.value {
+                        Some(v) => Message::ValueLoaded {
+                            vault,
+                            name,
+                            value: zeroize::Zeroizing::new(v.as_str().to_string()),
+                            content_type,
+                        },
+                        None => Message::Error(CrosstacheError::config(format!(
+                            "secret {name} has no value"
+                        ))),
+                    }
+                }
                 Err(e) => Message::Error(e),
             };
             let _ = tx.send(msg).await;

--- a/src/tui/message.rs
+++ b/src/tui/message.rs
@@ -13,6 +13,15 @@ pub enum Message {
         vault: String,
         name: String,
         value: zeroize::Zeroizing<String>,
+        /// The fetched secret's content type. Record-types plan (Bugbot
+        /// LOW review): the TUI detail pane must gate value-line masking
+        /// on the actual content-type marker at reveal time, not just the
+        /// list-summary's `xv-type` tag — a record whose `xv-type` tag is
+        /// absent/stripped but whose content type still says
+        /// `application/vnd.xv.record` is still a record, and printing its
+        /// raw envelope JSON would violate "content-type decides
+        /// record-ness".
+        content_type: String,
     },
     HistoryLoaded {
         vault: String,

--- a/src/tui/update.rs
+++ b/src/tui/update.rs
@@ -36,7 +36,14 @@ pub fn update(app: &mut App, msg: Message) -> Vec<Command> {
                 app.secret_state.select(Some(0));
             }
         }
-        Message::ValueLoaded { vault, name, value } => {
+        Message::ValueLoaded {
+            vault,
+            name,
+            value,
+            content_type,
+        } => {
+            app.value_content_types
+                .insert((vault.clone(), name.clone()), content_type);
             app.values.insert((vault, name), value);
             app.value_loading = false;
         }

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -22,6 +22,20 @@ const MASKED_FIELD_VALUE: &str = "●●●●●●●●";
 /// reveal/mask/loading behavior exactly.
 const TYPED_RECORD_VALUE_PLACEHOLDER: &str = "value: <typed record — see Fields>";
 
+/// Whether the detail pane should treat the selected secret as a typed
+/// record, for value-line masking purposes (Bugbot LOW review). Gates on
+/// the fetched content-type marker whenever it's known (the authoritative
+/// signal — "content-type decides record-ness", never tag/JSON sniffing),
+/// OR-ed with the list-summary's `xv-type` tag for the pre-fetch state
+/// (before reveal there's no fetched content-type yet to check). A record
+/// whose `xv-type` tag is absent or stripped but whose content type is
+/// still `application/vnd.xv.record` must still be masked — tag-only
+/// detection previously let that combination fall through and print the
+/// raw envelope JSON.
+fn is_typed_record(summary_has_type_tag: bool, fetched_content_type: Option<&str>) -> bool {
+    summary_has_type_tag || fetched_content_type.is_some_and(crate::records::is_record)
+}
+
 /// Pure formatter for the top `value:` line, so its branching (typed vs
 /// untyped, revealed vs masked vs loading vs no-selection) is unit
 /// testable without a real `App`/terminal.
@@ -175,11 +189,16 @@ fn render_detail(app: &App, frame: &mut Frame, area: Rect) {
             s.original_name.as_str()
         };
         lines.push(Line::raw(format!("name: {display}")));
-        let is_typed_record = s.tags.contains_key(crate::records::TYPE_TAG);
         let selection_key = app.selected_vault_and_name();
         let fetched = selection_key.as_ref().and_then(|k| app.values.get(k));
+        let fetched_content_type = selection_key
+            .as_ref()
+            .and_then(|k| app.value_content_types.get(k));
         let line = value_line(
-            is_typed_record,
+            is_typed_record(
+                s.tags.contains_key(crate::records::TYPE_TAG),
+                fetched_content_type.map(String::as_str),
+            ),
             app.value_revealed,
             selection_key.is_some(),
             fetched.map(|v| v.as_str()),
@@ -278,6 +297,35 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect()
+    }
+
+    #[test]
+    fn is_typed_record_gates_on_content_type_when_tag_absent() {
+        // Bugbot LOW review: a record whose `xv-type` tag is absent/
+        // stripped but whose fetched content type still says
+        // `application/vnd.xv.record` must still be treated as typed.
+        assert!(is_typed_record(
+            false,
+            Some(crate::records::RECORD_CONTENT_TYPE)
+        ));
+        // Tag present, content type not yet fetched (pre-reveal state).
+        assert!(is_typed_record(true, None));
+        // Neither signal present: a genuinely untyped secret.
+        assert!(!is_typed_record(false, None));
+        // Tag absent, fetched content type says plain text: not a record.
+        assert!(!is_typed_record(false, Some("text/plain")));
+    }
+
+    #[test]
+    fn value_line_masks_when_only_content_type_signals_a_record() {
+        // End-to-end through value_line: is_typed_record(false, Some(record
+        // content type)) must still route to the masked placeholder, not
+        // the raw envelope JSON.
+        let typed = is_typed_record(false, Some(crate::records::RECORD_CONTENT_TYPE));
+        assert_eq!(
+            value_line(typed, true, true, Some(r#"{"password":"hunter2"}"#), false),
+            TYPED_RECORD_VALUE_PLACEHOLDER,
+        );
     }
 
     #[test]

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -4,6 +4,36 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Line;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 use ratatui::Frame;
+use std::collections::BTreeMap;
+
+/// Placeholder shown for a secret-kind field's value in the TUI detail
+/// pane — the field's presence/name is informational, but its value is
+/// never rendered here (masked regardless of the top-level value's
+/// reveal state), matching record-types plan Task 11.
+const MASKED_FIELD_VALUE: &str = "●●●●●●●●";
+
+/// Pure formatter for a record's "Fields" section in the TUI detail pane
+/// (record-types plan Task 11): one line per field, sorted by name.
+/// Metadata fields render `name: value` plainly; fields named in
+/// `secret_names` always render with a masked placeholder value instead of
+/// whatever `fields` holds for them (defense in depth — even if a caller
+/// accidentally passes a real secret value in `fields` for a secret-kind
+/// field, it never reaches the rendered line).
+fn record_field_lines(
+    record_type: &str,
+    fields: &BTreeMap<String, String>,
+    secret_names: &[String],
+) -> Vec<String> {
+    let mut lines = vec![format!("type: {record_type}")];
+    for (name, value) in fields {
+        if secret_names.iter().any(|s| s == name) {
+            lines.push(format!("{name}: {MASKED_FIELD_VALUE}"));
+        } else {
+            lines.push(format!("{name}: {value}"));
+        }
+    }
+    lines
+}
 
 pub fn view(app: &App, frame: &mut Frame) {
     let area = frame.area();
@@ -132,6 +162,38 @@ fn render_detail(app: &App, frame: &mut Frame, area: Rect) {
             lines.push(Line::raw(format!("folder: {f}")));
         }
         lines.push(Line::raw(format!("updated: {}", s.updated_on)));
+
+        // Record-types plan Task 11: a "Fields" section for typed records.
+        // Metadata fields (f.* tags) are known without fetching the value;
+        // secret field NAMES only become known once the value has been
+        // fetched (the existing Space-to-reveal detail-fetch path), and
+        // their values are always masked regardless of the top `value:`
+        // line's reveal state.
+        if let Some(record_type) = s.tags.get(crate::records::TYPE_TAG) {
+            let mut fields: BTreeMap<String, String> = s
+                .tags
+                .iter()
+                .filter_map(|(k, v)| {
+                    k.strip_prefix(crate::records::FIELD_TAG_PREFIX)
+                        .map(|f| (f.to_string(), v.clone()))
+                })
+                .collect();
+            let secret_names: Vec<String> = app
+                .selected_vault_and_name()
+                .and_then(|key| app.values.get(&key))
+                .and_then(|val| crate::records::parse_envelope(val.as_str()).ok())
+                .map(|envelope| envelope.into_keys().collect())
+                .unwrap_or_default();
+            for name in &secret_names {
+                fields.entry(name.clone()).or_default();
+            }
+
+            lines.push(Line::raw(""));
+            lines.push(Line::raw("Fields:"));
+            for line in record_field_lines(record_type, &fields, &secret_names) {
+                lines.push(Line::raw(format!("  {line}")));
+            }
+        }
     } else {
         lines.push(Line::raw("(no secret selected)"));
     }
@@ -175,5 +237,75 @@ fn render_toast(app: &App, frame: &mut Frame, area: Rect) {
         );
         let p = Paragraph::new(line).style(Style::default().fg(Color::Yellow));
         frame.render_widget(p, area);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fields(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn record_field_lines_includes_type_header() {
+        let lines = record_field_lines("login", &BTreeMap::new(), &[]);
+        assert_eq!(lines, vec!["type: login".to_string()]);
+    }
+
+    #[test]
+    fn record_field_lines_renders_metadata_plain() {
+        let f = fields(&[("username", "bob"), ("url", "https://example.com")]);
+        let lines = record_field_lines("login", &f, &[]);
+        assert!(lines.contains(&"username: bob".to_string()));
+        assert!(lines.contains(&"url: https://example.com".to_string()));
+    }
+
+    #[test]
+    fn record_field_lines_masks_secret_field_values() {
+        let f = fields(&[("username", "bob"), ("password", "hunter2")]);
+        let secret_names = vec!["password".to_string()];
+        let lines = record_field_lines("login", &f, &secret_names);
+        assert!(lines.contains(&"username: bob".to_string()));
+        assert!(lines.contains(&format!("password: {MASKED_FIELD_VALUE}")));
+        assert!(
+            !lines.iter().any(|l| l.contains("hunter2")),
+            "secret value must never appear: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn record_field_lines_masks_even_when_value_is_populated() {
+        // Defense in depth: even if the caller passes a real value for a
+        // name also listed in secret_names, the rendered line still masks
+        // it rather than trusting the caller never to make that mistake.
+        let f = fields(&[("totp-seed", "ABCDEF")]);
+        let secret_names = vec!["totp-seed".to_string()];
+        let lines = record_field_lines("login", &f, &secret_names);
+        assert_eq!(
+            lines,
+            vec![
+                "type: login".to_string(),
+                format!("totp-seed: {MASKED_FIELD_VALUE}"),
+            ]
+        );
+    }
+
+    #[test]
+    fn record_field_lines_sorted_by_name() {
+        let f = fields(&[("zeta", "1"), ("alpha", "2")]);
+        let lines = record_field_lines("custom", &f, &[]);
+        assert_eq!(
+            lines,
+            vec![
+                "type: custom".to_string(),
+                "alpha: 2".to_string(),
+                "zeta: 1".to_string(),
+            ]
+        );
     }
 }

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -12,6 +12,42 @@ use std::collections::BTreeMap;
 /// reveal state), matching record-types plan Task 11.
 const MASKED_FIELD_VALUE: &str = "●●●●●●●●";
 
+/// Placeholder for the top `value:` line on typed records, regardless of
+/// reveal state. Showing the raw fetched value there for a typed record
+/// means showing the raw envelope JSON — every secret field's value at
+/// once — which defeats the masked "Fields" section below it (MINOR
+/// review finding on the first cut of Task 11: "TUI top value: line
+/// reveals the raw envelope JSON ... undermining the masked Fields
+/// section"). Untyped secrets are unaffected — they keep the existing
+/// reveal/mask/loading behavior exactly.
+const TYPED_RECORD_VALUE_PLACEHOLDER: &str = "value: <typed record — see Fields>";
+
+/// Pure formatter for the top `value:` line, so its branching (typed vs
+/// untyped, revealed vs masked vs loading vs no-selection) is unit
+/// testable without a real `App`/terminal.
+fn value_line(
+    is_typed_record: bool,
+    revealed: bool,
+    has_selection: bool,
+    fetched: Option<&str>,
+    loading: bool,
+) -> String {
+    if is_typed_record {
+        return TYPED_RECORD_VALUE_PLACEHOLDER.to_string();
+    }
+    if !has_selection {
+        return "value: ()".to_string();
+    }
+    if !revealed {
+        return "value: ●●●●●●●●".to_string();
+    }
+    match fetched {
+        Some(v) => format!("value: {v}"),
+        None if loading => "value: (loading…)".to_string(),
+        None => "value: (press Space)".to_string(),
+    }
+}
+
 /// Pure formatter for a record's "Fields" section in the TUI detail pane
 /// (record-types plan Task 11): one line per field, sorted by name.
 /// Metadata fields render `name: value` plainly; fields named in
@@ -139,22 +175,17 @@ fn render_detail(app: &App, frame: &mut Frame, area: Rect) {
             s.original_name.as_str()
         };
         lines.push(Line::raw(format!("name: {display}")));
-        let value_line = if app.value_revealed {
-            if let Some((v, n)) = app.selected_vault_and_name() {
-                if let Some(val) = app.values.get(&(v, n)) {
-                    format!("value: {}", val.as_str())
-                } else if app.value_loading {
-                    "value: (loading…)".to_string()
-                } else {
-                    "value: (press Space)".to_string()
-                }
-            } else {
-                "value: ()".to_string()
-            }
-        } else {
-            "value: ●●●●●●●●".to_string()
-        };
-        lines.push(Line::raw(value_line));
+        let is_typed_record = s.tags.contains_key(crate::records::TYPE_TAG);
+        let selection_key = app.selected_vault_and_name();
+        let fetched = selection_key.as_ref().and_then(|k| app.values.get(k));
+        let line = value_line(
+            is_typed_record,
+            app.value_revealed,
+            selection_key.is_some(),
+            fetched.map(|v| v.as_str()),
+            app.value_loading,
+        );
+        lines.push(Line::raw(line));
         if let Some(g) = &s.groups {
             lines.push(Line::raw(format!("groups: {g}")));
         }
@@ -178,9 +209,7 @@ fn render_detail(app: &App, frame: &mut Frame, area: Rect) {
                         .map(|f| (f.to_string(), v.clone()))
                 })
                 .collect();
-            let secret_names: Vec<String> = app
-                .selected_vault_and_name()
-                .and_then(|key| app.values.get(&key))
+            let secret_names: Vec<String> = fetched
                 .and_then(|val| crate::records::parse_envelope(val.as_str()).ok())
                 .map(|envelope| envelope.into_keys().collect())
                 .unwrap_or_default();
@@ -249,6 +278,42 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect()
+    }
+
+    #[test]
+    fn value_line_typed_record_never_reveals_raw_envelope() {
+        // Even "revealed" with a fetched value present, a typed record
+        // shows the placeholder, not the raw envelope JSON.
+        assert_eq!(
+            value_line(true, true, true, Some(r#"{"password":"hunter2"}"#), false),
+            TYPED_RECORD_VALUE_PLACEHOLDER,
+        );
+        // ...and while masked/unrevealed too.
+        assert_eq!(
+            value_line(true, false, true, None, false),
+            TYPED_RECORD_VALUE_PLACEHOLDER,
+        );
+    }
+
+    #[test]
+    fn value_line_untyped_secret_unaffected() {
+        assert_eq!(
+            value_line(false, false, true, None, false),
+            "value: ●●●●●●●●"
+        );
+        assert_eq!(
+            value_line(false, true, true, Some("hunter2"), false),
+            "value: hunter2"
+        );
+        assert_eq!(
+            value_line(false, true, true, None, true),
+            "value: (loading…)"
+        );
+        assert_eq!(
+            value_line(false, true, true, None, false),
+            "value: (press Space)"
+        );
+        assert_eq!(value_line(false, true, false, None, false), "value: ()");
     }
 
     #[test]

--- a/src/utils/fuzzy.rs
+++ b/src/utils/fuzzy.rs
@@ -220,6 +220,7 @@ mod tests {
             updated_on: String::new(),
             enabled: true,
             content_type: String::new(),
+            tags: std::collections::HashMap::new(),
         };
         let item = CandidateItem::from_secret_summary(&summary);
         // Prefer original_name over sanitized name (matches the user-typed form).

--- a/tests/aws_backend_tests.rs
+++ b/tests/aws_backend_tests.rs
@@ -501,6 +501,195 @@ async fn update_secret_enabled_flag_is_unsupported() {
     );
 }
 
+/// Bugbot MAJOR review on the record-types edit paths (Tasks 8/9):
+/// `AwsSecretBackend::update_secret` previously applied only note/tag/
+/// folder/expiry deltas and never wrote a value or touched content type —
+/// so `xv update --field-secret` silently discarded the new envelope on
+/// AWS while reporting success, and a record's content-type marker was
+/// never (re)written. This mirrors exactly what `xv update --field-secret`
+/// sends: `value: Some(new_envelope)`, `content_type:
+/// Some(RECORD_CONTENT_TYPE)`, and the FULL desired tag map with
+/// `replace_tags: true` (per the BLOCKER fix in
+/// `execute_record_field_update`, src/cli/secret_ops.rs).
+#[tokio::test]
+async fn update_secret_with_value_writes_value_and_content_type_tag() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use aws_sdk_secretsmanager::operation::put_secret_value::PutSecretValueOutput;
+    use aws_sdk_secretsmanager::operation::tag_resource::TagResourceOutput;
+    use aws_sdk_secretsmanager::operation::untag_resource::UntagResourceOutput;
+    use aws_sdk_secretsmanager::types::Tag;
+    use crosstache::backend::SecretBackend;
+    use crosstache::secret::manager::{FieldUpdate, SecretUpdateRequest};
+    use std::collections::HashMap;
+    use zeroize::Zeroizing;
+
+    // Step 1: the new envelope value must actually be written.
+    let put_value = mock!(Client::put_secret_value)
+        .match_requests(|req| {
+            req.secret_id() == Some("myproj-kv/cred")
+                && req.secret_string() == Some(r#"{"password":"hunter2"}"#)
+        })
+        .then_output(|| PutSecretValueOutput::builder().version_id("v2").build());
+
+    // Step 2 (replace_tags diff): current AWS-side tags include a plain
+    // "f.old-field" (must be dropped — absent from the new full map) and
+    // an "xv:groups" bookkeeping tag (must NOT be touched by the generic
+    // tags diff — it's managed by its own dedicated request field).
+    let describe_for_diff = mock!(Client::describe_secret)
+        .match_requests(|req| req.secret_id() == Some("myproj-kv/cred"))
+        .then_output(|| {
+            DescribeSecretOutput::builder()
+                .name("myproj-kv/cred")
+                .tags(Tag::builder().key("xv:groups").value("prod").build())
+                .tags(Tag::builder().key("xv-type").value("login").build())
+                .tags(Tag::builder().key("f.old-field").value("stale").build())
+                .build()
+        });
+
+    let untag = mock!(Client::untag_resource)
+        .match_requests(|req| req.tag_keys() == ["f.old-field".to_string()])
+        .then_output(|| UntagResourceOutput::builder().build());
+
+    let tag = mock!(Client::tag_resource)
+        .match_requests(|req| {
+            let tags = req.tags();
+            let has_content_type = tags.iter().any(|t| {
+                t.key() == Some("xv:content_type") && t.value() == Some("application/vnd.xv.record")
+            });
+            let has_type = tags
+                .iter()
+                .any(|t| t.key() == Some("xv-type") && t.value() == Some("login"));
+            let has_username = tags
+                .iter()
+                .any(|t| t.key() == Some("f.username") && t.value() == Some("bob"));
+            has_content_type && has_type && has_username
+        })
+        .then_output(|| TagResourceOutput::builder().build());
+
+    // Final `self.get_secret(vault, name, false)` at the end of update_secret.
+    let describe_final = mock!(Client::describe_secret).then_output(|| {
+        DescribeSecretOutput::builder()
+            .name("myproj-kv/cred")
+            .build()
+    });
+
+    let client = mock_client!(
+        aws_sdk_secretsmanager,
+        RuleMode::Sequential,
+        &[
+            &put_value,
+            &describe_for_diff,
+            &untag,
+            &tag,
+            &describe_final
+        ]
+    );
+    let backend = aws_secret_backend(client);
+
+    let mut full_tags = HashMap::new();
+    full_tags.insert("xv-type".to_string(), "login".to_string());
+    full_tags.insert("f.username".to_string(), "bob".to_string());
+
+    let request = SecretUpdateRequest {
+        name: "cred".to_string(),
+        value: Some(Zeroizing::new(r#"{"password":"hunter2"}"#.to_string())),
+        content_type: Some("application/vnd.xv.record".to_string()),
+        enabled: None,
+        expires_on: FieldUpdate::Unchanged,
+        not_before: FieldUpdate::Unchanged,
+        tags: Some(full_tags),
+        groups: None,
+        note: FieldUpdate::Unchanged,
+        folder: FieldUpdate::Unchanged,
+        replace_tags: true,
+        replace_groups: false,
+    };
+
+    backend
+        .update_secret("myproj-kv", "cred", request)
+        .await
+        .expect("update_secret should write the value and content-type tag");
+}
+
+/// Companion to the test above: `xv update --untype` on AWS must actually
+/// remove the `xv-type`/`f.*` tags (previously a no-op — Bugbot MAJOR:
+/// "untype no-ops ... xv-type tag survives since absent-from-map !=
+/// removed"). This exercises the metadata-only path (`value: None`), which
+/// stays off the `put_secret_value` call but must still honor
+/// `replace_tags` for the tag removal diff.
+#[tokio::test]
+async fn update_secret_untype_replace_tags_removes_dropped_keys() {
+    use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretOutput;
+    use aws_sdk_secretsmanager::operation::untag_resource::UntagResourceOutput;
+    use aws_sdk_secretsmanager::types::Tag;
+    use crosstache::backend::SecretBackend;
+    use crosstache::secret::manager::{FieldUpdate, SecretUpdateRequest};
+    use std::collections::HashMap;
+
+    // Untyping drops xv-type and every f.* tag entirely — the caller sends
+    // an EMPTY desired map (`execute_record_untype` omits them, it never
+    // sends them with an empty value), so the whole plain-tag namespace on
+    // the existing secret must be removed via the replace_tags diff.
+    let describe_for_diff = mock!(Client::describe_secret)
+        .match_requests(|req| req.secret_id() == Some("myproj-kv/cred"))
+        .then_output(|| {
+            DescribeSecretOutput::builder()
+                .name("myproj-kv/cred")
+                .tags(Tag::builder().key("xv:groups").value("prod").build())
+                .tags(Tag::builder().key("xv-type").value("login").build())
+                .tags(Tag::builder().key("f.username").value("bob").build())
+                .build()
+        });
+
+    let untag = mock!(Client::untag_resource)
+        .match_requests(|req| {
+            let keys = req.tag_keys();
+            // xv-type and f.username (plain namespace, absent from the
+            // empty desired map) must be removed, PLUS the content-type
+            // tag (content_type: Some("") below); the "xv:"-prefixed
+            // groups bookkeeping tag must be left alone — it isn't part
+            // of the generic tags diff at all.
+            keys.contains(&"xv-type".to_string())
+                && keys.contains(&"f.username".to_string())
+                && keys.contains(&"xv:content_type".to_string())
+                && !keys.contains(&"xv:groups".to_string())
+        })
+        .then_output(|| UntagResourceOutput::builder().build());
+
+    let describe_final = mock!(Client::describe_secret).then_output(|| {
+        DescribeSecretOutput::builder()
+            .name("myproj-kv/cred")
+            .build()
+    });
+
+    let client = mock_client!(
+        aws_sdk_secretsmanager,
+        RuleMode::Sequential,
+        &[&describe_for_diff, &untag, &describe_final]
+    );
+    let backend = aws_secret_backend(client);
+
+    let request = SecretUpdateRequest {
+        name: "cred".to_string(),
+        value: None,
+        content_type: Some(String::new()),
+        enabled: None,
+        expires_on: FieldUpdate::Unchanged,
+        not_before: FieldUpdate::Unchanged,
+        tags: Some(HashMap::new()),
+        groups: None,
+        note: FieldUpdate::Unchanged,
+        folder: FieldUpdate::Unchanged,
+        replace_tags: true,
+        replace_groups: false,
+    };
+
+    backend
+        .update_secret("myproj-kv", "cred", request)
+        .await
+        .expect("untype's replace_tags update should succeed");
+}
+
 #[tokio::test]
 async fn list_versions_returns_history() {
     use aws_sdk_secretsmanager::operation::list_secret_version_ids::ListSecretVersionIdsOutput;

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -1027,6 +1027,17 @@ fn update_secret_field_writes_new_envelope() {
     // New secret-field value forces a new version.
     assert_ne!(after["version"], version_before);
     assert!(after["tags"].get("f.totp-seed").is_none());
+    // Record identity must survive a secret-field edit (Bugbot BLOCKER:
+    // an Azure-specific bug relied on backend merge-on-None semantics for
+    // content_type/tags on this exact write shape — content_type: None
+    // and, when no --field accompanies --field-secret, tags: None too —
+    // which the Azure full-PUT path takes literally rather than treating
+    // as "leave unchanged". Local never had this bug (it does treat None
+    // as unchanged), so this assertion is a regression guard for the fix
+    // itself, not a reproduction of the original Azure bug.
+    assert_eq!(after["content_type"], "application/vnd.xv.record");
+    assert_eq!(after["tags"]["xv-type"], "login");
+    assert_eq!(after["tags"]["f.username"], "bob");
 
     let out3 = xv_same_env(temp.path())
         .args(["get", "cred", "--field", "totp-seed", "--raw"])
@@ -1302,6 +1313,27 @@ fn ls_untyped_only_output_unchanged() {
         "stdout: {stdout}"
     );
     assert!(!stdout.contains("Type"), "stdout: {stdout}");
+
+    // Byte-compare a DATA row too, not just the header — the date portion
+    // is the only part that legitimately varies run to run, so extract it
+    // from the actual row and rebuild the expected line around it; every
+    // other byte (name padding, column widths, box-drawing characters)
+    // must still match exactly.
+    let data_line = stdout
+        .lines()
+        .find(|l| l.contains("plain"))
+        .unwrap_or_else(|| panic!("no data row in: {stdout}"));
+    let date = data_line
+        .trim()
+        .split('│')
+        .nth(2)
+        .unwrap_or_else(|| panic!("row has no second column: {data_line}"))
+        .trim();
+    assert_eq!(
+        data_line.trim(),
+        format!("│ plain │ {date} │"),
+        "stdout: {stdout}"
+    );
 }
 
 #[test]

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -1223,6 +1223,168 @@ fn type_on_existing_record_errors() {
     assert!(stderr.contains("already"), "stderr: {stderr}");
 }
 
+// ---------------------------------------------------------------------------
+// Task 10: `ls` — type column, f.* fields in JSON, --type filter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ls_shows_type_column_when_typed_present() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let out_plain = xv_same_env(temp.path())
+        .args(["set", "plain", "--value", "just-a-value"])
+        .output()
+        .unwrap();
+    assert!(
+        out_plain.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out_plain)
+    );
+
+    let out2 = xv_same_env(temp.path())
+        .args(["ls", "--format", "table"])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let stdout = common::stdout_str(&out2);
+    assert!(stdout.contains("Type"), "stdout: {stdout}");
+    assert!(stdout.contains("login"), "stdout: {stdout}");
+}
+
+#[test]
+fn ls_untyped_only_output_unchanged() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args(["set", "plain", "--value", "just-a-value"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let out2 = xv_same_env(temp.path())
+        .args(["ls", "--format", "table"])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let stdout = common::stdout_str(&out2);
+    // Byte-compare the table header line against the pre-Task-10 shape:
+    // TableFormatter drops all-empty columns, so this fixture's table only
+    // ever showed Name/Updated — the point of this test is that adding
+    // record-types support doesn't introduce a Type column (or any other
+    // column) for an untyped-only listing.
+    let header_line = stdout
+        .lines()
+        .find(|l| l.contains("Name"))
+        .unwrap_or_else(|| panic!("no header line in: {stdout}"));
+    assert_eq!(
+        header_line.trim(),
+        "│ Name  │  Updated   │",
+        "stdout: {stdout}"
+    );
+    assert!(!stdout.contains("Type"), "stdout: {stdout}");
+}
+
+#[test]
+fn ls_json_lifts_fields_and_type() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let out2 = xv_same_env(temp.path())
+        .args(["ls", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let stdout = common::stdout_str(&out2);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    let entries = parsed.as_array().expect("array");
+    let cred = entries
+        .iter()
+        .find(|e| e["name"] == "cred")
+        .expect("cred entry present");
+    assert_eq!(cred["record_type"], "login");
+    assert_eq!(cred["fields"]["username"], "bob");
+}
+
+#[test]
+fn ls_type_filter() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let out_plain = xv_same_env(temp.path())
+        .args(["set", "plain", "--value", "just-a-value"])
+        .output()
+        .unwrap();
+    assert!(
+        out_plain.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out_plain)
+    );
+
+    let out2 = xv_same_env(temp.path())
+        .args(["ls", "--type", "login", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let stdout = common::stdout_str(&out2);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    let entries = parsed.as_array().expect("array");
+    assert_eq!(entries.len(), 1, "stdout: {stdout}");
+    assert_eq!(entries[0]["name"], "cred");
+}
+
 #[test]
 fn get_field_on_untyped_errors() {
     let (mut cmd, temp) = common::xv_isolated_local();

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -1083,6 +1083,8 @@ fn update_secret_field_preserves_group_note_folder_without_denormalizing_into_ta
             "hunter2",
             "--group",
             "prod",
+            "--group",
+            "team-a",
             "--note",
             "rotate monthly",
             "--folder",
@@ -1093,7 +1095,7 @@ fn update_secret_field_preserves_group_note_folder_without_denormalizing_into_ta
     assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
 
     let before = read_local_meta(temp.path(), "default", "cred");
-    assert_eq!(before["groups"], serde_json::json!(["prod"]));
+    assert_eq!(before["groups"], serde_json::json!(["prod", "team-a"]));
     assert_eq!(before["note"], "rotate monthly");
     assert_eq!(before["folder"], "app/db");
     // Never denormalized into tags in the first place (set path).
@@ -1113,7 +1115,7 @@ fn update_secret_field_preserves_group_note_folder_without_denormalizing_into_ta
 
     let after = read_local_meta(temp.path(), "default", "cred");
     // Dedicated metadata fields intact.
-    assert_eq!(after["groups"], serde_json::json!(["prod"]));
+    assert_eq!(after["groups"], serde_json::json!(["prod", "team-a"]));
     assert_eq!(after["note"], "rotate monthly");
     assert_eq!(after["folder"], "app/db");
     // Never leaked into the raw tag map by the write-back.
@@ -1150,6 +1152,8 @@ fn type_conversion_preserves_group_note_folder_without_denormalizing_into_tags()
             "hunter2",
             "--group",
             "prod",
+            "--group",
+            "team-a",
             "--note",
             "rotate monthly",
             "--folder",
@@ -1170,7 +1174,7 @@ fn type_conversion_preserves_group_note_folder_without_denormalizing_into_tags()
     );
 
     let after = read_local_meta(temp.path(), "default", "bare");
-    assert_eq!(after["groups"], serde_json::json!(["prod"]));
+    assert_eq!(after["groups"], serde_json::json!(["prod", "team-a"]));
     assert_eq!(after["note"], "rotate monthly");
     assert_eq!(after["folder"], "app/db");
     assert!(
@@ -1206,6 +1210,8 @@ fn untype_preserves_group_note_folder_without_denormalizing_into_tags() {
             "hunter2",
             "--group",
             "prod",
+            "--group",
+            "team-a",
             "--note",
             "rotate monthly",
             "--folder",
@@ -1226,7 +1232,7 @@ fn untype_preserves_group_note_folder_without_denormalizing_into_tags() {
     );
 
     let after = read_local_meta(temp.path(), "default", "cred");
-    assert_eq!(after["groups"], serde_json::json!(["prod"]));
+    assert_eq!(after["groups"], serde_json::json!(["prod", "team-a"]));
     assert_eq!(after["note"], "rotate monthly");
     assert_eq!(after["folder"], "app/db");
     assert!(
@@ -1683,6 +1689,42 @@ fn ls_type_filter() {
     let entries = parsed.as_array().expect("array");
     assert_eq!(entries.len(), 1, "stdout: {stdout}");
     assert_eq!(entries[0]["name"], "cred");
+}
+
+/// Bugbot LOW review, round 3: `DeletedSecretSummary` (the shape returned
+/// by `ls --deleted` on every backend) has no `tags` field at all — deleted
+/// listings never carry `xv-type`, so `--type` can't be threaded through
+/// and filtered without a bigger cross-backend change to start fetching
+/// tags for every deleted secret. Rather than a silent no-op (the filter
+/// looking like it did nothing), `--deleted --type` is a hard clap usage
+/// error in both flag orders.
+#[test]
+fn ls_deleted_with_type_filter_is_a_usage_error() {
+    let (mut cmd, _temp) = common::xv_isolated_local();
+    let out = cmd
+        .args(["ls", "--deleted", "--type", "login"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("cannot be used with"), "{stderr}");
+
+    let (mut cmd2, _temp2) = common::xv_isolated_local();
+    let out2 = cmd2
+        .args(["ls", "--type", "login", "--deleted"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out2.status.code(),
+        Some(2),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
 }
 
 #[test]

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -1058,6 +1058,194 @@ fn update_secret_field_writes_new_envelope() {
     assert_eq!(common::stdout_str(&out4), "hunter2");
 }
 
+/// Bugbot MEDIUM review, round 3: `SecretProperties.tags` (as returned by
+/// `get_secret`) is DENORMALIZED for display — groups/note/folder are
+/// folded into plain tag keys. The record write-back paths built their
+/// `replace_tags: true` map directly from `secret.tags.clone()`, so those
+/// denormalized keys rode along into the write. On local this means they'd
+/// persist into `SecretMeta.tags` even though the real values live in the
+/// dedicated `.groups`/`.note`/`.folder` fields — the exact bug class the
+/// #315 copy/move review caught. This test pins the fix: group/note/folder
+/// metadata survives a secret-field edit, AND `meta.tags` (the raw on-disk
+/// tag map) never contains `groups`/`note`/`folder` keys.
+#[test]
+fn update_secret_field_preserves_group_note_folder_without_denormalizing_into_tags() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+            "--group",
+            "prod",
+            "--note",
+            "rotate monthly",
+            "--folder",
+            "app/db",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let before = read_local_meta(temp.path(), "default", "cred");
+    assert_eq!(before["groups"], serde_json::json!(["prod"]));
+    assert_eq!(before["note"], "rotate monthly");
+    assert_eq!(before["folder"], "app/db");
+    // Never denormalized into tags in the first place (set path).
+    assert!(before["tags"].get("groups").is_none());
+    assert!(before["tags"].get("note").is_none());
+    assert!(before["tags"].get("folder").is_none());
+
+    let out2 = xv_same_env(temp.path())
+        .args(["update", "cred", "--field-secret", "totp-seed=ABCDEF"])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+
+    let after = read_local_meta(temp.path(), "default", "cred");
+    // Dedicated metadata fields intact.
+    assert_eq!(after["groups"], serde_json::json!(["prod"]));
+    assert_eq!(after["note"], "rotate monthly");
+    assert_eq!(after["folder"], "app/db");
+    // Never leaked into the raw tag map by the write-back.
+    assert!(
+        after["tags"].get("groups").is_none(),
+        "meta.tags: {:?}",
+        after["tags"]
+    );
+    assert!(
+        after["tags"].get("note").is_none(),
+        "meta.tags: {:?}",
+        after["tags"]
+    );
+    assert!(
+        after["tags"].get("folder").is_none(),
+        "meta.tags: {:?}",
+        after["tags"]
+    );
+    // Record identity and the field edit itself still landed correctly.
+    assert_eq!(after["content_type"], "application/vnd.xv.record");
+    assert_eq!(after["tags"]["xv-type"], "login");
+    assert_eq!(after["tags"]["f.username"], "bob");
+}
+
+/// Same denormalization guard as above, for `--type` conversion.
+#[test]
+fn type_conversion_preserves_group_note_folder_without_denormalizing_into_tags() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "bare",
+            "--value",
+            "hunter2",
+            "--group",
+            "prod",
+            "--note",
+            "rotate monthly",
+            "--folder",
+            "app/db",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let out2 = xv_same_env(temp.path())
+        .args(["update", "bare", "--type", "login"])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+
+    let after = read_local_meta(temp.path(), "default", "bare");
+    assert_eq!(after["groups"], serde_json::json!(["prod"]));
+    assert_eq!(after["note"], "rotate monthly");
+    assert_eq!(after["folder"], "app/db");
+    assert!(
+        after["tags"].get("groups").is_none(),
+        "meta.tags: {:?}",
+        after["tags"]
+    );
+    assert!(
+        after["tags"].get("note").is_none(),
+        "meta.tags: {:?}",
+        after["tags"]
+    );
+    assert!(
+        after["tags"].get("folder").is_none(),
+        "meta.tags: {:?}",
+        after["tags"]
+    );
+}
+
+/// Same denormalization guard as above, for `--untype`.
+#[test]
+fn untype_preserves_group_note_folder_without_denormalizing_into_tags() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+            "--group",
+            "prod",
+            "--note",
+            "rotate monthly",
+            "--folder",
+            "app/db",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let out2 = xv_same_env(temp.path())
+        .args(["update", "cred", "--untype", "--yes"])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+
+    let after = read_local_meta(temp.path(), "default", "cred");
+    assert_eq!(after["groups"], serde_json::json!(["prod"]));
+    assert_eq!(after["note"], "rotate monthly");
+    assert_eq!(after["folder"], "app/db");
+    assert!(
+        after["tags"].get("groups").is_none(),
+        "meta.tags: {:?}",
+        after["tags"]
+    );
+    assert!(
+        after["tags"].get("note").is_none(),
+        "meta.tags: {:?}",
+        after["tags"]
+    );
+    assert!(
+        after["tags"].get("folder").is_none(),
+        "meta.tags: {:?}",
+        after["tags"]
+    );
+}
+
 #[test]
 fn update_field_on_untyped_errors() {
     let (mut cmd, temp) = common::xv_isolated_local();

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -1079,6 +1079,86 @@ fn update_field_on_untyped_errors() {
     );
 }
 
+/// Bugbot MEDIUM review: combining a record-path flag (`--field`,
+/// `--field-secret`, `--type`, `--untype`) with a classic update flag
+/// (`--note`, `--tags`, `--folder`, the positional value, etc.) used to
+/// early-return after applying only the record edit, silently ignoring the
+/// classic flag while still reporting success. Now a clap usage error
+/// (exit 2) before anything runs, and nothing is changed.
+#[test]
+fn update_field_with_classic_flag_is_a_usage_error() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let before = read_local_meta(temp.path(), "default", "cred");
+
+    let out2 = xv_same_env(temp.path())
+        .args(["update", "cred", "--field", "username=alice", "--note", "n"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out2.status.code(),
+        Some(2),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+
+    // Nothing changed — neither the field edit nor the note was applied.
+    let after = read_local_meta(temp.path(), "default", "cred");
+    assert_eq!(before, after);
+}
+
+/// Bugbot MEDIUM review: `xv update <name> --type <t>` converting AND
+/// replacing the primary value in the same command (a positional VALUE
+/// arg alongside `--type`) is now a usage error — convert first, then set
+/// the primary via `xv update <name> --field-secret <primary>=<value>`.
+#[test]
+fn update_type_with_positional_value_is_a_usage_error() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args(["set", "bare", "--value", "hunter2"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let out2 = xv_same_env(temp.path())
+        .args(["update", "bare", "--type", "login", "new-value"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out2.status.code(),
+        Some(2),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let stderr = common::stderr_str(&out2);
+    assert!(stderr.contains("--type"), "stderr: {stderr}");
+
+    // Nothing changed — the secret is still untyped with its original value.
+    let out3 = xv_same_env(temp.path())
+        .args(["get", "bare", "--raw"])
+        .output()
+        .unwrap();
+    assert!(
+        out3.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out3)
+    );
+    assert_eq!(common::stdout_str(&out3), "hunter2");
+}
+
 // ---------------------------------------------------------------------------
 // Task 9: `xv update --type` / `--untype` conversion
 // ---------------------------------------------------------------------------

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -941,6 +941,288 @@ fn get_unknown_type_degrades() {
     assert_eq!(common::stdout_str(&out_field), "bob");
 }
 
+// ---------------------------------------------------------------------------
+// Task 8: `xv update --field`/`--field-secret`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn update_metadata_field_is_tag_only() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let before = read_local_meta(temp.path(), "default", "cred");
+    let version_before = before["version"].clone();
+
+    let out2 = xv_same_env(temp.path())
+        .args(["update", "cred", "--field", "username=alice"])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+
+    let after = read_local_meta(temp.path(), "default", "cred");
+    assert_eq!(after["tags"]["f.username"], "alice");
+    // Tag-only update: no new version.
+    assert_eq!(after["version"], version_before);
+
+    // Primary value untouched.
+    let out3 = xv_same_env(temp.path())
+        .args(["get", "cred", "--raw"])
+        .output()
+        .unwrap();
+    assert!(
+        out3.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out3)
+    );
+    assert_eq!(common::stdout_str(&out3), "hunter2");
+}
+
+#[test]
+fn update_secret_field_writes_new_envelope() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let before = read_local_meta(temp.path(), "default", "cred");
+    let version_before = before["version"].clone();
+
+    let out2 = xv_same_env(temp.path())
+        .args(["update", "cred", "--field-secret", "totp-seed=ABCDEF"])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+
+    let after = read_local_meta(temp.path(), "default", "cred");
+    // New secret-field value forces a new version.
+    assert_ne!(after["version"], version_before);
+    assert!(after["tags"].get("f.totp-seed").is_none());
+
+    let out3 = xv_same_env(temp.path())
+        .args(["get", "cred", "--field", "totp-seed", "--raw"])
+        .output()
+        .unwrap();
+    assert!(
+        out3.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out3)
+    );
+    assert_eq!(common::stdout_str(&out3), "ABCDEF");
+
+    // Primary value untouched by the merge.
+    let out4 = xv_same_env(temp.path())
+        .args(["get", "cred", "--raw"])
+        .output()
+        .unwrap();
+    assert_eq!(common::stdout_str(&out4), "hunter2");
+}
+
+#[test]
+fn update_field_on_untyped_errors() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args(["set", "plain", "--value", "just-a-value"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let out2 = xv_same_env(temp.path())
+        .args(["update", "plain", "--field", "username=bob"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out2.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Task 9: `xv update --type` / `--untype` conversion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn type_conversion_roundtrip() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args(["set", "bare", "--value", "hunter2"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let out2 = xv_same_env(temp.path())
+        .args(["update", "bare", "--type", "login"])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let meta = read_local_meta(temp.path(), "default", "bare");
+    assert_eq!(meta["content_type"], "application/vnd.xv.record");
+    assert_eq!(meta["tags"]["xv-type"], "login");
+
+    let out3 = xv_same_env(temp.path())
+        .args(["get", "bare", "--raw"])
+        .output()
+        .unwrap();
+    assert!(
+        out3.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out3)
+    );
+    assert_eq!(common::stdout_str(&out3), "hunter2");
+
+    let out4 = xv_same_env(temp.path())
+        .args(["update", "bare", "--untype", "--yes"])
+        .output()
+        .unwrap();
+    assert!(
+        out4.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out4)
+    );
+    let meta2 = read_local_meta(temp.path(), "default", "bare");
+    assert_eq!(meta2["content_type"], "");
+    assert!(meta2["tags"].get("xv-type").is_none());
+
+    let out5 = xv_same_env(temp.path())
+        .args(["get", "bare", "--raw"])
+        .output()
+        .unwrap();
+    assert!(
+        out5.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out5)
+    );
+    assert_eq!(common::stdout_str(&out5), "hunter2");
+}
+
+#[test]
+fn untype_with_extra_secret_fields_requires_yes() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--field-secret",
+            "totp-seed=ABCDEF",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    // Non-TTY without --yes: refuses, exit 3, nothing changed.
+    let out2 = xv_same_env(temp.path())
+        .args(["update", "cred", "--untype"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out2.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let stderr = common::stderr_str(&out2);
+    assert!(stderr.contains("--yes"), "stderr: {stderr}");
+    let meta_unchanged = read_local_meta(temp.path(), "default", "cred");
+    assert_eq!(meta_unchanged["content_type"], "application/vnd.xv.record");
+
+    // With --yes: succeeds, drops totp-seed, names it in output.
+    let out3 = xv_same_env(temp.path())
+        .args(["update", "cred", "--untype", "--yes"])
+        .output()
+        .unwrap();
+    assert!(
+        out3.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out3)
+    );
+    let stderr3 = common::stderr_str(&out3);
+    assert!(stderr3.contains("totp-seed"), "stderr: {stderr3}");
+
+    let meta = read_local_meta(temp.path(), "default", "cred");
+    assert_eq!(meta["content_type"], "");
+    assert!(meta["tags"].get("xv-type").is_none());
+    assert!(meta["tags"].get("f.username").is_none());
+
+    let out4 = xv_same_env(temp.path())
+        .args(["get", "cred", "--raw"])
+        .output()
+        .unwrap();
+    assert_eq!(common::stdout_str(&out4), "hunter2");
+}
+
+#[test]
+fn type_on_existing_record_errors() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let out2 = xv_same_env(temp.path())
+        .args(["update", "cred", "--type", "api-key"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out2.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let stderr = common::stderr_str(&out2);
+    assert!(stderr.contains("already"), "stderr: {stderr}");
+}
+
 #[test]
 fn get_field_on_untyped_errors() {
     let (mut cmd, temp) = common::xv_isolated_local();


### PR DESCRIPTION
Phase B of #321 (spec/plan in-repo since #322): record editing, explicit conversion, listing, and TUI display.

## What this adds

- **`xv update --field` / `--field-secret`**: metadata-field edits are tag-only (no new version); secret-field edits merge into the envelope and write a new version. Phase A's strictness carries over: reserved-tag collisions rejected, required fields can't be emptied (empty/whitespace), tag budget re-checked via the backend-derived predictor — all fail-before-write.
- **Explicit conversion**: `xv update <name> --type <t>` wraps a bare secret's value as the primary field (errors if already a record; existing tags untouched); `--untype` flattens back to the primary's bare value and strips the marker + `f.*` tags — with a confirmation listing any non-primary secret fields that would drop (`--yes` bypasses; non-TTY without it exits 3). A corrupt envelope fails loud before any destructive write.
- **`xv ls`**: `--type <t>` filter; a TYPE column that appears only when a typed secret is listed (untyped-only output is byte-pinned by test, header and row); `--format json` lifts `f.*` into a `fields` map and `xv-type` into `record_type`. No extra API calls — Azure reuses the already-fetched detail.
- **TUI**: record detail shows a Fields section (metadata plain, secret field names masked), and the top `value:` line no longer reveals the raw envelope JSON for typed records.

## Review catches worth reading

The independent review pass found (and this PR fixes) a blocker that local-only CI could not see: record updates relied on backend merge-on-`None` semantics that the local backend honors but Azure's PUT path does not — a `--field-secret` edit on Azure would have silently stripped the record's content-type marker and all its tags. Updates now always send an explicit content type and the full projected tag map. It also surfaced that AWS `update_secret` never wrote values at all (pre-existing, but Phase B is the first caller to need it): it now issues `put_secret_value`, maintains the `xv:content_type` tag, and honors `replace_tags` for removals — covered by `aws_smithy_mocks` tests since no LocalStack was available (`tests/aws_backend_tests.rs`).

## Tests

35 hermetic e2e tests in `tests/e2e_record_types.rs` (scrubbed-env verified), 2 new AWS mock tests, 9 TUI unit tests. Full workspace green including the AWS suite; clippy 0 warnings.

Phase C (inject field syntax + docs) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large cross-cutting changes to secret update semantics (Azure PUT, AWS value/tags, denormalized tag handling) and CLI record paths; mistakes could corrupt metadata, drop tags, or leak envelope JSON in the TUI.
> 
> **Overview**
> Phase B adds **typed record** workflows on top of existing `xv set --type` support: CLI editing/conversion, richer `ls` output, backend fixes, and safer TUI display.
> 
> **`xv update`** gains mutually exclusive record modes: `--field` / `--field-secret` (metadata vs envelope edits), `--type` (bare → record), and `--untype` (record → bare, with `--yes` / non-interactive exit 3 when non-primary secret fields would drop). Value-changing record writes now send an **explicit** record content type and a **full** tag map with `replace_tags: true`, and use shared **`split_denormalized_tags`** so groups/note/folder are not written back as duplicate plain tags (Azure full-PUT and AWS/local parity).
> 
> **`xv ls`** adds `--type` filtering, an optional **Type** column when any listed secret is typed, and JSON that lifts `xv-type` → `record_type` and `f.*` → `fields`. **`SecretSummary.tags`** is populated on list paths; secrets-list cache moves to **`secrets-list-v2.json`** so old cache entries miss instead of deserializing with empty tags.
> 
> **AWS `update_secret`** now calls `put_secret_value` when a value is supplied, handles **`content_type`**, and implements **`replace_tags`** removal for plain tags (e.g. untype). **TUI** masks typed records’ top `value:` line (no raw envelope JSON), shows a **Fields** section, and treats fetched content type as authoritative for record-ness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edd5538332ae00889e28b5fb3ca9665375e8d9c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->