### PR TITLE
chore: bump version to 0.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.19.3 — Record write-path integrity and types-only .xv.toml fixes (2026-07-04)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.19.2"
+version = "0.19.3"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Release prep for v0.19.3 — record write-path integrity (#330 via #332) and the types-only `.xv.toml` fix (#331 via #334), plus the README accuracy pass (#333). CHANGELOG `Unreleased` → **v0.19.3 — Record write-path integrity and types-only .xv.toml fixes (2026-07-04)**; Cargo.toml/Cargo.lock → 0.19.3. Tag `v0.19.3` follows the merge per the release convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release bump and changelog finalization with no runtime code changes in the PR diff.
> 
> **Overview**
> **Release prep only** — no application source changes in this diff.
> 
> The version moves from **0.19.2** to **0.19.3** in `Cargo.toml` and `Cargo.lock`. `CHANGELOG.md` renames **Unreleased** to **v0.19.3 — Record write-path integrity and types-only .xv.toml fixes (2026-07-04)**; the **Fixed** bullets under that section document what this tag covers (types-only `.xv.toml` no longer breaking write commands; bare-value `update`/`rotate` no longer corrupting typed records, plus related validation behavior described there).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cfdfbeedd8ffecc5445f2a58ebcd13553452a96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->