### PR TITLE
chore: bump version to 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## v0.22.0 — Vault alias ergonomics (2026-07-06)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Version bump for the v0.22.0 release: vault alias ergonomics (#349) — `--alias` spelling, `ls -l` vault-name display, and the `xv cx alias` rename/reset verb.

- Cargo.toml 0.21.0 → 0.22.0 (+ Cargo.lock)
- CHANGELOG.md: Unreleased → "v0.22.0 — Vault alias ergonomics (2026-07-06)"

Tag v0.22.0 will be pushed after this merges (per .omc/RELEASE_RULE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog edits only; no runtime behavior changes in this PR.
> 
> **Overview**
> Prepares the **v0.22.0** release in version-controlled metadata only—no application or library code changes in this diff.
> 
> **`Cargo.toml`** and the **`crosstache`** entry in **`Cargo.lock`** move from `0.21.0` to **`0.22.0`**. **`CHANGELOG.md`** renames the former **Unreleased** section to **`v0.22.0 — Vault alias ergonomics (2026-07-06)`**; the listed features (`--alias` on `cx add`, `xv cx alias`, `ls -l` vault-name display) stay as already documented under that heading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 694f9a16b360f6895dabfecf5339b0234933ac45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->