### PR TITLE
chore: bump version to 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.20.0 — Multi-vault workspaces (2026-07-04)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.19.3"
+version = "0.20.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Release prep for v0.20.0 — multi-vault workspaces (#336/#338/#339): `xv cx add`, colon addressing, union ls/find, workspace aliases in URIs/templates, cross-vault mv/copy, TUI workspace pane. CHANGELOG `Unreleased` → **v0.20.0 — Multi-vault workspaces (2026-07-04)**; Cargo.toml/Cargo.lock → 0.20.0. Tag `v0.20.0` follows the merge per the release convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release housekeeping with no runtime or behavioral changes in the diff.
> 
> **Overview**
> **Release prep for v0.20.0** — no application code changes in this PR.
> 
> Bumps **`crosstache` / `xv` from `0.19.3` to `0.20.0`** in `Cargo.toml` and `Cargo.lock`. Renames the changelog **`Unreleased`** section to **`v0.20.0 — Multi-vault workspaces (2026-07-04)`**; the listed features remain documentation of work already merged, not new edits in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e40896dad94d1bdeab519163420bb81e8911f199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->