### PR TITLE
feat: --filter glob on xv mv for bulk folder moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`--filter <GLOB>` on `xv mv`**, bulk-moving every secret whose name matches the glob into a destination folder in one plan/confirm step, instead of a shell loop (`xv find --filter 'test-*' --names-only | while read -r n; do xv mv "$n" archive/; done`). Matching is identical to `ls`/`find --filter` (#326): case-sensitive, whole-name, either the display or backend (sanitized) name, whole-vault scope. `SOURCE` and `--filter` are mutually exclusive (exactly one is required); with `--filter`, `DEST` must be a folder destination (`folder/` or `/`) since a rename is impossible for a multi-secret move. Matched secrets keep their names — only the `folder` metadata is rewritten, the same metadata-only update `xv mv`'s bulk folder moves already use. Reuses the existing bulk-move machinery: count + sample plan confirmation, `--yes` bypass, non-TTY refusal without `--yes`, `--dry-run` preview, a collision pre-check before any move, and attempt-all/report-failure-count partial-failure behavior. Secrets already in the destination are skipped and noted (not counted as moves, not an error); zero matches fails loud; an invalid glob fails with `invalid_argument` before any backend call.
+
 ## v0.19.1 — Name-glob filtering on ls and find (2026-07-03)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ xv mv db/pass app/pw        # move to folder 'app' and rename to 'pw'
 xv mv db/pass newname       # rename to 'newname' at root
 xv mv app/pass /            # move to root (clears the folder tag)
 xv mv app/ svc/             # bulk: re-folder every secret under 'app/' to 'svc/'
+xv mv --filter 'test-*' archive/   # bulk: re-folder every secret matching a glob
 ```
 
 A trailing `/` marks a folder path (source or destination); `/` alone means
@@ -456,6 +457,17 @@ within-vault only — for moving a secret between vaults see `xv move` under
 name-changing `mv` of a *disabled* secret can partially apply: the folder
 update succeeds but the rename fails with 403 because the value can't be
 read — the same limitation as `xv update --rename` on disabled secrets.
+
+`--filter <GLOB>` bulk-moves every secret whose name matches the glob (either
+its displayed name or its backend/sanitized name — the same either-name rule
+`ls`/`find --filter` use) into a destination folder, in one plan/confirm
+step instead of a shell loop like
+`xv find --filter 'test-*' --names-only | while read -r n; do xv mv "$n" archive/; done`.
+`SOURCE` and `--filter` are mutually exclusive — exactly one is required —
+and with `--filter`, `DEST` must be a folder destination (`folder/` or `/`):
+a rename is impossible for a multi-secret move. Matched secrets already in
+the destination are skipped (noted, not counted as moves); zero matches
+fails loud. Composes with `--yes` and `--dry-run` like a folder move.
 
 ### Delete and recover
 

--- a/docs/superpowers/specs/2026-07-03-mv-filter-design.md
+++ b/docs/superpowers/specs/2026-07-03-mv-filter-design.md
@@ -1,0 +1,80 @@
+# `--filter <GLOB>` on `xv mv`
+
+**Date:** 2026-07-03
+**Status:** Approved design, not yet implemented
+**Depends on:** the shared glob helper from #326 (`compile_name_glob` / `glob_matches_either_name` in `src/utils/helpers.rs`); `xv mv` bulk machinery (v0.18.0, PR #300)
+
+## Motivation
+
+Moving secrets that match a name pattern into a folder currently requires a
+shell loop (`xv find --filter 'test-*' --names-only | while read -r n; do
+xv mv "$n" archive/ ; done`) — N invocations, no unified plan/confirmation,
+no single dry-run. `xv mv` already has bulk-move machinery for folder
+moves; a `--filter` glob should reuse it.
+
+## CLI shape
+
+```
+xv mv --filter 'test-*' archive/     # move all matching secrets into archive/
+xv mv --filter 'test-*' /            # move matches to the vault root
+```
+
+- With `--filter`, the `SOURCE` positional must be omitted: exactly one of
+  (`SOURCE`, `--filter`) — violations are a usage error naming both forms.
+- `DEST` must be a folder destination (`folder/` or `/`): renames are
+  impossible for a multi-secret move. A non-folder dest errors with the
+  same shape as the existing "folder moves require a folder destination
+  ending in / (got '…'); did you mean '…/'?" message.
+- Composes with the existing `--yes` and `--dry-run` flags.
+
+## Semantics
+
+- **Matching** is identical to `ls`/`find --filter` (#326): `globset`,
+  case-sensitive, whole-name, matched against **either** the user-facing
+  name (`original_name`) or the backend (sanitized) name, bare names (not
+  folder-qualified), whole-vault scope.
+- Matched secrets keep their names; only the `folder` metadata is
+  rewritten to `DEST` — metadata-only, exactly like folder moves.
+- **Plan variant**: a new `MvPlan::Filter { pattern: String, dest_prefix:
+  Option<String> }` in `src/cli/mv_ops.rs` flowing through the existing
+  bulk path (`execute_folder_mv`'s machinery, generalized or mirrored):
+  count + sample plan confirmation, `--yes` bypass, non-TTY without
+  `--yes` refuses (same exit as bulk folder moves today), `--dry-run`
+  previews the full plan without moving, collision pre-check on backend
+  names before any move, attempt-all-report-failures partial-failure
+  behavior.
+- **Already-in-dest** secrets are skipped and noted in the plan output
+  (not errors, not counted as moves).
+- **Zero matches** → fail loud: `no secrets matched --filter 'test-*'`
+  (non-zero exit), consistent with `run`'s fail-loud posture.
+- **Invalid glob** → `invalid_argument` before any backend call (same
+  message shape as `ls`/`find`/`migrate`).
+
+## Rejected alternatives
+
+- Looping per-secret moves internally: loses the unified
+  plan/confirm/dry-run/partial-failure semantics — no better than the
+  shell loop.
+- A glob parameter on the existing `MvPlan::Folder` variant: muddies the
+  trailing-slash grammar; folder-scoped filtering can compose later if
+  ever needed (out of scope).
+
+## Testing
+
+Hermetic e2e (local backend, existing harness idioms): filter move
+relocates matches and only matches; either-name matching; dest-must-be-
+folder error; SOURCE-xor-`--filter` usage error; `--dry-run` previews
+without moving; non-TTY without `--yes` refuses with nothing moved;
+already-in-dest skip note; zero-match failure; invalid glob fails before
+listing; collision pre-check refuses before any move.
+
+## Docs
+
+`mv` help text; README bulk-move example replaces the shell loop with
+`xv mv --filter 'test-*' archive/`; CHANGELOG Added entry under
+Unreleased.
+
+## Out of scope
+
+Folder-scoped filtered moves (`xv mv src/ dest/ --filter 'x-*'`);
+cross-vault filtered moves; filters on fields other than the name.

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -808,6 +808,9 @@ pub enum Commands {
     },
     /// Move or rename a secret, re-folder a whole folder (trailing / = folder),
     /// or bulk-move every secret matching a glob (--filter) into a folder
+    #[command(
+        override_usage = "xv mv [OPTIONS] <SOURCE> <DEST>\n       xv mv [OPTIONS] --filter <GLOB> <DEST>"
+    )]
     Mv {
         /// SOURCE DEST, e.g. 'db/pass app/' or 'app/ svc/'; with --filter,
         /// provide DEST only (omit SOURCE) — DEST must then be a folder

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -806,12 +806,22 @@ pub enum Commands {
         #[arg(long, short = 'y')]
         yes: bool,
     },
-    /// Move or rename a secret, or re-folder a whole folder (trailing / = folder)
+    /// Move or rename a secret, re-folder a whole folder (trailing / = folder),
+    /// or bulk-move every secret matching a glob (--filter) into a folder
     Mv {
-        /// Source: 'folder/name', 'name', or a folder prefix ending in '/'
-        source: String,
-        /// Destination: 'folder/' (keep name), 'folder/newname', 'newname' (root), or '/'
-        dest: String,
+        /// SOURCE DEST, e.g. 'db/pass app/' or 'app/ svc/'; with --filter,
+        /// provide DEST only (omit SOURCE) — DEST must then be a folder
+        /// destination ('folder/' or '/'), since a rename is impossible for
+        /// a multi-secret move. SOURCE: 'folder/name', 'name', or a folder
+        /// prefix ending in '/'. DEST: 'folder/' (keep name),
+        /// 'folder/newname', 'newname' (root), or '/'.
+        #[arg(value_names = ["SOURCE", "DEST"], num_args = 0..=2)]
+        operands: Vec<String>,
+        /// Bulk-move every secret whose name matches GLOB into DEST (either
+        /// the display name or the backend name, same as `ls`/`find
+        /// --filter`); exactly one of SOURCE or --filter is required
+        #[arg(long)]
+        filter: Option<String>,
         /// Print the full move plan without changing anything
         #[arg(long)]
         dry_run: bool,
@@ -1894,11 +1904,32 @@ impl Cli {
                 .await
             }
             Commands::Mv {
-                source,
-                dest,
+                operands,
+                filter,
                 dry_run,
                 yes,
-            } => crate::cli::mv_ops::execute_mv(source, dest, dry_run, yes, config, registry).await,
+            } => {
+                // Two positionals normally map to (SOURCE, DEST); with
+                // --filter, SOURCE is omitted so a single leftover operand is
+                // DEST. Any other count is left for `execute_mv`'s runtime
+                // "exactly one of SOURCE/--filter" / "requires a DEST" checks
+                // to report with a clear message instead of a generic clap error.
+                let (source, dest) = if filter.is_some() {
+                    match operands.as_slice() {
+                        [] => (None, None),
+                        [dest] => (None, Some(dest.clone())),
+                        [source, dest, ..] => (Some(source.clone()), Some(dest.clone())),
+                    }
+                } else {
+                    match operands.as_slice() {
+                        [] => (None, None),
+                        [source] => (Some(source.clone()), None),
+                        [source, dest, ..] => (Some(source.clone()), Some(dest.clone())),
+                    }
+                };
+                crate::cli::mv_ops::execute_mv(source, dest, filter, dry_run, yes, config, registry)
+                    .await
+            }
             Commands::Diff {
                 vault1,
                 vault2,
@@ -2736,19 +2767,44 @@ mod tests {
             Cli::try_parse_from(["xv", "mv", "db/pass", "app/", "--dry-run", "--yes"]).unwrap();
         match cli.command {
             Commands::Mv {
-                source,
-                dest,
+                operands,
+                filter,
                 dry_run,
                 yes,
             } => {
-                assert_eq!(source, "db/pass");
-                assert_eq!(dest, "app/");
+                assert_eq!(operands, vec!["db/pass".to_string(), "app/".to_string()]);
+                assert_eq!(filter, None);
                 assert!(dry_run);
                 assert!(yes);
             }
             _ => panic!("expected mv command"),
         }
-        // Both operands are required.
-        assert!(Cli::try_parse_from(["xv", "mv", "onlyone"]).is_err());
+        // A single leftover positional and no --filter parses fine at the
+        // clap level (`operands` is just a positional collector) — DEST
+        // missing is enforced as a runtime error by `execute_mv`, exercised
+        // by `mv_ops::tests`.
+        match Cli::try_parse_from(["xv", "mv", "onlyone"])
+            .unwrap()
+            .command
+        {
+            Commands::Mv { operands, .. } => {
+                assert_eq!(operands, vec!["onlyone".to_string()]);
+            }
+            _ => panic!("expected mv command"),
+        }
+    }
+
+    #[test]
+    fn test_mv_filter_parse() {
+        let cli = Cli::try_parse_from(["xv", "mv", "--filter", "test-*", "archive/"]).unwrap();
+        match cli.command {
+            Commands::Mv {
+                operands, filter, ..
+            } => {
+                assert_eq!(operands, vec!["archive/".to_string()]);
+                assert_eq!(filter, Some("test-*".to_string()));
+            }
+            _ => panic!("expected mv command"),
+        }
     }
 }

