### PR TITLE
chore: bump version to 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.24.0 — Web UI record editing (2026-07-09)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Version bump for the v0.24.0 release (web UI record editing, dates-only display, loading indicators — #356). CHANGELOG Unreleased section renamed to the release heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only change with no runtime behavior modifications.
> 
> **Overview**
> **Release metadata only** — no application or UI code changes in this diff.
> 
> The package version moves from `0.23.0` to **`0.24.0`** in `Cargo.toml`, with the matching `crosstache` entry in `Cargo.lock`. The CHANGELOG **Unreleased** heading becomes **`v0.24.0 — Web UI record editing (2026-07-09)`**, keeping the existing bullet list for typed-record editing, dates-only display, and loading indicators as the published release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c812e8a4607b342a3da26c054087c1f1c5865d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->