### PR TITLE
chore: bump version to 0.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.19.2 — Bulk folder moves with mv --filter (2026-07-04)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Release prep for v0.19.2 — ships `xv mv --filter <GLOB>` bulk folder moves (#328). CHANGELOG `Unreleased` → **v0.19.2 — Bulk folder moves with mv --filter (2026-07-04)**; Cargo.toml/Cargo.lock → 0.19.2. Tag `v0.19.2` follows the merge per the release convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and changelog update with no runtime code changes in the PR diff.
> 
> **Overview**
> Prepares **v0.19.2** by bumping `crosstache` from **0.19.1** to **0.19.2** in `Cargo.toml` and `Cargo.lock` (workspace package entry).
> 
> The CHANGELOG **Unreleased** heading becomes **v0.19.2 — Bulk folder moves with mv --filter (2026-07-04)** and records the shipped feature: **`--filter <GLOB>` on `xv mv`** for one-shot bulk folder moves (same glob semantics as `ls`/`find`, folder-only `DEST`, existing bulk-move confirmations and safety checks). No application source changes appear in this diff—only version and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c54dcb90abce91fe6a7a25ae4aac540f78217ab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->