### PR TITLE
chore: bump version to 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.20.1 — First cx add keeps the current vault attached (2026-07-05)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Version bump for the v0.20.1 release: first `cx add` auto-attaches the current vault (#341, via #343) and `XV_CONTEXT_DIR` test isolation (#342).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release bump with no application code changes in this diff.
> 
> **Overview**
> **Release v0.20.1** — bumps `crosstache` / `xv` from **0.20.0** to **0.20.1** in `Cargo.toml` and `Cargo.lock`, and moves the **Unreleased** changelog into a dated **v0.20.1** section.
> 
> The release notes document behavior shipped in prior work: first **`xv cx add`** now also attaches the already-resolved vault (with profile-aware **`pre_flag_backend`**), and **`XV_CONTEXT_DIR`** isolates context/workspace for unit tests (skipping local `cwd/.xv/context` when set).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 750eb0a2c38330153a194fd9007ba7db0d28d834. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->