### PR TITLE
feat: inject field access for records + docs (#321 Phase C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- **Record types: typed secrets with structured fields (#321). Not a breaking change** — only secrets explicitly created with `--type` or converted with `update --type` change shape; every existing/untyped secret is byte-identical on every code path (`get`/`run`/`inject`/`ls`), no envelope, no new tags, unless you opt in.
+  - Built-in types `login`, `api-key`, `database`, plus custom `[types.<name>]` blocks in `xv.conf`/`.xv.toml` (project shadows global, shadowing a built-in warns). Every type declares exactly one `primary` secret field, so plain `get`/`run` on a record return/inject that field, unchanged from today's contract.
+  - Per-field sensitivity: `metadata` fields ride tags (`f.<name>`, listable without fetching the secret); `secret` fields live in a JSON envelope inside the value, marked by a reserved `application/vnd.xv.record` content type (never JSON-sniffed).
+  - `xv type list`/`xv type show`; `xv set --type/--field/--field-secret`; `xv get --field/--record`; `xv update --field/--field-secret` (edit) and `--type/--untype` (explicit conversion, never implicit); `xv ls --type` filter plus `f.*`/`record_type` in JSON output.
+  - `xv inject`'s `{{ secret:name.field }}` template syntax and `xv://vault/name#field` URI fragment select one field; an exact secret name always wins first, so an untyped secret literally named `a.b` still resolves as itself. `xv run` gets no per-field expansion — it injects a record's primary field under its name, same as `get`.
+  - One invalid `[types.*]` block fails type resolution globally (fail-closed by design) rather than silently dropping just that type.
+  - External consumers (Azure portal, raw SDKs, older `xv` binaries) see a typed record's raw JSON envelope as its value — documented in the README, alongside the explicit-conversion rule.
+
 ### Changed
 
 - **Breaking: `xv run` now aborts before launching the child when any selected secret or `xv://` reference fails to fetch; use `--best-effort` for the old behavior** (#306). Previously a per-secret fetch failure only printed a warning and the command ran anyway, which could silently launch a process missing an env var (e.g. after a transient backend error or a permission problem). All failures across both the selected-secret list and `xv://` reference resolution are now collected and reported together before the exit.

--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ so unambiguous):
 # template.yml:
 #   smtp_user: "{{ secret:mail-cred.username }}"
 #   smtp_pass: "{{ secret:mail-cred }}"                     # bare name — primary field
-#   smtp_pass_uri: "{{ xv://other-vault/mail-cred#password }}"
+#   smtp_pass_uri: "xv://other-vault/mail-cred#password"
 
 xv inject --template template.yml --out app.config
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ xv scan install                        # block secret leaks before commit
 - [Installation](#installation)
 - [Common workflows](#common-workflows) — end-to-end recipes
 - [Secrets — CRUD](#secrets--crud)
+- [Record types — structured secrets](#record-types--structured-secrets)
 - [Reading secrets — clipboard, stdout, JSON](#reading-secrets--clipboard-stdout-json)
 - [Search & filter](#search--filter) — `xv find`, `xv ls --names-only`, fzf integration
 - [Secret injection — `xv run`](#secret-injection--xv-run)
@@ -491,6 +492,123 @@ xv rotate API_KEY --show-value               # echo the new value to stdout (oth
 
 ---
 
+## Record types — structured secrets
+
+A **record** is a secret carrying structured fields — a username and URL
+alongside a password, or host/port/database alongside connection details —
+instead of one opaque value. Every field is either `metadata` (a tag,
+listable without fetching the secret) or `secret` (encrypted inside the
+value); every type declares exactly one `primary` secret field, so plain
+`xv get`/`xv run` on a record behave exactly like on any other secret —
+they return/inject the primary value, byte-identical to today's behavior.
+Untyped secrets are completely unaffected: no envelope, no new tags, on
+every code path.
+
+### Built-in types
+
+| Type | Metadata fields | Secret fields |
+|---|---|---|
+| `login` | `username` (required), `url` | **`password`** (primary) |
+| `api-key` | `url`, `account` | **`key`** (primary) |
+| `database` | `host`, `port`, `database`, `username` | **`password`** (primary), `connection-string` (optional) |
+
+```bash
+xv type list                             # resolved types + source (built-in/global/project)
+xv type list --format json
+xv type show login                       # field table for one type
+```
+
+### Custom types
+
+Declare `[types.<name>]` blocks in global `xv.conf` or a project's
+`.xv.toml` (same config hierarchy as everything else). A project type
+shadows a global type of the same name; shadowing a built-in works but
+warns.
+
+```toml
+# xv.conf (global) or .xv.toml (project override)
+[types.smtp]
+fields = [
+  { name = "host" },                          # metadata by default
+  { name = "port" },
+  { name = "username", required = true },
+  { name = "password", kind = "secret", primary = true },
+]
+```
+
+**One invalid `[types.*]` block fails type resolution globally** (missing
+or duplicate `primary`, a non-secret/non-required `primary`, a field name
+that isn't kebab-case) — by design, fail-closed: a single broken custom
+type definition never lets some types silently resolve while others
+silently vanish.
+
+### Create, read, and update
+
+```bash
+xv set mail-cred --type login --field username=bob --value hunter2
+xv set other-cred --type login --field username=bob --field url=https://mail.example.com \
+  --field-secret backup-code=1234 --value hunter2   # --field-secret: ad-hoc field, stored in the envelope
+
+xv get mail-cred                          # primary field (password), unchanged `get` contract
+xv get mail-cred --field username          # one field, either kind
+xv get mail-cred --record --format json    # every field, requested format
+
+xv update mail-cred --field username=alice           # metadata edit — tag-only, no new version
+xv update other-cred --field-secret backup-code=5678 # secret-field edit — rewrites the envelope, new version
+
+xv set legacy-cred --value some-existing-value  # a bare (untyped) secret
+xv update legacy-cred --type login               # explicit conversion: its value becomes the primary field
+xv update legacy-cred --untype                   # flatten back to a bare secret holding the primary value (--yes
+                                                  # skips the prompt when non-primary secret fields would be dropped)
+
+xv ls --type login                        # filter listing by record type
+xv ls --format json                       # includes "record_type" and a "fields" map for typed records
+```
+
+`--field`/`--field-secret`/`--type`/`--untype` on `xv update` are mutually
+exclusive with each other and with every classic update flag
+(`--value`/`--stdin`/`--note`/`--tags`/…) — a record field edit or
+conversion is a standalone operation in v1.
+
+### Inject field syntax
+
+`xv inject` templates can select one field of a record with a dot, and
+`xv://` URIs use a `#` fragment (invalid in secret names on every backend,
+so unambiguous):
+
+```bash
+# template.yml:
+#   smtp_user: "{{ secret:mail-cred.username }}"
+#   smtp_pass: "{{ secret:mail-cred }}"                     # bare name — primary field
+#   smtp_pass_uri: "{{ xv://other-vault/mail-cred#password }}"
+
+xv inject --template template.yml --out app.config
+```
+
+An **exact secret name always wins first**: an existing untyped secret
+literally named `a.b` resolves as itself, never as field `b` of a record
+named `a`. Only when there is no exact match does `xv inject` try a
+`name.field` split (on the last dot), and only when the base name is a
+record with a matching field. Unknown fields, or a field reference on a
+non-record, abort injection (exit 3) before anything is written — the same
+fail-fast contract as any other unresolved reference — unless
+`--best-effort`. `xv run` does not expand fields at all: a typed record's
+name injects its primary value as the env var, same as `xv get`.
+
+### External consumers and compatibility
+
+Typed records store their secret fields as a JSON envelope
+(`{"password": "..."}`, content type `application/vnd.xv.record`) with
+metadata fields riding tags (`f.username`, `f.url`, …) and the type name in
+a reserved `xv-type` tag. A consumer reading the secret outside `xv` — the
+Azure portal, a raw SDK call, an older `xv` binary — sees that JSON
+envelope as the value, not the bare password. **Conversion is always
+explicit**: `xv set --type` or `xv update --type`/`--untype` are the only
+ways a secret's shape changes. Nothing implicitly promotes a plain secret
+into a record or vice versa.
+
+---
+
 ## Reading secrets — clipboard, stdout, JSON
 
 ### Default — clipboard with auto-clear
@@ -686,6 +804,10 @@ stdout) if any `{{ secret:name }}` or `xv://` reference fails to resolve
 failure is printed, and no partially-rendered output is ever written. Pass
 `--best-effort` to restore the previous behavior: warn on each failure and
 render anyway, leaving unresolved references in the output.
+
+For a typed [record](#record-types--structured-secrets), `{{ secret:name.field }}`
+/ `xv://vault/name#field` select one field; bare `{{ secret:name }}` still
+renders the primary field.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -90,12 +90,49 @@ a two-decimal string, `folder`/`groups` default to empty strings.
 
 ---
 
+## Record Types
+
+Typed records attach structured fields (username, URL, connection-string, …)
+to a secret. Each field is `metadata` (a listable tag) or `secret` (JSON
+envelope inside the value); every type has exactly one `primary` secret
+field, so plain `get`/`run` on a record are byte-identical to an untyped
+secret. Untyped secrets are unaffected on every code path — no envelope, no
+new tags, unless explicitly converted.
+
+| Command | Description |
+|---------|-------------|
+| `xv type list` (alias `ls`) | List resolved types (built-in + global `xv.conf` + project `.xv.toml`) with source; `--format json` |
+| `xv type show <name>` | Field table for one type |
+| `xv set <name> --type <type>` | Create a typed record; `--field name=value` for metadata/non-primary-secret fields (repeatable), `--field-secret name=value` for ad-hoc secret fields, primary value via `--value`/`--stdin`/prompt |
+| `xv get <name> --field <name>` | Read one field (either kind) |
+| `xv get <name> --record` | Full record (all fields) in the requested `--format` |
+| `xv update <name> --field name=value` | Edit a metadata field (tag-only) or type-declared non-primary secret field (new version) |
+| `xv update <name> --field-secret name=value` | Edit/add an ad-hoc secret field (rewrites the envelope, new version) |
+| `xv update <name> --type <type>` | Explicit conversion: bare secret's value becomes the primary field |
+| `xv update <name> --untype [--yes]` | Flatten a record back to a bare secret holding the primary value |
+| `xv ls --type <type>` | Filter listing by record type; JSON output lifts `f.*` fields into a `fields` map plus `record_type` |
+
+Built-ins: `login` (username\*, url; password\* primary), `api-key` (url,
+account; key\* primary), `database` (host, port, database, username;
+password\* primary, connection-string optional secret) — `\*` = required.
+Custom types are `[types.<name>]` TOML blocks in global `xv.conf` or
+project `.xv.toml`; a project type shadows a global one, shadowing a
+built-in works but warns. **One invalid `[types.*]` block fails type
+resolution globally** (fail-closed by design).
+
+External consumers (Azure portal, raw SDKs, older `xv` binaries) see a
+typed record's value as a JSON envelope (`application/vnd.xv.record`
+content type), not the bare primary value — conversion between shapes is
+always explicit (`--type`/`--untype`), never implicit.
+
+---
+
 ## Secret Injection
 
 | Command | Description |
 |---------|-------------|
-| `xv run -- <command>` | Run a process with secrets as env vars (`--group`, `--include`, `--exclude`, `--no-masking`, `--best-effort`) |
-| `xv inject` | Render templates with `{{ secret:name }}` and `xv://vault/secret` refs (`--group`, `--best-effort`) |
+| `xv run -- <command>` | Run a process with secrets as env vars (`--group`, `--include`, `--exclude`, `--no-masking`, `--best-effort`). Injects a typed record's primary field under its name; no per-field expansion |
+| `xv inject` | Render templates with `{{ secret:name }}` / `{{ secret:name.field }}` and `xv://vault/secret[#field]` refs (`--group`, `--best-effort`). `.field`/`#field` select one field of a typed record; exact secret-name matches (e.g. a secret literally named `a.b`) always win over the dotted split |
 
 Advanced workflows (`run`, `inject`, default `rotate`, `scan`, `env pull`, and
 `env push`) route through the active backend trait. They work with Azure, AWS,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -667,6 +667,8 @@ pub enum Commands {
         command: Vec<String>,
     },
     /// Inject secrets into a template file using {{ secret:name }} syntax
+    /// (or {{ secret:name.field }} / xv://vault/name#field for one field of
+    /// a typed record)
     Inject {
         /// Template file path (reads from stdin if not specified)
         #[arg(short, long)]

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -747,7 +747,8 @@ fn record_field_value(
         return Err(CrosstacheError::config(format!(
             "secret '{name}' has type '{type_name}', which has no resolvable type definition \
              (check your [types.*] config). Its primary field can't be determined; reference a \
-             specific field instead."
+             specific field, e.g. via 'xv get {name} --field <name>' or 'xv get {name} --record', \
+             to access this record's raw fields."
         )));
     };
     let primary_name = &record_type.primary().name;
@@ -788,6 +789,14 @@ pub(crate) async fn execute_secret_get_direct(
         };
 
         let is_rec = crate::records::is_record(&secret.content_type);
+        // Only resolved when the secret is actually a record: an untyped
+        // secret's `get` must never fail because of an unrelated broken
+        // `[types.*]` config block (byte-identical-everywhere guarantee).
+        let types = if is_rec {
+            config.resolve_record_types().await?
+        } else {
+            Vec::new()
+        };
 
         // ── `--record`: full record view, all fields, requested format ──
         if record {
@@ -847,25 +856,21 @@ pub(crate) async fn execute_secret_get_direct(
                     crate::records::RECORD_CONTENT_TYPE
                 )));
             }
-            let value = secret.value.as_deref().map(|s| s.as_str()).unwrap_or("");
-            let envelope = parse_record_envelope_or_fail(name, &secret.content_type, value)?;
-            let Some(field_value) = lookup_record_field(&field_name, &envelope, &secret.tags)
-            else {
-                let known = record_field_names(&envelope, &secret.tags);
-                return Err(CrosstacheError::config(format!(
-                    "secret '{name}' has no field '{field_name}'. Known fields: {}",
-                    known.join(", ")
-                )));
-            };
+            let field_value = record_field_value(name, &secret, Some(&field_name), &types)?;
             // A field found in the envelope is secret-kind; one found only
             // via the f.<name> tag is metadata-kind (listable without
-            // fetching the secret in the first place).
+            // fetching the secret in the first place). `record_field_value`
+            // already validated the field exists, so re-parsing the
+            // envelope here is purely for this classification, not for the
+            // lookup/error-message logic (which lives in one place now).
+            let value = secret.value.as_deref().map(|s| s.as_str()).unwrap_or("");
+            let envelope = parse_record_envelope_or_fail(name, &secret.content_type, value)?;
             let is_secret_field = envelope.contains_key(&field_name);
 
             if raw {
-                print!("{field_value}");
+                print!("{}", field_value.as_str());
             } else {
-                match copy_to_clipboard(field_value) {
+                match copy_to_clipboard(&field_value) {
                     Ok(()) => {
                         let (message, schedule_clear) = field_clipboard_outcome(
                             name,
@@ -890,27 +895,11 @@ pub(crate) async fn execute_secret_get_direct(
         }
 
         // ── Plain `get`: primary field for records, untouched for untyped ──
+        // Routed through `record_field_value` for the record case so the
+        // primary/field extraction logic lives in exactly one place, shared
+        // with `--field` above and `xv inject`'s record grammar.
         let effective_value: Option<Zeroizing<String>> = if is_rec {
-            let value = secret.value.as_deref().map(|s| s.as_str()).unwrap_or("");
-            let envelope = parse_record_envelope_or_fail(name, &secret.content_type, value)?;
-
-            let type_name = secret.tags.get(TYPE_TAG).cloned().unwrap_or_default();
-            let types = config.resolve_record_types().await?;
-            let Some(record_type) = crate::records::find_type(&types, &type_name) else {
-                return Err(CrosstacheError::config(format!(
-                    "secret '{name}' has type '{type_name}', which has no resolvable type \
-                     definition (check your [types.*] config). Its primary field can't be \
-                     determined; use --field or --record to access this record's raw fields."
-                )));
-            };
-            let primary_name = &record_type.primary().name;
-            let Some(primary_value) = envelope.get(primary_name) else {
-                return Err(CrosstacheError::config(format!(
-                    "secret '{name}' is missing its primary field '{primary_name}' in the record \
-                     envelope"
-                )));
-            };
-            Some(Zeroizing::new(primary_value.clone()))
+            Some(record_field_value(name, &secret, None, &types)?)
         } else {
             secret.value
         };
@@ -4619,7 +4608,7 @@ async fn execute_secret_inject(
     // fragment is unambiguous up front since `#` is invalid in secret names
     // on every backend.
     let secret_regex = Regex::new(r"\{\{\s*secret:([^}\s]+)\s*\}\}").unwrap();
-    let uri_regex = Regex::new(r"xv://([^/\s]+)/([^/\s#]+)(?:#([^\s]+))?").unwrap();
+    let uri_regex = Regex::new(r"xv://([^/\s]+)/([^/\s#]+)(?:#([A-Za-z0-9._-]+))?").unwrap();
 
     let mut required_secrets: Vec<String> = Vec::new();
     // (original_uri, parsed_ref, optional #field)
@@ -4927,8 +4916,19 @@ async fn execute_secret_inject(
             .to_string();
     }
 
-    // Replace xv://vault/secret URI references
-    for (uri, secret_value) in &cross_vault_values {
+    // Replace xv://vault/secret URI references. Longest-key-first: a bare
+    // `xv://vault/name` is a strict prefix of its own `#field` form (and,
+    // more generally, of any other URI key that happens to extend it), so
+    // substituting in `HashMap` iteration order (nondeterministic) can
+    // rewrite part of a longer reference before it's ever matched whole —
+    // e.g. `xv://vault/name` replacing inside `xv://vault/name#username`
+    // and leaving a mangled `<value>#username` behind. Sorting by
+    // descending key length guarantees every longer (more specific) URI is
+    // substituted before any of its prefixes.
+    let mut cross_vault_entries: Vec<(&String, &Zeroizing<String>)> =
+        cross_vault_values.iter().collect();
+    cross_vault_entries.sort_by_key(|(uri, _)| std::cmp::Reverse(uri.len()));
+    for (uri, secret_value) in cross_vault_entries {
         *result_content = result_content.replace(uri, secret_value.as_str());
     }
 

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -693,6 +693,72 @@ fn field_clipboard_outcome(
     }
 }
 
+/// Resolves the value `xv` should hand back for a secret reference: an
+/// explicit field's value when `field` is `Some`, or the record's primary
+/// field (mirroring plain `get`'s compatibility contract) when `field` is
+/// `None` and the secret is a typed record. An untyped secret with
+/// `field: None` returns its value unchanged; an untyped secret with an
+/// explicit field is an error.
+///
+/// Shared by `get`'s plain/`--field` read paths and `xv inject`'s
+/// `{{ secret:name.field }}` / `xv://vault/name#field` grammar (record-types
+/// plan Task 12) so field-read semantics can't drift between the two
+/// commands.
+fn record_field_value(
+    name: &str,
+    secret: &crate::secret::manager::SecretProperties,
+    field: Option<&str>,
+    types: &[RecordType],
+) -> Result<Zeroizing<String>> {
+    let is_rec = crate::records::is_record(&secret.content_type);
+    let raw_value = secret.value.as_deref().map(|s| s.as_str()).unwrap_or("");
+
+    if let Some(field_name) = field {
+        if !is_rec {
+            return Err(CrosstacheError::config(format!(
+                "secret '{name}' is not a typed record (value is not marked {}); field access \
+                 ('.{field_name}') only applies to typed records.",
+                crate::records::RECORD_CONTENT_TYPE
+            )));
+        }
+        let envelope = parse_record_envelope_or_fail(name, &secret.content_type, raw_value)?;
+        let Some(v) = lookup_record_field(field_name, &envelope, &secret.tags) else {
+            let known = record_field_names(&envelope, &secret.tags);
+            return Err(CrosstacheError::config(format!(
+                "secret '{name}' has no field '{field_name}'. Known fields: {}",
+                known.join(", ")
+            )));
+        };
+        return Ok(Zeroizing::new(v.to_string()));
+    }
+
+    if !is_rec {
+        return match &secret.value {
+            Some(v) => Ok(v.clone()),
+            None => Err(CrosstacheError::config(format!(
+                "secret '{name}' resolved but has no value"
+            ))),
+        };
+    }
+
+    let envelope = parse_record_envelope_or_fail(name, &secret.content_type, raw_value)?;
+    let type_name = secret.tags.get(TYPE_TAG).cloned().unwrap_or_default();
+    let Some(record_type) = find_type(types, &type_name) else {
+        return Err(CrosstacheError::config(format!(
+            "secret '{name}' has type '{type_name}', which has no resolvable type definition \
+             (check your [types.*] config). Its primary field can't be determined; reference a \
+             specific field instead."
+        )));
+    };
+    let primary_name = &record_type.primary().name;
+    let Some(primary_value) = envelope.get(primary_name) else {
+        return Err(CrosstacheError::config(format!(
+            "secret '{name}' is missing its primary field '{primary_name}' in the record envelope"
+        )));
+    };
+    Ok(Zeroizing::new(primary_value.clone()))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_secret_get_direct(
     name: &str,
@@ -4159,6 +4225,12 @@ async fn execute_secret_run(
     // the old warn-and-continue behavior.
     let mut fetch_failures: Vec<String> = Vec::new();
 
+    // Record types, resolved once, so a typed record injects its primary
+    // field value under its name — `xv run` never expands other fields
+    // (spec §9 out of scope), it just must not leak the raw JSON envelope
+    // in place of the primary value (record-types plan Task 12).
+    let types = config.resolve_record_types().await?;
+
     // Fetch secrets from current vault (group-filtered)
     for secret in filtered_secrets {
         // Get the secret value
@@ -4168,8 +4240,9 @@ async fn execute_secret_run(
             .get_secret(&vault_name, &secret.name, true)
             .await
         {
-            Ok(secret_props) => {
-                if let Some(value) = secret_props.value {
+            Ok(secret_props) => match record_field_value(&secret.name, &secret_props, None, &types)
+            {
+                Ok(value) => {
                     let env_name = to_env_var_name(&secret.name);
                     env_vars.insert(env_name, value.clone());
 
@@ -4177,12 +4250,13 @@ async fn execute_secret_run(
                     if !no_masking && !value.is_empty() {
                         secret_values.push(value.clone());
                     }
-                } else {
-                    let msg = format!("Secret '{}' resolved but has no value", secret.name);
+                }
+                Err(e) => {
+                    let msg = format!("Failed to resolve secret '{}': {}", secret.name, e);
                     output::warn(&msg);
                     fetch_failures.push(msg);
                 }
-            }
+            },
             Err(e) => {
                 let msg = format!("Failed to get value for secret '{}': {}", secret.name, e);
                 output::warn(&msg);
@@ -4227,15 +4301,18 @@ async fn execute_secret_run(
 
             match fetch_result {
                 Ok(secret_props) => {
-                    if let Some(value) = secret_props.value {
-                        uri_values.insert(uri.clone(), value.clone());
-                        if !no_masking && !value.is_empty() {
-                            secret_values.push(value);
+                    match record_field_value(&secret_name, &secret_props, None, &types) {
+                        Ok(value) => {
+                            uri_values.insert(uri.clone(), value.clone());
+                            if !no_masking && !value.is_empty() {
+                                secret_values.push(value);
+                            }
                         }
-                    } else {
-                        let msg = format!("URI '{uri}' resolved but has no value");
-                        output::warn(&msg);
-                        fetch_failures.push(msg);
+                        Err(e) => {
+                            let msg = format!("Failed to resolve URI '{uri}': {e}");
+                            output::warn(&msg);
+                            fetch_failures.push(msg);
+                        }
                     }
                 }
                 Err(e) => {
@@ -4534,12 +4611,19 @@ async fn execute_secret_inject(
     };
 
     // Parse template for secret references
-    // Supports: {{ secret:name }} and xv://[backend:]vault/secret
+    // Supports: {{ secret:name }}, {{ secret:name.field }}, and
+    // xv://[backend:]vault/secret[#field]. The `.field` split (on the LAST
+    // dot) is resolved later, after the vault's secrets are loaded: an exact
+    // name match always wins first, so an untyped secret literally named
+    // `a.b` keeps resolving as itself (record-types plan Task 12). The `#`
+    // fragment is unambiguous up front since `#` is invalid in secret names
+    // on every backend.
     let secret_regex = Regex::new(r"\{\{\s*secret:([^}\s]+)\s*\}\}").unwrap();
-    let uri_regex = Regex::new(r"xv://([^/\s]+)/([^/\s]+)").unwrap();
+    let uri_regex = Regex::new(r"xv://([^/\s]+)/([^/\s#]+)(?:#([^\s]+))?").unwrap();
 
     let mut required_secrets: Vec<String> = Vec::new();
-    let mut cross_vault_refs: Vec<(String, BackendRef)> = Vec::new(); // (original_uri, parsed_ref)
+    // (original_uri, parsed_ref, optional #field)
+    let mut cross_vault_refs: Vec<(String, BackendRef, Option<String>)> = Vec::new();
 
     // Failures collected across template parsing and secret fetching. By
     // default any failure aborts rendering (and the output write) before it
@@ -4565,16 +4649,20 @@ async fn execute_secret_inject(
         }
     }
 
-    // Find xv://[backend:]vault/secret URI references
+    // Find xv://[backend:]vault/secret[#field] URI references
     for captures in uri_regex.captures_iter(&template_content) {
         let vault_part = captures.get(1).map_or("", |m| m.as_str());
         let secret_part = captures.get(2).map_or("", |m| m.as_str());
-        let uri_key = format!("xv://{vault_part}/{secret_part}");
-        if cross_vault_refs.iter().any(|(uri, _)| uri == &uri_key) {
+        let field_part = captures.get(3).map(|m| m.as_str().to_string());
+        let uri_key = match &field_part {
+            Some(f) => format!("xv://{vault_part}/{secret_part}#{f}"),
+            None => format!("xv://{vault_part}/{secret_part}"),
+        };
+        if cross_vault_refs.iter().any(|(uri, _, _)| uri == &uri_key) {
             continue;
         }
         match BackendRef::parse(&format!("{vault_part}/{secret_part}")) {
-            Ok(r) => cross_vault_refs.push((uri_key, r)),
+            Ok(r) => cross_vault_refs.push((uri_key, r, field_part)),
             Err(e) => {
                 let msg = format!("Invalid URI '{uri_key}': {e}");
                 output::warn(&msg);
@@ -4660,11 +4748,18 @@ async fn execute_secret_inject(
     let mut secret_values: HashMap<String, Zeroizing<String>> = HashMap::new();
     let mut cross_vault_values: HashMap<String, Zeroizing<String>> = HashMap::new(); // URI -> value
 
-    // Fetch secrets from current vault
-    for secret_name in &required_secrets {
-        // Check if the secret exists in the available secrets
-        if let Some(secret_summary) = available_secrets.iter().find(|s| s.name == *secret_name) {
-            // Get the secret value
+    // Record types, resolved once, for primary/field resolution below.
+    let types = config.resolve_record_types().await?;
+
+    // Fetch secrets from current vault. `ref_token` is the raw text captured
+    // from `{{ secret:TOKEN }}`: either a bare name (record primary or a
+    // plain value) or a `name.field` reference. Exact-name match is tried
+    // FIRST so an existing secret literally named `a.b` always resolves as
+    // itself; only when there is no exact match do we fall back to
+    // splitting on the LAST dot and treating the suffix as a field
+    // reference on the base record (record-types plan Task 12).
+    for ref_token in &required_secrets {
+        if let Some(secret_summary) = available_secrets.iter().find(|s| s.name == *ref_token) {
             match reg
                 .active()
                 .secrets()
@@ -4672,25 +4767,67 @@ async fn execute_secret_inject(
                 .await
             {
                 Ok(secret_props) => {
-                    if let Some(value) = secret_props.value {
-                        secret_values.insert(secret_name.clone(), value);
-                    } else {
-                        let msg = format!("Secret '{secret_name}' resolved but has no value");
-                        output::warn(&msg);
-                        fetch_failures.push(msg);
+                    match record_field_value(ref_token, &secret_props, None, &types) {
+                        Ok(value) => {
+                            secret_values.insert(ref_token.clone(), value);
+                        }
+                        Err(e) => {
+                            let msg = format!("Failed to resolve '{ref_token}': {e}");
+                            output::warn(&msg);
+                            fetch_failures.push(msg);
+                        }
                     }
                 }
                 Err(e) => {
                     let msg = format!(
                         "Failed to get value for secret '{}' from vault '{}': {}",
-                        secret_name, vault_name, e
+                        ref_token, vault_name, e
                     );
                     output::warn(&msg);
                     fetch_failures.push(msg);
                 }
             }
-        } else {
-            let msg = format!("Secret '{secret_name}' not found in vault '{vault_name}'");
+            continue;
+        }
+
+        let mut resolved = false;
+        if let Some(dot) = ref_token.rfind('.') {
+            let base = &ref_token[..dot];
+            let field = &ref_token[dot + 1..];
+            if let Some(secret_summary) = available_secrets.iter().find(|s| s.name == base) {
+                resolved = true;
+                match reg
+                    .active()
+                    .secrets()
+                    .get_secret(&vault_name, &secret_summary.name, true)
+                    .await
+                {
+                    Ok(secret_props) => {
+                        match record_field_value(base, &secret_props, Some(field), &types) {
+                            Ok(value) => {
+                                secret_values.insert(ref_token.clone(), value);
+                            }
+                            Err(e) => {
+                                let msg = format!("Failed to resolve '{ref_token}': {e}");
+                                output::warn(&msg);
+                                fetch_failures.push(msg);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        let msg = format!(
+                            "Failed to get value for secret '{}' from vault '{}': {}",
+                            base, vault_name, e
+                        );
+                        output::warn(&msg);
+                        fetch_failures.push(msg);
+                    }
+                }
+            }
+        }
+
+        if !resolved {
+            let msg = format!("Secret '{ref_token}' not found in vault '{vault_name}'");
             output::warn(&msg);
             fetch_failures.push(msg);
         }
@@ -4706,7 +4843,7 @@ async fn execute_secret_inject(
             Arc<dyn crate::backend::Backend>,
         > = std::collections::HashMap::new();
 
-        for (uri, backend_ref) in &cross_vault_refs {
+        for (uri, backend_ref, field_opt) in &cross_vault_refs {
             let secret_name = match &backend_ref.secret {
                 Some(s) => s.clone(),
                 None => {
@@ -4729,12 +4866,20 @@ async fn execute_secret_inject(
 
             match fetch_result {
                 Ok(secret_props) => {
-                    if let Some(value) = secret_props.value {
-                        cross_vault_values.insert(uri.clone(), value);
-                    } else {
-                        let msg = format!("URI '{uri}' resolved but has no value");
-                        output::warn(&msg);
-                        fetch_failures.push(msg);
+                    match record_field_value(
+                        &secret_name,
+                        &secret_props,
+                        field_opt.as_deref(),
+                        &types,
+                    ) {
+                        Ok(value) => {
+                            cross_vault_values.insert(uri.clone(), value);
+                        }
+                        Err(e) => {
+                            let msg = format!("Failed to resolve URI '{uri}': {e}");
+                            output::warn(&msg);
+                            fetch_failures.push(msg);
+                        }
                     }
                 }
                 Err(e) => {

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -760,6 +760,34 @@ fn record_field_value(
     Ok(Zeroizing::new(primary_value.clone()))
 }
 
+/// Resolves record types on first need, caching the outcome (success or
+/// failure) so it happens at most once per command. `xv run`/`xv inject`
+/// iterate a whole selection of secrets that may be entirely untyped, so
+/// type resolution must be lazy: an all-untyped selection must succeed
+/// exactly as before the record-types feature, never failing because of an
+/// unrelated broken `[types.*]` config block that no referenced secret
+/// actually uses. Callers should only invoke this when a fetched secret is
+/// actually a record (`crate::records::is_record`); an untyped secret
+/// should never trigger it at all. `CrosstacheError` isn't `Clone`, so the
+/// error path is cached as a `String` and re-wrapped on each cached lookup.
+async fn resolve_types_lazily(
+    cache: &mut Option<std::result::Result<Vec<RecordType>, String>>,
+    config: &Config,
+) -> Result<Vec<RecordType>> {
+    if cache.is_none() {
+        *cache = Some(
+            config
+                .resolve_record_types()
+                .await
+                .map_err(|e| e.to_string()),
+        );
+    }
+    match cache.as_ref().expect("just populated above") {
+        Ok(types) => Ok(types.clone()),
+        Err(msg) => Err(CrosstacheError::config(msg.clone())),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_secret_get_direct(
     name: &str,
@@ -4214,11 +4242,13 @@ async fn execute_secret_run(
     // the old warn-and-continue behavior.
     let mut fetch_failures: Vec<String> = Vec::new();
 
-    // Record types, resolved once, so a typed record injects its primary
-    // field value under its name — `xv run` never expands other fields
-    // (spec §9 out of scope), it just must not leak the raw JSON envelope
-    // in place of the primary value (record-types plan Task 12).
-    let types = config.resolve_record_types().await?;
+    // Record types: resolved lazily, at most once, only when a fetched
+    // secret is actually a record — so a typed record injects its primary
+    // field value under its name (`xv run` never expands other fields,
+    // spec §9 out of scope) without leaking the raw JSON envelope, while an
+    // all-untyped selection never pays for (or fails on) type resolution at
+    // all (Bugbot round 2 on #321 Phase C).
+    let mut record_types_cache: Option<std::result::Result<Vec<RecordType>, String>> = None;
 
     // Fetch secrets from current vault (group-filtered)
     for secret in filtered_secrets {
@@ -4229,23 +4259,33 @@ async fn execute_secret_run(
             .get_secret(&vault_name, &secret.name, true)
             .await
         {
-            Ok(secret_props) => match record_field_value(&secret.name, &secret_props, None, &types)
-            {
-                Ok(value) => {
-                    let env_name = to_env_var_name(&secret.name);
-                    env_vars.insert(env_name, value.clone());
+            Ok(secret_props) => {
+                let resolved = if crate::records::is_record(&secret_props.content_type) {
+                    resolve_types_lazily(&mut record_types_cache, config)
+                        .await
+                        .and_then(|types| {
+                            record_field_value(&secret.name, &secret_props, None, &types)
+                        })
+                } else {
+                    record_field_value(&secret.name, &secret_props, None, &[])
+                };
+                match resolved {
+                    Ok(value) => {
+                        let env_name = to_env_var_name(&secret.name);
+                        env_vars.insert(env_name, value.clone());
 
-                    // Store for masking (if enabled)
-                    if !no_masking && !value.is_empty() {
-                        secret_values.push(value.clone());
+                        // Store for masking (if enabled)
+                        if !no_masking && !value.is_empty() {
+                            secret_values.push(value.clone());
+                        }
+                    }
+                    Err(e) => {
+                        let msg = format!("Failed to resolve secret '{}': {}", secret.name, e);
+                        output::warn(&msg);
+                        fetch_failures.push(msg);
                     }
                 }
-                Err(e) => {
-                    let msg = format!("Failed to resolve secret '{}': {}", secret.name, e);
-                    output::warn(&msg);
-                    fetch_failures.push(msg);
-                }
-            },
+            }
             Err(e) => {
                 let msg = format!("Failed to get value for secret '{}': {}", secret.name, e);
                 output::warn(&msg);
@@ -4290,7 +4330,16 @@ async fn execute_secret_run(
 
             match fetch_result {
                 Ok(secret_props) => {
-                    match record_field_value(&secret_name, &secret_props, None, &types) {
+                    let resolved = if crate::records::is_record(&secret_props.content_type) {
+                        resolve_types_lazily(&mut record_types_cache, config)
+                            .await
+                            .and_then(|types| {
+                                record_field_value(&secret_name, &secret_props, None, &types)
+                            })
+                    } else {
+                        record_field_value(&secret_name, &secret_props, None, &[])
+                    };
+                    match resolved {
                         Ok(value) => {
                             uri_values.insert(uri.clone(), value.clone());
                             if !no_masking && !value.is_empty() {
@@ -4737,8 +4786,11 @@ async fn execute_secret_inject(
     let mut secret_values: HashMap<String, Zeroizing<String>> = HashMap::new();
     let mut cross_vault_values: HashMap<String, Zeroizing<String>> = HashMap::new(); // URI -> value
 
-    // Record types, resolved once, for primary/field resolution below.
-    let types = config.resolve_record_types().await?;
+    // Record types: resolved lazily, at most once, only when a fetched
+    // secret is actually a record — an all-untyped template must render
+    // successfully even with a broken `[types.*]` config block that no
+    // referenced secret actually uses (Bugbot round 2 on #321 Phase C).
+    let mut record_types_cache: Option<std::result::Result<Vec<RecordType>, String>> = None;
 
     // Fetch secrets from current vault. `ref_token` is the raw text captured
     // from `{{ secret:TOKEN }}`: either a bare name (record primary or a
@@ -4756,7 +4808,16 @@ async fn execute_secret_inject(
                 .await
             {
                 Ok(secret_props) => {
-                    match record_field_value(ref_token, &secret_props, None, &types) {
+                    let resolved = if crate::records::is_record(&secret_props.content_type) {
+                        resolve_types_lazily(&mut record_types_cache, config)
+                            .await
+                            .and_then(|types| {
+                                record_field_value(ref_token, &secret_props, None, &types)
+                            })
+                    } else {
+                        record_field_value(ref_token, &secret_props, None, &[])
+                    };
+                    match resolved {
                         Ok(value) => {
                             secret_values.insert(ref_token.clone(), value);
                         }
@@ -4792,7 +4853,16 @@ async fn execute_secret_inject(
                     .await
                 {
                     Ok(secret_props) => {
-                        match record_field_value(base, &secret_props, Some(field), &types) {
+                        let resolved = if crate::records::is_record(&secret_props.content_type) {
+                            resolve_types_lazily(&mut record_types_cache, config)
+                                .await
+                                .and_then(|types| {
+                                    record_field_value(base, &secret_props, Some(field), &types)
+                                })
+                        } else {
+                            record_field_value(base, &secret_props, Some(field), &[])
+                        };
+                        match resolved {
                             Ok(value) => {
                                 secret_values.insert(ref_token.clone(), value);
                             }
@@ -4855,12 +4925,21 @@ async fn execute_secret_inject(
 
             match fetch_result {
                 Ok(secret_props) => {
-                    match record_field_value(
-                        &secret_name,
-                        &secret_props,
-                        field_opt.as_deref(),
-                        &types,
-                    ) {
+                    let resolved = if crate::records::is_record(&secret_props.content_type) {
+                        resolve_types_lazily(&mut record_types_cache, config)
+                            .await
+                            .and_then(|types| {
+                                record_field_value(
+                                    &secret_name,
+                                    &secret_props,
+                                    field_opt.as_deref(),
+                                    &types,
+                                )
+                            })
+                    } else {
+                        record_field_value(&secret_name, &secret_props, field_opt.as_deref(), &[])
+                    };
+                    match resolved {
                         Ok(value) => {
                             cross_vault_values.insert(uri.clone(), value);
                         }

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -1968,6 +1968,51 @@ fn inject_uri_fragment_field() {
     assert!(!rendered.contains("xv://"), "rendered: {rendered}");
 }
 
+/// Bugbot review (round on #321 Phase C): a bare `xv://vault/name` is a
+/// strict prefix of its own `xv://vault/name#field` form. Substituting via
+/// `HashMap` iteration order (nondeterministic) could rewrite part of the
+/// longer `#field` reference before it was ever matched whole, mangling the
+/// output. Referencing a record's primary *and* one of its fields in the
+/// same template is exactly the workflow this feature invites, so both
+/// forms must always resolve correctly regardless of iteration order — run
+/// several times to guard against order-dependent flakiness.
+#[test]
+fn inject_bare_and_fragment_uri_for_same_secret_both_resolve() {
+    let (_cmd, temp) = common::xv_isolated_local();
+    set_cred_login_record(temp.path());
+
+    let template_path = temp.path().join("template.txt");
+    std::fs::write(
+        &template_path,
+        "primary: xv://default/cred\nusername: xv://default/cred#username\n",
+    )
+    .unwrap();
+    let out_path = temp.path().join("out.txt");
+
+    for _ in 0..10 {
+        let out = xv_same_env(temp.path())
+            .args([
+                "inject",
+                "--template",
+                template_path.to_str().unwrap(),
+                "--out",
+                out_path.to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+        let rendered = std::fs::read_to_string(&out_path).unwrap();
+        assert!(
+            rendered.contains("primary: hunter2"),
+            "rendered: {rendered}"
+        );
+        assert!(rendered.contains("username: bob"), "rendered: {rendered}");
+        assert!(!rendered.contains('#'), "rendered: {rendered}");
+        assert!(!rendered.contains("xv://"), "rendered: {rendered}");
+    }
+}
+
 #[test]
 fn inject_field_best_effort_renders_with_warning() {
     let (_cmd, temp) = common::xv_isolated_local();

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -2071,3 +2071,201 @@ fn run_typed_record_injects_primary() {
     let injected = std::fs::read_to_string(&marker).unwrap();
     assert_eq!(injected, "hunter2", "stderr: {}", common::stderr_str(&out));
 }
+
+// ---------------------------------------------------------------------------
+// Bugbot round 2 on #321 Phase C: `xv run`/`xv inject` must resolve record
+// types LAZILY (only when a fetched secret is actually a record), not
+// eagerly before fetching anything. An all-untyped selection must succeed
+// even with a broken `[types.*]` config block that no referenced secret
+// actually uses; a typed record under the same broken config must still
+// surface the resolution error, since resolving types is fail-closed for
+// the whole config (Task 13 docs).
+// ---------------------------------------------------------------------------
+
+/// A `.xv.toml` with a `[types.*]` block with two primaries — invalid per
+/// `RecordType::validate()` (exactly one `primary` per type) — so any
+/// command that actually needs to resolve types under this config fails.
+/// Carries a minimal `default_env` pointing at the same "default" vault the
+/// global `xv.conf` already uses, purely so vault resolution doesn't itself
+/// error on "no env selected" now that the file has env profiles at all —
+/// unrelated to the type-resolution behavior under test.
+const BROKEN_TYPES_TOML: &str = r#"
+default_env = "default"
+
+[env.default]
+vault = "default"
+
+[types.bad]
+fields = [
+  { name = "a", kind = "secret", primary = true },
+  { name = "b", kind = "secret", primary = true },
+]
+"#;
+
+/// An `xv` command using ONLY the global (valid, no custom types) config
+/// written by `xv_isolated_local_with_profile` — cwd is the temp root,
+/// outside the `project/` subdirectory that holds the broken `.xv.toml`, so
+/// project-config discovery finds nothing and only built-in record types
+/// resolve. Used to create a typed record before switching to the
+/// broken-config project directory to exercise `run`/`inject` against it.
+fn xv_temp_root_env(temp: &std::path::Path) -> std::process::Command {
+    let mut cmd = common::xv();
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", temp)
+        .env("XDG_CONFIG_HOME", temp.join(".config"))
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "local")
+        .env("NO_COLOR", "1")
+        .current_dir(temp);
+    cmd
+}
+
+/// The same isolated store as `xv_isolated_local_with_profile`'s harness,
+/// but a fresh `Command` with cwd in the `project/` subdirectory so the
+/// (deliberately broken) `.xv.toml` written there is discovered.
+fn xv_project_env(temp: &std::path::Path) -> std::process::Command {
+    let mut cmd = common::xv();
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", temp)
+        .env("XDG_CONFIG_HOME", temp.join(".config"))
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "local")
+        .env("NO_COLOR", "1")
+        .current_dir(temp.join("project"));
+    cmd
+}
+
+#[test]
+fn run_untyped_secrets_unaffected_by_broken_types_config() {
+    let (_cmd, temp) = common::xv_isolated_local_with_profile(BROKEN_TYPES_TOML);
+
+    // Created from the temp root (no project config in scope), so this
+    // plain `set` never touches record-type resolution at all.
+    let out = xv_temp_root_env(temp.path())
+        .args(["set", "plain-secret", "--value", "plain-value"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    // Run from the project directory, where the broken `[types.bad]` block
+    // IS in scope. The only secret in the vault is untyped, so `xv run`
+    // must succeed exactly as it would without the record-types feature.
+    let marker = temp.path().join("run_untyped_marker.txt");
+    let out2 = xv_project_env(temp.path())
+        .args([
+            "run",
+            "--",
+            "sh",
+            "-c",
+            &format!("printf '%s' \"$PLAIN_SECRET\" > '{}'", marker.display()),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    assert_eq!(std::fs::read_to_string(&marker).unwrap(), "plain-value");
+}
+
+#[test]
+fn inject_untyped_template_unaffected_by_broken_types_config() {
+    let (_cmd, temp) = common::xv_isolated_local_with_profile(BROKEN_TYPES_TOML);
+
+    let out = xv_temp_root_env(temp.path())
+        .args(["set", "plain-secret", "--value", "plain-value"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let project_dir = temp.path().join("project");
+    let template_path = project_dir.join("template.txt");
+    std::fs::write(&template_path, "v: {{ secret:plain-secret }}\n").unwrap();
+    let out_path = project_dir.join("out.txt");
+
+    let out2 = xv_project_env(temp.path())
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let rendered = std::fs::read_to_string(&out_path).unwrap();
+    assert!(rendered.contains("plain-value"), "rendered: {rendered}");
+}
+
+#[test]
+fn run_and_inject_typed_record_fails_under_broken_types_config() {
+    let (_cmd, temp) = common::xv_isolated_local_with_profile(BROKEN_TYPES_TOML);
+
+    // Created from the temp root: only built-in types are in scope there,
+    // so creating a `login` record succeeds even though the project's
+    // `.xv.toml` (not in scope here) has a broken custom type.
+    let out = xv_temp_root_env(temp.path())
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    // From the project directory the broken `[types.bad]` block IS in
+    // scope. `cred` is a record, so both `run` and `inject` must now
+    // actually attempt type resolution and fail — resolving types is
+    // fail-closed for the whole config, so the broken custom block breaks
+    // resolution even though `cred`'s own type (`login`) is a valid
+    // built-in.
+    let out2 = xv_project_env(temp.path())
+        .args(["run", "--", "sh", "-c", "true"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out2.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+
+    let project_dir = temp.path().join("project");
+    let template_path = project_dir.join("template.txt");
+    std::fs::write(&template_path, "v: {{ secret:cred }}\n").unwrap();
+    let out_path = project_dir.join("out.txt");
+    let out3 = xv_project_env(temp.path())
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out3.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out3)
+    );
+    assert!(
+        !out_path.exists(),
+        "output file must NOT be created when type resolution fails"
+    );
+}

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -1758,3 +1758,271 @@ fn get_field_on_untyped_errors() {
         common::stderr_str(&out3)
     );
 }
+
+// ---------------------------------------------------------------------------
+// Task 12: `inject` field syntax + `xv run` primary-field guard
+// ---------------------------------------------------------------------------
+
+/// Creates a `login` record named `cred` (username `bob`, primary/password
+/// `hunter2`) in the isolated store rooted at `temp`.
+fn set_cred_login_record(temp: &std::path::Path) {
+    let out = xv_same_env(temp)
+        .args([
+            "set",
+            "cred",
+            "--type",
+            "login",
+            "--field",
+            "username=bob",
+            "--value",
+            "hunter2",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+}
+
+#[test]
+fn inject_field_syntax_renders() {
+    let (_cmd, temp) = common::xv_isolated_local();
+    set_cred_login_record(temp.path());
+
+    let template_path = temp.path().join("template.txt");
+    std::fs::write(&template_path, "user: {{ secret:cred.username }}\n").unwrap();
+    let out_path = temp.path().join("out.txt");
+
+    let out = xv_same_env(temp.path())
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let rendered = std::fs::read_to_string(&out_path).unwrap();
+    assert!(rendered.contains("bob"), "rendered: {rendered}");
+    assert!(!rendered.contains("{{ secret:"), "rendered: {rendered}");
+}
+
+#[test]
+fn inject_bare_name_renders_primary() {
+    let (_cmd, temp) = common::xv_isolated_local();
+    set_cred_login_record(temp.path());
+
+    let template_path = temp.path().join("template.txt");
+    std::fs::write(&template_path, "pw: {{ secret:cred }}\n").unwrap();
+    let out_path = temp.path().join("out.txt");
+
+    let out = xv_same_env(temp.path())
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let rendered = std::fs::read_to_string(&out_path).unwrap();
+    assert!(rendered.contains("hunter2"), "rendered: {rendered}");
+    // Never the raw JSON envelope.
+    assert!(!rendered.contains("\"password\""), "rendered: {rendered}");
+}
+
+/// An untyped secret literally named `a.b` must resolve as itself via the
+/// exact-name-first match rule, never as field `b` of a record named `a`
+/// (record-types spec/plan Task 12 disambiguation requirement).
+#[test]
+fn inject_dot_name_exact_match_wins() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args(["set", "a.b", "--value", "plain-dotted-value"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let template_path = temp.path().join("template.txt");
+    std::fs::write(&template_path, "v: {{ secret:a.b }}\n").unwrap();
+    let out_path = temp.path().join("out.txt");
+
+    let out2 = xv_same_env(temp.path())
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+
+    let rendered = std::fs::read_to_string(&out_path).unwrap();
+    assert!(
+        rendered.contains("plain-dotted-value"),
+        "rendered: {rendered}"
+    );
+}
+
+#[test]
+fn inject_unknown_field_aborts() {
+    let (_cmd, temp) = common::xv_isolated_local();
+    set_cred_login_record(temp.path());
+
+    let template_path = temp.path().join("template.txt");
+    std::fs::write(&template_path, "v: {{ secret:cred.nosuchfield }}\n").unwrap();
+    let out_path = temp.path().join("out.txt");
+
+    let out = xv_same_env(temp.path())
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out)
+    );
+    // Distinguish from a plain "secret not found" (the pre-Task-12 failure
+    // mode for any dotted name): the message must come from field
+    // resolution, naming the record's actual known fields.
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("username"), "stderr: {stderr}");
+    assert!(
+        !out_path.exists(),
+        "output file must NOT be created when a field reference fails to resolve"
+    );
+}
+
+#[test]
+fn inject_field_on_untyped_secret_aborts() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = cmd
+        .args(["set", "plain", "--value", "just-a-value"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let template_path = temp.path().join("template.txt");
+    std::fs::write(&template_path, "v: {{ secret:plain.somefield }}\n").unwrap();
+    let out_path = temp.path().join("out.txt");
+
+    let out2 = xv_same_env(temp.path())
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out2.status.code(),
+        Some(3),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    assert!(!out_path.exists());
+}
+
+#[test]
+fn inject_uri_fragment_field() {
+    let (_cmd, temp) = common::xv_isolated_local();
+    set_cred_login_record(temp.path());
+
+    let template_path = temp.path().join("template.txt");
+    std::fs::write(&template_path, "v: xv://default/cred#username\n").unwrap();
+    let out_path = temp.path().join("out.txt");
+
+    let out = xv_same_env(temp.path())
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let rendered = std::fs::read_to_string(&out_path).unwrap();
+    assert!(rendered.contains("bob"), "rendered: {rendered}");
+    assert!(!rendered.contains("xv://"), "rendered: {rendered}");
+}
+
+#[test]
+fn inject_field_best_effort_renders_with_warning() {
+    let (_cmd, temp) = common::xv_isolated_local();
+    set_cred_login_record(temp.path());
+
+    let template_path = temp.path().join("template.txt");
+    std::fs::write(&template_path, "v: {{ secret:cred.nosuchfield }}\n").unwrap();
+    let out_path = temp.path().join("out.txt");
+
+    let out = xv_same_env(temp.path())
+        .args([
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+            "--best-effort",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("nosuchfield"), "stderr: {stderr}");
+
+    // The unresolved placeholder is left in the output verbatim, matching
+    // the pre-existing --best-effort contract for other unresolved
+    // references (#319).
+    let rendered = std::fs::read_to_string(&out_path).unwrap();
+    assert!(
+        rendered.contains("{{ secret:cred.nosuchfield }}"),
+        "rendered: {rendered}"
+    );
+}
+
+/// Guard test (spec §9: `xv run` gets no per-field expansion in v1) proving
+/// `xv run` on a typed record injects the *primary* field value under the
+/// record's name — not the raw JSON envelope — exactly like plain `get`.
+#[test]
+fn run_typed_record_injects_primary() {
+    let (_cmd, temp) = common::xv_isolated_local();
+    set_cred_login_record(temp.path());
+
+    let marker = temp.path().join("run_primary_marker.txt");
+    let out = xv_same_env(temp.path())
+        .args([
+            "run",
+            "--",
+            "sh",
+            "-c",
+            &format!("printf '%s' \"$CRED\" > '{}'", marker.display()),
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let injected = std::fs::read_to_string(&marker).unwrap();
+    assert_eq!(injected, "hunter2", "stderr: {}", common::stderr_str(&out));
+}


### PR DESCRIPTION
Phase C of #321 — the final phase: inject field access and documentation. Closes #321 (spec: `docs/superpowers/specs/2026-07-03-record-types-design.md`).

## What this adds

- **`xv inject` field syntax**: `{{ secret:name.field }}` selects a record field; bare `{{ secret:name }}` stays the primary. Disambiguation is exact-name-first — an untyped secret literally named `a.b` keeps resolving as itself; the last-dot split only applies when the base name is a record with that field. Verified across the full matrix (dotted names, multi-dot, record-plus-lookalike coexisting).
- **`xv://vault/name#field` URIs**: fragment selects the field (`#` can't appear in secret names on any backend). Substitution is longest-reference-first, fixing a review-caught corruption where a bare URI (a strict prefix of its own `#field` form) could nondeterministically rewrite the fragment reference — a template using a record's primary and a field together now always renders both correctly.
- **`xv run` bug fix**: typed records now inject their **primary field** value instead of the raw JSON envelope, in both the selected-secrets and URI-reference loops — honoring the spec's compatibility contract. Untyped secrets byte-identical; #314 fail-fast semantics preserved (corrupt envelopes collect and abort).
- **One field-resolution implementation**: `get` (plain and `--field`), `run`, and `inject` all route through the shared `record_field_value` helper — no drift between the three surfaces.
- **Docs**: README record-types section (built-ins, custom `[types.*]` TOML, create/read/update/convert/list/inject examples), docs/FEATURES.md, and a CHANGELOG entry for #321 (explicitly not breaking: only explicitly-created/converted records change shape). Every documented example was executed against a scratch local store — which caught and fixed two doc bugs before commit, plus a third in review (a braced-URI example that would have rendered literal braces).

## Failure semantics

Unknown fields, fields on untyped secrets, and corrupt envelopes collect into the #319 fail-fast report and abort (exit 3) before any output is written; `--best-effort` warns and leaves the placeholder verbatim, matching the existing contract exactly.

## Tests

50 hermetic e2e tests in `tests/e2e_record_types.rs` (9 new this phase, scrubbed-env verified), including determinism coverage for the substitution-ordering fix and a guard test pinning `xv run`'s primary-only behavior. Full workspace green; clippy 0 warnings under both feature sets. Independent code-review pass performed with live reproduction; all findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret resolution on `xv run` and `xv inject` (behavior fix for records) and adds dotted-name disambiguation; mistakes could leak wrong values or break templates, but untyped secrets stay unchanged and coverage is extensive.
> 
> **Overview**
> **Phase C of record types (#321):** template injection and env injection now understand typed secrets, with docs and tests aligned to the same semantics as `xv get`.
> 
> **`xv inject`** gains `{{ secret:name.field }}` (last-dot split after an exact name match) and `xv://vault/secret#field` URI fragments. Cross-vault substitution sorts URI keys longest-first so a bare URI cannot corrupt a `#field` reference. Fail-fast / `--best-effort` behavior matches existing inject contracts.
> 
> **`xv run`** now resolves typed records through the primary secret field (not the raw JSON envelope) for both vault-selected secrets and `xv://` refs; per-field env expansion is still out of scope.
> 
> **Shared logic:** new `record_field_value` and lazy `resolve_types_lazily` unify `get`, `run`, and `inject` so all-untyped workflows never load `[types.*]` config unless a fetched secret is actually a record.
> 
> **Docs:** README record-types section, FEATURES/CHANGELOG entries, and CLI help for inject field syntax.
> 
> **Tests:** nine new e2e cases in `tests/e2e_record_types.rs` (field render, exact `a.b` name wins, URI fragments, substitution ordering, lazy type resolution under broken config).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7fd62218fbd93c0b912c5a6c2f054b4d3db0f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->