### PR TITLE
chore: bump version to 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.25.0 — Web UI folder grouping (2026-07-10)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Version bump for the v0.25.0 release (web UI folder grouping + human-readable file sizes — #358). CHANGELOG Unreleased section renamed to the release heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata-only diff with no application code changes.
> 
> **Overview**
> Prepares the **v0.25.0** release by aligning crate metadata with the changelog: `Cargo.toml` and `Cargo.lock` move **0.24.0 → 0.25.0**, and the top of `CHANGELOG.md` renames **Unreleased** to **`v0.25.0 — Web UI folder grouping (2026-07-10)`** (the Added bullets for folder grouping and human-readable file sizes are unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c71babe3d4ddec68d73751f036a073baf1e76f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->