### PR TITLE
chore: bump version to 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.21.0 — Multi-backend workspace convergence (2026-07-05)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.20.1"
+version = "0.21.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Version bump for the v0.21.0 release: multi-backend workspace convergence (Phases 1–3, PRs #345/#346/#347).

- Cargo.toml 0.20.1 → 0.21.0 (+ Cargo.lock)
- CHANGELOG.md: Unreleased → "v0.21.0 — Multi-backend workspace convergence (2026-07-05)"

Tag v0.21.0 will be pushed after this merges (per .omc/RELEASE_RULE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and changelog header change with no application code modifications.
> 
> **Overview**
> Prepares the **v0.21.0** release by bumping the crate version from `0.20.1` to `0.21.0` in `Cargo.toml` and refreshing `Cargo.lock`.
> 
> The changelog header is retitled from **Unreleased** to **v0.21.0 — Multi-backend workspace convergence (2026-07-05)**; the substantive release notes were already under that section and are not edited in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1ac1104642c016fe0b4a79c991a68acea59d5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->