### PR TITLE
feat: --filter glob on xv ls and xv find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`--filter <GLOB>` on `xv ls`/`list` and `xv find`**, consistent with the existing `xv migrate --filter`. The glob matches either the secret's user-facing (`original_name`) or backend (sanitized) name — the same either-name convention `xv mv` and `xv run --include`/`--exclude` use — case-sensitive and whole-name (`test-*` matches `test-db`, never `latest-db`). On `ls` it's applied client-side before pagination/rendering and composes with the folder positional, `--type`, `--deleted`, and every output format. On `find` it's a hard pre-filter on the candidate set applied before fuzzy scoring, so `PATTERN` ranks only within the filtered set; `--filter` with no `PATTERN` yields an unranked filtered list — `xv find --filter 'test-*' --names-only` is the canonical "names starting with test-" one-liner. An invalid glob pattern fails fast with `invalid_argument`, before any backend call.
+
 ## v0.19.0 — Record types, fail-fast run/inject, and backend-resolution fixes (2026-07-03)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -705,9 +705,16 @@ Next page: xv list --page 3 --page-size 50
 xv ls --names-only                       # one name per line, no headers, no ANSI
 xv ls --names-only | wc -l               # count secrets
 xv ls --names-only --group production    # filter still applies
+xv ls --filter 'test-*' --names-only     # glob filter on the name, applied before rendering
 ```
 
 `--names-only` overrides `--format` and writes to stdout regardless of TTY status. Designed for scripts and pipes.
+
+`--filter <GLOB>` matches a glob pattern against the secret's name (either its
+displayed name or its backend/sanitized name), the same rule `xv migrate
+--filter` and `xv mv`/`xv run --include` use. Matching is case-sensitive and
+whole-name (`test-*` matches `test-db`, never `latest-db`). Composes with the
+folder positional, `--type`, `--deleted`, and every output format.
 
 ### Fuzzy — `xv find`
 
@@ -725,6 +732,8 @@ xv find db --all-vaults                  # search every vault you can list
 xv find db --names-only                  # pipe-friendly
 xv find db --format json                 # [{name, score, folder, groups}] — score is a "NN.00" string
 xv find db --format csv                  # Name,Score,Folder,Groups
+xv find db --filter 'test-*'             # hard pre-filter by glob before PATTERN is ranked
+xv find --filter 'test-*' --names-only   # canonical prefix search: names starting with "test-"
 ```
 
 ### Pipe into fzf — interactive picker

