### PR TITLE
feat(ui): record editing, dates-only display, loading indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Web UI typed-record editing.** `xv ui` gains a type picker on the "New
+  secret" drawer (`GET /api/types` backs the list) so a record can be
+  created field-by-field instead of typing raw JSON; existing typed records
+  (detected via the `xv-type` tag or the record content type) open the same
+  per-field editor, with secret-kind fields masked as password inputs and
+  a per-field Reveal/Copy control mirroring the whole-value one.
+- **Dates-only display and native date picker.** Timestamps that are really
+  dates (`updated_on`, `last_modified`, `expires_on`) render as `YYYY-MM-DD`
+  everywhere in the UI, and the Expires field uses a native `<input
+  type="date">` picker instead of free text.
+- **Loading indicators.** The secrets and files tables show a "Loading…"
+  placeholder row while their initial fetch is in flight (and a "failed to
+  load" placeholder if it errors), and a slim progress bar at the top of the
+  page tracks in-flight API calls.
+
 ## v0.23.0 — Embedded web UI (2026-07-08)
 
 ### Added

--- a/docs/superpowers/plans/2026-07-09-web-ui-tweaks.md
+++ b/docs/superpowers/plans/2026-07-09-web-ui-tweaks.md
@@ -1,0 +1,818 @@
+# Web UI Tweaks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dates-only display, full typed-record editing, and background-loading indicators in the embedded web UI (`xv ui`).
+
+**Architecture:** One new server endpoint (`GET /api/types`, resolved record types stored on `WebState` at startup); everything else is frontend work in the three embedded assets (`app.js`, `index.html`, `style.css`), which are `include_str!`-ed into the binary. Record saves reuse the existing PUT endpoint (it already accepts arbitrary `content_type` + `tags`).
+
+**Tech Stack:** Rust (axum, feature `ui`), vanilla JS/HTML/CSS assets.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-web-ui-tweaks-design.md`
+
+## Global Constraints
+
+- Everything web lives behind the `ui` cargo feature: build with `cargo build --features ui`, test with `cargo test --features ui web::`.
+- Record constants (must match `src/records/envelope.rs` exactly): content type `application/vnd.xv.record`, type tag `xv-type`, metadata-field tag prefix `f.`.
+- The raw record envelope JSON must never be rendered in the UI, and a record save must never write through the plain Value textarea.
+- The frontend has no JS test harness — do not add one. Frontend tasks verify via `cargo check --features ui` plus the final manual-verification task.
+- Branch: `web-ui-tweaks` (already created; spec committed).
+- Commit after each task. Commit messages end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: `GET /api/types` endpoint
+
+**Files:**
+- Modify: `src/web/mod.rs` (WebState struct ~line 25, `build_router` route list ~line 33, `run_web` ~line 108)
+- Modify: `src/web/testutil.rs:7-13`
+- Modify: `src/web/api.rs` (new handler + test)
+
+**Interfaces:**
+- Produces: `GET /api/types` → `200 {"types": [{"name": "login", "source": "builtin", "fields": [{"name": "username", "kind": "metadata", "required": true, "primary": false}, ...]}, ...]}`. `kind` serializes lowercase (`"metadata"`/`"secret"`), `source` lowercase (`"builtin"`/`"global"`/`"project"`). Task 5/6's frontend consumes this shape.
+- Produces: `WebState.types: Vec<crate::records::RecordType>` for any future handler.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module at the bottom of `src/web/api.rs` (alongside `vaults_falls_back_to_current_when_unsupported`):
+
+```rust
+#[tokio::test]
+async fn types_returns_builtin_types() {
+    let app = crate::web::build_router(testutil::test_state());
+    let (status, json_body) = get_json(app, "GET", "/api/types", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let types = json_body["types"].as_array().unwrap();
+    let login = types.iter().find(|t| t["name"] == "login").unwrap();
+    // login's declared field order and shape, exactly as builtin_types() defines
+    assert_eq!(login["source"], "builtin");
+    assert_eq!(login["fields"][0]["name"], "username");
+    assert_eq!(login["fields"][0]["kind"], "metadata");
+    assert_eq!(login["fields"][0]["required"], true);
+    assert_eq!(login["fields"][2]["name"], "password");
+    assert_eq!(login["fields"][2]["kind"], "secret");
+    assert_eq!(login["fields"][2]["primary"], true);
+    // all three builtins present
+    for name in ["login", "api-key", "database"] {
+        assert!(types.iter().any(|t| t["name"] == name), "{name} missing");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --features ui web::api::tests::types_returns_builtin_types`
+Expected: compile FAILS (`WebState` has no field `types` isn't hit yet — the route doesn't exist, so the test compiles but the request 404s). Either a 404 assertion failure or a compile error once Step 3 is partially applied is acceptable evidence; the point is red-before-green.
+
+- [ ] **Step 3: Implement**
+
+In `src/web/mod.rs`, add the field to `WebState`:
+
+```rust
+/// Shared state for all handlers.
+pub(crate) struct WebState {
+    pub backend: Arc<dyn Backend>,
+    pub token: String,
+    /// Default vault, resolved once at startup. Requests may override per-call.
+    pub vault: String,
+    /// Record types (builtin + [types.*] config), resolved once at startup.
+    pub types: Vec<crate::records::RecordType>,
+}
+```
+
+In `build_router`, add the route after the `/vaults` line:
+
+```rust
+        .route("/types", get(api::list_types))
+```
+
+In `run_web`, resolve types right after `resolve_vault_for_trait` and add to the state literal:
+
+```rust
+    let vault = crate::cli::helpers::resolve_vault_for_trait(&config, Some(registry)).await?;
+    let backend = registry.active_arc();
+    // Fail loud at startup on a broken [types.*] block, matching the CLI's
+    // eager type-resolution paths.
+    let types = config.resolve_record_types().await?;
+```
+
+```rust
+    let state = Arc::new(WebState {
+        backend,
+        token: token.clone(),
+        vault,
+        types,
+    });
+```
+
+In `src/web/testutil.rs`:
+
+```rust
+pub(crate) fn test_state_with_token(token: &str) -> Arc<WebState> {
+    Arc::new(WebState {
+        backend: Arc::new(stub::StubBackend::new()),
+        token: token.to_string(),
+        vault: "default".to_string(),
+        types: crate::records::builtin_types(),
+    })
+}
+```
+
+In `src/web/api.rs`, add the handler after `list_vaults`:
+
+```rust
+pub(crate) async fn list_types(State(state): State<Arc<WebState>>) -> Json<serde_json::Value> {
+    Json(json!({ "types": state.types }))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --features ui web::`
+Expected: all web tests PASS, including `types_returns_builtin_types`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/mod.rs src/web/api.rs src/web/testutil.rs
+git commit -m "feat(ui): expose resolved record types at GET /api/types"
+```
+
+---
+
+### Task 2: Record round-trip regression test (server, test-only)
+
+**Files:**
+- Modify: `src/web/api.rs` (tests module only)
+
+**Interfaces:**
+- Consumes: existing PUT/GET/reveal handlers; nothing new.
+- Produces: a pinned guarantee Task 5 relies on — record `content_type`, `xv-type`/`f.*` tags, and envelope value survive a PUT/GET cycle, and the list/metadata endpoints never leak the envelope.
+
+- [ ] **Step 1: Write the test**
+
+Add to the `tests` module in `src/web/api.rs`:
+
+```rust
+#[tokio::test]
+async fn record_roundtrip_preserves_envelope_and_field_tags() {
+    let app = crate::web::build_router(testutil::test_state());
+
+    // PUT a typed record the way the record drawer saves one
+    let (status, _) = get_json(
+        app.clone(),
+        "PUT",
+        "/api/secrets/gh-login",
+        Some(json!({
+            "value": r#"{"password":"hunter2"}"#,
+            "content_type": "application/vnd.xv.record",
+            "tags": {"xv-type": "login", "f.username": "bob"},
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // metadata GET: record markers survive, value stays null
+    let (status, meta) = get_json(app.clone(), "GET", "/api/secrets/gh-login", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(meta["content_type"], "application/vnd.xv.record");
+    assert_eq!(meta["tags"]["xv-type"], "login");
+    assert_eq!(meta["tags"]["f.username"], "bob");
+    assert!(meta["value"].is_null());
+
+    // the list never leaks envelope contents
+    let (_, list) = get_json(app.clone(), "GET", "/api/secrets", None).await;
+    assert!(!list.to_string().contains("hunter2"));
+
+    // reveal returns the raw envelope for the drawer to parse
+    let (_, revealed) = get_json(app, "POST", "/api/secrets/gh-login/value", None).await;
+    assert_eq!(revealed["value"], r#"{"password":"hunter2"}"#);
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cargo test --features ui web::api::tests::record_roundtrip_preserves_envelope_and_field_tags`
+Expected: PASS (this pins existing behavior; if it fails, stop — the drawer design assumption is wrong and the plan needs revisiting).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/web/api.rs
+git commit -m "test(ui): pin record envelope/tag round-trip through the web API"
+```
+
+---
+
+### Task 3: Dates-only display + Expires date picker (frontend)
+
+**Files:**
+- Modify: `src/web/assets/app.js` (helpers near top; `renderSecrets`; `openDrawer` expires line; submit handler expires values; `loadFiles` modified column)
+- Modify: `src/web/assets/index.html:55` (Expires input)
+
+**Interfaces:**
+- Produces: `fmtDate(s)` — returns `''` for falsy input, `YYYY-MM-DD` (UTC) for parseable datetimes, the raw string otherwise. Tasks 4–6 leave it untouched.
+- Produces: Expires drawer semantics later tasks must preserve — input is `type="date"`; PUT sends `<date>T00:00:00Z` or `null`; PATCH sends `<date>T00:00:00Z` or `''` (clear).
+
+- [ ] **Step 1: Add `fmtDate` and apply it to both tables**
+
+In `app.js`, add below the `fail` helper (line 36):
+
+```js
+// Dates only, never timestamps. Unparseable strings pass through raw.
+function fmtDate(s) {
+  if (!s) return '';
+  const d = new Date(s);
+  return isNaN(d) ? s : d.toISOString().slice(0, 10);
+}
+```
+
+In `renderSecrets`, change the cells line:
+
+```js
+    for (const cell of [name, s.folder, s.groups, s.note, fmtDate(s.updated_on)]) {
+```
+
+In `loadFiles`, change the cells line:
+
+```js
+    const cells = [f.name, `${f.size}`, f.content_type, fmtDate(f.last_modified)];
+```
+
+- [ ] **Step 2: Switch Expires to a date input**
+
+In `index.html`, replace line 55:
+
+```html
+    <label>Expires <input name="expires_on" type="date"></label>
+```
+
+In `app.js` `openDrawer`, replace the expires population line:
+
+```js
+      f.elements.expires_on.value = meta.expires_on ? meta.expires_on.slice(0, 10) : '';
+```
+
+In the submit handler, compute the wire values once at the top (after the `groups` line):
+
+```js
+  const expiresPut = f.expires_on.value ? `${f.expires_on.value}T00:00:00Z` : null;
+  const expiresPatch = f.expires_on.value ? `${f.expires_on.value}T00:00:00Z` : '';
+```
+
+and use them: in the PUT body `expires_on: expiresPut,` and in the PATCH body `expires_on: expiresPatch,`.
+
+- [ ] **Step 3: Verify the build**
+
+Run: `cargo check --features ui`
+Expected: clean check (assets are `include_str!`-ed; this confirms nothing Rust-side broke).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/web/assets/app.js src/web/assets/index.html
+git commit -m "feat(ui): dates-only display and a native date picker for expiry"
+```
+
+---
+
+### Task 4: Loading indicators (frontend)
+
+**Files:**
+- Modify: `src/web/assets/app.js` (`api()` wrapper, `loadSecrets`, `renderSecrets`, `loadFiles`, vault-switch handler)
+- Modify: `src/web/assets/index.html` (progress bar element)
+- Modify: `src/web/assets/style.css` (progress bar + placeholder styles)
+
+**Interfaces:**
+- Produces: `showPlaceholder(tbody, text, cols)` — replaces a table body with one muted full-width row. Task 5/6 must not break the "Loading secrets…" flow in `loadSecrets`.
+- Produces: global in-flight progress bar driven from inside `api()`; later tasks get it for free on every call.
+
+- [ ] **Step 1: Add the progress bar element and styles**
+
+In `index.html`, insert directly after `<body>`:
+
+```html
+<div id="progress" hidden></div>
+```
+
+In `style.css`, append:
+
+```css
+#progress { position:fixed; top:0; left:0; right:0; height:2px; overflow:hidden; z-index:10; }
+#progress::after { content:""; display:block; width:30%; height:100%; background:var(--accent);
+  animation:progress-slide 1.2s linear infinite; }
+@keyframes progress-slide { from { transform:translateX(-100vw); } to { transform:translateX(100vw); } }
+td.placeholder { color:var(--muted); text-align:center; padding:1rem; }
+```
+
+- [ ] **Step 2: Track in-flight calls in `api()`**
+
+In `app.js`, wrap the body of `api()` in try/finally with a module-level counter (the `#progress` lookup uses `document.getElementById` directly because `$` is declared after `api`):
+
+```js
+let inflight = 0;
+async function api(method, path, body, raw = false) {
+  inflight++;
+  document.getElementById('progress').hidden = false;
+  try {
+    const opts = { method, headers: { Authorization: `Bearer ${TOKEN}` } };
+    if (body instanceof FormData) {
+      opts.body = body;
+    } else if (body !== undefined) {
+      opts.headers['Content-Type'] = 'application/json';
+      opts.body = JSON.stringify(body);
+    }
+    const res = await fetch(path, opts);
+    if (!res.ok) {
+      let msg = res.statusText;
+      try { msg = (await res.json()).error || msg; } catch { /* not json */ }
+      throw new Error(msg);
+    }
+    if (raw) return res;
+    const text = await res.text();
+    return text ? JSON.parse(text) : null;
+  } finally {
+    if (--inflight <= 0) { inflight = 0; document.getElementById('progress').hidden = true; }
+  }
+}
+```
+
+- [ ] **Step 3: Placeholder rows in both tables**
+
+In `app.js`, add near `fmtDate`:
+
+```js
+function showPlaceholder(tbody, text, cols) {
+  tbody.innerHTML = '';
+  const tr = document.createElement('tr');
+  const td = document.createElement('td');
+  td.colSpan = cols;
+  td.className = 'placeholder';
+  td.textContent = text;
+  tr.appendChild(td);
+  tbody.appendChild(tr);
+}
+```
+
+Rewrite `loadSecrets`:
+
+```js
+async function loadSecrets() {
+  showPlaceholder($('#secrets-table tbody'), 'Loading secrets…', 5);
+  secrets = await api('GET', `/api/secrets${vaultQS()}`);
+  renderSecrets();
+}
+```
+
+At the end of `renderSecrets` (after the `for` loop), add an empty state:
+
+```js
+  if (!tbody.children.length) {
+    showPlaceholder(tbody, secrets.length ? 'no matching secrets' : 'no secrets', 5);
+  }
+```
+
+In `loadFiles`, after the capabilities guard and before the fetch:
+
+```js
+  showPlaceholder($('#files-table tbody'), 'Loading files…', 5);
+  const files = await api('GET', `/api/files${vaultQS()}`);
+```
+
+and at the end of `loadFiles`' row loop add:
+
+```js
+  if (!tbody.children.length) showPlaceholder(tbody, 'no files', 5);
+```
+
+In the vault `sel.onchange` handler, surface failures instead of dropping the promises:
+
+```js
+  sel.onchange = () => {
+    currentVault = sel.value;
+    // Close the drawer: anything open in it belongs to the previous vault,
+    // and saving/deleting it against the new vault would hit the wrong secret.
+    closeDrawer();
+    loadSecrets().catch(fail);
+    loadFiles().catch(fail);
+  };
+```
+
+- [ ] **Step 4: Verify the build**
+
+Run: `cargo check --features ui`
+Expected: clean check.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/assets/app.js src/web/assets/index.html src/web/assets/style.css
+git commit -m "feat(ui): loading placeholders and in-flight progress bar"
+```
+
+---
+
+### Task 5: Record editing for existing records (frontend)
+
+**Files:**
+- Modify: `src/web/assets/index.html` (drawer form: value section wrapper + record section)
+- Modify: `src/web/assets/app.js` (record constants/state, envelope parsing, field rendering, `openDrawer`, `closeDrawer`, submit handler)
+- Modify: `src/web/assets/style.css` (record field styles)
+
+**Interfaces:**
+- Consumes: `GET /api/types` from Task 1 (`{types: [{name, source, fields: [{name, kind, required, primary}]}]}`); `fmtDate`/expires semantics from Task 3; `showPlaceholder` untouched from Task 4.
+- Produces: module state `types` (array) and `recordState` (`{typeName, secretFields, metaFields}` or `null`); `renderRecordFields(typeName, secretFields, metaFields, forNew)`; `fieldRow(name, kind, value, required)`. Task 6 reuses all of these for creation.
+
+- [ ] **Step 1: Restructure the drawer form in `index.html`**
+
+Replace the Value label block (lines 45–51) with a wrapped value section followed by a record section:
+
+```html
+    <div id="value-section">
+      <label>Value
+        <textarea name="value" rows="4" placeholder="(leave blank to keep current value)"></textarea>
+        <span class="row">
+          <button type="button" id="reveal">Reveal</button>
+          <button type="button" id="copy">Copy</button>
+        </span>
+      </label>
+    </div>
+    <div id="record-section" hidden>
+      <div id="record-type"></div>
+      <div id="record-fields"></div>
+    </div>
+```
+
+Append to `style.css`:
+
+```css
+#record-type { color:var(--muted); margin-bottom:.5rem; }
+```
+
+- [ ] **Step 2: Record constants, state, and helpers in `app.js`**
+
+Below the `CANONICAL_TAGS` line, add:
+
+```js
+// Must match src/records/envelope.rs exactly.
+const RECORD_CONTENT_TYPE = 'application/vnd.xv.record';
+const TYPE_TAG = 'xv-type';
+const FIELD_TAG_PREFIX = 'f.';
+
+let types = []; // resolved record types from /api/types
+// Non-null while the drawer holds a typed record:
+// { typeName, secretFields: {name: value}, metaFields: {name: value} }
+let recordState = null;
+
+// Same rule as the TUI: the xv-type tag OR the exact record content type.
+function isRecordMeta(meta) {
+  return meta.content_type === RECORD_CONTENT_TYPE || !!(meta.tags || {})[TYPE_TAG];
+}
+
+// Strict, mirroring records::parse_envelope: a JSON object of strings.
+function parseEnvelope(raw) {
+  const obj = JSON.parse(raw);
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) throw new Error('not a JSON object');
+  for (const [k, v] of Object.entries(obj)) {
+    if (typeof v !== 'string') throw new Error(`field '${k}' is not a string`);
+  }
+  return obj;
+}
+
+function fieldRow(name, kind, value, required) {
+  const label = document.createElement('label');
+  label.append(`${name}${required ? ' *' : ''}`);
+  const input = document.createElement('input');
+  input.dataset.fieldName = name;
+  input.dataset.fieldKind = kind;
+  input.value = value || '';
+  if (required) input.required = true;
+  if (kind === 'secret') {
+    input.type = 'password';
+    const row = document.createElement('span');
+    row.className = 'row';
+    const rev = document.createElement('button');
+    rev.type = 'button';
+    rev.textContent = 'Reveal';
+    rev.onclick = () => {
+      const showing = input.type === 'text';
+      input.type = showing ? 'password' : 'text';
+      rev.textContent = showing ? 'Reveal' : 'Hide';
+    };
+    const cp = document.createElement('button');
+    cp.type = 'button';
+    cp.textContent = 'Copy';
+    cp.onclick = async () => {
+      try {
+        await navigator.clipboard.writeText(input.value);
+        toast('copied');
+      } catch (e) { fail(e); }
+    };
+    row.append(rev, cp);
+    label.append(input, row);
+  } else {
+    label.append(input);
+  }
+  return label;
+}
+
+// One input per field: declared fields in CLI prompt order (non-primary
+// first, primary last), then undeclared extras sorted by name.
+function renderRecordFields(typeName, secretFields, metaFields, forNew) {
+  const type = types.find((t) => t.name === typeName);
+  $('#record-type').textContent = `type: ${typeName || '(unknown)'}`;
+  const container = $('#record-fields');
+  container.innerHTML = '';
+  const seen = new Set();
+  const declared = type
+    ? [...type.fields.filter((f) => !f.primary), ...type.fields.filter((f) => f.primary)]
+    : [];
+  for (const def of declared) {
+    seen.add(def.name);
+    const value = def.kind === 'secret' ? secretFields[def.name] : metaFields[def.name];
+    container.appendChild(fieldRow(def.name, def.kind, value, forNew && def.required));
+  }
+  const extras = [
+    ...Object.keys(secretFields).filter((n) => !seen.has(n)).map((n) => [n, 'secret']),
+    ...Object.keys(metaFields).filter((n) => !seen.has(n)).map((n) => [n, 'metadata']),
+  ].sort((a, b) => a[0].localeCompare(b[0]));
+  for (const [n, kind] of extras) {
+    container.appendChild(fieldRow(n, kind, kind === 'secret' ? secretFields[n] : metaFields[n], false));
+  }
+  $('#record-section').hidden = false;
+  $('#value-section').hidden = true;
+}
+```
+
+- [ ] **Step 3: Fetch types at startup**
+
+In `init()`, after the context fetch (`ctx = await api(...)`) add:
+
+```js
+  ({ types } = await api('GET', '/api/types'));
+```
+
+- [ ] **Step 4: Open records in the drawer**
+
+Rewrite `closeDrawer` and `openDrawer`, and add `openRecord`:
+
+```js
+function closeDrawer() {
+  $('#drawer').hidden = true;
+  editing = null;
+  editingMeta = null;
+  recordState = null;
+}
+
+async function openDrawer(name) {
+  editing = name;
+  editingMeta = null;
+  recordState = null;
+  const f = $('#secret-form');
+  f.reset();
+  $('#drawer-title').textContent = name ? `Edit: ${name}` : 'New secret';
+  f.elements.name.value = name || '';
+  f.elements.name.readOnly = false;
+  $('#reveal').hidden = $('#copy').hidden = $('#delete').hidden = !name;
+  $('#record-section').hidden = true;
+  $('#value-section').hidden = false;
+  $('#record-fields').innerHTML = '';
+  $('#save').disabled = false;
+  if (name) {
+    try {
+      const meta = await api('GET', `/api/secrets/${encodeURIComponent(name)}${vaultQS()}`);
+      const tags = meta.tags || {};
+      f.elements.folder.value = tags.folder || '';
+      f.elements.groups.value = tags.groups || '';
+      f.elements.note.value = tags.note || '';
+      f.elements.expires_on.value = meta.expires_on ? meta.expires_on.slice(0, 10) : '';
+      const customTags = {};
+      for (const [k, v] of Object.entries(tags)) {
+        // xv-type and f.* are managed by the record editor, not echoed blindly.
+        if (!CANONICAL_TAGS.has(k) && k !== TYPE_TAG && !k.startsWith(FIELD_TAG_PREFIX)) {
+          customTags[k] = v;
+        }
+      }
+      editingMeta = {
+        content_type: meta.content_type || '',
+        tags: customTags,
+        enabled: meta.enabled,
+        not_before: meta.not_before || null,
+      };
+      if (isRecordMeta(meta)) await openRecord(name, tags);
+    } catch (e) {
+      // Without the fetched metadata a save would send enabled:true and no
+      // custom tags — silently mutating the secret. Don't open the drawer.
+      fail(e);
+      editing = null;
+      return;
+    }
+  }
+  $('#drawer').hidden = false;
+}
+
+// Fetches the envelope so secret fields are editable. Values live in JS
+// memory but display masked — the same exposure as the Reveal button.
+async function openRecord(name, tags) {
+  const { value } = await api('POST', `/api/secrets/${encodeURIComponent(name)}/value${vaultQS()}`);
+  let secretFields;
+  try {
+    secretFields = parseEnvelope(value ?? '');
+  } catch (e) {
+    // Content type says record but the value isn't a valid envelope: open
+    // read-only in the plain view rather than pretending fields are empty.
+    toast(`record envelope is invalid: ${e.message}`, true);
+    $('#save').disabled = true;
+    return;
+  }
+  const metaFields = {};
+  for (const [k, v] of Object.entries(tags)) {
+    if (k.startsWith(FIELD_TAG_PREFIX)) metaFields[k.slice(FIELD_TAG_PREFIX.length)] = v;
+  }
+  recordState = { typeName: tags[TYPE_TAG] || '', secretFields, metaFields };
+  // Whole-value reveal/copy would expose the raw envelope JSON.
+  $('#reveal').hidden = $('#copy').hidden = true;
+  renderRecordFields(recordState.typeName, secretFields, metaFields, false);
+}
+```
+
+- [ ] **Step 5: Record-aware save**
+
+Rewrite the submit handler (this is the complete final version, including Task 3's expires handling):
+
+```js
+$('#secret-form').onsubmit = async (ev) => {
+  ev.preventDefault();
+  const f = ev.target.elements;
+  const name = f.name.value.trim();
+  if (!name) return;
+  const groups = f.groups.value.split(',').map(s => s.trim()).filter(Boolean);
+  const expiresPut = f.expires_on.value ? `${f.expires_on.value}T00:00:00Z` : null;
+  const expiresPatch = f.expires_on.value ? `${f.expires_on.value}T00:00:00Z` : '';
+  try {
+    if (editing && name !== editing) {
+      await api('POST', `/api/secrets/${encodeURIComponent(editing)}/move${vaultQS()}`, { new_name: name });
+      editing = name;
+    }
+    if (recordState) {
+      // Records always take the full-PUT path: field edits change the value.
+      const envelope = {};
+      const fieldTags = {};
+      for (const input of $('#record-fields').querySelectorAll('input[data-field-name]')) {
+        if (!input.value) continue; // empty = omit field / drop tag
+        if (input.dataset.fieldKind === 'secret') envelope[input.dataset.fieldName] = input.value;
+        else fieldTags[FIELD_TAG_PREFIX + input.dataset.fieldName] = input.value;
+      }
+      const sorted = {};
+      for (const k of Object.keys(envelope).sort()) sorted[k] = envelope[k];
+      await api('PUT', `/api/secrets/${encodeURIComponent(name)}${vaultQS()}`, {
+        value: JSON.stringify(sorted),
+        content_type: RECORD_CONTENT_TYPE,
+        folder: f.folder.value || null,
+        note: f.note.value || null,
+        groups: groups.length ? groups : null,
+        expires_on: expiresPut,
+        tags: { ...(editingMeta?.tags || {}), [TYPE_TAG]: recordState.typeName, ...fieldTags },
+        enabled: editingMeta ? editingMeta.enabled : true,
+        not_before: editingMeta?.not_before || null,
+      });
+    } else if (f.value.value) {
+      // full write: value + all metadata
+      await api('PUT', `/api/secrets/${encodeURIComponent(name)}${vaultQS()}`, {
+        value: f.value.value,
+        folder: f.folder.value || null,
+        note: f.note.value || null,
+        groups: groups.length ? groups : null,
+        expires_on: expiresPut,
+        content_type: editingMeta?.content_type || null,
+        tags: editingMeta && Object.keys(editingMeta.tags).length ? editingMeta.tags : null,
+        enabled: editingMeta ? editingMeta.enabled : true,
+        not_before: editingMeta?.not_before || null,
+      });
+    } else if (editing) {
+      // metadata-only patch ("" clears)
+      await api('PATCH', `/api/secrets/${encodeURIComponent(name)}${vaultQS()}`, {
+        folder: f.folder.value,
+        note: f.note.value,
+        groups,
+        expires_on: expiresPatch,
+      });
+    } else {
+      throw new Error('a new secret needs a value');
+    }
+    closeDrawer();
+    toast('saved');
+    await loadSecrets();
+  } catch (e) { fail(e); }
+};
+```
+
+- [ ] **Step 6: Verify the build**
+
+Run: `cargo check --features ui && cargo test --features ui web::`
+Expected: clean check, all web tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/web/assets/app.js src/web/assets/index.html src/web/assets/style.css
+git commit -m "feat(ui): edit typed records field-by-field in the drawer"
+```
+
+---
+
+### Task 6: Record creation with a type picker (frontend)
+
+**Files:**
+- Modify: `src/web/assets/index.html` (type picker in the drawer form)
+- Modify: `src/web/assets/app.js` (`init()` picker population, `openDrawer` picker visibility)
+
+**Interfaces:**
+- Consumes: `types`, `recordState`, `renderRecordFields(typeName, {}, {}, true)` from Task 5. The submit handler already handles `recordState` for new secrets (`editingMeta` is null → `enabled: true`).
+
+- [ ] **Step 1: Add the picker to `index.html`**
+
+Insert between the Name label and `<div id="value-section">`:
+
+```html
+    <label id="type-picker-label" hidden>Type <select id="type-picker"></select></label>
+```
+
+- [ ] **Step 2: Populate and wire the picker in `app.js`**
+
+In `init()`, after the types fetch, add:
+
+```js
+  const picker = $('#type-picker');
+  picker.innerHTML = '';
+  const plain = document.createElement('option');
+  plain.value = '';
+  plain.textContent = 'plain secret';
+  picker.appendChild(plain);
+  for (const rt of types) {
+    const opt = document.createElement('option');
+    opt.value = opt.textContent = rt.name;
+    picker.appendChild(opt);
+  }
+  picker.onchange = () => {
+    if (!picker.value) {
+      recordState = null;
+      $('#record-section').hidden = true;
+      $('#value-section').hidden = false;
+      $('#record-fields').innerHTML = '';
+    } else {
+      recordState = { typeName: picker.value, secretFields: {}, metaFields: {} };
+      renderRecordFields(picker.value, {}, {}, true);
+    }
+  };
+```
+
+In `openDrawer`, alongside the other section resets (after `$('#save').disabled = false;`), add:
+
+```js
+  $('#type-picker-label').hidden = !!name; // type is chosen at creation only
+  $('#type-picker').value = '';
+```
+
+- [ ] **Step 3: Verify the build**
+
+Run: `cargo check --features ui`
+Expected: clean check.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/web/assets/app.js src/web/assets/index.html
+git commit -m "feat(ui): create typed records via a type picker"
+```
+
+---
+
+### Task 7: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Rust gates**
+
+Run:
+```bash
+cargo fmt --check && cargo clippy --features ui --all-targets && cargo test --features ui
+```
+Expected: fmt clean, clippy no new warnings, all tests PASS. Fix anything that fails before proceeding.
+
+- [ ] **Step 2: Manual end-to-end against the local backend**
+
+Drive `cargo run --features ui -- ui` (local backend). Verify each spec item:
+
+1. Secrets **Updated** and files **Modified** columns show `YYYY-MM-DD` only.
+2. On launch and on vault switch, the secrets table shows "Loading secrets…" then results; the top progress bar appears during any API call (e.g. a save).
+3. Create a record: New secret → Type `login` → the Value textarea is replaced by `username`/`url`/`password` inputs (password last, masked); save; the secret lists normally.
+4. Open that record: no Value textarea, `type: login` header, `username`/`url` plain, `password` masked with working per-field Reveal and Copy; edit a field, save, reopen — the edit stuck and `xv get <name> --field username` (CLI) agrees.
+5. Set an expiry via the date picker; reopen — the same date shows.
+6. Confirm the raw envelope JSON is never visible anywhere in the UI.
+
+If browser automation is available (browser-harness), use it for this; otherwise ask the user to click through.
+
+- [ ] **Step 3: Commit any fixes, then hand off**
+
+Use the superpowers:finishing-a-development-branch skill (expect: push `web-ui-tweaks`, open a PR per the repo's dev workflow, watch Bugbot).

--- a/docs/superpowers/specs/2026-07-09-web-ui-tweaks-design.md
+++ b/docs/superpowers/specs/2026-07-09-web-ui-tweaks-design.md
@@ -1,0 +1,139 @@
+# Web UI Tweaks: Dates, Record Editing, Loading Indicator
+
+**Date:** 2026-07-09
+**Status:** Approved design, not yet implemented
+
+## Motivation
+
+Three usability gaps in the embedded web UI (`xv ui`, shipped v0.23.0):
+
+1. Datetime columns show full timestamps; dates alone are enough.
+2. Typed records (record-types plan, `docs/superpowers/specs/2026-07-03-record-types-design.md`)
+   are invisible in the UI: the detail drawer shows none of a record's
+   fields, Reveal dumps the raw envelope JSON (every secret field at
+   once), and typing into Value silently overwrites the envelope.
+3. On launch (and vault switch) the secrets table is blank for several
+   seconds with no signal that loading is in progress.
+
+## 1. Dates only, everywhere
+
+- New `fmtDate()` helper in `app.js`: parse the datetime string with
+  `new Date()`, render `YYYY-MM-DD`; if unparseable, show the raw string
+  unchanged. Applied to the secrets **Updated** column and the files
+  **Modified** column.
+- The drawer's **Expires** field becomes a native `<input type="date">`.
+  Loading an existing secret shows the date portion of `expires_on`;
+  saving sends `<date>T00:00:00Z` (blank still clears). No server change
+  — the API keeps accepting RFC3339.
+
+## 2. Full record editing
+
+### Server
+
+- New endpoint `GET /api/types` returning the resolved record types
+  (builtin `login`/`api-key`/`database` + `[types.*]` from global and
+  project config), shape `{ "types": [RecordType...] }`. `RecordType`
+  is already `Serialize`. Types are resolved once at startup in
+  `run_web` via `config.resolve_record_types()` and stored on
+  `WebState`. A broken `[types.*]` config fails `xv ui` startup with
+  the config error (same fail-loud stance as the CLI's eager paths).
+  The test-only `WebState` constructor supplies `builtin_types()`.
+- No other server changes: the existing PUT already accepts arbitrary
+  `content_type` and `tags`, which is all a record save needs.
+
+### Frontend
+
+**Detecting a record** (same rule as the TUI): the secret has an
+`xv-type` tag, or content-type is exactly `application/vnd.xv.record`.
+
+**Editing an existing record:**
+
+- The raw Value textarea and whole-value Reveal/Copy are hidden — the
+  envelope JSON is never displayed and can't be clobbered.
+- The drawer shows `Type: <name>` (read-only) and one input per field:
+  the union of the type's declared fields, the secret's `f.*` metadata
+  tags, and the envelope keys. Metadata-kind fields are plain text
+  inputs; secret-kind fields are `type="password"` inputs (masked) with
+  per-field reveal (toggles the input to `type="text"`) and copy
+  buttons.
+- Field kind is decided by where the value lives on the secret
+  (envelope key → secret, `f.*` tag → metadata); a declared field not
+  yet present on the secret uses its `FieldDef.kind`. An unknown type
+  name (no `[types.*]` definition) still renders the union of envelope
+  keys and `f.*` tags — editing existing fields works; no new declared
+  fields are offered.
+- Opening a record fetches the envelope once via the existing
+  `POST /api/secrets/{name}/value` endpoint so secret fields are
+  editable. Values live in JS memory but display masked — the same
+  exposure as today's Reveal button.
+- If the envelope fails to parse (content-type says record but value
+  isn't a valid JSON string map): error toast, and the drawer opens
+  read-only in the plain-secret view (no Save) rather than pretending
+  fields are empty.
+
+**Saving a record:**
+
+- Secret-field inputs re-encode into the JSON envelope (sorted keys via
+  plain `JSON.stringify` of an object built in sorted order —
+  determinism matching `encode_envelope` is cosmetic, not required).
+- Metadata-field inputs route to `f.<name>` tags. `xv-type` and
+  non-field custom tags are preserved.
+- PUT with `content_type: application/vnd.xv.record`, echoing
+  `enabled`/`not_before` as the drawer already does. Records always use
+  the full PUT path — no metadata-only PATCH branch, since field edits
+  change the value.
+- Empty secret-field inputs are omitted from the envelope; empty
+  metadata inputs drop the `f.*` tag. Required-field enforcement is
+  advisory only (HTML `required` on declared required fields for new
+  records); the server does not validate.
+
+**Creating a record:**
+
+- The New-secret drawer gains a **Type** dropdown: `plain secret`
+  (default, current behavior) plus each resolved type from
+  `/api/types`.
+- Picking a type swaps the Value textarea for generated field inputs
+  from the type's `FieldDef` list: required fields marked, primary
+  field last (matching the CLI prompt order: non-primary declared
+  order, then primary).
+
+**Out of scope (YAGNI):** ad-hoc fields not declared by the type,
+changing a record's type after creation, a Type column in the secrets
+table, per-field expiry.
+
+**Alternative considered:** a server-side
+`/api/secrets/{name}/record` endpoint parsing and masking fields in
+Rust. Rejected: the client needs actual values for editing anyway, and
+the envelope is a flat JSON string map, trivially parsed client-side.
+
+## 3. Background-loading indicator
+
+- `loadSecrets()`/`loadFiles()` render a single placeholder row
+  ("Loading secrets…" / "Loading files…") in the table body while the
+  fetch is in flight, replaced by results — or an empty-state row
+  ("no secrets") when the result is empty. Covers launch and vault
+  switch.
+- A thin indeterminate progress bar fixed to the top of the page,
+  shown whenever any API call is in flight: an in-flight counter
+  incremented/decremented inside the `api()` wrapper (decrement in
+  `finally`), bar visible while counter > 0. Saves, deletes, uploads,
+  and reveals get feedback for free.
+
+## Error handling
+
+- `/api/types` has no failure mode at request time (types are resolved
+  at startup); startup resolution failure aborts `xv ui` with the
+  config error.
+- Record envelope parse failure on open: toast + read-only drawer (see
+  above).
+- Date parse failure in `fmtDate()`: raw string passthrough.
+
+## Testing
+
+- Rust (axum, `src/web/api.rs` tests): `/api/types` returns builtin
+  types; record round-trip — PUT a record (envelope value +
+  `xv-type`/`f.*` tags + record content type), GET it back, confirm
+  tags/content-type survive and the list never leaks the envelope.
+- Frontend: no JS test harness exists (matching the existing code);
+  verified manually by driving `cargo run --features ui -- ui` against
+  the local backend with builtin and custom types.

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -7,6 +7,10 @@ port on 127.0.0.1, prints a tokenized URL, and opens your browser
 Everything the UI does goes through the same backend layer as the CLI, so
 all backends (Azure, AWS, local) work, including offline local vaults.
 
+Typed records are supported: create one via the type picker on the "New
+secret" drawer or open an existing one to edit it field-by-field, with
+secret-kind fields masked and individually revealable/copyable.
+
 Scope note: the UI operates on the **active backend** — the vault switcher
 lists that backend's vaults and every operation targets it. Multi-backend
 workspaces (`xv cx` attached vaults and aliases) are not resolved here yet;

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -925,4 +925,39 @@ mod tests {
             assert!(types.iter().any(|t| t["name"] == name), "{name} missing");
         }
     }
+
+    #[tokio::test]
+    async fn record_roundtrip_preserves_envelope_and_field_tags() {
+        let app = crate::web::build_router(testutil::test_state());
+
+        // PUT a typed record the way the record drawer saves one
+        let (status, _) = get_json(
+            app.clone(),
+            "PUT",
+            "/api/secrets/gh-login",
+            Some(json!({
+                "value": r#"{"password":"hunter2"}"#,
+                "content_type": "application/vnd.xv.record",
+                "tags": {"xv-type": "login", "f.username": "bob"},
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        // metadata GET: record markers survive, value stays null
+        let (status, meta) = get_json(app.clone(), "GET", "/api/secrets/gh-login", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(meta["content_type"], "application/vnd.xv.record");
+        assert_eq!(meta["tags"]["xv-type"], "login");
+        assert_eq!(meta["tags"]["f.username"], "bob");
+        assert!(meta["value"].is_null());
+
+        // the list never leaks envelope contents
+        let (_, list) = get_json(app.clone(), "GET", "/api/secrets", None).await;
+        assert!(!list.to_string().contains("hunter2"));
+
+        // reveal returns the raw envelope for the drawer to parse
+        let (_, revealed) = get_json(app, "POST", "/api/secrets/gh-login/value", None).await;
+        assert_eq!(revealed["value"], r#"{"password":"hunter2"}"#);
+    }
 }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -91,6 +91,10 @@ pub(crate) async fn list_vaults(
     }
 }
 
+pub(crate) async fn list_types(State(state): State<Arc<WebState>>) -> Json<serde_json::Value> {
+    Json(json!({ "types": state.types }))
+}
+
 #[derive(Deserialize)]
 pub(crate) struct ListQuery {
     vault: Option<String>,
@@ -899,5 +903,26 @@ mod tests {
         assert_eq!(res.status(), StatusCode::OK);
         let cd = res.headers()["content-disposition"].to_str().unwrap();
         assert!(cd.contains("filename*=UTF-8''r%C3%A9sum%C3%A9.txt"));
+    }
+
+    #[tokio::test]
+    async fn types_returns_builtin_types() {
+        let app = crate::web::build_router(testutil::test_state());
+        let (status, json_body) = get_json(app, "GET", "/api/types", None).await;
+        assert_eq!(status, StatusCode::OK);
+        let types = json_body["types"].as_array().unwrap();
+        let login = types.iter().find(|t| t["name"] == "login").unwrap();
+        // login's declared field order and shape, exactly as builtin_types() defines
+        assert_eq!(login["source"], "builtin");
+        assert_eq!(login["fields"][0]["name"], "username");
+        assert_eq!(login["fields"][0]["kind"], "metadata");
+        assert_eq!(login["fields"][0]["required"], true);
+        assert_eq!(login["fields"][2]["name"], "password");
+        assert_eq!(login["fields"][2]["kind"], "secret");
+        assert_eq!(login["fields"][2]["primary"], true);
+        // all three builtins present
+        for name in ["login", "api-key", "database"] {
+            assert!(types.iter().any(|t| t["name"] == name), "{name} missing");
+        }
     }
 }

--- a/src/web/assets/app.js
+++ b/src/web/assets/app.js
@@ -5,23 +5,30 @@ const params = new URLSearchParams(location.search);
 const TOKEN = params.get('token') || '';
 if (params.has('token')) history.replaceState(null, '', location.pathname);
 
+let inflight = 0;
 async function api(method, path, body, raw = false) {
-  const opts = { method, headers: { Authorization: `Bearer ${TOKEN}` } };
-  if (body instanceof FormData) {
-    opts.body = body;
-  } else if (body !== undefined) {
-    opts.headers['Content-Type'] = 'application/json';
-    opts.body = JSON.stringify(body);
+  inflight++;
+  document.getElementById('progress').hidden = false;
+  try {
+    const opts = { method, headers: { Authorization: `Bearer ${TOKEN}` } };
+    if (body instanceof FormData) {
+      opts.body = body;
+    } else if (body !== undefined) {
+      opts.headers['Content-Type'] = 'application/json';
+      opts.body = JSON.stringify(body);
+    }
+    const res = await fetch(path, opts);
+    if (!res.ok) {
+      let msg = res.statusText;
+      try { msg = (await res.json()).error || msg; } catch { /* not json */ }
+      throw new Error(msg);
+    }
+    if (raw) return res;
+    const text = await res.text();
+    return text ? JSON.parse(text) : null;
+  } finally {
+    if (--inflight <= 0) { inflight = 0; document.getElementById('progress').hidden = true; }
   }
-  const res = await fetch(path, opts);
-  if (!res.ok) {
-    let msg = res.statusText;
-    try { msg = (await res.json()).error || msg; } catch { /* not json */ }
-    throw new Error(msg);
-  }
-  if (raw) return res;
-  const text = await res.text();
-  return text ? JSON.parse(text) : null;
 }
 
 const $ = (sel) => document.querySelector(sel);
@@ -40,6 +47,17 @@ function fmtDate(s) {
   if (!s) return '';
   const d = new Date(s);
   return isNaN(d) ? s : d.toISOString().slice(0, 10);
+}
+
+function showPlaceholder(tbody, text, cols) {
+  tbody.innerHTML = '';
+  const tr = document.createElement('tr');
+  const td = document.createElement('td');
+  td.colSpan = cols;
+  td.className = 'placeholder';
+  td.textContent = text;
+  tr.appendChild(td);
+  tbody.appendChild(tr);
 }
 
 // ---- state ----
@@ -74,8 +92,8 @@ async function init() {
     // Close the drawer: anything open in it belongs to the previous vault,
     // and saving/deleting it against the new vault would hit the wrong secret.
     closeDrawer();
-    loadSecrets();
-    loadFiles();
+    loadSecrets().catch(fail);
+    loadFiles().catch(fail);
   };
   await loadSecrets();
   if (ctx.capabilities.files) await loadFiles();
@@ -83,6 +101,7 @@ async function init() {
 
 // ---- secrets ----
 async function loadSecrets() {
+  showPlaceholder($('#secrets-table tbody'), 'Loading secrets…', 5);
   secrets = await api('GET', `/api/secrets${vaultQS()}`);
   renderSecrets();
 }
@@ -103,6 +122,9 @@ function renderSecrets() {
     }
     tr.onclick = () => openDrawer(name);
     tbody.appendChild(tr);
+  }
+  if (!tbody.children.length) {
+    showPlaceholder(tbody, secrets.length ? 'no matching secrets' : 'no secrets', 5);
   }
 }
 
@@ -242,6 +264,7 @@ function switchTab(which) {
 // ---- files ----
 async function loadFiles() {
   if (!ctx.capabilities.files) return;
+  showPlaceholder($('#files-table tbody'), 'Loading files…', 5);
   const files = await api('GET', `/api/files${vaultQS()}`);
   const tbody = $('#files-table tbody');
   tbody.innerHTML = '';
@@ -270,6 +293,7 @@ async function loadFiles() {
     tr.appendChild(td);
     tbody.appendChild(tr);
   }
+  if (!tbody.children.length) showPlaceholder(tbody, 'no files', 5);
 }
 
 async function downloadFile(name) {

--- a/src/web/assets/app.js
+++ b/src/web/assets/app.js
@@ -168,6 +168,28 @@ async function init() {
   $('#backend-badge').textContent = ctx.backend;
   $('#tab-files').hidden = !ctx.capabilities.files;
   ({ types } = await api('GET', '/api/types'));
+  const picker = $('#type-picker');
+  picker.innerHTML = '';
+  const plain = document.createElement('option');
+  plain.value = '';
+  plain.textContent = 'plain secret';
+  picker.appendChild(plain);
+  for (const rt of types) {
+    const opt = document.createElement('option');
+    opt.value = opt.textContent = rt.name;
+    picker.appendChild(opt);
+  }
+  picker.onchange = () => {
+    if (!picker.value) {
+      recordState = null;
+      $('#record-section').hidden = true;
+      $('#value-section').hidden = false;
+      $('#record-fields').innerHTML = '';
+    } else {
+      recordState = { typeName: picker.value, secretFields: {}, metaFields: {} };
+      renderRecordFields(picker.value, {}, {}, true);
+    }
+  };
   const { vaults } = await api('GET', '/api/vaults');
   const sel = $('#vault-select');
   sel.innerHTML = '';
@@ -242,6 +264,8 @@ async function openDrawer(name) {
   $('#value-section').hidden = false;
   $('#record-fields').innerHTML = '';
   $('#save').disabled = false;
+  $('#type-picker-label').hidden = !!name; // type is chosen at creation only
+  $('#type-picker').value = '';
   if (name) {
     try {
       const meta = await api('GET', `/api/secrets/${encodeURIComponent(name)}${vaultQS()}`);

--- a/src/web/assets/app.js
+++ b/src/web/assets/app.js
@@ -105,6 +105,7 @@ function fieldRow(name, kind, value, required) {
   if (required) input.required = true;
   if (kind === 'secret') {
     input.type = 'password';
+    input.autocomplete = 'new-password';
     const row = document.createElement('span');
     row.className = 'row';
     const rev = document.createElement('button');
@@ -214,7 +215,12 @@ async function init() {
 // ---- secrets ----
 async function loadSecrets() {
   showPlaceholder($('#secrets-table tbody'), 'Loading secrets…', 5);
-  secrets = await api('GET', `/api/secrets${vaultQS()}`);
+  try {
+    secrets = await api('GET', `/api/secrets${vaultQS()}`);
+  } catch (e) {
+    showPlaceholder($('#secrets-table tbody'), 'failed to load', 5);
+    throw e;
+  }
   renderSecrets();
 }
 
@@ -273,6 +279,8 @@ async function openDrawer(name) {
       f.elements.folder.value = tags.folder || '';
       f.elements.groups.value = tags.groups || '';
       f.elements.note.value = tags.note || '';
+      // Use the stored literal date on purpose, not fmtDate: fmtDate's
+      // toISOString conversion could shift the date across a timezone boundary.
       f.elements.expires_on.value = meta.expires_on ? meta.expires_on.slice(0, 10) : '';
       const customTags = {};
       for (const [k, v] of Object.entries(tags)) {
@@ -309,6 +317,9 @@ async function openRecord(name, tags) {
   } catch (e) {
     // Content type says record but the value isn't a valid envelope: open
     // read-only in the plain view rather than pretending fields are empty.
+    // Whole-value Reveal/Copy stay visible here (unlike the valid-record
+    // path below) because they're the only diagnostic escape hatch for
+    // inspecting a corrupt envelope.
     toast(`record envelope is invalid: ${e.message}`, true);
     $('#save').disabled = true;
     return;
@@ -364,6 +375,8 @@ $('#secret-form').onsubmit = async (ev) => {
       }
       const sorted = {};
       for (const k of Object.keys(envelope).sort()) sorted[k] = envelope[k];
+      const tags = { ...(editingMeta?.tags || {}), ...fieldTags };
+      if (recordState.typeName) tags[TYPE_TAG] = recordState.typeName;
       await api('PUT', `/api/secrets/${encodeURIComponent(name)}${vaultQS()}`, {
         value: JSON.stringify(sorted),
         content_type: RECORD_CONTENT_TYPE,
@@ -371,7 +384,7 @@ $('#secret-form').onsubmit = async (ev) => {
         note: f.note.value || null,
         groups: groups.length ? groups : null,
         expires_on: expiresPut,
-        tags: { ...(editingMeta?.tags || {}), [TYPE_TAG]: recordState.typeName, ...fieldTags },
+        tags,
         enabled: editingMeta ? editingMeta.enabled : true,
         not_before: editingMeta?.not_before || null,
       });
@@ -435,7 +448,13 @@ function switchTab(which) {
 async function loadFiles() {
   if (!ctx.capabilities.files) return;
   showPlaceholder($('#files-table tbody'), 'Loading files…', 5);
-  const files = await api('GET', `/api/files${vaultQS()}`);
+  let files;
+  try {
+    files = await api('GET', `/api/files${vaultQS()}`);
+  } catch (e) {
+    showPlaceholder($('#files-table tbody'), 'failed to load', 5);
+    throw e;
+  }
   const tbody = $('#files-table tbody');
   tbody.innerHTML = '';
   for (const f of files) {

--- a/src/web/assets/app.js
+++ b/src/web/assets/app.js
@@ -304,7 +304,7 @@ async function openDrawer(name) {
         enabled: meta.enabled,
         not_before: meta.not_before || null,
       };
-      if (isRecordMeta(meta)) await openRecord(name, tags);
+      if (isRecordMeta(meta)) await openRecord(name, meta, tags);
     } catch (e) {
       // Without the fetched metadata a save would send enabled:true and no
       // custom tags — silently mutating the secret. Don't open the drawer.
@@ -318,12 +318,18 @@ async function openDrawer(name) {
 
 // Fetches the envelope so secret fields are editable. Values live in JS
 // memory but display masked — the same exposure as the Reveal button.
-async function openRecord(name, tags) {
+async function openRecord(name, meta, tags) {
   const { value } = await api('POST', `/api/secrets/${encodeURIComponent(name)}/value${vaultQS()}`);
   let secretFields;
   try {
     secretFields = parseEnvelope(value ?? '');
   } catch (e) {
+    if (meta.content_type !== RECORD_CONTENT_TYPE) {
+      // Only an xv-type tag marked this as a record, and the value isn't
+      // an envelope. Content type decides record-ness (same rule as the
+      // CLI), so treat it as a plain secret: fully editable, no record UI.
+      return;
+    }
     // Content type says record but the value isn't a valid envelope: open
     // read-only in the plain view rather than pretending fields are empty.
     // Whole-value Reveal/Copy stay visible here (unlike the valid-record

--- a/src/web/assets/app.js
+++ b/src/web/assets/app.js
@@ -35,6 +35,13 @@ function toast(msg, isError = false) {
 }
 const fail = (e) => toast(e.message, true);
 
+// Dates only, never timestamps. Unparseable strings pass through raw.
+function fmtDate(s) {
+  if (!s) return '';
+  const d = new Date(s);
+  return isNaN(d) ? s : d.toISOString().slice(0, 10);
+}
+
 // ---- state ----
 let ctx = null;
 let currentVault = null;
@@ -89,7 +96,7 @@ function renderSecrets() {
     const hay = `${name} ${s.folder || ''} ${s.groups || ''} ${s.note || ''}`.toLowerCase();
     if (filter && !hay.includes(filter)) continue;
     const tr = document.createElement('tr');
-    for (const cell of [name, s.folder, s.groups, s.note, s.updated_on]) {
+    for (const cell of [name, s.folder, s.groups, s.note, fmtDate(s.updated_on)]) {
       const td = document.createElement('td');
       td.textContent = cell || '';
       tr.appendChild(td);
@@ -124,7 +131,7 @@ async function openDrawer(name) {
       f.elements.folder.value = tags.folder || '';
       f.elements.groups.value = tags.groups || '';
       f.elements.note.value = tags.note || '';
-      f.elements.expires_on.value = meta.expires_on || '';
+      f.elements.expires_on.value = meta.expires_on ? meta.expires_on.slice(0, 10) : '';
       const customTags = {};
       for (const [k, v] of Object.entries(tags)) {
         if (!CANONICAL_TAGS.has(k)) customTags[k] = v;
@@ -169,6 +176,8 @@ $('#secret-form').onsubmit = async (ev) => {
   const name = f.name.value.trim();
   if (!name) return;
   const groups = f.groups.value.split(',').map(s => s.trim()).filter(Boolean);
+  const expiresPut = f.expires_on.value ? `${f.expires_on.value}T00:00:00Z` : null;
+  const expiresPatch = f.expires_on.value ? `${f.expires_on.value}T00:00:00Z` : '';
   try {
     if (editing && name !== editing) {
       await api('POST', `/api/secrets/${encodeURIComponent(editing)}/move${vaultQS()}`, { new_name: name });
@@ -181,7 +190,7 @@ $('#secret-form').onsubmit = async (ev) => {
         folder: f.folder.value || null,
         note: f.note.value || null,
         groups: groups.length ? groups : null,
-        expires_on: f.expires_on.value || null,
+        expires_on: expiresPut,
         content_type: editingMeta?.content_type || null,
         tags: editingMeta && Object.keys(editingMeta.tags).length ? editingMeta.tags : null,
         enabled: editingMeta ? editingMeta.enabled : true,
@@ -193,7 +202,7 @@ $('#secret-form').onsubmit = async (ev) => {
         folder: f.folder.value,
         note: f.note.value,
         groups,
-        expires_on: f.expires_on.value,
+        expires_on: expiresPatch,
       });
     } else {
       throw new Error('a new secret needs a value');
@@ -238,7 +247,7 @@ async function loadFiles() {
   tbody.innerHTML = '';
   for (const f of files) {
     const tr = document.createElement('tr');
-    const cells = [f.name, `${f.size}`, f.content_type, f.last_modified];
+    const cells = [f.name, `${f.size}`, f.content_type, fmtDate(f.last_modified)];
     for (const c of cells) {
       const td = document.createElement('td');
       td.textContent = c || '';

--- a/src/web/assets/app.js
+++ b/src/web/assets/app.js
@@ -213,18 +213,27 @@ async function init() {
 }
 
 // ---- secrets ----
+// 'ready' | 'loading' | 'failed' — guards renderSecrets so a search-box
+// input during a vault switch can't paint the previous vault's rows (or
+// clobber the failed placeholder) while the fetch is in flight.
+let secretsState = 'ready';
 async function loadSecrets() {
+  secretsState = 'loading';
   showPlaceholder($('#secrets-table tbody'), 'Loading secrets…', 5);
   try {
     secrets = await api('GET', `/api/secrets${vaultQS()}`);
   } catch (e) {
+    secretsState = 'failed';
+    secrets = [];
     showPlaceholder($('#secrets-table tbody'), 'failed to load', 5);
     throw e;
   }
+  secretsState = 'ready';
   renderSecrets();
 }
 
 function renderSecrets() {
+  if (secretsState !== 'ready') return; // keep the loading/failed placeholder
   const filter = $('#search').value.toLowerCase();
   const tbody = $('#secrets-table tbody');
   tbody.innerHTML = '';

--- a/src/web/assets/app.js
+++ b/src/web/assets/app.js
@@ -70,6 +70,95 @@ let editing = null; // name of secret open in drawer, null = new
 let editingMeta = null;
 const CANONICAL_TAGS = new Set(['folder', 'groups', 'note', 'original_name', 'created_by']);
 
+// Must match src/records/envelope.rs exactly.
+const RECORD_CONTENT_TYPE = 'application/vnd.xv.record';
+const TYPE_TAG = 'xv-type';
+const FIELD_TAG_PREFIX = 'f.';
+
+let types = []; // resolved record types from /api/types
+// Non-null while the drawer holds a typed record:
+// { typeName, secretFields: {name: value}, metaFields: {name: value} }
+let recordState = null;
+
+// Same rule as the TUI: the xv-type tag OR the exact record content type.
+function isRecordMeta(meta) {
+  return meta.content_type === RECORD_CONTENT_TYPE || !!(meta.tags || {})[TYPE_TAG];
+}
+
+// Strict, mirroring records::parse_envelope: a JSON object of strings.
+function parseEnvelope(raw) {
+  const obj = JSON.parse(raw);
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) throw new Error('not a JSON object');
+  for (const [k, v] of Object.entries(obj)) {
+    if (typeof v !== 'string') throw new Error(`field '${k}' is not a string`);
+  }
+  return obj;
+}
+
+function fieldRow(name, kind, value, required) {
+  const label = document.createElement('label');
+  label.append(`${name}${required ? ' *' : ''}`);
+  const input = document.createElement('input');
+  input.dataset.fieldName = name;
+  input.dataset.fieldKind = kind;
+  input.value = value || '';
+  if (required) input.required = true;
+  if (kind === 'secret') {
+    input.type = 'password';
+    const row = document.createElement('span');
+    row.className = 'row';
+    const rev = document.createElement('button');
+    rev.type = 'button';
+    rev.textContent = 'Reveal';
+    rev.onclick = () => {
+      const showing = input.type === 'text';
+      input.type = showing ? 'password' : 'text';
+      rev.textContent = showing ? 'Reveal' : 'Hide';
+    };
+    const cp = document.createElement('button');
+    cp.type = 'button';
+    cp.textContent = 'Copy';
+    cp.onclick = async () => {
+      try {
+        await navigator.clipboard.writeText(input.value);
+        toast('copied');
+      } catch (e) { fail(e); }
+    };
+    row.append(rev, cp);
+    label.append(input, row);
+  } else {
+    label.append(input);
+  }
+  return label;
+}
+
+// One input per field: declared fields in CLI prompt order (non-primary
+// first, primary last), then undeclared extras sorted by name.
+function renderRecordFields(typeName, secretFields, metaFields, forNew) {
+  const type = types.find((t) => t.name === typeName);
+  $('#record-type').textContent = `type: ${typeName || '(unknown)'}`;
+  const container = $('#record-fields');
+  container.innerHTML = '';
+  const seen = new Set();
+  const declared = type
+    ? [...type.fields.filter((f) => !f.primary), ...type.fields.filter((f) => f.primary)]
+    : [];
+  for (const def of declared) {
+    seen.add(def.name);
+    const value = def.kind === 'secret' ? secretFields[def.name] : metaFields[def.name];
+    container.appendChild(fieldRow(def.name, def.kind, value, forNew && def.required));
+  }
+  const extras = [
+    ...Object.keys(secretFields).filter((n) => !seen.has(n)).map((n) => [n, 'secret']),
+    ...Object.keys(metaFields).filter((n) => !seen.has(n)).map((n) => [n, 'metadata']),
+  ].sort((a, b) => a[0].localeCompare(b[0]));
+  for (const [n, kind] of extras) {
+    container.appendChild(fieldRow(n, kind, kind === 'secret' ? secretFields[n] : metaFields[n], false));
+  }
+  $('#record-section').hidden = false;
+  $('#value-section').hidden = true;
+}
+
 const vaultQS = () => `?vault=${encodeURIComponent(currentVault)}`;
 
 // ---- context & vaults ----
@@ -78,6 +167,7 @@ async function init() {
   currentVault = ctx.vault;
   $('#backend-badge').textContent = ctx.backend;
   $('#tab-files').hidden = !ctx.capabilities.files;
+  ({ types } = await api('GET', '/api/types'));
   const { vaults } = await api('GET', '/api/vaults');
   const sel = $('#vault-select');
   sel.innerHTML = '';
@@ -135,17 +225,23 @@ function closeDrawer() {
   $('#drawer').hidden = true;
   editing = null;
   editingMeta = null;
+  recordState = null;
 }
 
 async function openDrawer(name) {
   editing = name;
   editingMeta = null;
+  recordState = null;
   const f = $('#secret-form');
   f.reset();
   $('#drawer-title').textContent = name ? `Edit: ${name}` : 'New secret';
   f.elements.name.value = name || '';
   f.elements.name.readOnly = false;
   $('#reveal').hidden = $('#copy').hidden = $('#delete').hidden = !name;
+  $('#record-section').hidden = true;
+  $('#value-section').hidden = false;
+  $('#record-fields').innerHTML = '';
+  $('#save').disabled = false;
   if (name) {
     try {
       const meta = await api('GET', `/api/secrets/${encodeURIComponent(name)}${vaultQS()}`);
@@ -156,7 +252,10 @@ async function openDrawer(name) {
       f.elements.expires_on.value = meta.expires_on ? meta.expires_on.slice(0, 10) : '';
       const customTags = {};
       for (const [k, v] of Object.entries(tags)) {
-        if (!CANONICAL_TAGS.has(k)) customTags[k] = v;
+        // xv-type and f.* are managed by the record editor, not echoed blindly.
+        if (!CANONICAL_TAGS.has(k) && k !== TYPE_TAG && !k.startsWith(FIELD_TAG_PREFIX)) {
+          customTags[k] = v;
+        }
       }
       editingMeta = {
         content_type: meta.content_type || '',
@@ -164,6 +263,7 @@ async function openDrawer(name) {
         enabled: meta.enabled,
         not_before: meta.not_before || null,
       };
+      if (isRecordMeta(meta)) await openRecord(name, tags);
     } catch (e) {
       // Without the fetched metadata a save would send enabled:true and no
       // custom tags — silently mutating the secret. Don't open the drawer.
@@ -173,6 +273,30 @@ async function openDrawer(name) {
     }
   }
   $('#drawer').hidden = false;
+}
+
+// Fetches the envelope so secret fields are editable. Values live in JS
+// memory but display masked — the same exposure as the Reveal button.
+async function openRecord(name, tags) {
+  const { value } = await api('POST', `/api/secrets/${encodeURIComponent(name)}/value${vaultQS()}`);
+  let secretFields;
+  try {
+    secretFields = parseEnvelope(value ?? '');
+  } catch (e) {
+    // Content type says record but the value isn't a valid envelope: open
+    // read-only in the plain view rather than pretending fields are empty.
+    toast(`record envelope is invalid: ${e.message}`, true);
+    $('#save').disabled = true;
+    return;
+  }
+  const metaFields = {};
+  for (const [k, v] of Object.entries(tags)) {
+    if (k.startsWith(FIELD_TAG_PREFIX)) metaFields[k.slice(FIELD_TAG_PREFIX.length)] = v;
+  }
+  recordState = { typeName: tags[TYPE_TAG] || '', secretFields, metaFields };
+  // Whole-value reveal/copy would expose the raw envelope JSON.
+  $('#reveal').hidden = $('#copy').hidden = true;
+  renderRecordFields(recordState.typeName, secretFields, metaFields, false);
 }
 
 $('#close-drawer').onclick = closeDrawer;
@@ -205,7 +329,29 @@ $('#secret-form').onsubmit = async (ev) => {
       await api('POST', `/api/secrets/${encodeURIComponent(editing)}/move${vaultQS()}`, { new_name: name });
       editing = name;
     }
-    if (f.value.value) {
+    if (recordState) {
+      // Records always take the full-PUT path: field edits change the value.
+      const envelope = {};
+      const fieldTags = {};
+      for (const input of $('#record-fields').querySelectorAll('input[data-field-name]')) {
+        if (!input.value) continue; // empty = omit field / drop tag
+        if (input.dataset.fieldKind === 'secret') envelope[input.dataset.fieldName] = input.value;
+        else fieldTags[FIELD_TAG_PREFIX + input.dataset.fieldName] = input.value;
+      }
+      const sorted = {};
+      for (const k of Object.keys(envelope).sort()) sorted[k] = envelope[k];
+      await api('PUT', `/api/secrets/${encodeURIComponent(name)}${vaultQS()}`, {
+        value: JSON.stringify(sorted),
+        content_type: RECORD_CONTENT_TYPE,
+        folder: f.folder.value || null,
+        note: f.note.value || null,
+        groups: groups.length ? groups : null,
+        expires_on: expiresPut,
+        tags: { ...(editingMeta?.tags || {}), [TYPE_TAG]: recordState.typeName, ...fieldTags },
+        enabled: editingMeta ? editingMeta.enabled : true,
+        not_before: editingMeta?.not_before || null,
+      });
+    } else if (f.value.value) {
       // full write: value + all metadata
       await api('PUT', `/api/secrets/${encodeURIComponent(name)}${vaultQS()}`, {
         value: f.value.value,
@@ -229,7 +375,7 @@ $('#secret-form').onsubmit = async (ev) => {
     } else {
       throw new Error('a new secret needs a value');
     }
-    $('#drawer').hidden = true;
+    closeDrawer();
     toast('saved');
     await loadSecrets();
   } catch (e) { fail(e); }

--- a/src/web/assets/index.html
+++ b/src/web/assets/index.html
@@ -52,7 +52,7 @@
     <label>Folder <input name="folder"></label>
     <label>Groups (comma-separated) <input name="groups"></label>
     <label>Note <input name="note"></label>
-    <label>Expires (RFC3339, blank = never) <input name="expires_on" placeholder="2027-01-01T00:00:00Z"></label>
+    <label>Expires <input name="expires_on" type="date"></label>
     <div class="row">
       <button type="submit" id="save">Save</button>
       <button type="button" id="delete" class="danger">Delete</button>

--- a/src/web/assets/index.html
+++ b/src/web/assets/index.html
@@ -43,13 +43,19 @@
   <h2 id="drawer-title"></h2>
   <form id="secret-form">
     <label>Name <input name="name" required></label>
-    <label>Value
-      <textarea name="value" rows="4" placeholder="(leave blank to keep current value)"></textarea>
-      <span class="row">
-        <button type="button" id="reveal">Reveal</button>
-        <button type="button" id="copy">Copy</button>
-      </span>
-    </label>
+    <div id="value-section">
+      <label>Value
+        <textarea name="value" rows="4" placeholder="(leave blank to keep current value)"></textarea>
+        <span class="row">
+          <button type="button" id="reveal">Reveal</button>
+          <button type="button" id="copy">Copy</button>
+        </span>
+      </label>
+    </div>
+    <div id="record-section" hidden>
+      <div id="record-type"></div>
+      <div id="record-fields"></div>
+    </div>
     <label>Folder <input name="folder"></label>
     <label>Groups (comma-separated) <input name="groups"></label>
     <label>Note <input name="note"></label>

--- a/src/web/assets/index.html
+++ b/src/web/assets/index.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="/style.css">
 </head>
 <body>
+<div id="progress" hidden></div>
 <header>
   <strong>xv</strong>
   <span id="backend-badge"></span>

--- a/src/web/assets/index.html
+++ b/src/web/assets/index.html
@@ -41,7 +41,7 @@
 
 <aside id="drawer" hidden>
   <h2 id="drawer-title"></h2>
-  <form id="secret-form">
+  <form id="secret-form" autocomplete="off">
     <label>Name <input name="name" required></label>
     <label id="type-picker-label" hidden>Type <select id="type-picker"></select></label>
     <div id="value-section">

--- a/src/web/assets/index.html
+++ b/src/web/assets/index.html
@@ -43,6 +43,7 @@
   <h2 id="drawer-title"></h2>
   <form id="secret-form">
     <label>Name <input name="name" required></label>
+    <label id="type-picker-label" hidden>Type <select id="type-picker"></select></label>
     <div id="value-section">
       <label>Value
         <textarea name="value" rows="4" placeholder="(leave blank to keep current value)"></textarea>

--- a/src/web/assets/style.css
+++ b/src/web/assets/style.css
@@ -38,3 +38,4 @@ button.danger { color:var(--danger); }
   animation:progress-slide 1.2s linear infinite; }
 @keyframes progress-slide { from { transform:translateX(-100vw); } to { transform:translateX(100vw); } }
 td.placeholder { color:var(--muted); text-align:center; padding:1rem; }
+#record-type { color:var(--muted); margin-bottom:.5rem; }

--- a/src/web/assets/style.css
+++ b/src/web/assets/style.css
@@ -3,6 +3,9 @@
   :root { --fg:#e6e6e6; --bg:#161616; --muted:#999; --line:#333; --accent:#4cc38a; }
 }
 * { box-sizing: border-box; }
+/* Author display rules (e.g. #drawer label { display:block }) must not
+   defeat the hidden attribute's UA display:none. */
+[hidden] { display: none !important; }
 body { margin:0; font:14px/1.5 system-ui, sans-serif; color:var(--fg); background:var(--bg); }
 header { display:flex; gap:.75rem; align-items:center; padding:.5rem 1rem; border-bottom:1px solid var(--line); }
 header nav { margin-left:auto; }

--- a/src/web/assets/style.css
+++ b/src/web/assets/style.css
@@ -33,3 +33,8 @@ button.danger { color:var(--danger); }
 #toast { position:fixed; bottom:1rem; left:50%; transform:translateX(-50%); background:var(--fg);
   color:var(--bg); padding:.5rem 1rem; border-radius:6px; }
 #toast.error { background:var(--danger); color:#fff; }
+#progress { position:fixed; top:0; left:0; right:0; height:2px; overflow:hidden; z-index:10; }
+#progress::after { content:""; display:block; width:30%; height:100%; background:var(--accent);
+  animation:progress-slide 1.2s linear infinite; }
+@keyframes progress-slide { from { transform:translateX(-100vw); } to { transform:translateX(100vw); } }
+td.placeholder { color:var(--muted); text-align:center; padding:1rem; }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -27,12 +27,15 @@ pub(crate) struct WebState {
     pub token: String,
     /// Default vault, resolved once at startup. Requests may override per-call.
     pub vault: String,
+    /// Record types (builtin + [types.*] config), resolved once at startup.
+    pub types: Vec<crate::records::RecordType>,
 }
 
 pub(crate) fn build_router(state: Arc<WebState>) -> Router {
     let api = Router::new()
         .route("/context", get(api::get_context))
         .route("/vaults", get(api::list_vaults))
+        .route("/types", get(api::list_types))
         .route("/secrets", get(api::list_secrets))
         .route(
             "/secrets/{name}",
@@ -100,6 +103,9 @@ pub async fn run_web(
     })?;
     let vault = crate::cli::helpers::resolve_vault_for_trait(&config, Some(registry)).await?;
     let backend = registry.active_arc();
+    // Fail loud at startup on a broken [types.*] block, matching the CLI's
+    // eager type-resolution paths.
+    let types = config.resolve_record_types().await?;
 
     let mut buf = [0u8; 32];
     rand::rng().fill_bytes(&mut buf);
@@ -109,6 +115,7 @@ pub async fn run_web(
         backend,
         token: token.clone(),
         vault,
+        types,
     });
     let app = build_router(state);
 

--- a/src/web/testutil.rs
+++ b/src/web/testutil.rs
@@ -9,6 +9,7 @@ pub(crate) fn test_state_with_token(token: &str) -> Arc<WebState> {
         backend: Arc::new(stub::StubBackend::new()),
         token: token.to_string(),
         vault: "default".to_string(),
+        types: crate::records::builtin_types(),
     })
 }
 


### PR DESCRIPTION
## Summary

Three UX tweaks to the embedded web UI (`xv ui`), per the approved spec (`docs/superpowers/specs/2026-07-09-web-ui-tweaks-design.md`):

1. **Dates only, everywhere** — the secrets *Updated* and files *Modified* columns render `YYYY-MM-DD` (raw string passthrough if unparseable), and the *Expires* field is now a native date picker (PUT sends `<date>T00:00:00Z`, blank still clears).
2. **Full typed-record editing** — new `GET /api/types` endpoint exposes resolved record types (builtin + `[types.*]` config, resolved once at startup, fail-loud on broken config). The drawer detects records (same rule as the TUI: `xv-type` tag or record content type), hides the raw Value textarea and whole-value Reveal/Copy so the envelope JSON is never rendered, and shows one input per field — metadata fields plain, secret fields masked (`type="password"`, `autocomplete="new-password"`) with per-field Reveal/Copy. New records are created via a type picker. Saves re-encode the envelope through the existing PUT.
3. **Loading indicators** — "Loading…" placeholder rows in both tables (plus empty/failed states) and a slim top-of-page progress bar driven by an in-flight counter in the `api()` wrapper.

Also fixed along the way: author display rules (`#drawer label { display:block }`) were defeating the `hidden` attribute; a `[hidden]{display:none !important}` rule restores attribute semantics.

## Verification

- `cargo fmt --check`, `cargo clippy --features ui --all-targets`, full `cargo test --features ui` — green.
- New axum tests: `/api/types` shape, record envelope/tag round-trip through PUT/GET/reveal (list never leaks the envelope).
- Browser e2e (playwright + headless Chrome against a hermetic local backend): 13/13 — dates-only columns, loading placeholder + progress bar, record create/edit via picker, per-field reveal/copy toggling, envelope never present in the DOM, expiry date round-trip, picker hidden when editing.
- CLI cross-check: a record created/edited in the UI reads back correctly via `xv get --field`/`--record`.

## Notes for review

- Whole-branch review applied a hardening pass: `autocomplete` attributes so browser password managers don't capture secret-field values; records detected by content type alone no longer gain an empty `xv-type` tag on save.
- Deferred minors (non-blocking): substring-only leak assertion in the round-trip test, `inflight++` outside `try` (latent only), search-during-load flicker, `/api/types` fetch serialized in `init()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Record saves and reveal paths handle secret material in the browser (same as before for reveal); startup now fails on invalid type config, and the large frontend drawer logic increases regression risk for secret CRUD.
> 
> **Overview**
> **`xv ui`** gains three UX improvements behind the existing `ui` feature, mostly in embedded `app.js` / `index.html` / `style.css`, plus a small Rust API addition.
> 
> **Server:** **`GET /api/types`** returns record types resolved once at **`xv ui`** startup via `config.resolve_record_types()` (stored on `WebState`; broken `[types.*]` config fails startup). New axum tests cover builtin type shape and typed-record PUT/GET/reveal round-trip without list leakage.
> 
> **Typed records in the drawer:** On create, a **Type** picker (plain secret vs types from `/api/types`) swaps the value textarea for per-field inputs. Existing records ( **`xv-type`** tag or record content type) open a field editor: metadata vs secret fields, masked passwords with per-field Reveal/Copy, envelope fetched via reveal; raw envelope JSON is not shown. Saves use full **PUT** with sorted envelope JSON and `f.*` tags. Hardening includes `autocomplete="new-password"`, only adding **`xv-type`** when a type name exists, and treating **`xv-type`-only** mismatches as plain secrets.
> 
> **Dates & expiry:** Table columns use **`YYYY-MM-DD`** via `fmtDate`; **Expires** is `<input type="date">` with RFC3339 midnight UTC on save.
> 
> **Loading UX:** Table placeholder rows (loading / failed / empty), a top **in-flight progress bar** in `api()`, `secretsState` to avoid stale rows while switching vaults, and **`[hidden] { display: none !important }`** so drawer CSS does not break `hidden`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac973e5ea3d9511001469a3f13f04cd4b9306a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->