### PR TITLE
chore: bump version to 0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.25.1 — Security hardening (2026-07-11)
+
+### Security
+
+- Hardened file downloads, sync, archives, and configuration/state writes
+  against path traversal and symlink attacks across the CLI and Azure Function
+  installer.
+- Tightened Azure RBAC provisioning, authorization scopes, resource ownership,
+  and teardown so privileged operations apply only to exact, verified
+  resources and identities.
+- Strengthened the release supply chain with pinned GitHub Actions, verified
+  minisign tooling, mandatory signed archives, and release-tag/version binding
+  in installers and the self-updater.
+- Made workspace/config resolution, staged leak scanning, migration checks, and
+  secret-to-environment mapping fail closed on ambiguous or incomplete state.
+
+### Fixed
+
+- Preserved explicit workspace-alias precedence and rejected record-type
+  overrides that could expose secret fields as metadata.
+- Completed AWS audit pagination for the requested time window and corrected
+  exact-scope Azure role-assignment handling.
+
 ## v0.25.0 — Web UI folder grouping (2026-07-10)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
## Summary

- bump the crate version to 0.25.1
- add the v0.25.1 security-hardening changelog entry
- keep Cargo.toml and Cargo.lock versions aligned

## Verification

- `RUST_LOG=off cargo test --all-features -- --test-threads=1`
- `xfunction/.venv/bin/python -m pytest xfunction/tests` (117 passed, 1 skipped)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUST_LOG=off cargo test --all-features version -- --test-threads=1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only change with no runtime code modifications in the diff.
> 
> **Overview**
> **Release v0.25.1** — bumps the `crosstache` crate from **0.25.0** to **0.25.1** in `Cargo.toml` and the matching `crosstache` entry in `Cargo.lock`.
> 
> Adds a **v0.25.1 — Security hardening** section at the top of `CHANGELOG.md`, documenting the security fixes and related bugfixes shipped in this tag (path traversal/symlink hardening, Azure RBAC scoping, release supply-chain checks, fail-closed config/workspace behavior, workspace-alias/record-type fixes, AWS audit pagination, and Azure role-assignment scope). This PR does not include application code changes—only version alignment and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bf75863fe352a0953f4b70d508edf9aa6fcea01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->