### PR TITLE
feat: vault alias ergonomics — --alias spelling, ls -l vault names, cx alias verb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **`--alias` spelling for `cx add`.** `xv cx add <vault> --alias <name>` now
+  works as a visible alias of the existing `--as` flag, matching the spelling
+  most users reach for first. Both spellings are equivalent.
+- **`xv cx alias <entry> <new-alias>` to re-alias an attached entry.** Rename
+  the alias on any attached vault — including the default entry — addressing it
+  by its current alias or its vault name (ambiguous vault names across backends
+  error and list the candidates). `xv cx alias <entry> --reset` restores the
+  vault name. Renames reuse the same validation as `cx add` (charset,
+  uniqueness, no collision with a backend name); a `.xv.toml`-defined workspace
+  is refused with a pointer to the file, matching `cx add`/`rm`/`default`.
+
+### Changed
+
+- **`xv ls -l` shows the real vault name behind an alias.** In a multi-vault
+  workspace, the long listing now appends the backing vault name to each row
+  whose alias differs from it — e.g. `kv/SECRET (kv-scottzionic)` — so `-l`
+  identifies the actual vault even when the alias was renamed. Rows whose
+  alias equals the vault name are unchanged, and the default grid view, the
+  `--format table` Vault column, and single-vault/no-workspace `ls -l` output
+  are all byte-identical to before.
+
 ## v0.21.0 — Multi-backend workspace convergence (2026-07-05)
 
 ### Changed

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1509,7 +1509,7 @@ pub enum ContextCommands {
         #[arg(long)]
         backend: Option<String>,
         /// Alias for this entry (defaults to the vault name)
-        #[arg(long = "as")]
+        #[arg(long = "as", visible_alias = "alias")]
         r#as: Option<String>,
         /// Make this the workspace's default (write target) vault
         #[arg(long)]
@@ -1533,6 +1533,19 @@ pub enum ContextCommands {
     Default {
         /// Alias to make the new default
         alias: String,
+        /// Operate on the local (per-directory) context instead of global
+        #[arg(long)]
+        local: bool,
+    },
+    /// Rename (or reset) the alias on an attached entry
+    Alias {
+        /// Entry to re-alias: its current alias, or its vault name
+        entry: String,
+        /// The new alias (omit when using --reset)
+        new_alias: Option<String>,
+        /// Reset the alias back to the entry's vault name
+        #[arg(long)]
+        reset: bool,
         /// Operate on the local (per-directory) context instead of global
         #[arg(long)]
         local: bool,

--- a/src/cli/config_ops.rs
+++ b/src/cli/config_ops.rs
@@ -988,6 +988,14 @@ pub(crate) async fn execute_context_command(
         ContextCommands::Default { alias, local } => {
             execute_cx_default(&alias, local, &config).await?;
         }
+        ContextCommands::Alias {
+            entry,
+            new_alias,
+            reset,
+            local,
+        } => {
+            execute_cx_alias(&entry, new_alias, reset, local, &config).await?;
+        }
         ContextCommands::Ls => {
             execute_cx_ls(&config).await?;
         }
@@ -1741,6 +1749,137 @@ async fn execute_cx_default(alias: &str, local: bool, config: &Config) -> Result
     context_manager.workspace = Some(ws_state);
     context_manager.save().await?;
     output::success(&format!("'{alias}' is now the workspace default"));
+    Ok(())
+}
+
+/// Locate the entry to re-alias: an exact alias match first (aliases are
+/// unique), then a vault-name match. A vault name can match several attached
+/// entries (same vault name on different backends), which is ambiguous — list
+/// the candidates and ask the user to disambiguate by alias.
+fn resolve_alias_target_index(
+    entries: &[crate::workspace::WorkspaceEntryConfig],
+    entry: &str,
+) -> Result<usize> {
+    if let Some(i) = entries.iter().position(|e| e.resolved_alias() == entry) {
+        return Ok(i);
+    }
+    let matches: Vec<usize> = entries
+        .iter()
+        .enumerate()
+        .filter(|(_, e)| e.vault == entry)
+        .map(|(i, _)| i)
+        .collect();
+    match matches.as_slice() {
+        [i] => Ok(*i),
+        [] => {
+            let attached: Vec<String> = entries.iter().map(|e| e.resolved_alias()).collect();
+            Err(CrosstacheError::invalid_argument(format!(
+                "unknown workspace entry '{entry}'; attached aliases: {}",
+                attached.join(", ")
+            )))
+        }
+        _ => {
+            let candidates: Vec<String> = matches
+                .iter()
+                .map(|&i| {
+                    let e = &entries[i];
+                    format!(
+                        "alias '{}' (backend '{}')",
+                        e.resolved_alias(),
+                        e.backend.clone().unwrap_or_else(|| "active".to_string())
+                    )
+                })
+                .collect();
+            Err(CrosstacheError::invalid_argument(format!(
+                "vault name '{entry}' matches multiple attached entries; disambiguate by alias: {}",
+                candidates.join(", ")
+            )))
+        }
+    }
+}
+
+/// `xv cx alias <entry> <new-alias>` / `xv cx alias <entry> --reset`.
+/// Renames the alias on an attached entry (looked up by its current alias or
+/// its vault name), or resets it back to the vault name. Reuses the same
+/// validation as `cx add` (charset, uniqueness, backend-name collision).
+async fn execute_cx_alias(
+    entry: &str,
+    new_alias: Option<String>,
+    reset: bool,
+    local: bool,
+    config: &Config,
+) -> Result<()> {
+    guard_against_project_vaults_overlay(config).await?;
+
+    if reset && new_alias.is_some() {
+        return Err(CrosstacheError::invalid_argument(
+            "pass either a new alias or --reset, not both",
+        ));
+    }
+    if !reset && new_alias.is_none() {
+        return Err(CrosstacheError::invalid_argument(
+            "provide a new alias, or use --reset to restore the vault name",
+        ));
+    }
+
+    let mut context_manager = load_cx_context(local).await?;
+    let mut ws_state = context_manager.workspace.clone().unwrap_or_default();
+
+    if ws_state.entries.is_empty() {
+        return Err(CrosstacheError::config("no workspace is attached"));
+    }
+
+    let idx = resolve_alias_target_index(&ws_state.entries, entry)?;
+    let target_vault = ws_state.entries[idx].vault.clone();
+    let old = ws_state.entries[idx].resolved_alias();
+    // --reset restores the vault name; aliases default to the vault name, so a
+    // "reset" is just clearing the explicit alias.
+    let new = if reset {
+        target_vault.clone()
+    } else {
+        new_alias.unwrap_or_default()
+    };
+
+    if old == new {
+        output::success(&format!(
+            "alias for '{entry}' is already '{new}'; nothing to change"
+        ));
+        return Ok(());
+    }
+
+    // Store the alias explicitly, except when it equals the vault name (drop to
+    // None so `resolved_alias()` derives it) — keeping the persisted shape
+    // identical to `cx add`'s default-alias case.
+    ws_state.entries[idx].alias = if new == target_vault {
+        None
+    } else {
+        Some(new.clone())
+    };
+
+    // Validate the mutated workspace (charset, duplicate alias, backend-name
+    // collision, exactly-one-default) via the same path `cx add` uses; the new
+    // alias — or the vault name on --reset — must pass unchanged, no fallback.
+    let active_backend = config.effective_backend_name().to_string();
+    let mut backend_names: Vec<String> = crate::workspace::BUILTIN_BACKEND_NAMES
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    for k in config.named_backends.keys() {
+        if !backend_names.iter().any(|n| n == k) {
+            backend_names.push(k.clone());
+        }
+    }
+    let backend_name_refs: Vec<&str> = backend_names.iter().map(|s| s.as_str()).collect();
+    crate::workspace::build_workspace(
+        &ws_state.entries,
+        &active_backend,
+        crate::workspace::WorkspaceSource::Context,
+        &backend_name_refs,
+    )?;
+
+    context_manager.workspace = Some(ws_state);
+    context_manager.save().await?;
+    output::success(&format!("renamed alias '{old}' to '{new}'"));
     Ok(())
 }
 
@@ -2567,5 +2706,70 @@ mod tests {
         // happens at the call site in execute_config_edit.
         let got = resolve_editor_from(Some("code --wait".into()), None);
         assert_eq!(got, "code --wait");
+    }
+
+    mod resolve_alias_target {
+        use super::super::resolve_alias_target_index;
+        use crate::workspace::WorkspaceEntryConfig;
+
+        fn entry(
+            vault: &str,
+            backend: &str,
+            alias: Option<&str>,
+            default: bool,
+        ) -> WorkspaceEntryConfig {
+            WorkspaceEntryConfig {
+                vault: vault.to_string(),
+                backend: Some(backend.to_string()),
+                alias: alias.map(str::to_string),
+                default,
+            }
+        }
+
+        #[test]
+        fn matches_by_alias_first() {
+            let entries = vec![
+                entry("vault-a", "local", Some("a"), true),
+                entry("vault-b", "local", Some("b"), false),
+            ];
+            assert_eq!(resolve_alias_target_index(&entries, "b").unwrap(), 1);
+        }
+
+        #[test]
+        fn falls_back_to_a_unique_vault_name() {
+            let entries = vec![
+                entry("kv-scottzionic", "local", Some("kv"), true),
+                entry("other", "local", None, false),
+            ];
+            // Addressed by vault name, not alias.
+            assert_eq!(
+                resolve_alias_target_index(&entries, "kv-scottzionic").unwrap(),
+                0
+            );
+        }
+
+        #[test]
+        fn ambiguous_vault_name_across_backends_lists_candidates() {
+            // Same vault name attached on two backends: the vault name alone is
+            // ambiguous, so it must error and name the aliases to disambiguate.
+            let entries = vec![
+                entry("shared", "local", Some("a"), true),
+                entry("shared", "aws", Some("b"), false),
+            ];
+            let err = resolve_alias_target_index(&entries, "shared").unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("matches multiple attached entries"), "{msg}");
+            assert!(
+                msg.contains("alias 'a'") && msg.contains("alias 'b'"),
+                "{msg}"
+            );
+        }
+
+        #[test]
+        fn unknown_entry_lists_attached_aliases() {
+            let entries = vec![entry("vault-a", "local", Some("a"), true)];
+            let err = resolve_alias_target_index(&entries, "nope").unwrap_err();
+            assert!(err.to_string().contains("unknown workspace entry"), "{err}");
+        }
     }
 }

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -1187,10 +1187,20 @@ const SECRET_LIST_NOTE_WRAP_WIDTH: usize = 40;
 /// existing folder-scoping/sort/render helper unchanged.
 const WORKSPACE_ALIAS_TAG: &str = "__xv_workspace_alias";
 
+/// Companion to [`WORKSPACE_ALIAS_TAG`] carrying the entry's real vault name,
+/// so the long (`-l`) view can show the actual vault behind an alias.
+const WORKSPACE_VAULT_TAG: &str = "__xv_workspace_vault";
+
 /// Read back a [`WORKSPACE_ALIAS_TAG`] value stashed by the union `ls` path.
 /// `None` for ordinary (non-workspace or single-vault) listings.
 fn workspace_alias_of(s: &crate::secret::manager::SecretSummary) -> Option<&str> {
     s.tags.get(WORKSPACE_ALIAS_TAG).map(String::as_str)
+}
+
+/// Read back the [`WORKSPACE_VAULT_TAG`] value (the entry's real vault name).
+/// `None` for ordinary (non-workspace or single-vault) listings.
+fn workspace_vault_of(s: &crate::secret::manager::SecretSummary) -> Option<&str> {
+    s.tags.get(WORKSPACE_VAULT_TAG).map(String::as_str)
 }
 
 #[derive(Debug, Clone, serde::Serialize, tabled::Tabled)]
@@ -1778,6 +1788,9 @@ pub(crate) fn display_cached_secret_list(
     // to — union listings instead prefix `alias/` onto the displayed name,
     // mirroring `find`'s existing vault-prefix convention (folder entries
     // are virtual groupings that can span vaults, so they stay unprefixed).
+    // The long (`-l`) view additionally appends the real vault name when it
+    // differs from the alias, so `-l` identifies the backing vault (aliases
+    // can be renamed) without the grid/table views changing.
     let entries: Vec<LsEntry> = if show_vault {
         entries
             .into_iter()
@@ -1785,7 +1798,11 @@ pub(crate) fn display_cached_secret_list(
                 LsEntry::Secret(mut s) => {
                     if let Some(alias) = workspace_alias_of(&s) {
                         let label = ls_view::display_name(&s).to_string();
-                        s.original_name = format!("{alias}/{label}");
+                        let vault_suffix = match workspace_vault_of(&s).filter(|_| long) {
+                            Some(vault) if vault != alias => format!(" ({vault})"),
+                            _ => String::new(),
+                        };
+                        s.original_name = format!("{alias}/{label}{vault_suffix}");
                     }
                     LsEntry::Secret(s)
                 }
@@ -2381,6 +2398,8 @@ async fn execute_secret_list_workspace(
         for s in &mut secrets {
             s.tags
                 .insert(WORKSPACE_ALIAS_TAG.to_string(), entry.alias.clone());
+            s.tags
+                .insert(WORKSPACE_VAULT_TAG.to_string(), entry.vault.clone());
         }
         merged.extend(secrets);
     }

--- a/tests/e2e_vault_alias_ux.rs
+++ b/tests/e2e_vault_alias_ux.rs
@@ -1,0 +1,269 @@
+//! Behavior locks for the vault-alias ergonomics: the `--alias` spelling on
+//! `cx add`, and the long (`-l`) listing surfacing the real vault name behind
+//! an alias. Fully hermetic against the local (age-encrypted file) backend.
+//!
+//! Note on output format: `xv`'s `Auto` format resolves to JSON when stdout is
+//! not a TTY (as under `cargo test`), so these tests pass `--format table`
+//! explicitly to reach the human table / long views.
+
+mod common;
+
+use common::{xv, xv_isolated_local, xv_isolated_local_with_profile};
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn local_cmd(temp: &Path) -> Command {
+    let mut c = xv();
+    c.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", temp)
+        .env("XDG_CONFIG_HOME", temp.join(".config"))
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "local")
+        .env("NO_COLOR", "1")
+        .current_dir(temp);
+    c
+}
+
+fn run(temp: &Path, args: &[&str]) -> Output {
+    local_cmd(temp).args(args).output().expect("spawn xv")
+}
+
+/// Run and assert success, returning stdout as a String.
+fn ok(temp: &Path, args: &[&str]) -> String {
+    let out = run(temp, args);
+    assert!(
+        out.status.success(),
+        "expected success for {args:?}\n--stdout--\n{}\n--stderr--\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+// ---------------------------------------------------------------------------
+// 1. `--alias` spelling on `cx add`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cx_add_alias_flag_attaches_with_that_alias() {
+    let (_seed, temp) = xv_isolated_local();
+    let t = temp.path();
+    ok(t, &["vault", "create", "kv-scottzionic"]);
+    // The user reaches for `--alias` (a visible alias of `--as`).
+    ok(t, &["cx", "add", "kv-scottzionic", "--alias", "kv"]);
+
+    let json = ok(t, &["cx", "ls", "--format", "json"]);
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&json).expect("valid json");
+    assert!(
+        rows.iter()
+            .any(|r| r["alias"] == "kv" && r["vault"] == "kv-scottzionic"),
+        "cx ls should show the entry attached under alias 'kv': {json}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Union listing: Vault column keeps the alias; long view adds the vault name
+// ---------------------------------------------------------------------------
+
+/// Attach `kv-scottzionic` as `kv` (alias differs from vault) plus the
+/// auto-attached `default` (alias == vault), and seed one secret in each.
+fn workspace_with_kv(t: &Path) {
+    ok(t, &["vault", "create", "kv-scottzionic"]);
+    ok(t, &["cx", "add", "kv-scottzionic", "--alias", "kv"]);
+    ok(t, &["set", "S_DEF", "--value", "v0"]);
+    ok(t, &["set", "kv:S_KV", "--value", "v1"]);
+}
+
+#[test]
+fn union_table_vault_column_shows_the_alias_not_the_vault_name() {
+    let (_seed, temp) = xv_isolated_local();
+    let t = temp.path();
+    workspace_with_kv(t);
+
+    // Default/table view: the Vault column carries the alias, never the raw
+    // vault name — unchanged by the long-view work.
+    let table = ok(t, &["--format", "table", "ls"]);
+    assert!(
+        table.contains("kv"),
+        "Vault column should show the alias: {table}"
+    );
+    assert!(
+        !table.contains("kv-scottzionic"),
+        "the legacy table shows the alias, not the real vault name: {table}"
+    );
+}
+
+#[test]
+fn long_view_surfaces_the_real_vault_name_when_alias_differs() {
+    let (_seed, temp) = xv_isolated_local();
+    let t = temp.path();
+    workspace_with_kv(t);
+
+    let long = ok(t, &["--format", "table", "ls", "-l"]);
+    // Alias 'kv' differs from vault 'kv-scottzionic' -> the vault name is shown.
+    assert!(
+        long.contains("kv/S_KV (kv-scottzionic)"),
+        "-l must surface the real vault name when it differs from the alias: {long}"
+    );
+    // Alias 'default' equals its vault -> no redundant suffix.
+    assert!(long.contains("default/S_DEF"), "{long}");
+    assert!(
+        !long.contains("default/S_DEF ("),
+        "no vault suffix when alias == vault: {long}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. No-workspace long view is unchanged
+// ---------------------------------------------------------------------------
+
+#[test]
+fn long_view_without_workspace_is_plain() {
+    let (_seed, temp) = xv_isolated_local();
+    let t = temp.path();
+    ok(t, &["set", "AAA", "--value", "1"]);
+    ok(t, &["set", "BBB", "--value", "2"]);
+
+    // Single vault, no workspace: names render plainly — no `alias/` prefix and
+    // no `(vault)` suffix (the union path is skipped entirely).
+    let long = ok(t, &["--format", "table", "ls", "-l"]);
+    assert!(long.contains("AAA") && long.contains("BBB"), "{long}");
+    assert!(
+        !long.contains("/AAA") && !long.contains("/BBB"),
+        "no alias prefix without a workspace: {long}"
+    );
+    assert!(
+        !long.contains('('),
+        "no vault suffix without a workspace: {long}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. `cx alias` — rename / reset the alias on an attached entry
+// ---------------------------------------------------------------------------
+
+/// The aliases currently attached, read from `cx ls --format json`.
+fn cx_aliases(t: &Path) -> Vec<String> {
+    let json = ok(t, &["cx", "ls", "--format", "json"]);
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&json).expect("valid json");
+    rows.iter()
+        .filter_map(|r| r["alias"].as_str().map(String::from))
+        .collect()
+}
+
+fn seed_kv_workspace(t: &Path) {
+    ok(t, &["vault", "create", "kv-scottzionic"]);
+    ok(t, &["cx", "add", "kv-scottzionic", "--alias", "kv"]);
+}
+
+#[test]
+fn cx_alias_renames_non_default_and_default_entries() {
+    let (_seed, temp) = xv_isolated_local();
+    let t = temp.path();
+    seed_kv_workspace(t);
+
+    // Non-default entry: kv -> prod.
+    ok(t, &["cx", "alias", "kv", "prod"]);
+    let a = cx_aliases(t);
+    assert!(
+        a.contains(&"prod".to_string()) && !a.contains(&"kv".to_string()),
+        "{a:?}"
+    );
+
+    // The default entry re-aliases like any other: default -> home.
+    ok(t, &["cx", "alias", "default", "home"]);
+    let a = cx_aliases(t);
+    assert!(
+        a.contains(&"home".to_string()) && a.contains(&"prod".to_string()),
+        "{a:?}"
+    );
+    assert!(!a.contains(&"default".to_string()), "{a:?}");
+}
+
+#[test]
+fn cx_alias_reset_restores_the_vault_name() {
+    let (_seed, temp) = xv_isolated_local();
+    let t = temp.path();
+    seed_kv_workspace(t);
+
+    ok(t, &["cx", "alias", "kv", "--reset"]);
+    let a = cx_aliases(t);
+    assert!(
+        a.contains(&"kv-scottzionic".to_string()) && !a.contains(&"kv".to_string()),
+        "--reset should restore the vault name: {a:?}"
+    );
+}
+
+#[test]
+fn cx_alias_looks_up_the_entry_by_vault_name() {
+    let (_seed, temp) = xv_isolated_local();
+    let t = temp.path();
+    seed_kv_workspace(t);
+
+    // The user thinks in vault names: address the entry by its vault, not alias.
+    ok(t, &["cx", "alias", "kv-scottzionic", "renamed"]);
+    assert!(cx_aliases(t).contains(&"renamed".to_string()));
+}
+
+#[test]
+fn cx_alias_rejects_duplicate_and_backend_name_collisions() {
+    let (_seed, temp) = xv_isolated_local();
+    let t = temp.path();
+    seed_kv_workspace(t);
+
+    // Duplicate: 'default' is already the auto-attached entry's alias.
+    let dup = run(t, &["cx", "alias", "kv", "default"]);
+    assert!(!dup.status.success(), "duplicate alias must be rejected");
+    assert!(
+        String::from_utf8_lossy(&dup.stderr).contains("duplicate workspace alias"),
+        "stderr: {}",
+        String::from_utf8_lossy(&dup.stderr)
+    );
+
+    // Backend-name collision: 'local' is a registry backend name.
+    let col = run(t, &["cx", "alias", "kv", "local"]);
+    assert!(
+        !col.status.success(),
+        "backend-name collision must be rejected"
+    );
+    assert!(
+        String::from_utf8_lossy(&col.stderr).contains("collides with a registry backend name"),
+        "stderr: {}",
+        String::from_utf8_lossy(&col.stderr)
+    );
+
+    // Both rejections left the workspace untouched.
+    assert!(
+        cx_aliases(t).contains(&"kv".to_string()),
+        "alias must be unchanged after rejection"
+    );
+}
+
+#[test]
+fn cx_alias_errors_from_an_xv_toml_workspace() {
+    // A `.xv.toml`-sourced workspace is the explicit source of truth; cx
+    // mutations must refuse and point at the file (cx add/rm/default precedent).
+    let toml = r#"
+default_env = "dev"
+
+[env.dev]
+vaults = [
+  { vault = "projvault", backend = "local", alias = "proj", default = true },
+]
+"#;
+    let (mut cmd, _temp) = xv_isolated_local_with_profile(toml);
+    let out = cmd
+        .args(["cx", "alias", "proj", "renamed"])
+        .output()
+        .expect("spawn xv");
+    assert!(
+        !out.status.success(),
+        "cx alias must refuse a .xv.toml workspace"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(".xv.toml"),
+        "expected the .xv.toml guard error: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Vault alias quality-of-life improvements, per user request: typing fully-qualified vault names is a pain.

- **`--alias` flag spelling:** `xv cx add kv-scottzionic --alias kv` now works as a visible synonym of the existing `--as` (both spellings shown in help).
- **`ls` shows aliases; `ls -l` shows vault names:** the default/table/grid views keep showing the workspace alias in the Vault column (existing behavior); the long view (`ls -l`) now appends the real vault name when it differs from the alias — `kv/SECRET (kv-scottzionic)` — with no suffix when alias == vault. Single-vault/no-workspace output is byte-identical.
- **New `xv cx alias` verb** for managing aliases on attached entries, including the default vault:
  - `xv cx alias <entry> <new-alias>` — rename; `<entry>` accepts the current alias or the vault name (ambiguity across backends errors with candidates); same-value rename is a friendly no-op.
  - `xv cx alias <entry> --reset` — restores the alias to the vault name (aliases default to the vault name, so "remove" = reset).
  - Validation reuses the `cx add` rules (charset, registry-backend-name collision, duplicate alias); `.xv.toml`-sourced workspaces refuse with the file pointer (same as other `cx` mutations); `--local` parity.

## Verification

- 9 new hermetic e2e tests (`tests/e2e_vault_alias_ux.rs`) + 4 unit tests for the entry-lookup helper
- Full suites: **2117/0** (default), **2304/0** (`--features aws`); clippy clean on both; `cargo fmt --check` clean
- Hands-on smoke: attach with `--alias kv` → rename `kv`→`keyv` → `--reset` restores `kv-scottzionic` — all verified against the real binary in an isolated env

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only workspace context and listing display changes; no auth, secret values, or backend protocol changes, with behavior locked by e2e and unit tests.
> 
> **Overview**
> Improves multi-vault workspace alias ergonomics so users can attach and manage short names without typing full vault IDs everywhere.
> 
> **`xv cx add`** now accepts **`--alias`** as a visible synonym of **`--as`** (both spellings are equivalent in help and parsing).
> 
> **New `xv cx alias`** renames or resets aliases on attached entries (including the default vault). Entries are addressed by current alias or vault name; duplicate vault names across backends error with candidate hints. **`--reset`** restores the vault name; validation matches **`cx add`** (charset, uniqueness, backend-name collision). **`.xv.toml`** workspaces refuse mutation with the same guard as other **`cx`** write verbs.
> 
> **Multi-vault `xv ls -l`** appends the real vault name when it differs from the alias (e.g. `kv/SECRET (kv-scottzionic)`), via an in-memory **`__xv_workspace_vault`** tag on union listings. Grid view, table Vault column, and single-vault / no-workspace **`ls -l`** output stay unchanged.
> 
> Changelog updated; hermetic e2e tests in **`tests/e2e_vault_alias_ux.rs`** and unit tests for **`resolve_alias_target_index`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d5cf1a047c4498804173991fa86b203f6f509e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->