--- a/src/cli/mv_ops.rs
+++ b/src/cli/mv_ops.rs
@@ -30,6 +30,14 @@ pub(crate) enum MvPlan {
         src_prefix: String,
         dest_prefix: Option<String>,
     },
+    /// Bulk-move every secret whose name matches a glob into a destination
+    /// folder (2026-07-03 mv-filter design). Matched secrets keep their
+    /// names; only the `folder` metadata is rewritten — a rename is
+    /// impossible for a multi-secret move.
+    Filter {
+        pattern: String,
+        dest_prefix: Option<String>,
+    },
 }
 
 /// Parse the `xv mv` operands into a move plan. See the module doc for the
@@ -57,22 +65,7 @@ pub(crate) fn parse_mv(source: &str, dest: &str) -> Result<MvPlan> {
                 "invalid source folder '{source}'"
             )));
         }
-        let dest_prefix = if dest == "/" {
-            None
-        } else if let Some(stripped) = dest.strip_suffix('/') {
-            let p = stripped.trim_start_matches('/');
-            if p.is_empty() || p.split('/').any(str::is_empty) {
-                return Err(CrosstacheError::invalid_argument(format!(
-                    "invalid destination folder '{dest}'"
-                )));
-            }
-            Some(p.to_string())
-        } else {
-            return Err(CrosstacheError::invalid_argument(format!(
-                "folder moves require a folder destination ending in / (got '{dest}'); \
-                 did you mean '{dest}/'?"
-            )));
-        };
+        let dest_prefix = parse_folder_dest(dest)?;
         return Ok(MvPlan::Folder {
             src_prefix: src_prefix.to_string(),
             dest_prefix,
@@ -99,6 +92,53 @@ pub(crate) fn parse_mv(source: &str, dest: &str) -> Result<MvPlan> {
         src_name,
         dest_folder,
         dest_name,
+    })
+}
+
+/// Parse a folder-only destination (`folder/` or `/`) — shared by folder
+/// moves and `--filter` moves, since a rename is impossible for a
+/// multi-secret move. Same error shape as the original inline folder-move
+/// check: "folder moves require a folder destination ending in / (got
+/// '...'); did you mean '.../'?".
+fn parse_folder_dest(dest: &str) -> Result<Option<String>> {
+    if dest == "/" {
+        return Ok(None);
+    }
+    if let Some(stripped) = dest.strip_suffix('/') {
+        let p = stripped.trim_start_matches('/');
+        if p.is_empty() || p.split('/').any(str::is_empty) {
+            return Err(CrosstacheError::invalid_argument(format!(
+                "invalid destination folder '{dest}'"
+            )));
+        }
+        return Ok(Some(p.to_string()));
+    }
+    Err(CrosstacheError::invalid_argument(format!(
+        "folder moves require a folder destination ending in / (got '{dest}'); \
+         did you mean '{dest}/'?"
+    )))
+}
+
+/// Parse `xv mv --filter <GLOB> DEST`. Validates the glob compiles (fails
+/// loud with `invalid_argument`, matching `ls`/`find --filter`, before any
+/// backend call) and that `DEST` is a folder destination.
+pub(crate) fn parse_mv_filter(pattern: &str, dest: &str) -> Result<MvPlan> {
+    let pattern = pattern.trim();
+    let dest = dest.trim();
+    if pattern.is_empty() {
+        return Err(CrosstacheError::invalid_argument(
+            "--filter requires a non-empty glob pattern",
+        ));
+    }
+    if dest.is_empty() {
+        return Err(CrosstacheError::invalid_argument("mv requires a DEST"));
+    }
+    // Validate the glob compiles before any backend call.
+    crate::utils::helpers::compile_name_glob(pattern)?;
+    let dest_prefix = parse_folder_dest(dest)?;
+    Ok(MvPlan::Filter {
+        pattern: pattern.to_string(),
+        dest_prefix,
     })
 }
 
