### PR TITLE
fix(ci): extract root-level macOS minisign binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           curl -fsSLo minisign.zip https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.11-macos.zip
           echo "e7c410ae8b8960d7087392472b040bda9b2f307c76df0384ac37f9ad103fc893  minisign.zip" | shasum -a 256 --check
-          unzip -j minisign.zip '*/minisign' -d minisign-bin
+          unzip -j minisign.zip minisign -d minisign-bin
           chmod +x minisign-bin/minisign
           echo "MINISIGN_BIN=./minisign-bin/minisign" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary

- fix the macOS minisign extraction glob in the release workflow
- the upstream ZIP stores `minisign` at the archive root, not in a subdirectory

## Verification

- reproduced the old command failing with exit 11 and `filename not matched: */minisign`
- downloaded the pinned archive, verified the existing SHA-256, extracted `minisign`, and ran `minisign -v` successfully
- parsed `.github/workflows/release.yml` with Ruby YAML

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI unzip fix with no application, auth, or release-signing logic changes beyond restoring the intended macOS install path.
> 
> **Overview**
> Fixes the **macOS** release workflow step that installs minisign before signing artifacts.
> 
> The pinned `minisign-0.11-macos.zip` puts the binary at the archive root, but `unzip` was using the glob `*/minisign`, which fails with “filename not matched” and blocked install/signing on macOS matrix jobs. The step now extracts the root entry `minisign` into `minisign-bin` so `MINISIGN_BIN` is set and the existing **Sign release archive** step can run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 944b24ad58bc1f6900fe0bc7d52dedbdf9567643. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->