--- a/docs/superpowers/specs/2026-07-03-ls-find-filter-design.md
+++ b/docs/superpowers/specs/2026-07-03-ls-find-filter-design.md
@@ -1,0 +1,70 @@
+# `--filter <GLOB>` on `xv ls` and `xv find`
+
+**Date:** 2026-07-03
+**Status:** Approved design, not yet implemented
+
+## Motivation
+
+Finding secrets by name pattern currently requires piping (`xv find
+--names-only | grep '^test-'`) or JSON + jq. `xv migrate` already has a
+`--filter` glob; `ls` and `find` should offer the same, consistently.
+
+## Design
+
+### Shared helper
+
+One helper beside the existing migrate logic (e.g. in `src/cli/` shared
+module or `src/utils/`): compile the pattern with `globset::Glob` (exactly
+as `src/cli/migrate_ops.rs:51` does), returning
+`CrosstacheError::invalid_argument("Invalid glob pattern: …")` on a bad
+pattern — before any backend call. A name-match predicate implements the
+matching rule below. `migrate_ops` may adopt the helper if trivial; no
+behavior change there either way.
+
+### Matching rule
+
+A secret matches when the glob matches **either**:
+- its user-facing name (`original_name` when present — what `ls` displays), or
+- its backend (sanitized) name.
+
+This mirrors the either-name convention used by `xv mv` and `xv run
+--include`. Matching is case-sensitive and whole-name (`test-*` matches
+`test-db`, never `latest-db`), identical to `migrate --filter`.
+
+### `xv ls --filter <GLOB>`
+
+- Applied client-side after listing, before pagination/rendering.
+- Composes with the folder positional, `--type`, `--deleted` (deleted
+  summaries carry `original_name` since #304), and every output format.
+- Help text mirrors migrate's: `Filter secrets by glob pattern on the name
+  (e.g., "test-*", "api-*")`.
+
+### `xv find --filter <GLOB>`
+
+- Hard pre-filter on the candidate set, applied before fuzzy scoring; the
+  optional PATTERN then ranks within the filtered set.
+- Composes with `--in`, `--folder`, `--limit`, `--min-score`,
+  `--names-only`, `--all-vaults`.
+- `--filter` with no PATTERN = unranked filtered list (consistent with
+  today's no-pattern behavior), so
+  `xv find --filter 'test-*' --names-only` is the canonical
+  "names starting with test-" one-liner.
+
+## Error handling
+
+Invalid glob → `invalid_argument`, fail before any backend call, message
+identical in shape to migrate's.
+
+## Testing
+
+Hermetic e2e (local backend, isolated harness): prefix anchoring
+(`test-*` excludes `latest-x`); either-name matching (secret whose backend
+name differs from its display name); glob specials (`?`, `[ab]`);
+composition with `--type`, folder scope, `--deleted`, and a fuzzy PATTERN
+on find; invalid pattern errors before listing; `--names-only` piping.
+
+## Out of scope
+
+Server-side filtering (no backend supports it); case-insensitivity flags;
+globs on fields other than the name (`--in` already covers find's field
+selection for scoring).

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -501,6 +501,12 @@ pub enum Commands {
         /// JSON when stdout is not a TTY.
         #[arg(long)]
         names_only: bool,
+
+        /// Hard-filter the candidate set by glob pattern on the name (e.g.,
+        /// "test-*", "api-*") before PATTERN is scored. With no PATTERN,
+        /// yields an unranked filtered list.
+        #[arg(long, value_name = "GLOB")]
+        filter: Option<String>,
     },
     /// List secrets in the current vault context (alias: ls). Use --format table for the classic table view
     #[command(alias = "ls")]
@@ -560,6 +566,9 @@ pub enum Commands {
         /// tags on any backend, so there's no `xv-type` to filter on.
         #[arg(long = "type")]
         type_filter: Option<String>,
+        /// Filter secrets by glob pattern on the name (e.g., "test-*", "api-*")
+        #[arg(long, value_name = "GLOB")]
+        filter: Option<String>,
     },
     /// Delete a secret from the current vault context (alias: rm)
     #[command(alias = "rm")]
@@ -1672,6 +1681,7 @@ impl Cli {
                 folder,
                 all_vaults,
                 names_only,
+                filter,
             } => {
                 crate::cli::secret_ops::execute_secret_find_direct(
                     pattern,
@@ -1682,6 +1692,7 @@ impl Cli {
                     all_vaults,
                     names_only,
                     self.format,
+                    filter,
                     config,
                     registry,
                 )
@@ -1703,12 +1714,13 @@ impl Cli {
                 sort,
                 deleted,
                 type_filter,
+                filter,
             } => {
                 let pagination = crate::utils::pagination::Pagination::from_args(page, page_size)?;
                 let pager = pager.map(PagerWhen::wants_pager).unwrap_or(false);
                 if deleted {
                     crate::cli::secret_ops::execute_deleted_secret_list(
-                        pagination, pager, names_only, long, sort, config, registry,
+                        pagination, pager, names_only, long, sort, filter, config, registry,
                     )
                     .await
                 } else {
@@ -1736,6 +1748,7 @@ impl Cli {
                         recursive,
                         sort,
                         type_filter,
+                        filter,
                         config,
                         registry,
                     )

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -1218,6 +1218,39 @@ fn filter_secrets_by_type(
     secrets
 }
 
+/// Filters `secrets` down to those whose name (either the user-facing
+/// `original_name` or the backend `name`) matches `filter`'s glob pattern.
+/// Used by `xv ls --filter` and, on the pre-scoring candidate set, by
+/// `xv find --filter`. `filter` must already have been validated by
+/// [`crate::utils::helpers::compile_name_glob`] before any backend call;
+/// this recompiles the (now-known-valid) pattern to apply it.
+fn filter_secrets_by_glob(
+    mut secrets: Vec<crate::secret::manager::SecretSummary>,
+    filter: Option<&str>,
+) -> Result<Vec<crate::secret::manager::SecretSummary>> {
+    if let Some(pattern) = filter {
+        let matcher = crate::utils::helpers::compile_name_glob(pattern)?;
+        secrets.retain(|s| {
+            crate::utils::helpers::glob_matches_either_name(&matcher, &s.name, &s.original_name)
+        });
+    }
+    Ok(secrets)
+}
+
+/// Same as [`filter_secrets_by_glob`] but for `xv ls --deleted` summaries.
+fn filter_deleted_secrets_by_glob(
+    mut items: Vec<crate::secret::manager::DeletedSecretSummary>,
+    filter: Option<&str>,
+) -> Result<Vec<crate::secret::manager::DeletedSecretSummary>> {
+    if let Some(pattern) = filter {
+        let matcher = crate::utils::helpers::compile_name_glob(pattern)?;
+        items.retain(|s| {
+            crate::utils::helpers::glob_matches_either_name(&matcher, &s.name, &s.original_name)
+        });
+    }
+    Ok(items)
+}
+
 /// Lifts a `SecretSummary`'s `f.*` tags into a `fields` map and its
 /// `xv-type` tag into `record_type`, for `ls --format json` (record-types
 /// plan Task 10). Other keys match `SecretSummary`'s existing JSON shape
@@ -1329,6 +1362,7 @@ pub(crate) fn display_cached_secret_list(
     config: &Config,
     names_only: bool,
     type_filter: Option<&str>,
+    filter: Option<&str>,
 ) -> Result<()> {
     use crate::cli::ls_view::{self, LsEntry};
     use crate::utils::format::TableFormatter;
@@ -1337,6 +1371,7 @@ pub(crate) fn display_cached_secret_list(
 
     let filtered = filter_secret_summaries_for_display(secrets, group.as_deref(), all);
     let filtered = filter_secrets_by_type(filtered, type_filter);
+    let filtered = filter_secrets_by_glob(filtered, filter)?;
     let mut scoped = ls_view::scope_secrets(filtered, path);
     if sort == crate::cli::commands::LsSort::Updated {
         ls_view::sort_secrets_by_updated_desc(&mut scoped.secrets);
@@ -1599,12 +1634,14 @@ fn deleted_list_rows(
 /// `xv ls --deleted`: list soft-deleted secrets awaiting restore/purge.
 /// Always bypasses the secrets-list cache (which only holds live secrets)
 /// and requires the backend to advertise `has_soft_delete`.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_deleted_secret_list(
     pagination: Pagination,
     pager: bool,
     names_only: bool,
     long: bool,
     sort: crate::cli::commands::LsSort,
+    filter: Option<String>,
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
@@ -1613,6 +1650,11 @@ pub(crate) async fn execute_deleted_secret_list(
     use crate::utils::format::TableFormatter;
     use crate::utils::pagination::{paginate_slice, pagination_footer_text};
     use std::fmt::Write as _;
+
+    // Validate the glob before any backend call.
+    if let Some(pattern) = filter.as_deref() {
+        crate::utils::helpers::compile_name_glob(pattern)?;
+    }
 
     if !use_trait_path(registry) {
         return Err(CrosstacheError::config(
@@ -1635,7 +1677,7 @@ pub(crate) async fn execute_deleted_secret_list(
     let vault_name = resolve_vault_for_trait(&config, registry).await?;
     // Always live — the SecretsList cache holds live secrets only, and trash
     // freshness matters right after a delete.
-    let mut items = match reg
+    let items = match reg
         .active()
         .secrets()
         .list_deleted_secrets(&vault_name)
@@ -1645,6 +1687,8 @@ pub(crate) async fn execute_deleted_secret_list(
         Err(crate::backend::BackendError::Unsupported(_)) => return Err(unsupported()),
         Err(e) => return Err(e.into()),
     };
+
+    let mut items = filter_deleted_secrets_by_glob(items, filter.as_deref())?;
 
     match sort {
         LsSort::Name => items.sort_by(|a, b| deleted_display_name(a).cmp(deleted_display_name(b))),
@@ -1788,9 +1832,15 @@ pub(crate) async fn execute_secret_list_direct(
     recursive: bool,
     sort: crate::cli::commands::LsSort,
     type_filter: Option<String>,
+    filter: Option<String>,
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
+    // Validate the glob before any backend call.
+    if let Some(pattern) = filter.as_deref() {
+        crate::utils::helpers::compile_name_glob(pattern)?;
+    }
+
     // ── Trait-based path (all backends) ───────────────────────────────
     if use_trait_path(registry) {
         use crate::cache::CacheManager;
@@ -1820,6 +1870,7 @@ pub(crate) async fn execute_secret_list_direct(
                     &config,
                     names_only,
                     type_filter.as_deref(),
+                    filter.as_deref(),
                 );
             }
         }
@@ -1906,6 +1957,7 @@ pub(crate) async fn execute_secret_list_direct(
             &config,
             names_only,
             type_filter.as_deref(),
+            filter.as_deref(),
         );
     }
 
@@ -3474,9 +3526,16 @@ pub(crate) async fn execute_secret_find_direct(
     all_vaults: bool,
     names_only: bool,
     format: crate::utils::format::OutputFormat,
+    filter: Option<String>,
     config: Config,
     registry: Option<&crate::backend::BackendRegistry>,
 ) -> Result<()> {
+    // Validate the glob before any backend call — the hard pre-filter is
+    // applied on the candidate set before fuzzy scoring (see below).
+    if let Some(pattern) = filter.as_deref() {
+        crate::utils::helpers::compile_name_glob(pattern)?;
+    }
+
     // Normalize --folder: trim trailing '/', validate, treat empty as absent.
     let folder_scope: Option<String> = match folder {
         Some(raw) => {
@@ -3525,6 +3584,7 @@ pub(crate) async fn execute_secret_find_direct(
                 for v in &vaults {
                     match reg.active().secrets().list_secrets(&v.name, None).await {
                         Ok(secrets) => {
+                            let secrets = filter_secrets_by_glob(secrets, filter.as_deref())?;
                             for s in &secrets {
                                 let mut item = CandidateItem::from_secret_summary(s);
                                 item.name = format!("{}/{}", v.name, item.name);
@@ -3546,6 +3606,7 @@ pub(crate) async fn execute_secret_find_direct(
                 .secrets()
                 .list_secrets(&vault_name, None)
                 .await?;
+            let all_secrets = filter_secrets_by_glob(all_secrets, filter.as_deref())?;
             all_secrets
                 .iter()
                 .map(CandidateItem::from_secret_summary)
@@ -3604,6 +3665,7 @@ pub(crate) async fn execute_secret_find_direct(
         all_vaults,
         names_only,
         format,
+        filter.as_deref(),
         &config,
     )
     .await
@@ -3620,6 +3682,7 @@ async fn execute_secret_find(
     all_vaults: bool,
     names_only: bool,
     format: crate::utils::format::OutputFormat,
+    filter: Option<&str>,
     config: &Config,
 ) -> Result<()> {
     use crate::config::ContextManager;
@@ -3695,6 +3758,7 @@ async fn execute_secret_find(
                 .await
             {
                 Ok(secrets) => {
+                    let secrets = filter_secrets_by_glob(secrets, filter)?;
                     for s in &secrets {
                         let mut item = CandidateItem::from_secret_summary(s);
                         // Prefix the vault name into the displayed name so
@@ -3722,6 +3786,7 @@ async fn execute_secret_find(
             .await;
         progress.finish_clear();
         let all_secrets = all_secrets?;
+        let all_secrets = filter_secrets_by_glob(all_secrets, filter)?;
         all_secrets
             .iter()
             .map(CandidateItem::from_secret_summary)

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -244,6 +244,29 @@ pub fn safe_join(base: &Path, untrusted: &str) -> Result<PathBuf> {
     Ok(base.join(untrusted_path))
 }
 
+/// Compile `pattern` into a whole-name, case-sensitive glob matcher, exactly
+/// as `xv migrate --filter` does. Used by `xv ls --filter` and `xv find
+/// --filter` (shared helper). Returns `invalid_argument` on a bad pattern —
+/// callers must invoke this before any backend call so a typo'd glob fails
+/// fast.
+pub fn compile_name_glob(pattern: &str) -> Result<globset::GlobMatcher> {
+    Ok(globset::Glob::new(pattern)
+        .map_err(|e| CrosstacheError::invalid_argument(format!("Invalid glob pattern: {e}")))?
+        .compile_matcher())
+}
+
+/// True when `matcher` matches either `name` (the backend/sanitized name) or
+/// `original_name` (the user-facing display name, when set) — the
+/// either-name convention shared with `xv mv` and `xv run --include`/
+/// `--exclude`.
+pub fn glob_matches_either_name(
+    matcher: &globset::GlobMatcher,
+    name: &str,
+    original_name: &str,
+) -> bool {
+    matcher.is_match(name) || (!original_name.is_empty() && matcher.is_match(original_name))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -336,6 +359,52 @@ mod tests {
 
         let result = safe_join(base, "docs/readme.md").unwrap();
         assert_eq!(result, std::path::Path::new("/tmp/base/docs/readme.md"));
+    }
+
+    #[test]
+    fn test_compile_name_glob_rejects_invalid_pattern() {
+        let err = compile_name_glob("test-[").unwrap_err();
+        assert!(err.to_string().contains("Invalid glob pattern"));
+    }
+
+    #[test]
+    fn test_compile_name_glob_prefix_anchoring() {
+        let matcher = compile_name_glob("test-*").unwrap();
+        assert!(matcher.is_match("test-db"));
+        assert!(!matcher.is_match("latest-db"));
+    }
+
+    #[test]
+    fn test_compile_name_glob_specials() {
+        let q = compile_name_glob("ab?").unwrap();
+        assert!(q.is_match("abc"));
+        assert!(!q.is_match("ab"));
+        assert!(!q.is_match("abcd"));
+
+        let bracket = compile_name_glob("f[ab]o").unwrap();
+        assert!(bracket.is_match("fao"));
+        assert!(bracket.is_match("fbo"));
+        assert!(!bracket.is_match("fco"));
+    }
+
+    #[test]
+    fn test_glob_matches_either_name() {
+        let matcher = compile_name_glob("display-*").unwrap();
+        // Matches on original_name (display), not on backend name.
+        assert!(glob_matches_either_name(
+            &matcher,
+            "sanitized-name",
+            "display-thing"
+        ));
+        // Matches on backend name when original_name is empty.
+        let matcher2 = compile_name_glob("backend-*").unwrap();
+        assert!(glob_matches_either_name(&matcher2, "backend-thing", ""));
+        // Neither matches.
+        assert!(!glob_matches_either_name(
+            &matcher2,
+            "other",
+            "other-display"
+        ));
     }
 
     #[test]

--- a/tests/e2e_filter_glob.rs
+++ b/tests/e2e_filter_glob.rs
@@ -1,0 +1,349 @@
+//! End-to-end CLI tests for `--filter <GLOB>` on `xv ls` and `xv find`
+//! (2026-07-03 design doc: docs/superpowers/specs/2026-07-03-ls-find-filter-design.md).
+//!
+//! Hermetic: every test uses the isolated local-backend harness from
+//! `tests/common/mod.rs` — no Azure credentials or network access required.
+//!
+//! Run with:
+//!   cargo test --test e2e_filter_glob
+
+mod common;
+
+/// Builds a fresh `xv` `Command` bound to the same isolated store/env as an
+/// existing `xv_isolated_local()` tempdir, for a second (or third, ...) CLI
+/// invocation against the same store (each `Command` is single-use). Mirrors
+/// `xv_same_env` in `tests/e2e_record_types.rs`.
+fn xv_same_env(temp: &std::path::Path) -> std::process::Command {
+    let mut cmd = common::xv();
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", temp)
+        .env("XDG_CONFIG_HOME", temp.join(".config"))
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "local")
+        .env("NO_COLOR", "1")
+        .current_dir(temp);
+    cmd
+}
+
+/// Set a secret with a plain value via `xv set NAME --value VALUE`.
+fn set_secret(temp: &std::path::Path, name: &str, value: &str) {
+    let out = xv_same_env(temp)
+        .args(["set", name, "--value", value])
+        .output()
+        .expect("execute xv set");
+    assert!(
+        out.status.success(),
+        "xv set {name} failed: stderr: {}",
+        common::stderr_str(&out)
+    );
+}
+
+// ===========================================================================
+// `xv ls --filter`
+// ===========================================================================
+
+#[test]
+fn ls_filter_prefix_anchoring() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-db", "v1");
+    set_secret(temp.path(), "latest-db", "v2");
+
+    let out = cmd
+        .args(["ls", "--filter", "test-*", "--names-only"])
+        .output()
+        .expect("execute xv ls");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(
+        stdout.contains("test-db"),
+        "filter 'test-*' should match test-db: {stdout}"
+    );
+    assert!(
+        !stdout.contains("latest-db"),
+        "filter 'test-*' must NOT match latest-db (prefix anchoring): {stdout}"
+    );
+}
+
+/// Either-name matching (design doc's "matching rule"): a filter matches
+/// either the user-facing display name or the backend (sanitized) name.
+/// The local backend never sanitizes (name == original_name always — see
+/// `set_secret` in `src/backend/local/secrets.rs`), so this test can only
+/// exercise the display-name side end-to-end; the backend-name side of the
+/// predicate is covered directly by
+/// `crate::utils::helpers::tests::test_glob_matches_either_name` in
+/// `src/utils/helpers.rs`, with a synthetic summary whose `name` and
+/// `original_name` differ.
+#[test]
+fn ls_filter_matches_display_name() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "display-thing", "v1");
+
+    let out = cmd
+        .args(["ls", "--filter", "display-*", "--names-only"])
+        .output()
+        .expect("execute xv ls");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(stdout.contains("display-thing"), "stdout: {stdout}");
+}
+
+#[test]
+fn ls_filter_glob_question_mark() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "abc", "v1");
+    set_secret(temp.path(), "abcd", "v2");
+
+    let out = cmd
+        .args(["ls", "--filter", "ab?", "--names-only"])
+        .output()
+        .expect("execute xv ls");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(
+        stdout.contains("abc"),
+        "'?' should match one char: {stdout}"
+    );
+    assert!(
+        !stdout.contains("abcd"),
+        "'?' must not match two chars: {stdout}"
+    );
+}
+
+#[test]
+fn ls_filter_glob_char_class() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "fao", "v1");
+    set_secret(temp.path(), "fbo", "v2");
+    set_secret(temp.path(), "fco", "v3");
+
+    let out = cmd
+        .args(["ls", "--filter", "f[ab]o", "--names-only"])
+        .output()
+        .expect("execute xv ls");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(stdout.contains("fao"), "stdout: {stdout}");
+    assert!(stdout.contains("fbo"), "stdout: {stdout}");
+    assert!(!stdout.contains("fco"), "stdout: {stdout}");
+}
+
+#[test]
+fn ls_filter_composes_with_type() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = xv_same_env(temp.path())
+        .args([
+            "set",
+            "test-login",
+            "--type",
+            "login",
+            "--value",
+            "hunter2",
+            "--field",
+            "username=alice",
+        ])
+        .output()
+        .expect("execute xv set --type");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    set_secret(temp.path(), "test-plain", "v1");
+    set_secret(temp.path(), "other-login-shape", "v2");
+
+    let out = cmd
+        .args([
+            "ls",
+            "--filter",
+            "test-*",
+            "--type",
+            "login",
+            "--names-only",
+        ])
+        .output()
+        .expect("execute xv ls");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(
+        stdout.contains("test-login"),
+        "should match glob + type: {stdout}"
+    );
+    assert!(
+        !stdout.contains("test-plain"),
+        "type filter should exclude untyped secret: {stdout}"
+    );
+    assert!(
+        !stdout.contains("other-login-shape"),
+        "glob filter should exclude non-matching name: {stdout}"
+    );
+}
+
+#[test]
+fn ls_filter_composes_with_folder_scope() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    let out = xv_same_env(temp.path())
+        .args(["set", "test-db", "--value", "v1", "--folder", "prod"])
+        .output()
+        .expect("execute xv set");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    set_secret(temp.path(), "test-other", "v2"); // root, not in 'prod'
+
+    let out = cmd
+        .args(["ls", "prod", "--filter", "test-*", "--names-only"])
+        .output()
+        .expect("execute xv ls");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(stdout.contains("test-db"), "stdout: {stdout}");
+    assert!(
+        !stdout.contains("test-other"),
+        "folder scope should exclude root secret: {stdout}"
+    );
+}
+
+#[test]
+fn ls_filter_composes_with_deleted() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-deleted", "v1");
+    set_secret(temp.path(), "latest-deleted", "v2");
+
+    let out = xv_same_env(temp.path())
+        .args(["rm", "test-deleted", "--force"])
+        .output()
+        .expect("execute xv rm");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let out2 = xv_same_env(temp.path())
+        .args(["rm", "latest-deleted", "--force"])
+        .output()
+        .expect("execute xv rm");
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+
+    let out = cmd
+        .args(["ls", "--deleted", "--filter", "test-*", "--names-only"])
+        .output()
+        .expect("execute xv ls --deleted");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(stdout.contains("test-deleted"), "stdout: {stdout}");
+    assert!(
+        !stdout.contains("latest-deleted"),
+        "prefix anchoring should exclude latest-deleted: {stdout}"
+    );
+}
+
+#[test]
+fn ls_filter_invalid_glob_errors_before_listing() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-db", "v1");
+
+    let out = cmd
+        .args(["ls", "--filter", "test-["])
+        .output()
+        .expect("execute xv ls");
+    assert!(
+        !out.status.success(),
+        "invalid glob should fail: stdout: {}",
+        common::stdout_str(&out)
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "invalid_argument exit code is 2: stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("Invalid glob pattern"), "stderr: {stderr}");
+}
+
+// ===========================================================================
+// `xv find --filter`
+// ===========================================================================
+
+#[test]
+fn find_filter_prefilters_before_fuzzy_scoring() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-alpha", "v1");
+    set_secret(temp.path(), "test-beta", "v2");
+    set_secret(temp.path(), "latest-alpha", "v3");
+
+    // "alpha" fuzzy-matches both test-alpha and latest-alpha, but --filter
+    // 'test-*' hard-excludes latest-alpha before scoring even starts.
+    let out = cmd
+        .args(["find", "alpha", "--filter", "test-*", "--names-only"])
+        .output()
+        .expect("execute xv find");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(stdout.contains("test-alpha"), "stdout: {stdout}");
+    assert!(
+        !stdout.contains("latest-alpha"),
+        "hard pre-filter should exclude latest-alpha even though it fuzzy-matches 'alpha': {stdout}"
+    );
+    assert!(
+        !stdout.contains("test-beta"),
+        "'test-beta' does not fuzzy-match 'alpha': {stdout}"
+    );
+}
+
+#[test]
+fn find_filter_no_pattern_is_unranked_list() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-one", "v1");
+    set_secret(temp.path(), "test-two", "v2");
+    set_secret(temp.path(), "other", "v3");
+
+    let out = cmd
+        .args(["find", "--filter", "test-*", "--names-only"])
+        .output()
+        .expect("execute xv find");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(stdout.contains("test-one"), "stdout: {stdout}");
+    assert!(stdout.contains("test-two"), "stdout: {stdout}");
+    assert!(!stdout.contains("other"), "stdout: {stdout}");
+}
+
+#[test]
+fn find_filter_names_only_is_pipe_friendly() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-a", "v1");
+    set_secret(temp.path(), "test-b", "v2");
+    set_secret(temp.path(), "skip-me", "v3");
+
+    let out = cmd
+        .args(["find", "--filter", "test-*", "--names-only"])
+        .output()
+        .expect("execute xv find");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines.len(), 2, "bare names only, one per line: {stdout}");
+    assert!(lines.contains(&"test-a"), "stdout: {stdout}");
+    assert!(lines.contains(&"test-b"), "stdout: {stdout}");
+}
+
+#[test]
+fn find_filter_invalid_glob_errors_before_listing() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-db", "v1");
+
+    let out = cmd
+        .args(["find", "--filter", "test-["])
+        .output()
+        .expect("execute xv find");
+    assert!(
+        !out.status.success(),
+        "invalid glob should fail: stdout: {}",
+        common::stdout_str(&out)
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "invalid_argument exit code is 2: stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("Invalid glob pattern"), "stderr: {stderr}");
+}