@@ -136,8 +176,9 @@ fn dest_collides(secrets: &[SecretSummary], dest_name: &str) -> bool {
 }
 
 pub(crate) async fn execute_mv(
-    source: String,
-    dest: String,
+    source: Option<String>,
+    dest: Option<String>,
+    filter: Option<String>,
     dry_run: bool,
     yes: bool,
     config: Config,
@@ -148,7 +189,29 @@ pub(crate) async fn execute_mv(
             "No backend registry available. Run 'xv config show' to check your configuration.",
         ));
     }
-    let plan = parse_mv(&source, &dest)?;
+
+    // DEST is `Option<String>` in the arg parser only so clap accepts a
+    // non-required SOURCE positional (clap forbids optional-then-required);
+    // it is always required in practice.
+    let dest = dest.ok_or_else(|| CrosstacheError::invalid_argument("mv requires a DEST"))?;
+
+    // Exactly one of SOURCE / --filter — checked, and (for --filter) the
+    // glob compiled and validated, before any backend call below.
+    let filter_plan = match (&source, &filter) {
+        (Some(_), Some(_)) => {
+            return Err(CrosstacheError::invalid_argument(
+                "mv accepts either SOURCE or --filter <GLOB>, not both",
+            ));
+        }
+        (None, None) => {
+            return Err(CrosstacheError::invalid_argument(
+                "mv requires either a SOURCE argument or --filter <GLOB>",
+            ));
+        }
+        (None, Some(pattern)) => Some(parse_mv_filter(pattern, &dest)?),
+        (Some(_), None) => None,
+    };
+
     let reg = registry.expect("use_trait_path guarantees Some");
     let vault_name = resolve_vault_for_trait(&config, registry).await?;
     let secrets = reg
@@ -156,6 +219,27 @@ pub(crate) async fn execute_mv(
         .secrets()
         .list_secrets(&vault_name, None)
         .await?;
+
+    if let Some(MvPlan::Filter {
+        pattern,
+        dest_prefix,
+    }) = filter_plan
+    {
+        return execute_filter_mv(
+            reg,
+            &config,
+            &vault_name,
+            secrets,
+            pattern,
+            dest_prefix,
+            dry_run,
+            yes,
+        )
+        .await;
+    }
+
+    let source = source.expect("checked above: exactly one of SOURCE/--filter is Some");
+    let plan = parse_mv(&source, &dest)?;
 
     match plan {
         MvPlan::Secret {
@@ -195,6 +279,7 @@ pub(crate) async fn execute_mv(
             )
             .await
         }
+        MvPlan::Filter { .. } => unreachable!("parse_mv never returns MvPlan::Filter"),
     }
 }
 
