### PR TITLE
chore: bump version to 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.19.1 — Name-glob filtering on ls and find (2026-07-03)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Release prep for v0.19.1 — ships the `--filter <GLOB>` support on `xv ls`/`xv find` (#326). CHANGELOG `Unreleased` → **v0.19.1 — Name-glob filtering on ls and find (2026-07-03)**; Cargo.toml/Cargo.lock → 0.19.1. Tag `v0.19.1` follows the merge per the release convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no runtime or dependency logic updates beyond the package version pin.
> 
> **Overview**
> **Release prep for v0.19.1** — no functional code changes in this diff.
> 
> Bumps `crosstache` from **0.19.0** to **0.19.1** in `Cargo.toml` and `Cargo.lock`, and retitles the changelog **Unreleased** section to **v0.19.1 — Name-glob filtering on ls and find (2026-07-03)**. That entry documents **`--filter <GLOB>`** on `xv ls`/`list` and `xv find` (aligned with `xv migrate --filter`), which ships via the prior feature work referenced in the release notes (#326).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e366fd2a790eabdd67383b34f20d92315c7e1caf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->