--- a/tests/e2e_filter_glob.rs
+++ b/tests/e2e_filter_glob.rs
@@ -261,15 +261,51 @@ fn ls_filter_invalid_glob_errors_before_listing() {
 // `xv find --filter`
 // ===========================================================================
 
+/// Placement matters, not just presence: a filter applied *after* fuzzy
+/// scoring can produce the exact same `--names-only` output as a correct
+/// pre-filter whenever `--min-score`'s relative cutoff happens to land in
+/// the same place either way (e.g. with the default 0.3 and no excluded
+/// candidate scoring anywhere near the top). To make the placement itself
+/// observable, this test includes a filtered-OUT candidate ("alpha", bare)
+/// that is the single highest fuzzy scorer for the pattern "alpha" — higher
+/// even than "test-alpha", which the glob *does* admit — and pairs it with
+/// an explicit `--min-score` tuned so the two placements disagree on
+/// whether a third, low (but real) scorer survives:
+///
+/// Scores against pattern "alpha" (verified via `--format json`): bare
+/// "alpha" = 140, "latest-alpha" = "test-alpha" = 128, "test-a1l2p3h4a" = 84
+/// (gapped match), "test-zzz" = no match at all (dropped unconditionally).
+///
+/// - Correct (pre-filter): candidate set is glob-restricted to
+///   {test-alpha, test-a1l2p3h4a, test-zzz} *before* scoring, so the top
+///   score used for the relative cutoff is test-alpha's 128. At
+///   `--min-score 0.62`, cutoff = ceil(128 * 0.62) = 80, and 84 >= 80, so
+///   test-a1l2p3h4a survives.
+/// - Buggy (post-scoring filter): the cutoff is computed against the full,
+///   unfiltered candidate set, so bare "alpha" (140) sets the top score
+///   instead. cutoff = ceil(140 * 0.62) = 87, and 84 < 87 — test-a1l2p3h4a
+///   is dropped before the glob filter even gets a chance to run, even
+///   though it belongs in the answer. (Empirically confirmed against a
+///   temporarily bug-simulated build during development of this test: the
+///   post-scoring placement returns only `test-alpha`, missing
+///   `test-a1l2p3h4a`.)
+///
+/// So this test fails under a post-scoring filter placement but passes
+/// under the correct pre-filter placement — the earlier bare "excludes
+/// latest-alpha" assertion alone could not tell the two apart.
 #[test]
 fn find_filter_prefilters_before_fuzzy_scoring() {
     let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "alpha", "v0"); // excluded by filter; top fuzzy scorer
     set_secret(temp.path(), "test-alpha", "v1");
     set_secret(temp.path(), "test-beta", "v2");
     set_secret(temp.path(), "latest-alpha", "v3");
+    set_secret(temp.path(), "test-a1l2p3h4a", "v4"); // included; low (gapped) score
+    set_secret(temp.path(), "test-zzz", "v5"); // included; no fuzzy match at all
 
-    // "alpha" fuzzy-matches both test-alpha and latest-alpha, but --filter
-    // 'test-*' hard-excludes latest-alpha before scoring even starts.
+    // "alpha" fuzzy-matches "alpha", "latest-alpha", and "test-alpha", but
+    // --filter 'test-*' hard-excludes "alpha" and "latest-alpha" before
+    // scoring even starts.
     let out = cmd
         .args(["find", "alpha", "--filter", "test-*", "--names-only"])
         .output()
@@ -284,6 +320,52 @@ fn find_filter_prefilters_before_fuzzy_scoring() {
     assert!(
         !stdout.contains("test-beta"),
         "'test-beta' does not fuzzy-match 'alpha': {stdout}"
+    );
+
+    // The placement-sensitive case: --min-score's cutoff must be computed
+    // relative to the top score *within the glob-filtered set* (128, from
+    // test-alpha), not the unfiltered set (140, from the excluded "alpha").
+    let out2 = xv_same_env(temp.path())
+        .args([
+            "find",
+            "alpha",
+            "--filter",
+            "test-*",
+            "--min-score",
+            "0.62",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("execute xv find --format json");
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        common::stderr_str(&out2)
+    );
+    let json: serde_json::Value =
+        serde_json::from_str(&common::stdout_str(&out2)).expect("find --format json output");
+    let names: Vec<&str> = json
+        .as_array()
+        .expect("json array")
+        .iter()
+        .map(|v| v["name"].as_str().expect("name field"))
+        .collect();
+    assert!(
+        names.contains(&"test-alpha"),
+        "top-of-filtered-set survivor should always pass: {names:?}"
+    );
+    assert!(
+        names.contains(&"test-a1l2p3h4a"),
+        "test-a1l2p3h4a (score 84) must survive a cutoff computed from the \
+         filtered set's top score (128 * 0.62 = 80) — a post-scoring filter \
+         would instead compute the cutoff from the excluded 'alpha' (140 * \
+         0.62 = 87) and wrongly drop it: {names:?}"
+    );
+    assert_eq!(
+        names.len(),
+        2,
+        "only the two glob-admitted, score-surviving secrets should appear: {names:?}"
     );
 }
 


### PR DESCRIPTION
Adds `--filter <GLOB>` to `xv ls`/`list` and `xv find`, consistent with the existing `xv migrate --filter`. Spec rides this PR (`docs/superpowers/specs/2026-07-03-ls-find-filter-design.md`).

## Behavior

- **`xv ls --filter 'test-*'`** — client-side name-glob filter, composing with the folder positional, `--type`, `--deleted`, pagination (applied to the full collected set, not per page), and every output format.
- **`xv find --filter 'test-*'`** — hard pre-filter on the candidate set **before** fuzzy scoring, in both single-vault and `--all-vaults` branches (and the legacy Azure path); the optional PATTERN then ranks within the filtered set, and `--min-score`'s relative cutoff is computed from the filtered top-scorer. With no PATTERN: the unranked filtered list — so `xv find --filter 'test-*' --names-only` is the canonical prefix search.
- **Matching**: `globset` semantics identical to `migrate --filter`; case-sensitive whole-name; matches **either** the display name (`original_name`) or the backend (sanitized) name — the same either-name convention as `xv mv` and `run --include`. An invalid glob fails with `invalid_argument` before any backend or cache call.
- No `--filter` → every touched path byte-identical to before (verified in review: no eager compilation, no ordering or pagination drift).
- `migrate --filter` intentionally untouched: it matches backend names only, so adopting the either-name helper would have changed its behavior.

## Tests

12 hermetic e2e tests (`tests/e2e_filter_glob.rs`, scrubbed-env verified) plus unit tests for the shared predicate: prefix anchoring, either-name matching, `?`/`[ab]` globs, composition with `--type`/folder/`--deleted`/fuzzy patterns, invalid-pattern failure, `--names-only` piping. The pre-filter-placement test was hardened after review by simulating the buggy post-scoring placement and confirming the test fails against it (a filtered-out top-scorer plus `--min-score` makes the placement observable through the relative cutoff).

Full workspace green; clippy 0 warnings under both feature sets. Independent code-review pass: approve on all eight priority dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, client-side listing/search filtering with no changes to secret storage, auth, or migrate behavior; extensive e2e and unit tests limit regression risk.
> 
> **Overview**
> Adds **`--filter <GLOB>`** to **`xv ls`** and **`xv find`**, aligned with migrate-style `globset` semantics but using a shared **either-name** rule (display `original_name` or backend `name`), matching `xv mv` / `run --include`.
> 
> **`xv ls --filter`** applies the glob client-side after fetch, before folder scoping, pagination, and rendering; it composes with **`--type`**, **`--deleted`**, folder positional, and all output modes. **`xv find --filter`** narrows the candidate set **before** fuzzy scoring (including **`--all-vaults`** and the legacy path), so **`--min-score`** uses the top score within the filtered set; with no pattern, you get an unranked filtered list (e.g. prefix search via **`xv find --filter 'test-*' --names-only`**).
> 
> Shared **`compile_name_glob`** / **`glob_matches_either_name`** live in **`src/utils/helpers.rs`**; invalid patterns return **`invalid_argument`** before any backend or cache access. **`xv migrate --filter`** is unchanged (backend names only).
> 
> Docs (**README**, **CHANGELOG**), an approved design spec, unit tests on the helpers, and hermetic e2e coverage (**`tests/e2e_filter_glob.rs`**) ship with the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cfa2bb6cbf2e273344f630061aacea15cc80153. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->