@@ -442,6 +527,197 @@ async fn execute_folder_mv(
     Ok(())
 }
 
+/// True if `moving` (secrets about to be re-foldered into `dest_prefix`)
+/// would collide with a secret that already resides in `dest_prefix` and is
+/// NOT itself one of the moving secrets — either by display name or by
+/// backend (sanitized) name, mirroring `dest_collides` (#302). A filter
+/// move only rewrites the `folder` tag (names never change), so the only
+/// place a collision can arise is inside the destination folder itself.
+/// Returns the colliding display name for the error message.
+fn dest_folder_collision<'a>(
+    secrets: &'a [SecretSummary],
+    moving: &[&'a SecretSummary],
+    dest_prefix: Option<&str>,
+) -> Option<&'a str> {
+    let dest_norm = norm_folder(dest_prefix);
+    let moving_backend_names: std::collections::HashSet<&str> =
+        moving.iter().map(|s| s.name.as_str()).collect();
+
+    for occupant in secrets {
+        if moving_backend_names.contains(occupant.name.as_str()) {
+            continue; // this secret is itself moving, not a foreign occupant
+        }
+        if norm_folder(occupant.folder.as_deref()) != dest_norm {
+            continue;
+        }
+        let occupant_display = display_name(occupant);
+        for m in moving {
+            if display_name(m) == occupant_display || m.name == occupant.name {
+                return Some(occupant_display);
+            }
+        }
+    }
+    None
+}
+
+/// Execute an `xv mv --filter <GLOB> DEST` bulk folder move (2026-07-03
+/// mv-filter design). Mirrors `execute_folder_mv`'s bulk machinery — count +
+/// sample plan confirmation, `--yes` bypass, non-TTY refusal, `--dry-run`
+/// preview, collision pre-check before any move, attempt-all /
+/// report-failure-count partial-failure behavior — but the candidate set is
+/// every secret in the vault matching `pattern` (either display or backend
+/// name, same predicate as `ls`/`find --filter`) instead of a folder subtree.
+#[allow(clippy::too_many_arguments)]
+async fn execute_filter_mv(
+    reg: &BackendRegistry,
+    config: &Config,
+    vault_name: &str,
+    secrets: Vec<SecretSummary>,
+    pattern: String,
+    dest_prefix: Option<String>,
+    dry_run: bool,
+    yes: bool,
+) -> Result<()> {
+    use crate::cli::helpers::confirm_proceed;
+    use crate::utils::helpers::{compile_name_glob, glob_matches_either_name};
+
+    let matcher = compile_name_glob(&pattern)?;
+
+    let matched: Vec<&SecretSummary> = secrets
+        .iter()
+        .filter(|s| glob_matches_either_name(&matcher, &s.name, &s.original_name))
+        .collect();
+
+    if matched.is_empty() {
+        return Err(CrosstacheError::invalid_argument(format!(
+            "no secrets matched --filter '{pattern}'"
+        )));
+    }
+
+    let dest_norm = norm_folder(dest_prefix.as_deref());
+    let mut moving: Vec<&SecretSummary> = Vec::new();
+    let mut skipped = 0usize;
+    for s in &matched {
+        let folder = s.folder.as_deref().unwrap_or("");
+        if norm_folder(Some(folder)) == dest_norm {
+            skipped += 1;
+        } else {
+            moving.push(s);
+        }
+    }
+
+    let dest_label = dest_prefix
+        .as_deref()
+        .map_or("/".to_string(), |d| format!("{d}/"));
+
+    // Collision pre-check — before any mutation, and before --dry-run even
+    // returns, mirroring the ordering in `execute_secret_mv`.
+    if let Some(occupant) = dest_folder_collision(&secrets, &moving, dest_prefix.as_deref()) {
+        return Err(CrosstacheError::conflict(format!(
+            "secret '{occupant}' already exists in '{dest_label}' — delete it first or pick another destination"
+        )));
+    }
+
+    if moving.is_empty() {
+        output::info(&format!(
+            "{skipped} secret(s) already in '{dest_label}'; nothing to move"
+        ));
+        return Ok(());
+    }
+
+    // (old qualified path, new qualified path, name to call the API with)
+    let moves: Vec<(String, String, String)> = moving
+        .iter()
+        .map(|s| {
+            let folder = s.folder.as_deref().unwrap_or("");
+            let name = display_name(s).to_string();
+            let old_path = if folder.is_empty() {
+                name.clone()
+            } else {
+                format!("{folder}/{name}")
+            };
+            let new_path = match &dest_prefix {
+                Some(f) => format!("{f}/{name}"),
+                None => name.clone(),
+            };
+            (old_path, new_path, name)
+        })
+        .collect();
+
+    if dry_run {
+        for (old, new, _) in &moves {
+            println!("{old} -> {new}");
+        }
+        if skipped > 0 {
+            output::info(&format!(
+                "{skipped} secret(s) already in '{dest_label}' (skipped)"
+            ));
+        }
+        output::info(&format!("{} secrets would move (dry run)", moves.len()));
+        return Ok(());
+    }
+
+    eprintln!(
+        "Moving {} secrets matching --filter '{pattern}' to '{dest_label}':",
+        moves.len()
+    );
+    for (old, new, _) in moves.iter().take(10) {
+        eprintln!("  {old} -> {new}");
+    }
+    if moves.len() > 10 {
+        eprintln!("  ... ({} more; --dry-run to list all)", moves.len() - 10);
+    }
+    if skipped > 0 {
+        eprintln!("  ({skipped} secret(s) already in '{dest_label}', skipped)");
+    }
+    if !confirm_proceed(yes, &format!("Move {} secrets?", moves.len()), "--yes")? {
+        output::info("Aborted; nothing moved.");
+        return Ok(());
+    }
+
+    let mut failures = 0usize;
+    for (old, new, name) in &moves {
+        let request = SecretUpdateRequest {
+            name: name.clone(),
+            value: None,
+            content_type: None,
+            enabled: None,
+            expires_on: FieldUpdate::Unchanged,
+            not_before: FieldUpdate::Unchanged,
+            tags: None,
+            groups: None,
+            note: FieldUpdate::Unchanged,
+            folder: match &dest_prefix {
+                Some(f) => FieldUpdate::Set(f.clone()),
+                None => FieldUpdate::Clear,
+            },
+            replace_tags: false,
+            replace_groups: false,
+        };
+        if let Err(e) = reg
+            .active()
+            .secrets()
+            .update_secret(vault_name, name, request)
+            .await
+        {
+            failures += 1;
+            output::warn(&format!("failed to move '{old}' to '{new}': {e}"));
+        }
+    }
+    invalidate_trait_secret_cache(config, vault_name);
+    let moved = moves.len() - failures;
+    if failures > 0 {
+        return Err(CrosstacheError::unknown(format!(
+            "moved {moved} of {} secrets; {failures} failed (see warnings above)",
+            moves.len()
+        )));
+    }
+    output::success(&format!(
+        "Moved {moved} secrets matching --filter '{pattern}' to '{dest_label}'"
+    ));
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -562,6 +838,68 @@ mod tests {
     fn dest_collides_no_match() {
         let secrets = vec![summary("sanitized-name", "pretty-name")];
         assert!(!dest_collides(&secrets, "unrelated-name"));
+    }
+
+    // -----------------------------------------------------------------
+    // dest_folder_collision — `--filter` move collision pre-check.
+    //
+    // A filter move only rewrites the `folder` tag: matched secrets keep
+    // their names, so a collision can only arise when a *different* secret
+    // already resident in the destination folder shares a moving secret's
+    // display or backend name. The local backend never diverges name from
+    // original_name (see the comment above `mv_sanitized_name_rename_with_space`
+    // in `tests/e2e_local_backend.rs`), so — same escape hatch as #326's
+    // either-name matching — this is exercised at the unit level with
+    // synthetic summaries whose name and original_name differ.
+    // -----------------------------------------------------------------
+
+    fn summary_full(name: &str, original_name: &str, folder: Option<&str>) -> SecretSummary {
+        SecretSummary {
+            name: name.to_string(),
+            original_name: original_name.to_string(),
+            note: None,
+            folder: folder.map(String::from),
+            groups: None,
+            updated_on: String::new(),
+            enabled: true,
+            content_type: String::new(),
+            tags: std::collections::HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn dest_folder_collision_matches_display_name_of_dest_occupant() {
+        // Already in 'archive/': backend name "raw-o", displays as "test-x".
+        let occupant = summary_full("raw-o", "test-x", Some("archive"));
+        // Moving in from elsewhere: backend name "raw-m", also displays as
+        // "test-x" — a different secret that would collide in 'archive/'.
+        let moving_secret = summary_full("raw-m", "test-x", Some("other"));
+        let secrets = vec![occupant, moving_secret.clone()];
+        let moving = vec![&secrets[1]];
+
+        let collision = dest_folder_collision(&secrets, &moving, Some("archive"));
+        assert_eq!(collision, Some("test-x"));
+    }
+
+    #[test]
+    fn dest_folder_collision_ignores_secrets_outside_dest_folder() {
+        let elsewhere = summary_full("raw-o", "test-x", Some("not-dest"));
+        let moving_secret = summary_full("raw-m", "test-x", Some("other"));
+        let secrets = vec![elsewhere, moving_secret.clone()];
+        let moving = vec![&secrets[1]];
+
+        assert!(dest_folder_collision(&secrets, &moving, Some("archive")).is_none());
+    }
+
+    #[test]
+    fn dest_folder_collision_ignores_the_moving_secret_itself() {
+        // The secret already sitting in the destination IS one of the
+        // moving secrets (already-in-dest case) — not a foreign occupant.
+        let moving_secret = summary_full("raw-m", "test-x", Some("archive"));
+        let secrets = vec![moving_secret.clone()];
+        let moving = vec![&secrets[0]];
+
+        assert!(dest_folder_collision(&secrets, &moving, Some("archive")).is_none());
     }
 
     // -----------------------------------------------------------------

--- a/src/cli/mv_ops.rs
+++ b/src/cli/mv_ops.rs
@@ -193,7 +193,17 @@ pub(crate) async fn execute_mv(
     // DEST is `Option<String>` in the arg parser only so clap accepts a
     // non-required SOURCE positional (clap forbids optional-then-required);
     // it is always required in practice.
-    let dest = dest.ok_or_else(|| CrosstacheError::invalid_argument("mv requires a DEST"))?;
+    let dest = match dest {
+        Some(d) => d,
+        None if source.is_none() && filter.is_none() => {
+            // Neither SOURCE, --filter, nor DEST given — match parse_mv's own
+            // "both operands missing" wording rather than naming DEST alone.
+            return Err(CrosstacheError::invalid_argument(
+                "mv requires a SOURCE and a DEST",
+            ));
+        }
+        None => return Err(CrosstacheError::invalid_argument("mv requires a DEST")),
+    };
 
     // Exactly one of SOURCE / --filter — checked, and (for --filter) the
     // glob compiled and validated, before any backend call below.
@@ -529,10 +539,15 @@ async fn execute_folder_mv(
 
 /// True if `moving` (secrets about to be re-foldered into `dest_prefix`)
 /// would collide with a secret that already resides in `dest_prefix` and is
-/// NOT itself one of the moving secrets — either by display name or by
-/// backend (sanitized) name, mirroring `dest_collides` (#302). A filter
-/// move only rewrites the `folder` tag (names never change), so the only
-/// place a collision can arise is inside the destination folder itself.
+/// NOT itself one of the moving secrets — by display name, mirroring
+/// `dest_collides` (#302). A filter move only rewrites the `folder` tag
+/// (names never change), so the only place a collision can arise is inside
+/// the destination folder itself.
+///
+/// Note: `execute_folder_mv` (whole-folder moves) has no equivalent guard
+/// today — this asymmetry is accepted for now as a candidate for future
+/// alignment, not addressed here.
+///
 /// Returns the colliding display name for the error message.
 fn dest_folder_collision<'a>(
     secrets: &'a [SecretSummary],
@@ -551,8 +566,13 @@ fn dest_folder_collision<'a>(
             continue;
         }
         let occupant_display = display_name(occupant);
+        // Backend names are globally unique per vault, and any occupant
+        // sharing a moving secret's backend name would already have been
+        // filtered out above as "itself moving" — so only a display-name
+        // match can indicate a genuine collision between two distinct
+        // secrets here.
         for m in moving {
-            if display_name(m) == occupant_display || m.name == occupant.name {
+            if display_name(m) == occupant_display {
                 return Some(occupant_display);
             }
         }

--- a/src/cli/mv_ops.rs
+++ b/src/cli/mv_ops.rs
@@ -539,10 +539,19 @@ async fn execute_folder_mv(
 
 /// True if `moving` (secrets about to be re-foldered into `dest_prefix`)
 /// would collide with a secret that already resides in `dest_prefix` and is
-/// NOT itself one of the moving secrets — by display name, mirroring
-/// `dest_collides` (#302). A filter move only rewrites the `folder` tag
-/// (names never change), so the only place a collision can arise is inside
-/// the destination folder itself.
+/// NOT itself one of the moving secrets. A filter move only rewrites the
+/// `folder` tag (names never change), so the only place a collision can
+/// arise is inside the destination folder itself — but a moving secret's
+/// *display* name can still equal an unrelated occupant's *backend*
+/// (sanitized) name, or vice versa, so the comparison mirrors
+/// `dest_collides` (#302) exactly: for each moving secret, its display name
+/// is checked against both the occupant's display name AND its backend
+/// name (`display_name(occupant) == moving_display || occupant.name ==
+/// moving_display`), not display-vs-display alone. Missing the
+/// backend-name leg would let a mismatched-name pair (e.g. moving secret
+/// displays as "x", occupant's raw backend name is "x") slip past this
+/// pre-check and have downstream name resolution against the destination
+/// folder resolve the wrong secret.
 ///
 /// Note: `execute_folder_mv` (whole-folder moves) has no equivalent guard
 /// today — this asymmetry is accepted for now as a candidate for future
@@ -566,13 +575,11 @@ fn dest_folder_collision<'a>(
             continue;
         }
         let occupant_display = display_name(occupant);
-        // Backend names are globally unique per vault, and any occupant
-        // sharing a moving secret's backend name would already have been
-        // filtered out above as "itself moving" — so only a display-name
-        // match can indicate a genuine collision between two distinct
-        // secrets here.
         for m in moving {
-            if display_name(m) == occupant_display {
+            let moving_display = display_name(m);
+            // Same predicate as `dest_collides`: match on either the
+            // occupant's display name or its backend (sanitized) name.
+            if occupant_display == moving_display || occupant.name == moving_display {
                 return Some(occupant_display);
             }
         }
@@ -899,6 +906,34 @@ mod tests {
 
         let collision = dest_folder_collision(&secrets, &moving, Some("archive"));
         assert_eq!(collision, Some("test-x"));
+    }
+
+    #[test]
+    fn dest_folder_collision_matches_moving_display_against_occupant_backend_name() {
+        // Already in 'archive/': backend name "test-x" (the raw, sanitized
+        // name), displays as an unrelated "pretty-occupant".
+        let occupant = summary_full("test-x", "pretty-occupant", Some("archive"));
+        // Moving in from elsewhere: displays as "test-x" — matches the
+        // occupant's *backend* name, not its display name. This is the
+        // Bugbot-flagged gap: a display-vs-display-only check would miss
+        // this and let the bulk pre-check pass.
+        let moving_secret = summary_full("raw-m", "test-x", Some("other"));
+        let secrets = vec![occupant, moving_secret.clone()];
+        let moving = vec![&secrets[1]];
+
+        let collision = dest_folder_collision(&secrets, &moving, Some("archive"));
+        assert_eq!(collision, Some("pretty-occupant"));
+    }
+
+    #[test]
+    fn dest_folder_collision_no_overlap_passes() {
+        // Same destination folder, but no name overlap on either side.
+        let occupant = summary_full("raw-o", "test-x", Some("archive"));
+        let moving_secret = summary_full("raw-m", "test-y", Some("other"));
+        let secrets = vec![occupant, moving_secret.clone()];
+        let moving = vec![&secrets[1]];
+
+        assert!(dest_folder_collision(&secrets, &moving, Some("archive")).is_none());
     }
 
     #[test]

--- a/tests/e2e_mv_filter.rs
+++ b/tests/e2e_mv_filter.rs
@@ -1,0 +1,352 @@
+//! End-to-end CLI tests for `--filter <GLOB>` on `xv mv` (2026-07-03 design
+//! doc: docs/superpowers/specs/2026-07-03-mv-filter-design.md).
+//!
+//! A dedicated file rather than an extension of `e2e_filter_glob.rs`: `mv
+//! --filter` needs its own folder/dest setup (bulk-move confirmation, TTY
+//! refusal, collision, already-in-dest skip) that doesn't share fixtures
+//! with the `ls`/`find --filter` tests, and keeping it separate mirrors how
+//! `mv`'s own grammar/bulk-machinery tests already live apart from
+//! `ls`/`find` in `e2e_local_backend.rs` vs `e2e_filter_glob.rs`. It reuses
+//! the same hermetic harness (`tests/common/mod.rs`) and either-name glob
+//! predicate (`compile_name_glob` / `glob_matches_either_name` in
+//! `src/utils/helpers.rs`, already exhaustively unit-tested) as #326.
+//!
+//! Hermetic: every test uses the isolated local-backend harness from
+//! `tests/common/mod.rs` — no Azure credentials or network access required.
+//!
+//! Run with:
+//!   cargo test --test e2e_mv_filter
+
+mod common;
+
+/// Builds a fresh `xv` `Command` bound to the same isolated store/env as an
+/// existing `xv_isolated_local()` tempdir, for a second (or third, ...) CLI
+/// invocation against the same store (each `Command` is single-use). Mirrors
+/// `xv_same_env` in `e2e_filter_glob.rs` / `e2e_record_types.rs`.
+fn xv_same_env(temp: &std::path::Path) -> std::process::Command {
+    let mut cmd = common::xv();
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", temp)
+        .env("XDG_CONFIG_HOME", temp.join(".config"))
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "local")
+        .env("NO_COLOR", "1")
+        .current_dir(temp);
+    cmd
+}
+
+/// Set a secret with a plain value via `xv set NAME --value VALUE`, optionally
+/// scoped to a folder.
+fn set_secret(temp: &std::path::Path, name: &str, value: &str, folder: Option<&str>) {
+    let mut args = vec!["set", name, "--value", value];
+    if let Some(f) = folder {
+        args.push("--folder");
+        args.push(f);
+    }
+    let out = xv_same_env(temp)
+        .args(&args)
+        .output()
+        .expect("execute xv set");
+    assert!(
+        out.status.success(),
+        "xv set {name} failed: stderr: {}",
+        common::stderr_str(&out)
+    );
+}
+
+/// `xv ls --format json` as a parsed value, for folder/name assertions.
+fn ls_json(temp: &std::path::Path) -> serde_json::Value {
+    let out = xv_same_env(temp)
+        .args(["ls", "--format", "json"])
+        .output()
+        .expect("execute xv ls");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    serde_json::from_str(&common::stdout_str(&out)).expect("ls --format json output")
+}
+
+/// `folder` tag for the secret named `name` in a parsed `ls --format json`
+/// value, or `None` if unset / not found.
+fn folder_of<'a>(json: &'a serde_json::Value, name: &str) -> Option<&'a str> {
+    json.as_array()
+        .expect("json array")
+        .iter()
+        .find(|v| v["name"].as_str() == Some(name))
+        .and_then(|v| v["folder"].as_str())
+}
+
+// ===========================================================================
+// `xv mv --filter` — bulk filtered move
+// ===========================================================================
+
+#[test]
+fn mv_filter_relocates_only_matches() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-a", "v1", None);
+    set_secret(temp.path(), "test-b", "v2", None);
+    set_secret(temp.path(), "latest-x", "v3", None);
+
+    let out = cmd
+        .args(["mv", "--filter", "test-*", "archive/", "--yes"])
+        .output()
+        .expect("execute xv mv --filter");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let json = ls_json(temp.path());
+    assert_eq!(folder_of(&json, "test-a"), Some("archive"), "{json}");
+    assert_eq!(folder_of(&json, "test-b"), Some("archive"), "{json}");
+    assert_eq!(
+        folder_of(&json, "latest-x"),
+        None,
+        "non-matching secret must not move: {json}"
+    );
+}
+
+#[test]
+fn mv_filter_dest_must_be_folder_errors() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-a", "v1", None);
+
+    let out = cmd
+        .args(["mv", "--filter", "test-*", "notafolder", "--yes"])
+        .output()
+        .expect("execute xv mv --filter");
+    assert!(
+        !out.status.success(),
+        "non-folder dest should fail: stdout: {}",
+        common::stdout_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(
+        stderr.contains("folder moves require a folder destination ending in /"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("did you mean 'notafolder/'"), "{stderr}");
+}
+
+#[test]
+fn mv_filter_source_and_filter_together_is_usage_error() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-a", "v1", None);
+
+    // Both orders: --filter before the trailing positionals, and SOURCE
+    // supplied ahead of --filter.
+    let out = cmd
+        .args(["mv", "--filter", "test-*", "some-source", "archive/"])
+        .output()
+        .expect("execute xv mv");
+    assert!(
+        !out.status.success(),
+        "stdout: {}",
+        common::stdout_str(&out)
+    );
+    assert!(
+        common::stderr_str(&out).contains("either SOURCE or --filter"),
+        "{}",
+        common::stderr_str(&out)
+    );
+
+    let out2 = xv_same_env(temp.path())
+        .args(["mv", "some-source", "--filter", "test-*", "archive/"])
+        .output()
+        .expect("execute xv mv");
+    assert!(
+        !out2.status.success(),
+        "stdout: {}",
+        common::stdout_str(&out2)
+    );
+    assert!(
+        common::stderr_str(&out2).contains("either SOURCE or --filter"),
+        "{}",
+        common::stderr_str(&out2)
+    );
+}
+
+#[test]
+fn mv_filter_neither_source_nor_filter_is_usage_error() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-a", "v1", None);
+
+    // Only DEST given: no SOURCE, no --filter.
+    let out = cmd
+        .args(["mv", "archive/"])
+        .output()
+        .expect("execute xv mv");
+    assert!(
+        !out.status.success(),
+        "stdout: {}",
+        common::stdout_str(&out)
+    );
+}
+
+#[test]
+fn mv_filter_dry_run_previews_without_moving() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-a", "v1", None);
+    set_secret(temp.path(), "test-b", "v2", None);
+    set_secret(temp.path(), "latest-x", "v3", None);
+
+    let out = cmd
+        .args(["mv", "--filter", "test-*", "archive/", "--dry-run"])
+        .output()
+        .expect("execute xv mv --filter --dry-run");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    assert!(
+        stdout.contains("test-a -> archive/test-a"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("test-b -> archive/test-b"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("latest-x"),
+        "dry-run must not list non-matches: {stdout}"
+    );
+
+    let json = ls_json(temp.path());
+    assert_eq!(
+        folder_of(&json, "test-a"),
+        None,
+        "dry-run must not mutate: {json}"
+    );
+    assert_eq!(
+        folder_of(&json, "test-b"),
+        None,
+        "dry-run must not mutate: {json}"
+    );
+}
+
+#[test]
+fn mv_filter_non_tty_without_yes_refuses() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-a", "v1", None);
+    set_secret(temp.path(), "test-b", "v2", None);
+
+    // Tests run with piped stdin (not a TTY): without --yes this must refuse.
+    let out = cmd
+        .args(["mv", "--filter", "test-*", "archive/"])
+        .output()
+        .expect("execute xv mv --filter");
+    assert!(
+        !out.status.success(),
+        "stdout: {}",
+        common::stdout_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("--yes"), "should mention --yes: {stderr}");
+
+    let json = ls_json(temp.path());
+    assert_eq!(
+        folder_of(&json, "test-a"),
+        None,
+        "refusal must not mutate: {json}"
+    );
+}
+
+#[test]
+fn mv_filter_yes_bypasses_confirmation() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-a", "v1", None);
+
+    let out = cmd
+        .args(["mv", "--filter", "test-*", "archive/", "--yes"])
+        .output()
+        .expect("execute xv mv --filter --yes");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+
+    let json = ls_json(temp.path());
+    assert_eq!(folder_of(&json, "test-a"), Some("archive"), "{json}");
+}
+
+#[test]
+fn mv_filter_already_in_dest_is_skipped_not_error() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-already", "v1", Some("archive"));
+    set_secret(temp.path(), "test-new", "v2", None);
+
+    let out = cmd
+        .args(["mv", "--filter", "test-*", "archive/", "--yes"])
+        .output()
+        .expect("execute xv mv --filter --yes");
+    assert!(out.status.success(), "stderr: {}", common::stderr_str(&out));
+    let stdout = common::stdout_str(&out);
+    let stderr = common::stderr_str(&out);
+    assert!(
+        stderr.contains("already in") || stdout.contains("already in"),
+        "already-in-dest secret should be noted, not silently ignored: stdout={stdout} stderr={stderr}"
+    );
+
+    let json = ls_json(temp.path());
+    assert_eq!(folder_of(&json, "test-already"), Some("archive"), "{json}");
+    assert_eq!(folder_of(&json, "test-new"), Some("archive"), "{json}");
+}
+
+#[test]
+fn mv_filter_all_matches_already_in_dest_is_a_noop_not_error() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-already", "v1", Some("archive"));
+
+    let out = cmd
+        .args(["mv", "--filter", "test-*", "archive/"])
+        .output()
+        .expect("execute xv mv --filter");
+    assert!(
+        out.status.success(),
+        "all-already-in-dest must succeed with nothing to move: stderr: {}",
+        common::stderr_str(&out)
+    );
+
+    let json = ls_json(temp.path());
+    assert_eq!(folder_of(&json, "test-already"), Some("archive"), "{json}");
+}
+
+#[test]
+fn mv_filter_zero_matches_fails_loud() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "latest-x", "v1", None);
+
+    let out = cmd
+        .args(["mv", "--filter", "test-*", "archive/", "--yes"])
+        .output()
+        .expect("execute xv mv --filter --yes");
+    assert!(
+        !out.status.success(),
+        "zero matches must fail loud: stdout: {}",
+        common::stdout_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(
+        stderr.contains("no secrets matched --filter 'test-*'"),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn mv_filter_invalid_glob_errors_before_listing() {
+    let (mut cmd, temp) = common::xv_isolated_local();
+    set_secret(temp.path(), "test-a", "v1", None);
+
+    let out = cmd
+        .args(["mv", "--filter", "test-[", "archive/"])
+        .output()
+        .expect("execute xv mv --filter");
+    assert!(
+        !out.status.success(),
+        "invalid glob should fail: stdout: {}",
+        common::stdout_str(&out)
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "invalid_argument exit code is 2: stderr: {}",
+        common::stderr_str(&out)
+    );
+    let stderr = common::stderr_str(&out);
+    assert!(stderr.contains("Invalid glob pattern"), "stderr: {stderr}");
+
+    // Nothing was moved: the (only) secret is untouched (still no folder).
+    let json = ls_json(temp.path());
+    assert_eq!(folder_of(&json, "test-a"), None, "{json}");
+}


### PR DESCRIPTION
Adds `--filter <GLOB>` to `xv mv` for bulk folder moves. Spec rides this PR (`docs/superpowers/specs/2026-07-03-mv-filter-design.md`). Follow-up to #326.

## Behavior

```
xv mv --filter 'test-*' archive/ --dry-run   # preview the plan
xv mv --filter 'test-*' archive/             # count + sample confirmation, then move
```

- **Matching** is identical to `ls`/`find --filter` (#326): globset, case-sensitive, whole-name, either display name or backend name; invalid patterns fail with `invalid_argument` before any backend call.
- With `--filter`, `SOURCE` is omitted (exactly one of the two — violations are a clear usage error) and `DEST` must be a folder (`archive/` or `/`), since a multi-secret move can't rename. Matched secrets keep their names; only the folder metadata is rewritten — the request is field-for-field identical to the proven folder-move path (metadata-only, no value write).
- **Bulk machinery reused**: count + sample plan confirmation, `--yes` bypass, non-TTY refusal without `--yes`, `--dry-run`, a destination display-name collision pre-check that runs before the confirmation (you never confirm a doomed plan), and attempt-all/report-failures partial-failure semantics.
- Already-in-dest matches are skipped with a note; zero matches fails loud (`no secrets matched --filter 'test-*'`).
- Plain `xv mv SOURCE DEST` is unchanged (existing `mv_*` e2e tests untouched and green). The clap definition moved to a bounded operand list to accommodate the optional SOURCE — `override_usage` keeps the help honest (`xv mv <SOURCE> <DEST>` / `xv mv --filter <GLOB> <DEST>`), and the bare-`mv` error now names both missing operands.

## Tests

11 hermetic e2e tests (`tests/e2e_mv_filter.rs`, scrubbed-env verified) + unit tests for parsing and the collision guard: relocates matches and only matches, dest-must-be-folder, SOURCE-xor-filter (both orders), dry-run non-mutation, non-TTY refusal non-mutation, already-in-dest skip, zero-match failure, invalid-glob exit 2, collision refusal. Fail-first proven against unpatched code.

Full workspace green; clippy 0 warnings under both feature sets. Independent code-review pass: approve (spec-compliant on every clause; polish items applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk metadata updates can relocate many secrets in one confirmed operation; mistakes are mitigated by dry-run, confirmation, and collision pre-checks, but partial failures still leave some secrets moved.
> 
> **Overview**
> **`xv mv --filter <GLOB> <DEST>`** bulk-moves every vault secret whose display or backend name matches the glob into a folder destination (`archive/` or `/`), replacing shell loops over `xv find --filter`.
> 
> The `mv` CLI now takes optional `SOURCE` plus `--filter` (mutually exclusive) and routes filter plans through a new **`MvPlan::Filter`** path in `mv_ops.rs`. That path mirrors existing bulk folder moves: plan/confirm, `--yes` / `--dry-run`, non-TTY refusal, metadata-only folder updates, skip-if-already-in-dest, zero-match error, and a **`dest_folder_collision`** pre-check (display vs backend names) before any write.
> 
> Folder-only destination parsing is shared via **`parse_folder_dest`**. Docs and an approved design spec are updated; **11 hermetic e2e tests** cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f8d2a3bac08b7469fc47e1e7fd9d440874e014b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->