### PR TITLE
fix(ci): include ui feature in release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,12 +139,13 @@ jobs:
           echo "MINISIGN_BIN=./minisign-bin/minisign.exe" >> "$GITHUB_ENV"
 
       - name: Build release binary
-        # Distribution binaries ship ALL backends: tui (read-only UI) + aws
-        # (Secrets Manager / CloudTrail / S3). AWS is a feature-gated dep
-        # (~1.5 MB/service) kept off the default `cargo build` for lean
-        # source builds, but release artifacts are batteries-included so a
-        # downloaded `xv` supports `--backend aws` out of the box.
-        run: cargo build --release --features tui,aws --target ${{ matrix.target }}
+        # Distribution binaries ship ALL backends and UIs: tui (read-only
+        # terminal UI) + ui (embedded web UI) + aws (Secrets Manager /
+        # CloudTrail / S3). These are feature-gated deps kept off the
+        # default `cargo build` for lean source builds, but release
+        # artifacts are batteries-included so a downloaded `xv` supports
+        # `--backend aws` and `xv ui` out of the box.
+        run: cargo build --release --features tui,ui,aws --target ${{ matrix.target }}
 
       - name: Create archive (Windows)
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
The v0.23.0 release built with `--features tui,aws`, so the published binaries lack `xv ui` — the release's headline feature. Adds `ui` to the release feature set. After merge, the v0.23.0 tag and release will be recreated so the artifacts actually contain the web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to release build flags; no runtime or auth logic touched.
> 
> **Overview**
> **Fixes release artifacts missing the embedded web UI.** The v0.23.0 pipeline built with `--features tui,aws`, so downloaded `xv` binaries did not include the `ui` feature (gated on `axum` in `Cargo.toml`).
> 
> The **Build release binary** step in `.github/workflows/release.yml` now runs `cargo build --release --features tui,ui,aws` for all matrix targets. Comments were updated to document that distribution builds are batteries-included for `xv ui` as well as TUI and AWS backends.
> 
> No application code changes—only CI packaging. After merge, the v0.23.0 tag/release is expected to be recreated so artifacts match the advertised feature set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9405189e8cc2c7eb6e13b2dfae9a3718ea8d1466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->