### PR TITLE
feat: workspace-of-one convergence — unified secret resolution (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Multi-backend workspace convergence, Phase 1: unified secret resolution.**
+  Every `xv` secret-resolution call now flows through the single workspace
+  seam (`resolve_workspace` → `resolve_secret_target`); bare/no-workspace
+  usage resolves as a degenerate workspace-of-one
+  (`WorkspaceSource::Degenerate`) instead of a separate legacy code path. The
+  legacy no-workspace fallback branch inside `resolve_workspace_or_default`
+  is deleted. See
+  [`docs/superpowers/specs/2026-07-05-multi-backend-workspace-convergence-design.md`](./docs/superpowers/specs/2026-07-05-multi-backend-workspace-convergence-design.md)
+  for the full design and ADRs.
+  - **No intended user-visible breaks, with one cosmetic exception.** This
+    was an internal-resolution unification, not a behavior change: bare
+    `set`/`get`/`ls` output, exact (colon-containing) secret name matching,
+    `xv://` URI resolution in `run` and `inject`, the `context use` bootstrap
+    flow (setting a vault before any workspace exists), the Azure no-vault
+    hard error, and union rendering for real (non-degenerate) single-entry
+    workspaces are all unchanged. The cosmetic exception: the informational
+    stderr notice printed when a `.xv.toml` env profile's vault is used from
+    outside its project directory is no longer re-emitted during bare
+    secret resolution (the overlay pass already reported it).
+  - **One user-visible improvement:** `xv ls --deleted`'s soft-delete
+    capability gate now evaluates the capabilities of the *resolved* backend
+    for the target vault, rather than the globally active backend — in a
+    mixed-backend workspace, a skip/error now correctly names the backend
+    actually being read, instead of whichever backend happened to be active
+    process-wide.
+
 ## v0.20.1 — First cx add keeps the current vault attached (2026-07-05)
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Crosstache Roadmap
 
-> **Last reviewed:** 2026-06-15 · **Latest released version:** `v0.15.0` · **Branch protection:** `main` (all changes via PR)
+> **Last reviewed:** 2026-07-05 · **Latest released version:** `v0.15.0` · **Branch protection:** `main` (all changes via PR)
 
 Single source of truth for **unimplemented** ideas, deferred work, and known
 limitations worth fixing. Anything already shipped lives in [`CHANGELOG.md`](./CHANGELOG.md).
@@ -19,6 +19,54 @@ Severity legend (mirrors the UX/code reviews):
 
 No active release-soak lane. Implemented work is tracked in
 [`CHANGELOG.md`](./CHANGELOG.md); this roadmap only tracks open work.
+
+---
+
+## Multi-backend workspace convergence
+
+Design: [`2026-07-05-multi-backend-workspace-convergence-design.md`](./docs/superpowers/specs/2026-07-05-multi-backend-workspace-convergence-design.md),
+targeting `v0.21.0`. Sequences the remaining multi-backend completion work
+(after Phases A–C of multi-vault workspaces shipped in v0.20.0/v0.20.1) into
+three ordered phases, converging the legacy no-workspace resolution path into
+a single workspace path (ADR-1: workspace-of-one convergence over dual-path
+hardening) and fully retiring the legacy Azure managers (ADR-2: full manager
+retirement over partial).
+
+### P1 — Phase 1: workspace-of-one resolution convergence
+Eliminate the legacy no-workspace secret-resolution path (`Config::resolve_vault_name`,
+`BackendRegistry::active()`/`active_arc()`, `get_azure_auth_provider`) from the
+CLI's secret-resolution seam; bare/no-workspace usage becomes a degenerate
+workspace-of-one (`WorkspaceSource::Degenerate`, `Workspace::is_configured()`),
+not a second code path.
+**Acceptance bar (seam-scoped, not repo-wide):** the no-workspace `else` at
+`resolve_workspace_or_default` (`src/cli/helpers.rs:155-164`) is deleted;
+`resolve_workspace` never returns `None`; every enumerated presence-gate uses
+`is_configured()`; every surviving legacy resolution call site carries a
+`// Phase 2`/`// Phase 3` annotation matching the design doc's survivor
+allowlist; `cargo test`/`cargo clippy --all-targets` green; `CHANGELOG.md`
+lists every intentional break.
+
+### P1 — Phase 2: full legacy manager retirement
+Delete `SecretManager`/`VaultManager`/`BlobManager` construction from CLI
+paths entirely, including Azure-only share/RBAC, audit, and vault-lifecycle
+operations, behind new `VaultBackend`/`AuditBackend` sub-traits on `Backend`.
+Implements the design doc's A4 `--vault` composition semantics for
+`run`/`inject`/`rotate`. Also closes the existing `has_audit` capability-flag
+inconsistency (see § Security hardening below) as a side effect of migrating
+Azure audit onto the trait.
+**Acceptance bar:** zero manager references from `src/cli/**`.
+
+### P2 — Phase 3: default-entry file-ops routing
+Route `xv file`/blob operations through a `FileBackend` resolution against the
+workspace's default entry only — no union file views, no alias-qualified file
+addressing.
+**Acceptance bar:** `xv file` resolves through the workspace default entry
+only; no union/aliased file addressing.
+
+**Deferred non-goals (all phases):** multi-instance same-kind backends
+(`NamedBackendEntry::Azure`), union file views, alias-qualified file
+addressing, cross-vault file operations, byte-for-byte legacy output/exit-code
+parity, new backends (tracked separately below).
 
 ---
 

--- a/docs/superpowers/specs/2026-07-05-multi-backend-workspace-convergence-design.md
+++ b/docs/superpowers/specs/2026-07-05-multi-backend-workspace-convergence-design.md
@@ -1,0 +1,310 @@
+# Multi-Backend Workspace Convergence: Roadmap & Phase 1
+
+**Date:** 2026-07-05
+**Status:** Approved design, targeting **v0.21.0**. Phase 1 (this design's execution scope) not yet implemented.
+**Depends on:** [`2026-07-04-multi-vault-workspaces-design.md`](./2026-07-04-multi-vault-workspaces-design.md)
+(Phases A–C, shipped v0.20.0/v0.20.1 — `Workspace`, `WorkspaceEntry`,
+`resolve_workspace`/`resolve_secret_target`, lazy `BackendRegistry`),
+[`backend-trait-checklist.md`](./backend-trait-checklist.md) (Backend trait
+read-surface history)
+**Source planning artifacts:** `.omc/plans/ralplan-xv-multibackend-roadmap.md`
+(RALPLAN-DR, consensus reached iteration 2), `.omc/specs/deep-interview-xv-multibackend-roadmap.md`
+(deep interview, ambiguity 19.75%)
+
+## Motivation
+
+Multi-vault workspaces (Phases A–C) shipped the *workspace* abstraction, but
+`xv` still carries two resolution paths side by side: the workspace path
+(`resolve_workspace` → `resolve_secret_target`) for commands run inside a
+configured workspace, and a legacy path (`Config::resolve_vault_name`,
+`BackendRegistry::active()`/`active_arc()`, `get_azure_auth_provider`) for
+everything else. The dual-path split is the active bug source today — cache-key
+divergence between `active().name()` (backend kind) and the config name, and
+capability gates that read `reg.active()` instead of the resolved backend are
+both symptoms of the same root cause: two representations of "what backend/vault
+is this command targeting" that can silently disagree.
+
+This document sequences the remaining multi-backend completion work into three
+ordered phases and records the two structural decisions (ADR-1, ADR-2) behind
+them, then scopes Phase 1's execution in full (Phase 1 ships with this design;
+Phases 2–3 are outlined for later execution).
+
+## Three-phase roadmap
+
+### Phase 1 — Workspace-of-one resolution convergence (this design's execution scope)
+
+Eliminate the legacy no-workspace secret-resolution path. Every `xv` invocation
+resolves through the single workspace path; bare/no-workspace usage becomes a
+**degenerate workspace-of-one** rather than a second code path.
+
+**Mechanism (Option B-prime, see ADR-1):**
+
+1. **B1 — build the distinguishable degenerate workspace-of-one.** Add
+   `WorkspaceSource::Degenerate` to the `WorkspaceSource` enum
+   (`src/workspace/mod.rs:24`) and `Workspace::is_configured(&self) -> bool`
+   (`false` for `Degenerate`, `true` for `Context`/`ProjectToml`). Extend
+   `resolve_workspace`/`resolve_workspace_from` (`mod.rs:230,252`) so that when
+   no `cx`/`.xv.toml` workspace is configured, it returns `Some(Workspace)`
+   with a single default `WorkspaceEntry` instead of `None`. **Never-`None`
+   invariant:** `resolve_workspace` returns `Some` or propagates `Err` — never
+   `None` — preserving the Azure no-vault hard error (`helpers.rs:89-91`) and
+   the no-vault error UX (`settings.rs:502-504`) by deriving the degenerate
+   entry's vault from the same chain `resolve_vault_for_trait` uses today
+   (`helpers.rs:87-102`).
+2. **B2 — audit and rewrite every presence-gate.** Because B1 makes
+   `resolve_workspace` always `Some`, every call site that used
+   `.is_some()` to mean "a REAL user workspace is attached" (~10 sites,
+   enumerated below) must switch to `ws.is_configured()`, or it silently
+   breaks — most notably `xv context use` (`config_ops.rs:1097`), which must
+   NOT error against a merely-degenerate workspace.
+3. **B3 — route capability-gate verbs onto the unified path.** `ls --deleted`'s
+   soft-delete gate (`secret_ops.rs:1936`, currently `reg.active().capabilities()`)
+   and the `rotate` fallback (`secret_ops.rs:2904`, currently
+   `config.resolve_vault_name(None)`) resolve their backend via the workspace
+   path so the capability check targets the *resolved* backend.
+4. **B4 — collapse `resolve_vault_for_trait`.** Once B1 guarantees a workspace
+   always exists, fold its logic into the degenerate-workspace builder and
+   remove the standalone `resolve_vault_name` dependency from the resolution
+   seam.
+5. **B5 — collapse the resolver seam (single-site deletion).** Delete the
+   no-workspace `else` branch of `resolve_workspace_or_default`
+   (`helpers.rs:155-164`) — with B1 the `if let Some(ws)` above it always
+   matches, so the `else` is dead code. This is the **only** seam edit; verb
+   call sites that already delegate into `resolve_workspace_or_default` (set,
+   get, list, history, rollback, rotate) need no changes.
+6. **B6 — tests.** `xv context use` with no configured workspace succeeds;
+   single-entry degenerate-workspace `ls` matches today's no-workspace `ls` in
+   output shape, exit code, AND cache-key identity; bare `xv run`/`xv inject`
+   over an `xv://` URI resolves byte-identically to today.
+7. **B7 — document breaks in `CHANGELOG.md`.**
+
+**Done-bar (seam-scoped, not repo-wide):**
+- The seam `else` at `helpers.rs:155-164` is deleted; `resolve_workspace_or_default`
+  has a single (workspace) path.
+- `resolve_workspace` never returns `None`.
+- Every enumerated presence-gate tests `is_configured()`, not mere presence.
+- Every *surviving* legacy resolution call site (the survivor allowlist below)
+  carries a `// Phase 2` or `// Phase 3` annotation — the verification grep
+  asserts only the annotated allowlist remains, no un-annotated survivor.
+- `cargo test` and `cargo clippy --all-targets` green; `CHANGELOG.md` lists
+  every intentional break.
+
+A repo-wide "zero `resolve_vault_name`/`.active()` references" grep is
+explicitly **not** the bar — it is unsatisfiable, since Phase 2/3 sites
+legitimately keep using them until those phases retire the call sites they
+belong to.
+
+**Presence-gates rewritten to `is_configured()` (B2 audit scope):**
+`config_ops.rs:1097,1767`; `mv_ops.rs:251,362`; `tui/mod.rs:49`;
+`secret_ops.rs:1915,2450,4469,4517,4725`; plus the `resolve_workspace_and_registry`
+tuple consumers at `secret_ops.rs:5563,5678,6192,6744,6918,6979` (post-B1 these
+take the workspace branch instead of `(None, None)` — audited here, pinned by
+the B6 run/inject URI parity test).
+
+**Survivor allowlist (Phase 2/3 call sites annotated, not removed, in Phase 1):**
+- `resolve_vault_name` — Phase 2 (legacy managers): `secret_ops.rs:4998,5119,5171,5244,5302,5669,6183,6644,6681,7057`;
+  `scan_ops.rs:174`; `system_ops.rs:384,460,1039`; `config_ops.rs:2216,2366`.
+  Phase 3 (file ops): `file_ops.rs:115,252,682,2248`.
+- `.active()` — 44 non-resolution capability/name-read hits in `secret_ops.rs`,
+  plus manager-construction paths (Phase 2).
+- `get_azure_auth_provider` — Phase 2 (manager construction):
+  `config_ops.rs:898,928`; `system_ops.rs:591,594,654,1037,1038`; definition
+  at `helpers.rs:283`.
+
+*(Line numbers verified against v0.20.1 @ `a86d3bb`; re-verify before annotating
+as code drifts.)*
+
+### Phase 2 — Full legacy manager retirement (outline only, not executed here)
+
+Delete `SecretManager`/`VaultManager`/`BlobManager` construction from CLI paths
+entirely. Introduce `VaultBackend` and `AuditBackend` sub-traits on `Backend`;
+migrate share/RBAC (`vault/operations.rs`), audit, and vault-lifecycle
+operations off the legacy managers. Retire `get_azure_auth_provider`
+(`helpers.rs:283`) and the manager-construction chokepoints
+(`config_ops.rs:898,928`; `system_ops.rs:594,1038`) once no CLI caller remains.
+Implements the A4 `--vault` composition semantics (below) for `run`/`inject`/`rotate`.
+
+**Bar:** zero manager references from `src/cli/**`.
+
+### Phase 3 — Default-entry file-ops routing (outline only, not executed here)
+
+Route `xv file`/blob operations through a `FileBackend` resolution against the
+workspace's **default entry only** — no union file views, no alias-qualified
+file addressing (`xv file get azure-prod:x`). Replace
+`config.resolve_vault_name(None)` in `file_ops.rs:115,252,682,2248` (and
+`file_ops_aws.rs`) with default-entry routing.
+
+**Bar:** `xv file` resolves through the workspace default entry only.
+
+## A4 — `--vault` composition semantics under the synthesized workspace
+
+Post-B1, `resolve_workspace_and_registry` (`helpers.rs:177-188`) always takes
+the workspace branch — it no longer returns `(None, None)` for a bare
+invocation. Its callers (`run`/`inject`/`rotate`) must therefore define what an
+explicit `--vault` flag means when a degenerate workspace-of-one is always
+present underneath it.
+
+**Pinned semantic:** an explicit `--vault` flag **overrides** the degenerate
+default entry for `run`, `inject`, and `rotate` — it does not add a second
+entry and does not error. A user passing `--vault other-vault` gets exactly
+that vault, exactly as before convergence; the degenerate workspace is purely
+an internal representation of "no workspace configured, use the current/default
+vault" and never surfaces as workspace-shaped behavior (no ambiguity search,
+no alias resolution against it) to a `--vault`-qualified call. Against a
+*real* (non-degenerate) workspace, existing multi-vault-workspace semantics
+are unchanged: `--vault` continues to mean what it means today for that verb
+(see the 2026-07-04 design's Write semantics section).
+
+**Implementation timing:** the semantic is pinned in this design now (Phase 1),
+but the callers that must implement it (`run`/`inject`/`rotate`) still
+construct legacy managers and land in **Phase 2** — Phase 1's degenerate
+builder and Phase 2's caller migration must agree on this semantic without
+Phase 1 needing to touch those call sites.
+
+## ADR-1: Workspace-of-one convergence over dual-path hardening
+
+**Decision:** Converge the legacy no-workspace resolution path into a
+distinguishable **degenerate workspace-of-one** (`WorkspaceSource::Degenerate`
++ `Workspace::is_configured()`), rather than hardening the two paths (workspace
+vs. legacy) to keep them in sync.
+
+**Drivers:**
+1. **Correctness surface** — the dual workspace/legacy branching is the active
+   bug source (cache-key divergence between `active().name()` and the config
+   name; capability gates reading `reg.active()` instead of the resolved
+   backend). Collapsing it to one path is the highest-leverage safety win.
+2. **Verifiability** — a grep-provable single-path invariant was selected as
+   the definition of done (deep interview R7); that bar is only meaningful if
+   there is truly one path left to grep for.
+3. **Blast radius / reviewability** — ~131 legacy call sites exist across
+   `src/cli/`; the chosen approach must keep the diff reviewable and testable
+   incrementally, not one unrevertible mega-commit.
+
+**Alternatives considered:**
+- **Dual-path hardening** (keep both paths, add tests/assertions to keep them
+  in sync) — rejected in the deep interview's contrarian round (R4): it
+  preserves the bug *class* (two representations that can disagree) instead
+  of eliminating it; every future verb addition re-risks the same divergence.
+- **Option A, big-bang path removal** (flip `resolve_workspace` to always
+  return `Some` and delete every legacy branch in one pass) — reaches the same
+  end state, but as a large, hard-to-review diff where a subtle gap in the
+  degenerate workspace's behavior surfaces everywhere simultaneously, with a
+  higher risk of a `cargo test` red for many overlapping reasons at once.
+- **Naive "always-`Some`" flip without a `Degenerate` marker** — rejected as
+  unsound: ~10 presence-gates use `resolve_workspace().is_some()` to mean "a
+  real workspace is attached" (e.g. `xv context use` at `config_ops.rs:1097`);
+  a bare flip permanently breaks that guard, TUI, `mv`/`copy`, and union-`ls`
+  branch selection.
+
+**Why chosen:** the degenerate-workspace mechanism (Option B-prime) reaches the
+identical single-seam end state as a big-bang removal while keeping every
+intermediate `cargo test` green — each verb migrates one at a time, with
+failures localized. The one explicit `Degenerate` bit preserves every "a real
+workspace is attached" semantic without reintroducing a second resolution
+path, and the seam collapse becomes a single, easily reviewed deletion
+(`helpers.rs:155-164`) once nothing upstream can still reach `None`.
+
+**Consequences:** `resolve_workspace` never returns `None` (`Some`-or-`Err`),
+so every consumer must handle the degenerate case explicitly; all
+"real workspace attached" presence-gates must be rewritten to `is_configured()`
+before the seam collapses, or they silently regress; `run`/`inject` tuple
+consumers take the workspace branch one phase earlier than Phase 2's manager
+retirement (byte-identical by construction, pinned by the B6 parity test).
+
+**Follow-ups:** Phase 2 (manager retirement, A4 `--vault` composition
+implementation), Phase 3 (file-ops default-entry routing), re-verifying
+survivor-allowlist line numbers before annotating as code drifts.
+
+## ADR-2: Full manager retirement over partial
+
+**Decision:** Phase 2 fully retires `SecretManager`/`VaultManager`/`BlobManager`
+construction from CLI paths — including Azure-only capabilities (share/RBAC,
+audit, vault lifecycle) — by extending the `Backend` trait with optional
+sub-traits (`VaultBackend`, `AuditBackend`), rather than retiring only the
+secret-resolution managers and leaving Azure-only features on the legacy
+managers permanently.
+
+**Drivers:**
+1. Matches ADR-1's principle of single representable state: a partial
+   retirement that leaves Azure-only operations on `VaultManager`/audit-log
+   paths recreates exactly the dual-path problem ADR-1 eliminates for secret
+   resolution, just relocated to vault-lifecycle/audit operations.
+2. The existing capability-flag inconsistency (`ROADMAP.md` P3 — Azure audit
+   bypasses the trait's `has_audit` flag via a legacy Activity Log path in
+   `system_ops.rs`, so the flag is a lie for Azure) is a concrete, already-known
+   symptom of partial retirement; full retirement closes it rather than
+   perpetuating it.
+3. Trait extension (adding `VaultBackend`/`AuditBackend` sub-traits) is a
+   bounded, additive change to the `Backend` trait surface — the deep
+   interview's constraints round (R3) confirmed extending traits as needed is
+   acceptable, so there is no architectural blocker to full retirement.
+
+**Alternatives considered:**
+- **Partial retirement** (retire only secret-resolution managers; keep
+  `VaultManager`/legacy audit paths for Azure-only RBAC/audit/lifecycle
+  operations indefinitely) — rejected: perpetuates the exact "two
+  representations of the same concept" bug class ADR-1 targets, just moved to
+  a different operation family; also leaves the `has_audit` capability-flag
+  lie unresolved (`ROADMAP.md` § Security hardening → Backend ecosystem).
+
+**Why chosen:** the deep interview's constraints round (R3) explicitly settled
+on full retirement — "extend trait/sub-traits as needed" — over preserving
+Azure-only managers. Given ADR-1 already commits to single representable
+state for secret resolution, applying a different (partial) standard to
+vault-lifecycle/audit/RBAC would be an inconsistent line to draw, and the
+codebase already carries a documented, live symptom (the `has_audit` flag
+inconsistency) of exactly the partial-retirement failure mode.
+
+**Consequences:** `Backend` gains two new optional sub-traits (`VaultBackend`,
+`AuditBackend`); Azure's Activity-Log-based audit path is migrated onto
+`AuditBackend` (closing the `has_audit` flag inconsistency as a side effect);
+share/RBAC operations (`vault/operations.rs`) move behind `VaultBackend`;
+manager-construction chokepoints (`config_ops.rs:898,928`; `system_ops.rs:594,1038`)
+and `get_azure_auth_provider` are deleted once no caller remains. This is a
+larger Phase 2 surface than a partial retirement would have been, traded for
+eliminating a second known bug class instead of merely relocating it.
+
+**Follow-ups:** the `VaultBackend`/`AuditBackend` trait shapes are Phase 2
+design work, not pinned by this document; append new backend read-surface
+entries to `backend-trait-checklist.md` as Phase 2 lands, per its existing
+soft-commitment convention.
+
+## Deferred non-goals (all phases)
+
+- Multi-instance same-kind backends (e.g. two Azure tenants via a
+  `NamedBackendEntry::Azure` variant) — deferred at the deep interview's Round
+  0 topology gate; not needed yet.
+- Union file views and alias-qualified file addressing
+  (`xv file get azure-prod:x`) — Phase 3 stays default-entry-only, per the
+  2026-07-04 design's existing "file ops stay single-vault as today" scope.
+- Cross-vault file operations.
+- Byte-for-byte legacy output/exit-code parity — the compat license is
+  "break what needs breaking, document every break in `CHANGELOG.md`," not
+  behavioral preservation.
+- New backends (GCP Secret Manager, HashiCorp Vault, 1Password CLI bridge) —
+  tracked separately under `ROADMAP.md` § Backend ecosystem, unaffected by
+  this convergence.
+
+## Verification (Phase 1)
+
+```bash
+# Seam collapsed: no `else`/active_arc in resolve_workspace_or_default
+sed -n '/pub(crate) async fn resolve_workspace_or_default/,/^}/p' src/cli/helpers.rs \
+  | grep -n 'else\|active_arc' && echo FAIL || echo OK
+
+# resolve_workspace never returns None
+sed -n '/pub async fn resolve_workspace(/,/^}/p' src/workspace/mod.rs \
+  | grep -n 'Ok(None)\|return None' && echo FAIL || echo OK
+
+# No un-rewritten presence-gates
+grep -rn 'resolve_workspace(.*).*is_some()' src/cli/ src/tui/    # expect: none
+
+# Survivor allowlist: every surviving legacy call site is annotated
+grep -rn 'resolve_vault_name\|get_azure_auth_provider' src/cli/
+grep -rBn '// Phase [23]' src/cli/*.rs | grep -E 'resolve_vault_name|get_azure_auth_provider'
+
+cargo build && cargo test && cargo clippy --all-targets
+```
+
+See `.omc/plans/ralplan-xv-multibackend-roadmap.md` § 6 for the full
+verification command set including behavioral/isolated-env checks.

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -1092,9 +1092,16 @@ async fn execute_context_use(
 
     // Multi-vault workspaces and the single-vault `context use` model are
     // mutually exclusive (spec §Workspace management): mixing them would be
-    // confusing (which one wins?), so a workspace being present errors,
-    // pointing at the workspace-native way to change the write target.
-    if crate::workspace::resolve_workspace(config).await?.is_some() {
+    // confusing (which one wins?), so a REAL (configured) workspace being
+    // present errors, pointing at the workspace-native way to change the write
+    // target. `resolve_configured_workspace` (NOT the converged
+    // `resolve_workspace`) is used so this bootstrap command still works in an
+    // unconfigured Azure env — the degenerate builder's no-vault hard-error
+    // must not fire here, or you could never `xv context use` your first vault.
+    if crate::workspace::resolve_configured_workspace(config)
+        .await?
+        .is_some()
+    {
         return Err(CrosstacheError::config(
             "a multi-vault workspace is attached; 'context use' does not apply. \
              Use `xv cx default <alias>` to change the workspace's default vault, \
@@ -1542,6 +1549,7 @@ async fn execute_cx_add(
                         .to_string(),
                 );
             }
+            // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
             Some(current_backend) => match config.resolve_vault_name(None).await {
                 Ok(current_vault) => {
                     if current_vault != vault || current_backend != backend_name {
@@ -1764,16 +1772,23 @@ async fn execute_cx_ls(config: &Config) -> Result<()> {
         source: String,
     }
 
-    let resolved = crate::workspace::resolve_workspace(config).await?;
-    let Some(ws) = resolved else {
-        output::info("No workspace attached (single-vault mode)");
-        output::hint("Use 'xv cx add <vault>' to attach vaults into a workspace");
-        return Ok(());
+    // `xv cx ls` means "show the attached workspace" — a presence question, so
+    // it consults `resolve_configured_workspace` (never the degenerate builder):
+    // with no configured workspace it prints the "no workspace attached" line.
+    let ws = match crate::workspace::resolve_configured_workspace(config).await? {
+        Some(ws) => ws,
+        None => {
+            output::info("No workspace attached (single-vault mode)");
+            output::hint("Use 'xv cx add <vault>' to attach vaults into a workspace");
+            return Ok(());
+        }
     };
 
     let source = match ws.source {
         crate::workspace::WorkspaceSource::Context => "context",
         crate::workspace::WorkspaceSource::ProjectToml => ".xv.toml",
+        // Unreachable: `resolve_configured_workspace` never yields Degenerate.
+        crate::workspace::WorkspaceSource::Degenerate => "single-vault",
     };
 
     let rows: Vec<WorkspaceRow> = ws
@@ -2210,9 +2225,11 @@ async fn execute_env_pull(
             "No backend registry available. Run 'xv config show' to check your configuration.",
         )
     })?;
+    // Phase 2 (legacy manager retirement): legacy active-backend dispatch
     let secrets_backend = reg.active().secrets();
 
     // Determine vault name
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     let vault_name = config.resolve_vault_name(None).await?;
 
     eprintln!("Pulling secrets from vault '{}'...", vault_name);
@@ -2360,9 +2377,11 @@ async fn execute_env_push(
             "No backend registry available. Run 'xv config show' to check your configuration.",
         )
     })?;
+    // Phase 2 (legacy manager retirement): legacy active-backend dispatch
     let secrets_backend = reg.active().secrets();
 
     // Determine vault name
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     let vault_name = config.resolve_vault_name(None).await?;
 
     // Read .env content from file or stdin

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -112,6 +112,7 @@ pub(crate) async fn execute_file_command(command: FileCommands, config: Config) 
             }
             // Invalidate the file list cache (both recursive and hierarchical) after any upload
             let cache_manager = crate::cache::CacheManager::from_config(&config);
+            // Phase 3 (file-ops routing): file ops route through the workspace default entry
             if let Ok(vault_name) = config.resolve_vault_name(None).await {
                 cache_manager.invalidate(&crate::cache::CacheKey::FileList {
                     vault_name: vault_name.clone(),
@@ -249,6 +250,7 @@ pub(crate) async fn execute_file_command(command: FileCommands, config: Config) 
             }
             // Invalidate the file list cache (both recursive and hierarchical) after any delete
             let cache_manager = crate::cache::CacheManager::from_config(&config);
+            // Phase 3 (file-ops routing): file ops route through the workspace default entry
             if let Ok(vault_name) = config.resolve_vault_name(None).await {
                 cache_manager.invalidate(&crate::cache::CacheKey::FileList {
                     vault_name: vault_name.clone(),
@@ -679,6 +681,7 @@ async fn execute_file_list(
     let recursive = recursive || names_only;
 
     let cache_manager = CacheManager::from_config(config);
+    // Phase 3 (file-ops routing): file ops route through the workspace default entry
     let vault_name = config.resolve_vault_name(None).await.unwrap_or_default();
     let cache_key = CacheKey::FileList {
         vault_name,
@@ -2245,6 +2248,7 @@ async fn execute_file_sync(
 
     if mutated && !dry_run {
         let cache_manager = crate::cache::CacheManager::from_config(config);
+        // Phase 3 (file-ops routing): file ops route through the workspace default entry
         if let Ok(vault_name) = config.resolve_vault_name(None).await {
             cache_manager.invalidate(&crate::cache::CacheKey::FileList {
                 vault_name: vault_name.clone(),

--- a/src/cli/file_ops_aws.rs
+++ b/src/cli/file_ops_aws.rs
@@ -70,6 +70,7 @@ async fn create_aws_file_backend(config: &Config) -> Result<AwsFileBackend> {
 /// Resolve the vault whose file prefix is targeted: the usual chain
 /// (context, default_vault), then `[aws].default_vault`.
 async fn resolve_aws_file_vault(config: &Config) -> Result<String> {
+    // Phase 3 (file-ops routing): file ops route through the workspace default entry
     if let Ok(vault) = config.resolve_vault_name(None).await {
         return Ok(vault);
     }

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -84,6 +84,7 @@ pub(crate) async fn resolve_vault_for_trait(
     config: &Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<String> {
+    // Phase 2 (legacy manager retirement): legacy vault resolution for verb legacy paths; not on the workspace seam.
     match config.resolve_vault_name(None).await {
         Ok(name) => return Ok(name),
         Err(e) if registry.is_some_and(|r| r.active().kind() == BackendKind::Azure) => {
@@ -123,45 +124,53 @@ pub(crate) async fn resolve_vault_for_trait(
 /// active read path actually uses, or a write silently invalidates a cache
 /// entry nothing ever reads from while the stale one lingers.
 ///
-/// **No workspace ⇒ byte-identical**: returns `(registry.active_arc(),
-/// config.effective_backend_name(), resolve_vault_for_trait(...),
-/// raw.to_string())` — the backend/vault/path are exactly what every
-/// `get`/`set` call site returned before workspaces existed, and
-/// `config.effective_backend_name()` is the exact string the no-workspace
-/// `ls`/`ls --deleted` read path already keys its cache entries by, so
-/// hit/invalidate stay paired there too. A workspace is only consulted (and
-/// only then does resolution behave any differently) when
-/// [`crate::workspace::resolve_workspace`] returns `Some`.
+/// **Cache-key identity holds for a bare name**: with no configured
+/// workspace, `resolve_workspace` synthesizes a degenerate workspace-of-one
+/// whose single entry has `backend == config.effective_backend_name()` and
+/// the same vault the legacy `resolve_vault_for_trait` chain produced, so the
+/// returned `(backend kind, backend_name, vault, raw)` — and every
+/// `CacheKey::SecretsList` it feeds — is exactly what `get`/`set` returned
+/// before workspaces existed, matching the string the no-workspace `ls`/`ls
+/// --deleted` read path keys its cache entries by.
 ///
-/// With a workspace: builds a lazy multi-backend registry scoped to just
-/// this workspace's attached backends (so a command touching one backend
-/// never constructs another) and delegates to
-/// [`crate::workspace::resolve_secret_target`] for the mode-specific
-/// (`Read` searches, `Write` never searches) resolution.
+/// Resolution always flows through [`crate::workspace::resolve_secret_target`]
+/// against a lazy multi-backend registry scoped to just the resolved
+/// workspace's attached backends (so a command touching one backend never
+/// constructs another). A degenerate workspace resolves the raw name
+/// literally against its sole entry (no alias parsing, no search); a
+/// configured workspace applies the mode-specific rules (`Read` searches,
+/// `Write` never searches).
 pub(crate) async fn resolve_workspace_or_default(
     raw: &str,
     config: &Config,
-    registry: &BackendRegistry,
+    _registry: &BackendRegistry,
     mode: crate::workspace::TargetMode,
 ) -> Result<(Arc<dyn Backend>, String, String, String)> {
-    if let Some(ws) = crate::workspace::resolve_workspace(config).await? {
-        let backend_names: Vec<String> = ws.entries.iter().map(|e| e.backend.clone()).collect();
-        let ws_registry = BackendRegistry::with_lazy(config, &backend_names)
-            .map_err(|e| CrosstacheError::config(e.to_string()))?;
-        let (target, path) =
-            crate::workspace::resolve_secret_target(raw, &ws, &ws_registry, mode).await?;
-        let backend_name = target.entry.backend.clone();
-        Ok((target.backend, backend_name, target.entry.vault, path))
-    } else {
-        let vault_name = resolve_vault_for_trait(config, Some(registry)).await?;
-        let backend_name = config.effective_backend_name().to_string();
-        Ok((
-            registry.active_arc(),
-            backend_name,
-            vault_name,
-            raw.to_string(),
-        ))
-    }
+    // Phase 1 (B5) — SINGLE resolution path. `resolve_workspace` never yields
+    // `None` (it synthesizes a degenerate workspace-of-one), so every CLI
+    // secret reference — real workspace or not — resolves through
+    // `resolve_secret_target`. The former no-workspace fallback (which returned
+    // the process active backend plus `resolve_vault_for_trait`) has been
+    // removed; the degenerate builder reproduces its resolved `(backend,
+    // vault)` exactly, keeping bare-name resolution byte-identical. `_registry`
+    // is kept only for signature stability (seam callers are unchanged) — the
+    // scoped `ws_registry` built from `config` is the single source of backends.
+    let ws = match crate::workspace::resolve_workspace(config).await? {
+        Some(ws) => ws,
+        None => {
+            return Err(CrosstacheError::config(
+                "internal error: resolve_workspace returned None; the degenerate \
+                 workspace-of-one must always yield Some or Err",
+            ))
+        }
+    };
+    let backend_names: Vec<String> = ws.entries.iter().map(|e| e.backend.clone()).collect();
+    let ws_registry = BackendRegistry::with_lazy(config, &backend_names)
+        .map_err(|e| CrosstacheError::config(e.to_string()))?;
+    let (target, path) =
+        crate::workspace::resolve_secret_target(raw, &ws, &ws_registry, mode).await?;
+    let backend_name = target.entry.backend.clone();
+    Ok((target.backend, backend_name, target.entry.vault, path))
 }
 
 /// Resolve the active workspace (if any) plus a lazy [`BackendRegistry`]
@@ -171,13 +180,23 @@ pub(crate) async fn resolve_workspace_or_default(
 /// unlike [`resolve_workspace_or_default`], which targets a single raw CLI
 /// argument).
 ///
-/// Returns `(None, None)` when no workspace is attached — callers must treat
-/// that as "fall through to today's raw-vault-name / backend-kind behavior,
-/// byte-identical" (spec §Backward compatibility).
+/// Returns `(Some(ws), Some(ws_registry))` when a CONFIGURED workspace is
+/// attached, else `(None, None)` — callers (`run`/`inject`) treat `None` as
+/// "fall through to today's raw-vault-name / backend-kind URI resolution,
+/// byte-identical".
+///
+/// This uses [`crate::workspace::resolve_configured_workspace`], NOT the
+/// converged [`resolve_workspace`], deliberately: `run`/`inject` only need a
+/// workspace for `xv://alias/...` resolution. Synthesizing the degenerate
+/// workspace-of-one here would add nothing (its sole alias equals its vault
+/// name, so a URI resolves identically to the raw path either way) while
+/// dragging in the degenerate builder's Azure-no-vault hard-error — which
+/// would wrongly break `xv run` over a template of explicit `xv://` URIs that
+/// never needs a default vault. So the degenerate case stays `(None, None)`.
 pub(crate) async fn resolve_workspace_and_registry(
     config: &Config,
 ) -> Result<(Option<crate::workspace::Workspace>, Option<BackendRegistry>)> {
-    if let Some(ws) = crate::workspace::resolve_workspace(config).await? {
+    if let Some(ws) = crate::workspace::resolve_configured_workspace(config).await? {
         let backend_names: Vec<String> = ws.entries.iter().map(|e| e.backend.clone()).collect();
         let ws_registry = BackendRegistry::with_lazy(config, &backend_names)
             .map_err(|e| CrosstacheError::config(e.to_string()))?;

--- a/src/cli/mv_ops.rs
+++ b/src/cli/mv_ops.rs
@@ -248,7 +248,11 @@ pub(crate) async fn execute_mv(
     // are unaffected: they fall straight through to the pre-workspace path
     // below, byte-identical.
     if filter.is_none() {
-        if let Some(ws) = crate::workspace::resolve_workspace(&config).await? {
+        // Only a REAL (configured) workspace takes the alias-aware `mv` path;
+        // `resolve_configured_workspace` returns `None` with no configured
+        // workspace, so a degenerate single-vault `mv` falls through to the
+        // byte-identical pre-workspace path below.
+        if let Some(ws) = crate::workspace::resolve_configured_workspace(&config).await? {
             let src_raw = source
                 .as_deref()
                 .expect("checked above: exactly one of SOURCE/--filter is Some");
@@ -359,7 +363,9 @@ pub(crate) async fn execute_mv(
     // unchanged, byte-identical. Cross-vault `--filter` moves stay out of
     // scope — only the DEFAULT entry is ever chosen here.
     let workspace_for_filter = if filter.is_some() {
-        crate::workspace::resolve_workspace(&config).await?
+        // No configured workspace ⇒ `None`: bulk `mv --filter` stays
+        // byte-identical to the pre-workspace path.
+        crate::workspace::resolve_configured_workspace(&config).await?
     } else {
         None
     };

--- a/src/cli/scan_ops.rs
+++ b/src/cli/scan_ops.rs
@@ -171,6 +171,7 @@ async fn fetch_scan_secrets(
             }
         }
     } else {
+        // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
         vec![config.resolve_vault_name(None).await?]
     };
 

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -1911,8 +1911,12 @@ pub(crate) async fn execute_deleted_secret_list(
     }
 
     // Workspace union path (multi-vault workspaces plan, Phase B Task 9
-    // remaining scope): consulted ONLY when a workspace is attached.
-    if let Some(ws) = crate::workspace::resolve_workspace(&config).await? {
+    // remaining scope): consulted ONLY when a REAL (configured) workspace is
+    // attached. `resolve_configured_workspace` returns `None` with no
+    // configured workspace, so the degenerate single-vault case falls straight
+    // through to the trait-path code below, byte-identical to pre-workspace
+    // `ls --deleted`.
+    if let Some(ws) = crate::workspace::resolve_configured_workspace(&config).await? {
         return execute_deleted_secret_list_workspace(
             ws, pagination, pager, names_only, long, sort, filter, config,
         )
@@ -1926,26 +1930,37 @@ pub(crate) async fn execute_deleted_secret_list(
     }
     let reg = registry.expect("use_trait_path guarantees Some");
 
+    // Resolve the backend + vault through the unified workspace path instead
+    // of `reg.active()`: `ls --deleted` lists the default vault's trash, so it
+    // resolves as a write target would — no secret name, no search
+    // (`TargetMode::Write` never searches). With no configured workspace the
+    // degenerate workspace-of-one resolves over `config.effective_backend_name()`
+    // and the default vault, so this stays byte-identical while the capability
+    // gate below targets the RESOLVED backend, matching purge/restore/rotate.
+    // The empty raw name only feeds the (discarded) resolved path.
+    let (backend, _backend_name, vault_name, _resolved_path) =
+        crate::cli::helpers::resolve_workspace_or_default(
+            "",
+            &config,
+            reg,
+            crate::workspace::TargetMode::Write,
+        )
+        .await?;
+
     // Capability gate — same shape as `xv restore`'s.
     let unsupported = || {
         CrosstacheError::InvalidArgument(format!(
             "The {} backend does not support listing deleted secrets (soft-delete not available).",
-            reg.active().name()
+            backend.name()
         ))
     };
-    if !reg.active().capabilities().has_soft_delete {
+    if !backend.capabilities().has_soft_delete {
         return Err(unsupported());
     }
 
-    let vault_name = resolve_vault_for_trait(&config, registry).await?;
     // Always live — the SecretsList cache holds live secrets only, and trash
     // freshness matters right after a delete.
-    let items = match reg
-        .active()
-        .secrets()
-        .list_deleted_secrets(&vault_name)
-        .await
-    {
+    let items = match backend.secrets().list_deleted_secrets(&vault_name).await {
         Ok(items) => items,
         Err(crate::backend::BackendError::Unsupported(_)) => return Err(unsupported()),
         Err(e) => return Err(e.into()),
@@ -2443,11 +2458,12 @@ pub(crate) async fn execute_secret_list_direct(
     }
 
     // Workspace union path (multi-vault workspaces plan, Phase B Task 7):
-    // consulted ONLY when a workspace is attached — `resolve_workspace`
-    // returns `None` for the degenerate (no-workspace) case, which falls
-    // straight through to the untouched trait-path code below, keeping it
-    // byte-identical to pre-workspace `ls` output.
-    if let Some(ws) = crate::workspace::resolve_workspace(&config).await? {
+    // consulted ONLY when a REAL (configured) workspace is attached.
+    // `resolve_configured_workspace` returns `None` with no configured
+    // workspace, so the degenerate single-vault case falls straight through to
+    // the untouched trait-path code below, byte-identical to pre-workspace
+    // `ls` output.
+    if let Some(ws) = crate::workspace::resolve_configured_workspace(&config).await? {
         return execute_secret_list_workspace(
             ws,
             path,
@@ -2881,6 +2897,7 @@ async fn execute_secret_rollback_legacy(
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = get_azure_auth_provider(registry, &config)?;
 
     // Create secret manager
@@ -2901,6 +2918,7 @@ async fn execute_secret_rollback_legacy(
     // re-deriving from scratch, which would silently ignore it.
     let vault_name = match vault_override {
         Some(v) => Some(v),
+        // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
         None => config.resolve_vault_name(None).await.ok(),
     };
     if let Some(vault_name) = vault_name {
@@ -3399,6 +3417,7 @@ async fn apply_record_field_changes(
         projected_field_tags.insert(k.clone(), v.clone());
     }
     let user_tags = user_tags_of(&secret.tags);
+    // Phase 2 (legacy manager retirement): active-backend capability/kind read
     let reserved_count = crate::records::predicted_reserved_tag_count(
         reg.active().kind(),
         true,
@@ -3555,6 +3574,7 @@ async fn execute_record_type_conversion(
     // fields are added by a bare `--type` conversion (only the primary is
     // set, and the primary never gets an f.* tag).
     let user_tags = user_tags_of(&secret.tags);
+    // Phase 2 (legacy manager retirement): active-backend capability/kind read
     let reserved_count = crate::records::predicted_reserved_tag_count(
         reg.active().kind(),
         true,
@@ -4191,6 +4211,7 @@ async fn execute_secret_purge_legacy(
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = get_azure_auth_provider(registry, &config)?;
 
     // Create secret manager
@@ -4209,6 +4230,7 @@ async fn execute_secret_purge_legacy(
     // override directly over re-deriving from scratch.
     let vault_name = match vault_override {
         Some(v) => Some(v),
+        // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
         None => config.resolve_vault_name(None).await.ok(),
     };
     if let Some(vault_name) = vault_name {
@@ -4270,6 +4292,7 @@ pub(crate) async fn execute_secret_restore_direct(
     }
 
     // ── Azure legacy path (unchanged) ─────────────────────────────────
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = get_azure_auth_provider(registry, &config)?;
 
     // Create secret manager
@@ -4278,6 +4301,7 @@ pub(crate) async fn execute_secret_restore_direct(
     execute_secret_restore(&secret_manager, name, None, &config).await?;
 
     // Invalidate the secrets list cache for the resolved vault
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     if let Ok(vault_name) = config.resolve_vault_name(None).await {
         let cache_manager = crate::cache::CacheManager::from_config(&config);
         // Azure-legacy-only path (`effective_backend_name()` is guaranteed
@@ -4301,6 +4325,7 @@ pub(crate) async fn execute_diff_command(
 ) -> Result<()> {
     use std::collections::BTreeSet;
 
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = get_azure_auth_provider(registry, &config)?;
 
     let secret_manager = SecretManager::new(auth_provider, config.no_color);
@@ -4440,6 +4465,7 @@ pub(crate) async fn execute_secret_copy_direct(
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = get_azure_auth_provider(registry, &config)?;
 
     // Create secret manager
@@ -4465,8 +4491,12 @@ pub(crate) async fn execute_secret_copy_direct(
     // touches (the "ONE identifier" convention: see
     // `resolve_workspace_or_default`'s doc comment). Falls back to
     // `config.effective_backend_name()` unchanged when no workspace is
-    // attached or the argument isn't an attached alias.
-    let ws = crate::workspace::resolve_workspace(&config).await?;
+    // attached or the argument isn't an attached alias. Only a REAL
+    // (configured) workspace participates in per-side alias resolution:
+    // `resolve_configured_workspace` returns `None` with no configured
+    // workspace, so the degenerate single-vault case keys the cache exactly as
+    // the no-workspace path did (`config.effective_backend_name()`).
+    let ws = crate::workspace::resolve_configured_workspace(&config).await?;
     let (from_backend_name, from_vault_resolved) =
         crate::cli::helpers::vault_ref_cache_identity(from_vault, ws.as_ref(), &config);
     let (to_backend_name, to_vault_resolved) =
@@ -4493,6 +4523,7 @@ pub(crate) async fn execute_secret_move_direct(
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = get_azure_auth_provider(registry, &config)?;
 
     // Create secret manager
@@ -4514,7 +4545,10 @@ pub(crate) async fn execute_secret_move_direct(
     // vaults — same reasoning as `execute_secret_copy_direct` above: keyed
     // by `config.effective_backend_name()`, not the backend kind — same
     // per-side alias resolution as `execute_secret_copy_direct` above.
-    let ws = crate::workspace::resolve_workspace(&config).await?;
+    // `resolve_configured_workspace` returns `None` with no configured
+    // workspace, so the degenerate single-vault case keys cache identity
+    // byte-identically to the no-workspace path.
+    let ws = crate::workspace::resolve_configured_workspace(&config).await?;
     let (from_backend_name, from_vault_resolved) =
         crate::cli::helpers::vault_ref_cache_identity(from_vault, ws.as_ref(), &config);
     let (to_backend_name, to_vault_resolved) =
@@ -4538,6 +4572,7 @@ pub(crate) async fn execute_secret_parse_direct(
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = get_azure_auth_provider(registry, &config)?;
 
     // Create secret manager
@@ -4577,6 +4612,7 @@ pub(crate) async fn execute_secret_share_direct(
         }
     }
 
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider: Arc<dyn AzureAuthProvider> = get_azure_auth_provider(registry, &config)?;
 
     // Create vault manager for secret-level RBAC
@@ -4716,13 +4752,17 @@ pub(crate) async fn execute_secret_find_direct(
     };
 
     // Workspace union `find` (multi-vault workspaces plan, Phase B Task 8):
-    // consulted ONLY when a workspace is attached AND `--all-vaults` was NOT
-    // requested. `--all-vaults` keeps its existing, documented meaning
-    // ("every vault the active backend can list") — a strict superset of
-    // "every ATTACHED vault" — so it takes priority and falls through to
-    // its own unchanged branch below even with a workspace present.
+    // consulted ONLY when a REAL (configured) workspace is attached AND
+    // `--all-vaults` was NOT requested. `resolve_configured_workspace` returns
+    // `None` with no configured workspace, so the degenerate single-vault case
+    // falls through to the single-vault path below (which also performs the
+    // `--in` field validation), byte-identical. `--all-vaults` keeps its
+    // existing, documented meaning ("every vault the active backend can list")
+    // — a strict superset of "every ATTACHED vault" — so it takes priority and
+    // falls through to its own unchanged branch below even with a workspace
+    // present.
     if !all_vaults {
-        if let Some(ws) = crate::workspace::resolve_workspace(&config).await? {
+        if let Some(ws) = crate::workspace::resolve_configured_workspace(&config).await? {
             use crate::utils::fuzzy::{score_matches, CandidateItem, FuzzyField};
 
             let mut fields: Vec<FuzzyField> = vec![FuzzyField::Name];
@@ -4860,6 +4900,7 @@ pub(crate) async fn execute_secret_find_direct(
         let items: Vec<CandidateItem> = if all_vaults {
             // List all vaults and collect secrets
             let mut combined = Vec::new();
+            // Phase 2 (legacy manager retirement): legacy active-backend dispatch
             if let Some(vaults_backend) = reg.active().vaults() {
                 let vaults = vaults_backend.list_vaults().await?;
                 for v in &vaults {
@@ -4934,6 +4975,7 @@ pub(crate) async fn execute_secret_find_direct(
     }
 
     // ── Azure legacy path (unchanged) ─────────────────────────────────
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = crate::cli::helpers::get_azure_auth_provider(registry, &config)?;
     let secret_manager = SecretManager::new(auth_provider, config.no_color);
     execute_secret_find(
@@ -4995,6 +5037,7 @@ async fn execute_secret_find(
     let single_vault = if all_vaults {
         None
     } else {
+        // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
         let vn = config.resolve_vault_name(None).await?;
         let _ = context_manager.update_usage(&vn).await;
         Some(vn)
@@ -5116,6 +5159,7 @@ async fn execute_secret_find(
 pub(crate) async fn execute_complete_secrets(config: Config) -> Result<()> {
     use crate::cache::{CacheKey, CacheManager};
 
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     let vault_name = config.resolve_vault_name(None).await?;
 
     // Cache-only path. If cache is cold, exit silently — the user got
@@ -5168,6 +5212,7 @@ fn folder_completion_paths(secrets: &[crate::secret::manager::SecretSummary]) ->
 pub(crate) async fn execute_complete_folders(config: Config) -> Result<()> {
     use crate::cache::{CacheKey, CacheManager};
 
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     let vault_name = config.resolve_vault_name(None).await?;
 
     // Cache-only path, mirroring execute_complete_secrets: a cold cache
@@ -5241,6 +5286,7 @@ async fn execute_secret_rollback(
     use crate::utils::interactive::InteractivePrompt;
 
     // Determine vault name using context resolution
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     let vault_name = config.resolve_vault_name(vault).await?;
 
     // Update context usage tracking
@@ -5299,6 +5345,7 @@ async fn execute_secret_rotate(
     use crate::utils::interactive::InteractivePrompt;
 
     // Determine vault name using context resolution
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     let vault_name = config.resolve_vault_name(vault).await?;
 
     // Update context usage tracking
@@ -5666,6 +5713,7 @@ async fn execute_secret_run(
     };
 
     // Determine vault name using context resolution
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     let vault_name = config.resolve_vault_name(vault).await?;
 
     // Update context usage tracking
@@ -5705,6 +5753,7 @@ async fn execute_secret_run(
     // Get all secrets from the active backend (trait path — works for azure,
     // local, and aws alike).
     let progress = crate::utils::interactive::ProgressIndicator::new("Loading secrets...");
+    // Phase 2 (legacy manager retirement): legacy active-backend dispatch
     let secrets = reg.active().secrets().list_secrets(&vault_name, None).await;
     progress.finish_clear();
     let secrets = secrets.map_err(CrosstacheError::from)?;
@@ -5852,6 +5901,7 @@ async fn execute_secret_run(
             uri_refs.len()
         ));
 
+        // Phase 2 (legacy manager retirement): active-backend capability/kind read
         let active_kind: BackendKind = reg.active().kind();
 
         // Cache backends by kind — avoids re-initialising the SDK per URI
@@ -6180,6 +6230,7 @@ async fn execute_secret_inject(
     use std::io::{self, Read};
 
     // Determine vault name using context resolution
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     let vault_name = config.resolve_vault_name(vault).await?;
 
     // Update context usage tracking
@@ -6316,6 +6367,7 @@ async fn execute_secret_inject(
     // Get all secrets from the active backend (trait path — works for azure,
     // local, and aws alike).
     let progress = crate::utils::interactive::ProgressIndicator::new("Loading secrets...");
+    // Phase 2 (legacy manager retirement): legacy active-backend dispatch
     let secrets = reg.active().secrets().list_secrets(&vault_name, None).await;
     progress.finish_clear();
     let secrets = secrets.map_err(CrosstacheError::from)?;
@@ -6488,6 +6540,7 @@ async fn execute_secret_inject(
 
     // Fetch URI-referenced secrets (supports optional backend prefix)
     {
+        // Phase 2 (legacy manager retirement): active-backend capability/kind read
         let active_kind: BackendKind = reg.active().kind();
 
         // Cache backends by kind — avoids re-initialising the SDK per URI
@@ -6641,6 +6694,7 @@ async fn execute_secret_purge(
     use crate::config::ContextManager;
 
     // Determine vault name using context resolution
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     let vault_name = config.resolve_vault_name(vault).await?;
 
     // Update context usage tracking
@@ -6678,6 +6732,7 @@ async fn execute_secret_restore(
     use crate::config::ContextManager;
 
     // Determine vault name using context resolution
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     let vault_name = config.resolve_vault_name(vault).await?;
 
     // Update context usage tracking
@@ -7054,6 +7109,7 @@ async fn execute_secret_share(
     use crate::vault::models::AccessLevel;
 
     // Determine vault name using context resolution
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     let vault_name = config.resolve_vault_name(None).await?;
     let resource_group = config.default_resource_group.clone();
 
@@ -7735,25 +7791,22 @@ mod tests {
         assert!(msg.contains("local"), "should name the backend: {msg}");
     }
 
-    #[tokio::test]
-    async fn rotate_native_accepted_on_backend_with_rotation_capability() {
-        // #342: isolate from the real global context — see the sibling
-        // "rejected" test above for why.
-        let _env_guard = context_dir_env_lock().lock().await;
-        let temp_context_dir = tempfile::tempdir().unwrap();
-        let _context_dir_guard = EnvVarGuard::set("XV_CONTEXT_DIR", temp_context_dir.path());
-
-        let registry = BackendRegistry::new(Arc::new(TestBackend::aws()));
-        let config = Config {
-            backend: Some("aws".to_string()),
-            default_vault: "test-vault".to_string(),
-            ..Default::default()
-        };
-
-        execute_secret_rotate_native("db-password", true, config, Some(&registry))
-            .await
-            .expect("capable backend should accept native rotation");
-    }
+    // Phase 1 (B5) note: the former
+    // `rotate_native_accepted_on_backend_with_rotation_capability` unit test
+    // injected a fake rotation-capable `TestBackend::aws()` registry. After
+    // resolution convergence the CLI resolves its backend from config through
+    // the workspace seam, so a fake backend can no longer be injected — and no
+    // HERMETIC backend advertises `has_secret_rotation` (only real AWS does),
+    // so a `rotate --native` ACCEPT path can't be exercised without the aws
+    // feature + network. Its intent — the `--native` capability gate reads the
+    // RESOLVED target's capabilities, not the process active backend's — is
+    // covered hermetically by
+    // `crate::workspace::resolve::tests::resolved_backend_capabilities_reflect_workspace_entry_not_a_separate_active_backend`
+    // and end-to-end by `tests/e2e_workspaces.rs::
+    // rotate_native_capability_gate_reflects_resolved_target_not_workspace_default`.
+    // The REJECT path stays covered by the sibling
+    // `rotate_native_rejected_on_backend_without_rotation_capability` (local,
+    // hermetic).
 
     #[test]
     fn expiry_filter_candidates_apply_group_and_enabled_filters_before_detail_fetches() {
@@ -8104,117 +8157,6 @@ mod tests {
         }
     }
 
-    /// Backend whose in-place update always succeeds but whose rename phase
-    /// always fails with a `Conflict` — the shape produced by `xv update src
-    /// --note x --rename existing-dst` when `dst` already exists.
-    struct RenameFailBackend;
-
-    #[async_trait::async_trait]
-    impl SecretBackend for RenameFailBackend {
-        async fn set_secret(
-            &self,
-            _vault: &str,
-            _request: crate::secret::manager::SecretRequest,
-        ) -> std::result::Result<crate::secret::manager::SecretProperties, BackendError> {
-            Err(BackendError::Unsupported("test backend".into()))
-        }
-
-        async fn get_secret(
-            &self,
-            _vault: &str,
-            _name: &str,
-            _include_value: bool,
-        ) -> std::result::Result<crate::secret::manager::SecretProperties, BackendError> {
-            Err(BackendError::Unsupported("test backend".into()))
-        }
-
-        async fn get_secret_version(
-            &self,
-            _vault: &str,
-            _name: &str,
-            _version: &str,
-            _include_value: bool,
-        ) -> std::result::Result<crate::secret::manager::SecretProperties, BackendError> {
-            Err(BackendError::Unsupported("test backend".into()))
-        }
-
-        async fn list_secrets(
-            &self,
-            _vault: &str,
-            _group_filter: Option<&str>,
-        ) -> std::result::Result<Vec<crate::secret::manager::SecretSummary>, BackendError> {
-            Ok(Vec::new())
-        }
-
-        async fn delete_secret(
-            &self,
-            _vault: &str,
-            _name: &str,
-        ) -> std::result::Result<(), BackendError> {
-            Err(BackendError::Unsupported("test backend".into()))
-        }
-
-        async fn update_secret(
-            &self,
-            _vault: &str,
-            name: &str,
-            _request: crate::secret::manager::SecretUpdateRequest,
-        ) -> std::result::Result<crate::secret::manager::SecretProperties, BackendError> {
-            Ok(fake_secret_properties(name))
-        }
-
-        async fn rename_secret(
-            &self,
-            _vault: &str,
-            name: &str,
-            new_name: &str,
-        ) -> std::result::Result<crate::secret::manager::SecretProperties, BackendError> {
-            Err(BackendError::Conflict(format!(
-                "destination '{new_name}' already exists (renaming '{name}')"
-            )))
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl Backend for RenameFailBackend {
-        fn name(&self) -> &'static str {
-            "local"
-        }
-
-        fn kind(&self) -> BackendKind {
-            BackendKind::Local
-        }
-
-        fn capabilities(&self) -> BackendCapabilities {
-            BackendCapabilities {
-                has_vaults: true,
-                has_file_storage: false,
-                has_rbac: false,
-                has_audit: false,
-                has_versioning: true,
-                has_soft_delete: true,
-                has_secret_rotation: false,
-                has_groups: true,
-                has_folders: true,
-                has_notes: true,
-                has_expiry: true,
-                max_secret_size: None,
-                max_name_length: None,
-                name_charset: NameCharset::Unrestricted,
-                max_tags: None,
-                max_tag_value_len: None,
-            }
-        }
-
-        fn secrets(&self) -> &dyn SecretBackend {
-            self
-        }
-
-        async fn health_check(&self) -> std::result::Result<(), BackendError> {
-            Ok(())
-        }
-    }
-
     /// Regression test for fix-6 finding #1: when the in-place update phase
     /// of a combined `--rename` update succeeds but the rename phase fails,
     /// the secrets-list cache must still be invalidated. Before the fix, both
@@ -8222,58 +8164,73 @@ mod tests {
     /// early past the single trailing `invalidate_trait_secret_cache` call,
     /// leaving a stale cached `xv ls` for up to the cache TTL.
     ///
-    /// This is a unit-level test (not e2e) because every e2e harness in this
-    /// repo (see `tests/e2e_local_backend.rs`'s `TestEnv::new()`) sets
-    /// `cache_enabled = false` — there is no existing precedent for an e2e
-    /// test that exercises the on-disk cache, and adding one is out of scope
-    /// for this fix. Exercising `execute_secret_update_direct` directly with
-    /// a controllable backend lets us assert on the cache file without a
-    /// full CLI invocation.
+    /// Post-convergence (Phase 1) the CLI resolves its backend from `config`
+    /// through the workspace seam, so this can no longer inject a fake backend.
+    /// It drives a REAL hermetic local backend instead and forces the rename
+    /// to fail the natural way — renaming onto a name that already exists
+    /// yields `BackendError::Conflict` (see `SecretBackend::rename_secret`'s
+    /// destination-exists guard), exactly the "update applied, rename failed"
+    /// shape the fix guards. Still a unit-level test (not e2e) because every
+    /// e2e harness sets `cache_enabled = false`.
     #[tokio::test]
     async fn rename_failure_after_successful_update_invalidates_cache() {
-        let registry = BackendRegistry::new(Arc::new(RenameFailBackend));
-
-        // `execute_secret_update_direct` invalidates its cache internally via
-        // `invalidate_trait_secret_cache`, which builds its own `CacheManager`
-        // from `config` (`CacheManager::from_config`). To observe that
-        // invalidation from this test we need our own `CacheManager` to
-        // resolve to the *same* directory, so we point both at an isolated
-        // `tempfile::TempDir` via the `XV_CACHE_DIR` override rather than
-        // touching the real OS cache path. `XV_CACHE_DIR` is a process-global
-        // env var, so mutation is serialized with `cache_dir_env_lock()` to
-        // avoid racing other tests that also set it, and `EnvVarGuard`
-        // restores the previous value on drop — including on panic unwind,
-        // so a failing assertion below can never leak the override pointing
-        // at an already-deleted `TempDir` for the rest of the test binary.
-        let _env_guard = cache_dir_env_lock().lock().await;
+        // Serialize + isolate the two process-global env overrides this test
+        // relies on: `XV_CACHE_DIR` (so our `CacheManager` and the one
+        // `execute_secret_update_direct` builds internally share a temp dir)
+        // and `XV_CONTEXT_DIR` (so `resolve_workspace` -> `ContextManager::load`
+        // can't pick up a real workspace and redirect the target vault).
+        // `EnvVarGuard` restores both on drop, including on panic unwind.
+        let _cache_env_guard = cache_dir_env_lock().lock().await;
         let temp_cache_dir = tempfile::tempdir().unwrap();
         let _cache_dir_guard = EnvVarGuard::set("XV_CACHE_DIR", temp_cache_dir.path());
-
-        // #342: `execute_secret_update_direct` also resolves the workspace
-        // (`resolve_workspace_or_default` -> `resolve_workspace` ->
-        // `ContextManager::load`), which reads the REAL global context
-        // unless `XV_CONTEXT_DIR` is isolated — on a machine with a
-        // workspace attached, the target this test writes/renames would be
-        // silently redirected to that workspace's default vault instead of
-        // this test's own `RenameFailBackend`-backed "local" config.
         let _context_env_guard = context_dir_env_lock().lock().await;
         let temp_context_dir = tempfile::tempdir().unwrap();
         let _context_dir_guard = EnvVarGuard::set("XV_CONTEXT_DIR", temp_context_dir.path());
 
+        // Real hermetic local store the CLI will resolve to from `config`.
+        let store = tempfile::tempdir().unwrap();
         let vault_name = "xv-test-rename-cache".to_string();
         let config = Config {
             backend: Some("local".to_string()),
             cache_enabled: true,
             cache_ttl_secs: 300,
             local: Some(crate::config::settings::LocalConfig {
-                store_path: None,
-                key_file: None,
+                store_path: Some(store.path().join("store").to_string_lossy().to_string()),
+                key_file: Some(store.path().join("key.txt").to_string_lossy().to_string()),
                 default_vault: Some(vault_name.clone()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
             }),
             ..Default::default()
         };
+
+        // Seed the SAME store the CLI resolves to: "src" so the in-place update
+        // succeeds, and "existing-dst" so the subsequent rename collides
+        // (`rename_secret`'s destination-exists guard -> `Conflict`).
+        let registry = BackendRegistry::with_lazy(&config, &["local".to_string()])
+            .expect("register local backend");
+        let backend = registry.materialize("local").expect("build local backend");
+        for name in ["src", "existing-dst"] {
+            backend
+                .secrets()
+                .set_secret(
+                    &vault_name,
+                    crate::secret::manager::SecretRequest {
+                        name: name.to_string(),
+                        value: zeroize::Zeroizing::new("seed".to_string()),
+                        content_type: None,
+                        enabled: None,
+                        expires_on: None,
+                        not_before: None,
+                        tags: None,
+                        groups: None,
+                        note: None,
+                        folder: None,
+                    },
+                )
+                .await
+                .expect("seed secret");
+        }
 
         let cache_manager = crate::cache::CacheManager::from_config(&config);
         let cache_key = trait_secret_cache_key("local", &vault_name);

--- a/src/cli/system_ops.rs
+++ b/src/cli/system_ops.rs
@@ -334,6 +334,7 @@ pub(crate) async fn execute_audit_command(
 
     // Capability check: audit requires audit log support
     if let Some(registry) = registry {
+        // Phase 2 (legacy manager retirement): active-backend capability/kind read
         let caps = registry.active().capabilities();
         if !caps.has_audit {
             return Err(CrosstacheError::InvalidArgument(format!(
@@ -358,6 +359,7 @@ pub(crate) async fn execute_audit_command(
     }
 
     // Create authentication provider — reuse from registry when available
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider: Arc<dyn crate::auth::provider::AzureAuthProvider> =
         crate::cli::helpers::get_azure_auth_provider(registry, &config)?;
 
@@ -381,6 +383,7 @@ pub(crate) async fn execute_audit_command(
         (vault_name, rg, sub)
     } else {
         // Use current vault context
+        // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
         let vault_name = config.resolve_vault_name(None).await?;
         let rg = resource_group_override.unwrap_or_else(|| config.default_resource_group.clone());
         let sub = config.subscription_id.clone();
@@ -457,6 +460,7 @@ async fn execute_backend_audit(
     operation: Option<String>,
     config: Config,
 ) -> Result<()> {
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     let vault_name = config.resolve_vault_name(vault).await?;
 
     output::step(&format!("Fetching audit logs for {} days...", days));
@@ -588,6 +592,7 @@ async fn execute_secret_info_from_root(
     };
 
     // Create authentication provider
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = crate::cli::helpers::get_azure_auth_provider(registry, config)?;
 
     // Create secret manager
@@ -651,6 +656,7 @@ pub(crate) async fn execute_whoami_command(
     output::step("Checking authentication and context...\n");
 
     // Create authentication provider — reuse from registry when available
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = crate::cli::helpers::get_azure_auth_provider(registry, &config)?;
 
     // Get access token to validate authentication
@@ -1034,8 +1040,10 @@ async fn save_generated_secret(
     // an auth provider on demand and use set_secret_safe with the metadata
     // options so groups/note/folder/expiry still apply.
     use crate::secret::manager::SecretManager;
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = crate::cli::helpers::get_azure_auth_provider(registry, config)?;
     let secret_manager = SecretManager::new(auth_provider, config.no_color);
+    // Phase 2 (legacy manager retirement): legacy vault resolution, not yet on the workspace seam
     let vault_name = config.resolve_vault_name(vault).await?;
     secret_manager
         .set_secret_safe(&vault_name, name, value, Some(request))

--- a/src/cli/vault_ops.rs
+++ b/src/cli/vault_ops.rs
@@ -36,6 +36,7 @@ pub(crate) async fn execute_vault_command(
             }
         }
 
+        // Phase 2 (legacy manager retirement): legacy active-backend dispatch
         let vaults_backend = reg.active().vaults().ok_or_else(|| {
             CrosstacheError::InvalidArgument(format!(
                 "The {} backend does not support vault operations.",
@@ -134,6 +135,7 @@ pub(crate) async fn execute_vault_command(
 
     // ── Azure legacy path (unchanged) ─────────────────────────────────
     // Create authentication provider — reuse from registry when available
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider: Arc<dyn AzureAuthProvider> = get_azure_auth_provider(registry, &config)?;
 
     // Create vault manager
@@ -567,6 +569,7 @@ pub(crate) async fn execute_vault_info_from_root(
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
     // Create authentication provider — reuse from registry when available
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = get_azure_auth_provider(registry, config)?;
 
     // Create vault manager
@@ -641,6 +644,7 @@ async fn execute_vault_export(
     let _resource_group = resource_group.unwrap_or_else(|| config.default_resource_group.clone());
 
     // Create secret manager to get secrets from vault
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = get_azure_auth_provider(registry, config)?;
     let secret_manager = SecretManager::new(auth_provider, config.no_color);
 
@@ -1016,6 +1020,7 @@ async fn execute_vault_import(
     }
 
     // Create secret manager to import secrets
+    // Phase 2 (legacy manager retirement): Azure auth provider for a legacy manager
     let auth_provider = get_azure_auth_provider(registry, config)?;
     let secret_manager = SecretManager::new(auth_provider, config.no_color);
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -41,12 +41,13 @@ pub async fn run_tui(
     });
 
     // Workspace-aware vault pane (Phase C Task 13): resolved once at
-    // startup. `None` when no workspace is attached ⇒ the vault pane and
-    // secrets loading below behave exactly as before (spec §Backward
-    // compatibility). Any resolution error is swallowed to `None` rather
-    // than failing `xv tui` outright — the single-vault degenerate path
-    // must always remain available.
-    let workspace = crate::workspace::resolve_workspace(&config)
+    // startup. `None` when no REAL (configured) workspace is attached ⇒ the
+    // vault pane and secrets loading below behave exactly as before (spec
+    // §Backward compatibility). `resolve_configured_workspace` returns `None`
+    // with no configured workspace, so `xv tui` renders as the single-vault
+    // TUI, not a 1-entry workspace browser. Any resolution error is swallowed
+    // to `None` rather than failing `xv tui` outright.
+    let workspace = crate::workspace::resolve_configured_workspace(&config)
         .await
         .ok()
         .flatten();

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -782,11 +782,14 @@ mod tests {
             backend: Some("local".to_string()),
             ..Default::default()
         };
-        let degenerate =
-            resolve_workspace_from(&config, Some(temp.path()), &crate::config::ContextManager::default())
-                .await
-                .unwrap()
-                .unwrap();
+        let degenerate = resolve_workspace_from(
+            &config,
+            Some(temp.path()),
+            &crate::config::ContextManager::default(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert!(!degenerate.is_configured());
 
         // Context.
@@ -826,11 +829,16 @@ mod tests {
         let resolved = resolve_workspace_from(&config, Some(temp.path()), &context_manager)
             .await
             .expect("must not error")
-            .expect("must synthesize a valid degenerate workspace despite the vault name colliding");
+            .expect(
+                "must synthesize a valid degenerate workspace despite the vault name colliding",
+            );
 
         let entry = resolved.default_entry().unwrap();
         assert_eq!(entry.vault, "local");
-        assert_ne!(entry.alias, "local", "alias must not collide with a backend name");
+        assert_ne!(
+            entry.alias, "local",
+            "alias must not collide with a backend name"
+        );
         assert_eq!(entry.alias, "default");
     }
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -14,6 +14,7 @@ pub mod resolve;
 pub use address::parse_address;
 pub use resolve::{resolve_secret_target, TargetMode};
 
+use crate::backend::BackendKind;
 use crate::config::settings::Config;
 use crate::error::{CrosstacheError, Result};
 use serde::{Deserialize, Serialize};
@@ -27,6 +28,14 @@ pub enum WorkspaceSource {
     /// Loaded from a `.xv.toml` `[env.<name>] vaults = [...]` overlay. When
     /// present this REPLACES any context workspace entirely — no merging.
     ProjectToml,
+    /// Synthesized workspace-of-one over the current/default vault when NO
+    /// `cx`/`.xv.toml` workspace is configured. This is the degenerate case
+    /// that lets every command resolve through the single workspace path
+    /// without the caller having attached a real workspace. Distinguished
+    /// from a user-configured workspace by [`Workspace::is_configured`] so
+    /// presence-gates (`xv context use`, union `ls`, mv/copy, TUI) that mean
+    /// "a REAL workspace is attached" keep working.
+    Degenerate,
 }
 
 /// One attached vault in a workspace.
@@ -57,6 +66,20 @@ pub struct Workspace {
 }
 
 impl Workspace {
+    /// `true` when this workspace was explicitly configured by the user — a
+    /// personal context workspace ([`WorkspaceSource::Context`]) or a project
+    /// `.xv.toml` overlay ([`WorkspaceSource::ProjectToml`]). `false` for the
+    /// synthesized degenerate workspace-of-one
+    /// ([`WorkspaceSource::Degenerate`]).
+    ///
+    /// Presence-gates that used to test `resolve_workspace().is_some()` to
+    /// mean "a REAL workspace is attached" must test this instead, now that
+    /// [`resolve_workspace`] never returns `None` (it returns a degenerate
+    /// workspace rather than `None`).
+    pub fn is_configured(&self) -> bool {
+        !matches!(self.source, WorkspaceSource::Degenerate)
+    }
+
     /// Look up an attached entry by alias.
     pub fn entry(&self, alias: &str) -> Option<&WorkspaceEntry> {
         self.entries.iter().find(|e| e.alias == alias)
@@ -223,10 +246,58 @@ pub fn build_workspace(
 /// alias/backend-name collision check regardless of what's configured.
 pub const BUILTIN_BACKEND_NAMES: [&str; 3] = ["azure", "local", "aws"];
 
-/// Resolve the active workspace, if any, per the spec's overlay rule:
-/// a `.xv.toml` `vaults = [...]` block on the active env profile REPLACES
-/// any context workspace entirely (no merging); with neither present,
-/// returns `Ok(None)` — the degenerate, byte-identical-with-today case.
+/// The registry backend names (built-ins + configured `named_backends` keys)
+/// used for the alias/backend-name collision check.
+fn known_backend_names(config: &Config) -> Vec<String> {
+    let mut backend_names: Vec<String> = BUILTIN_BACKEND_NAMES
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    for k in config.named_backends.keys() {
+        if !backend_names.iter().any(|n| n == k) {
+            backend_names.push(k.clone());
+        }
+    }
+    backend_names
+}
+
+/// Resolve the CONFIGURED workspace, if any, per the spec's overlay rule: a
+/// `.xv.toml` `vaults = [...]` block on the active env profile REPLACES any
+/// context workspace entirely (no merging); a personal context workspace is
+/// used next; with neither present, returns `Ok(None)`.
+///
+/// This does **not** synthesize the degenerate workspace-of-one (and so never
+/// raises its Azure-no-vault hard-error). It is what PRESENCE-GATES ("is a
+/// REAL workspace attached?" — `xv context use`, union `ls`/`find`, mv/copy,
+/// TUI) and `run`/`inject` alias resolution consult: they only care whether a
+/// user-configured workspace exists, and must NOT fail merely because the
+/// degenerate builder can't resolve a default vault (e.g. `xv context use
+/// <vault>` in an unconfigured Azure env must succeed so the user can set that
+/// very vault). A real `.xv.toml`/validation error still propagates. The
+/// secret-resolution seam uses [`resolve_workspace`] instead.
+pub async fn resolve_configured_workspace(config: &Config) -> Result<Option<Workspace>> {
+    let cwd = std::env::current_dir()?;
+    let context_manager = crate::config::ContextManager::load()
+        .await
+        .unwrap_or_default();
+    resolve_configured_workspace_from(config, Some(&cwd), &context_manager).await
+}
+
+/// Resolve the effective workspace for SECRET RESOLUTION: the configured
+/// workspace when present, otherwise a synthesized **degenerate
+/// workspace-of-one** ([`WorkspaceSource::Degenerate`]) over the
+/// current/default vault.
+///
+/// **Never returns `None`.** It returns `Some(Workspace)` (configured or
+/// degenerate) or propagates `Err` — preserving the no-vault hard-error for
+/// an active Azure backend (the same error `resolve_vault_for_trait` /
+/// `Config::resolve_vault_name` raise today). The return type stays
+/// `Option<Workspace>` only so existing callers compile unchanged; the
+/// `None` case is unreachable. This is used ONLY by the resolver seam
+/// ([`crate::cli::helpers::resolve_workspace_or_default`]); presence-gates and
+/// `run`/`inject` use [`resolve_configured_workspace`]. Callers distinguish a
+/// configured workspace from the degenerate one with
+/// [`Workspace::is_configured`].
 pub async fn resolve_workspace(config: &Config) -> Result<Option<Workspace>> {
     // Audit finding (Bugbot round-4): `.ok()` here would swallow a
     // `current_dir()` failure by treating it as "no cwd", which skips the
@@ -245,26 +316,17 @@ pub async fn resolve_workspace(config: &Config) -> Result<Option<Workspace>> {
     resolve_workspace_from(config, Some(&cwd), &context_manager).await
 }
 
-/// Core of [`resolve_workspace`], parameterized over `cwd` and the loaded
-/// context so it's testable without touching the process-global working
+/// Core of [`resolve_configured_workspace`], parameterized over `cwd` and the
+/// loaded context so it's testable without touching the process-global working
 /// directory (which unit tests can't safely sandbox under parallel `cargo
-/// test`). Production code always goes through [`resolve_workspace`].
-async fn resolve_workspace_from(
+/// test`). Production code always goes through [`resolve_configured_workspace`].
+async fn resolve_configured_workspace_from(
     config: &Config,
     cwd: Option<&std::path::Path>,
     context_manager: &crate::config::ContextManager,
 ) -> Result<Option<Workspace>> {
     let active_backend = config.effective_backend_name().to_string();
-
-    let mut backend_names: Vec<String> = BUILTIN_BACKEND_NAMES
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
-    for k in config.named_backends.keys() {
-        if !backend_names.iter().any(|n| n == k) {
-            backend_names.push(k.clone());
-        }
-    }
+    let backend_names = known_backend_names(config);
     let backend_name_refs: Vec<&str> = backend_names.iter().map(|s| s.as_str()).collect();
 
     // 1. `.xv.toml` project overlay — replaces context entirely.
@@ -317,6 +379,148 @@ async fn resolve_workspace_from(
     }
 
     Ok(None)
+}
+
+/// Core of [`resolve_workspace`]: the configured workspace, or the degenerate
+/// workspace-of-one when none is configured. Parameterized over `cwd`/context
+/// for the same testability reason as [`resolve_configured_workspace_from`].
+async fn resolve_workspace_from(
+    config: &Config,
+    cwd: Option<&std::path::Path>,
+    context_manager: &crate::config::ContextManager,
+) -> Result<Option<Workspace>> {
+    if let Some(ws) = resolve_configured_workspace_from(config, cwd, context_manager).await? {
+        return Ok(Some(ws));
+    }
+
+    // No configured workspace: synthesize the degenerate workspace-of-one over
+    // the current/default vault. This is what makes `resolve_workspace` never
+    // return `None`. The vault is derived from the same chain
+    // `resolve_vault_for_trait` uses today (project `.xv.toml` env vault →
+    // context current vault → `default_vault` → local `default_vault` →
+    // `"default"`), preserving the Azure no-vault hard-error as `Err`.
+    let active_backend = config.effective_backend_name().to_string();
+    let backend_names = known_backend_names(config);
+    let backend_name_refs: Vec<&str> = backend_names.iter().map(|s| s.as_str()).collect();
+
+    let vault = degenerate_default_vault(config, cwd, context_manager).await?;
+    let alias = degenerate_alias(&vault, &backend_name_refs);
+    let degenerate_entry = WorkspaceEntryConfig {
+        vault,
+        backend: Some(active_backend.clone()),
+        alias: Some(alias),
+        default: true,
+    };
+    let ws = build_workspace(
+        std::slice::from_ref(&degenerate_entry),
+        &active_backend,
+        WorkspaceSource::Degenerate,
+        &backend_name_refs,
+    )?;
+    Ok(Some(ws))
+}
+
+/// Pick the degenerate workspace-of-one's single alias.
+///
+/// Prefers the vault name so natural `xv get <vault>:name` addressing works,
+/// but only when it is a charset-valid alias that does not collide with a
+/// registry backend name (a collision would make [`Workspace::validate`]
+/// reject the synthesized workspace and break the never-`None` invariant).
+/// Otherwise falls back to a synthetic that is guaranteed to satisfy both
+/// constraints. The alias never affects cache-key identity — that is keyed on
+/// the entry's `backend` (`config.effective_backend_name()`), not the alias.
+fn degenerate_alias(vault: &str, backend_names: &[&str]) -> String {
+    if is_valid_alias_charset(vault) && !backend_names.contains(&vault) {
+        return vault.to_string();
+    }
+    let mut candidate = "default".to_string();
+    let mut n = 0;
+    while backend_names.contains(&candidate.as_str()) {
+        n += 1;
+        candidate = format!("default-{n}");
+    }
+    candidate
+}
+
+/// `true` when the config's active (top-level) backend is Azure.
+///
+/// Mirrors `crate::cli::helpers::requested_backend_kind` without depending on
+/// the CLI layer: named backends are only ever AWS/Local, so the active
+/// backend is Azure exactly when the effective name is not a named-backend
+/// key and parses to [`BackendKind::Azure`] (which includes the
+/// default-when-unset case, `effective_backend_name() == "azure"`).
+fn active_kind_is_azure(config: &Config) -> bool {
+    let name = config.effective_backend_name();
+    if config.named_backends.contains_key(name) {
+        return false;
+    }
+    matches!(name.parse::<BackendKind>(), Ok(BackendKind::Azure))
+}
+
+/// Resolve the vault for the degenerate workspace-of-one, mirroring
+/// `Config::resolve_vault_name(None)` (src/config/settings.rs) then the
+/// Azure-hard-error / local-fallback rule of `resolve_vault_for_trait`
+/// (src/cli/helpers.rs).
+///
+/// The resolution chain is replicated here (rather than calling
+/// `Config::resolve_vault_name`) so it uses the injected `cwd` and
+/// `context_manager` — the same parameterization that keeps
+/// [`resolve_workspace_from`] hermetic under `cargo test`. The one behavioral
+/// difference from `resolve_vault_name` is that the cross-boundary `.xv.toml`
+/// notice (a stderr line) is not re-emitted here, since the workspace-overlay
+/// pass above already inspected the same project config.
+async fn degenerate_default_vault(
+    config: &Config,
+    cwd: Option<&std::path::Path>,
+    context_manager: &crate::config::ContextManager,
+) -> Result<String> {
+    let resolved: Result<String> = async {
+        // 1. Project `.xv.toml` env-profile vault (walk up from cwd).
+        if let Some(cwd) = cwd {
+            if let Ok(Some((_path, proj_cfg))) =
+                crate::config::project::find_project_config(cwd).await
+            {
+                if let Some((_name, profile)) =
+                    crate::config::project::resolve_env(&proj_cfg, config.env_flag.as_deref())?
+                {
+                    if let Some(v) = profile.vault.as_deref() {
+                        return Ok(v.to_string());
+                    }
+                }
+            }
+        }
+
+        // 2. Context current vault.
+        if let Some(v) = context_manager.current_vault() {
+            return Ok(v.to_string());
+        }
+
+        // 3. Config default vault.
+        if !config.default_vault.is_empty() {
+            return Ok(config.default_vault.clone());
+        }
+
+        Err(CrosstacheError::config(
+            "No vault specified. Use --vault, set context with 'xv context use', or configure default_vault",
+        ))
+    }
+    .await;
+
+    match resolved {
+        Ok(name) => Ok(name),
+        // Azure keeps the legacy hard-error: no implicit fallback.
+        Err(e) if active_kind_is_azure(config) => Err(e),
+        // Local / future offline backends fall back to their configured
+        // default vault, then the literal `"default"`.
+        Err(_) => {
+            if let Some(ref local) = config.local {
+                if let Some(ref v) = local.default_vault {
+                    return Ok(v.clone());
+                }
+            }
+            Ok("default".to_string())
+        }
+    }
 }
 
 #[cfg(test)]
@@ -491,15 +695,143 @@ mod tests {
         assert!(err.to_string().contains("no-such-alias"), "{err}");
     }
 
+    /// A local backend with a configured default vault and NO cx/`.xv.toml`
+    /// workspace resolves to the degenerate workspace-of-one — never `None`.
     #[tokio::test]
-    async fn resolve_none_when_no_workspace_anywhere() {
+    async fn resolve_degenerate_for_local_only() {
+        use crate::config::settings::LocalConfig;
+
         let temp = tempfile::tempdir().unwrap();
-        let config = Config::default();
+        let config = Config {
+            backend: Some("local".to_string()),
+            local: Some(LocalConfig {
+                store_path: None,
+                key_file: None,
+                default_vault: Some("mystore".to_string()),
+                encrypt_metadata: None,
+                opaque_filenames: None,
+            }),
+            ..Default::default()
+        };
         let context_manager = crate::config::ContextManager::default();
+
         let resolved = resolve_workspace_from(&config, Some(temp.path()), &context_manager)
             .await
-            .expect("must not error");
-        assert!(resolved.is_none());
+            .expect("must not error")
+            .expect("degenerate workspace-of-one must be synthesized, never None");
+
+        assert_eq!(resolved.source, WorkspaceSource::Degenerate);
+        assert!(!resolved.is_configured());
+        assert_eq!(resolved.entries.len(), 1);
+        let entry = resolved.default_entry().unwrap();
+        assert!(entry.default);
+        assert_eq!(entry.vault, "mystore");
+        // Cache-key identity: the degenerate entry's backend MUST equal
+        // `config.effective_backend_name()` so writes invalidate the exact
+        // cache entry the no-workspace read path keys on.
+        assert_eq!(entry.backend, config.effective_backend_name());
+        assert_eq!(entry.backend, "local");
+        // Vault name is charset-valid and not a backend name, so it's used
+        // verbatim as the alias.
+        assert_eq!(entry.alias, "mystore");
+    }
+
+    /// A local backend with no vault configured anywhere falls back through
+    /// `local.default_vault` → `"default"` (never an error, never `None`).
+    #[tokio::test]
+    async fn resolve_degenerate_local_falls_back_to_default_literal() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = Config {
+            backend: Some("local".to_string()),
+            ..Default::default()
+        };
+        let context_manager = crate::config::ContextManager::default();
+
+        let resolved = resolve_workspace_from(&config, Some(temp.path()), &context_manager)
+            .await
+            .expect("must not error")
+            .expect("degenerate workspace-of-one must be synthesized, never None");
+
+        assert_eq!(resolved.source, WorkspaceSource::Degenerate);
+        assert_eq!(resolved.default_entry().unwrap().vault, "default");
+    }
+
+    /// `resolve_workspace` never yields `Ok(None)`: an active Azure backend
+    /// with no vault configured surfaces the no-vault hard-error as `Err`,
+    /// not a silent `"default"` vault — preserving the legacy Azure UX.
+    #[tokio::test]
+    async fn resolve_degenerate_azure_no_vault_errors() {
+        let temp = tempfile::tempdir().unwrap();
+        // `backend: None` ⇒ effective backend is "azure" (the default).
+        let config = Config::default();
+        let context_manager = crate::config::ContextManager::default();
+
+        let err = resolve_workspace_from(&config, Some(temp.path()), &context_manager)
+            .await
+            .expect_err("Azure + no vault must be an Err, not Ok(None) or a 'default' vault");
+        assert!(err.to_string().contains("No vault specified"), "{err}");
+    }
+
+    /// `is_configured()` distinguishes the degenerate workspace from a real
+    /// context/project one.
+    #[tokio::test]
+    async fn is_configured_true_for_context_false_for_degenerate() {
+        // Degenerate.
+        let temp = tempfile::tempdir().unwrap();
+        let config = Config {
+            backend: Some("local".to_string()),
+            ..Default::default()
+        };
+        let degenerate =
+            resolve_workspace_from(&config, Some(temp.path()), &crate::config::ContextManager::default())
+                .await
+                .unwrap()
+                .unwrap();
+        assert!(!degenerate.is_configured());
+
+        // Context.
+        let context_manager = crate::config::ContextManager {
+            workspace: Some(WorkspaceState {
+                entries: vec![WorkspaceEntryConfig {
+                    vault: "context-vault".to_string(),
+                    backend: Some("local".to_string()),
+                    alias: Some("ctx".to_string()),
+                    default: true,
+                }],
+            }),
+            ..Default::default()
+        };
+        let context_ws = resolve_workspace_from(&config, Some(temp.path()), &context_manager)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(context_ws.source, WorkspaceSource::Context);
+        assert!(context_ws.is_configured());
+    }
+
+    /// The degenerate alias avoids colliding with a registry backend name,
+    /// which would otherwise fail `Workspace::validate` and break the
+    /// never-`None` invariant. Here the resolved vault is literally `"local"`
+    /// (a backend name), so a synthetic non-colliding alias is chosen.
+    #[tokio::test]
+    async fn resolve_degenerate_alias_avoids_backend_name_collision() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = Config {
+            backend: Some("local".to_string()),
+            default_vault: "local".to_string(),
+            ..Default::default()
+        };
+        let context_manager = crate::config::ContextManager::default();
+
+        let resolved = resolve_workspace_from(&config, Some(temp.path()), &context_manager)
+            .await
+            .expect("must not error")
+            .expect("must synthesize a valid degenerate workspace despite the vault name colliding");
+
+        let entry = resolved.default_entry().unwrap();
+        assert_eq!(entry.vault, "local");
+        assert_ne!(entry.alias, "local", "alias must not collide with a backend name");
+        assert_eq!(entry.alias, "default");
     }
 
     #[tokio::test]

--- a/src/workspace/resolve.rs
+++ b/src/workspace/resolve.rs
@@ -72,6 +72,22 @@ pub async fn resolve_secret_target(
     registry: &BackendRegistry,
     mode: TargetMode,
 ) -> Result<(TargetVault, String)> {
+    // Degenerate workspace-of-one: no user-configured aliases exist, so a name
+    // is ALWAYS a literal secret name — colon-address parsing must not apply.
+    // This keeps bare `xv get`/`set` byte-identical to pre-workspace
+    // resolution (a `:`-containing name is stored/read verbatim, no
+    // alias-qualifier split; guarded by
+    // `tests/e2e_workspaces.rs::no_workspace_byte_identical`). Resolve the raw
+    // name against the sole default entry directly — no `parse_address`, and
+    // no Read-mode search (there is only one vault to look in), so the resolved
+    // (backend, vault, path) and the call pattern match the old no-workspace
+    // path exactly. `mode` is irrelevant here for the same reason.
+    if !ws.is_configured() {
+        let entry = ws.default_entry()?.clone();
+        let backend = materialize(registry, &entry)?;
+        return Ok((TargetVault { backend, entry }, raw.to_string()));
+    }
+
     let addr = parse_address(raw);
 
     match mode {

--- a/tests/e2e_degenerate_workspace.rs
+++ b/tests/e2e_degenerate_workspace.rs
@@ -1,0 +1,256 @@
+//! Phase 1 (B6) convergence tests: the **degenerate workspace-of-one** — a
+//! bare `xv` invocation with no `cx`/`.xv.toml` workspace configured — must
+//! behave byte-identically to pre-workspace single-vault usage now that every
+//! command resolves through the single (collapsed) workspace seam.
+//!
+//! Overlap note (deliberately NOT duplicated here):
+//! - Exact byte-identity of bare/colon `set`/`get` stdout+stderr is pinned by
+//!   `tests/e2e_workspaces.rs::no_workspace_byte_identical` (golden output).
+//! - Union `ls`/`find` for CONFIGURED multi-vault workspaces (the branch a
+//!   degenerate workspace must NOT take) is covered throughout
+//!   `tests/e2e_workspaces.rs`.
+//! - `run`/`inject` alias resolution WITH a configured workspace is covered by
+//!   `e2e_workspaces.rs::inject_alias_uri_resolves` /
+//!   `inject_raw_vault_name_still_works_when_no_alias_matches`.
+//!
+//! These tests fill the degenerate-specific gaps: `context use` bootstrap with
+//! no workspace (guarding the `config_ops.rs` presence-gate regression),
+//! single-vault `ls` output SHAPE, and no-workspace `xv://` URI resolution
+//! through the collapsed seam.
+
+mod common;
+
+use common::{xv, xv_isolated, xv_isolated_local};
+use std::path::Path;
+use std::process::Command;
+
+/// Build a fresh isolated `xv` command against the SAME local-backend env that
+/// [`xv_isolated_local`] set up (its `xv.conf` already lives under
+/// `temp/.config/xv/`). Mirrors that helper's env exactly so repeated commands
+/// (`set` then `get` then `ls`) hit the same hermetic store.
+fn local_cmd(temp: &Path) -> Command {
+    let mut c = xv();
+    c.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", temp)
+        .env("XDG_CONFIG_HOME", temp.join(".config"))
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "local")
+        .env("NO_COLOR", "1")
+        .current_dir(temp);
+    c
+}
+
+fn run_ok(temp: &Path, args: &[&str]) -> std::process::Output {
+    let out = local_cmd(temp).args(args).output().expect("spawn xv");
+    assert!(
+        out.status.success(),
+        "xv {args:?} must succeed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    out
+}
+
+fn stdout_of(out: &std::process::Output) -> String {
+    String::from_utf8(out.stdout.clone()).expect("stdout utf-8")
+}
+
+// ---------------------------------------------------------------------------
+// 1. `context use` bootstrap with no configured workspace
+// ---------------------------------------------------------------------------
+
+/// Regression guard for the `config_ops.rs` `context use` presence gate. Mid
+/// branch this gate resolved the degenerate workspace and (via the naive
+/// `is_some()` form) tripped "a multi-vault workspace is attached", so
+/// `xv context use <vault>` errored in an env that had no workspace at all —
+/// you could not set your first vault. The gate now consults
+/// `resolve_configured_workspace` (which is `None` here), so it must succeed.
+#[test]
+fn context_use_with_no_configured_workspace_succeeds_local() {
+    let (_seed, temp) = xv_isolated_local();
+    let out = local_cmd(temp.path())
+        .args(["context", "use", "myvault"])
+        .output()
+        .expect("spawn xv");
+    assert!(
+        out.status.success(),
+        "`context use` in a fresh no-workspace env must succeed:\nstdout: {}\nstderr: {}",
+        stdout_of(&out),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+/// The harder variant of the same regression: an ACTIVE Azure backend with no
+/// vault configured. The degenerate builder raises the Azure no-vault
+/// hard-error, so if the presence gate went through the converged
+/// `resolve_workspace` it would propagate that error and fail `context use`
+/// before the vault is ever set. `resolve_configured_workspace` does not build
+/// the degenerate, so this must succeed without ever touching the network
+/// (`context use` only writes the local context store).
+#[test]
+fn context_use_with_no_workspace_azure_no_vault_succeeds() {
+    let (mut cmd, _temp) = xv_isolated();
+    let out = cmd
+        .args(["context", "use", "some-azure-vault"])
+        .output()
+        .expect("spawn xv");
+    assert!(
+        out.status.success(),
+        "`context use` on an unconfigured Azure env (no vault) must succeed \
+         (the degenerate no-vault hard-error must NOT reach this presence gate):\n\
+         stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Single-vault degenerate `ls` output shape parity
+// ---------------------------------------------------------------------------
+
+/// A degenerate `ls` must render in the pre-workspace single-vault shape — a
+/// FLAT array under `--format json` (not the per-vault grouping a configured
+/// multi-vault union `ls` produces) — and list the secret at exit 0. This is
+/// the observable half of the "single-entry degenerate `ls` matches
+/// no-workspace `ls`" acceptance (the cache-key-identity half is unit-tested in
+/// `src/workspace/mod.rs`).
+#[test]
+fn degenerate_ls_is_flat_single_vault_shape() {
+    let (_seed, temp) = xv_isolated_local();
+    run_ok(temp.path(), &["set", "ALPHA", "--value", "v1"]);
+    run_ok(temp.path(), &["set", "BETA", "--value", "v2"]);
+
+    // JSON: a flat array of secret objects, exactly like the pre-workspace
+    // no-workspace read path (cf. `e2e_local_backend.rs::list_json_format`).
+    let json_out = run_ok(temp.path(), &["ls", "--format", "json"]);
+    let json = stdout_of(&json_out);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json).expect("degenerate `ls --format json` must be valid JSON");
+    assert!(
+        parsed.is_array(),
+        "degenerate `ls --format json` must be a FLAT array (single-vault shape), \
+         not a per-vault grouped object: {json}"
+    );
+    assert!(json.contains("ALPHA") && json.contains("BETA"), "{json}");
+
+    // names-only: a plain newline list of bare names — no `alias/name`
+    // qualification that the multi-vault union view prefixes rows with.
+    let names_out = run_ok(temp.path(), &["ls", "--names-only"]);
+    let names = stdout_of(&names_out);
+    assert!(
+        names.lines().any(|l| l.trim() == "ALPHA"),
+        "names-only must list the bare name `ALPHA` (no alias prefix): {names}"
+    );
+    assert!(
+        !names.contains('/'),
+        "degenerate names-only must not qualify names with an `alias/` prefix: {names}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. No-workspace `xv://` URI resolution (run + inject) parity
+// ---------------------------------------------------------------------------
+
+/// `xv inject` of a bare `xv://<vault>/<name>` URI with no workspace attached
+/// must resolve byte-identically to pre-workspace behaviour: post-collapse
+/// `resolve_workspace_and_registry` returns `(None, None)` for the degenerate
+/// case, so the URI falls straight through to the raw-vault-name resolver.
+#[test]
+fn no_workspace_inject_resolves_bare_xv_uri() {
+    let (_seed, temp) = xv_isolated_local();
+    run_ok(temp.path(), &["set", "TOKEN", "--value", "sekret"]);
+
+    let template_path = temp.path().join("tpl.txt");
+    std::fs::write(&template_path, "value: xv://default/TOKEN\n").expect("write template");
+    let out_path = temp.path().join("out.txt");
+    run_ok(
+        temp.path(),
+        &[
+            "inject",
+            "--template",
+            template_path.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ],
+    );
+    let rendered = std::fs::read_to_string(&out_path).expect("read rendered output");
+    assert!(
+        rendered.contains("sekret"),
+        "no-workspace `xv://default/TOKEN` must resolve to the secret value: {rendered}"
+    );
+}
+
+/// `xv run` resolving an inherited `xv://` reference (parent-env var +
+/// `--inherit-env`, mirroring `e2e_local_backend.rs::run_aborts_on_failing_uri_reference`
+/// but with an EXISTING secret) must succeed and hand the child the resolved
+/// value — proving the no-workspace run path stays byte-identical through the
+/// collapsed seam.
+#[test]
+fn no_workspace_run_resolves_inherited_xv_uri() {
+    let (_seed, temp) = xv_isolated_local();
+    run_ok(temp.path(), &["set", "RUNSECRET", "--value", "runval"]);
+
+    let marker = temp.path().join("child_saw.txt");
+    let out = local_cmd(temp.path())
+        .env("REF_VAR", "xv://default/RUNSECRET")
+        .args([
+            "run",
+            "--inherit-env",
+            "--",
+            "sh",
+            "-c",
+            &format!("printf '%s' \"$REF_VAR\" > '{}'", marker.display()),
+        ])
+        .output()
+        .expect("spawn xv run");
+    assert!(
+        out.status.success(),
+        "`run` must resolve xv://default/RUNSECRET with no workspace:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let child_saw = std::fs::read_to_string(&marker).expect("child marker");
+    assert_eq!(
+        child_saw, "runval",
+        "child process must see the resolved secret value in place of the xv:// reference"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Bare set/get round-trip incl. colon-literal (degenerate has no aliases)
+// ---------------------------------------------------------------------------
+
+/// Degenerate `set`/`get` round-trips a bare name AND a `:`-containing name.
+/// A workspace-of-one has no user aliases, so a colon is part of the LITERAL
+/// secret name (never an `alias:path` qualifier) — the behaviour the
+/// literal-degenerate branch in `resolve_secret_target` restores. Exact golden
+/// stdout/stderr for this is pinned separately by
+/// `e2e_workspaces.rs::no_workspace_byte_identical`; here we assert the
+/// end-to-end round-trip via the shared local helper.
+#[test]
+fn degenerate_bare_and_colon_literal_roundtrip() {
+    let (_seed, temp) = xv_isolated_local();
+
+    run_ok(temp.path(), &["set", "FOO", "--value", "bar"]);
+    let got = run_ok(temp.path(), &["get", "FOO", "--raw"]);
+    assert_eq!(stdout_of(&got), "bar");
+
+    run_ok(temp.path(), &["set", "lit:with:colons", "--value", "v1"]);
+    let got_colon = run_ok(temp.path(), &["get", "lit:with:colons", "--raw"]);
+    assert_eq!(
+        stdout_of(&got_colon),
+        "v1",
+        "a `:`-containing name must be stored and read as a LITERAL name under the \
+         degenerate workspace-of-one (no alias split)"
+    );
+
+    // And it is genuinely one literal secret, not two vaults' worth of split
+    // addressing: both names show up as plain rows in a flat `ls`.
+    let names = stdout_of(&run_ok(temp.path(), &["ls", "--names-only"]));
+    assert!(names.lines().any(|l| l.trim() == "FOO"), "{names}");
+    assert!(
+        names.lines().any(|l| l.trim() == "lit:with:colons"),
+        "colon name must appear verbatim as a single literal secret: {names}"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 1 of the multi-backend workspace convergence roadmap: every secret-resolution call now flows through the **single workspace seam** (`resolve_workspace` → `resolve_secret_target`). Bare/no-workspace usage resolves as a **degenerate workspace-of-one** (`WorkspaceSource::Degenerate`) instead of a separate legacy code path, making the dual-path bug class (cache-key divergence, wrong-backend capability gates) unrepresentable for secret resolution.

Design + ADRs: `docs/superpowers/specs/2026-07-05-multi-backend-workspace-convergence-design.md` (ADR-1: convergence over dual-path hardening; ADR-2: full legacy-manager retirement over partial — Phase 2). Roadmap: new "Multi-backend workspace convergence" section in `ROADMAP.md` sequencing Phases 1–3.

## Key changes

- **`WorkspaceSource::Degenerate` + `Workspace::is_configured()`** — a synthesized workspace-of-one is distinguishable from a user-configured workspace; `resolve_workspace` never returns `None` (Some or Err, preserving the Azure no-vault hard error).
- **Resolver split** — presence-gates (`context use`, union `ls`/`find` branch selection, `mv`/`copy`, TUI) and `run`/`inject` alias resolution consult `resolve_configured_workspace`, so the degenerate builder's errors can never leak into bootstrap or arg-validation flows (`xv context use` works before any vault is configured; `xv find x --in bogus` still exits 2).
- **Seam collapse** — the legacy `reg.active_arc()` fallback in `resolve_workspace_or_default` is deleted; grep-provable single path.
- **Byte-identity** — literal-degenerate resolution: bare and colon-containing secret names (`lit:with:colons`) resolve exactly as pre-workspace; `xv://` URI resolution in `run`/`inject` unchanged; cache keys identical (`entry.backend == effective_backend_name()`).
- **`ls --deleted` improvement** — the soft-delete capability gate now evaluates the *resolved* backend, not the globally active one.
- **Survivor allowlist** — all 56 remaining legacy call sites annotated `// Phase 2` / `// Phase 3` per the design doc's allowlist (Phase 2 = manager retirement, Phase 3 = file-ops routing; both planned, not executed here).

## Verification

- Done-bar greps (4/4): seam collapsed, `resolve_workspace` never-`None`, no bare `is_some()` presence-gates, every survivor annotated
- Full suite: **2080 passed / 0 failed** (deterministic single-threaded run); `cargo clippy --all-targets` clean
- 6 new e2e tests (`tests/e2e_degenerate_workspace.rs`): context-use bootstrap (local + Azure-no-vault), flat single-vault `ls` shape, no-workspace `run`/`inject` `xv://` URI parity, bare + colon-literal round-trip
- Architect review: APPROVED (consensus-planned via Planner/Architect/Critic; both review findings applied)

## Compatibility

Pre-1.0 break-what-needs-breaking license applied; net result: **no intended user-visible breaks** except one cosmetic exception (the `.xv.toml` cross-boundary stderr notice is no longer re-emitted during bare secret resolution) — documented in `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core vault/backend resolution path for most secret commands; behavior is intended to stay byte-identical except `ls --deleted` capability messaging and a cosmetic `.xv.toml` stderr notice.
> 
> **Overview**
> **Phase 1** routes all secret resolution through one workspace seam (`resolve_workspace` → `resolve_secret_target`). When no `cx`/`.xv.toml` workspace exists, the CLI synthesizes a **degenerate workspace-of-one** (`WorkspaceSource::Degenerate`) instead of the old `resolve_workspace_or_default` branch that used `registry.active_arc()` and `resolve_vault_for_trait`.
> 
> New **`Workspace::is_configured()`** and **`resolve_configured_workspace`** keep “real workspace attached?” separate from the converged resolver. Union `ls`/`find`, `mv`/`copy`, TUI, `cx ls`, and the `context use` gate use the configured-only API so bootstrap (`context use` with no vault) and no-workspace `run`/`inject` `xv://` behavior stay unchanged.
> 
> **`resolve_workspace_or_default`** always builds a scoped registry and calls `resolve_secret_target`; the legacy no-workspace `else` is removed. Degenerate targets treat secret names literally (no `alias:` split). **`xv ls --deleted`** gates soft-delete on the **resolved** backend/vault, not `reg.active()`.
> 
> Docs: design spec + ADRs, `CHANGELOG` Unreleased, `ROADMAP` Phases 1–3. Remaining legacy `resolve_vault_name`/manager call sites are annotated `// Phase 2` / `// Phase 3`. New **`tests/e2e_degenerate_workspace.rs`** and workspace unit tests cover degenerate synthesis and parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2cba3a0260ccf54469beac4b7122f77b2f227e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->