### PR TITLE
fix: restore Windows release compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,18 @@ jobs:
 
       - name: Test (with TUI feature)
         run: cargo test --features tui --verbose
+
+  windows-check:
+    name: Windows All-Features Check
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: windows-all-features
+
+      - name: Check all features on Windows
+        run: cargo check --all-features

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -9,6 +9,11 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
+#[cfg(unix)]
+type FileMode = libc::mode_t;
+#[cfg(not(unix))]
+type FileMode = u32;
+
 /// Write bytes to a file with mode 0o600 (owner read/write only).
 /// Refuses to follow symlinks on Unix (O_NOFOLLOW).
 pub fn write_private(
@@ -94,8 +99,8 @@ fn write_file_no_follow_with_mode(
     path: &Path,
     content: &[u8],
     overwrite: bool,
-    file_mode: libc::mode_t,
-    directory_mode: libc::mode_t,
+    file_mode: FileMode,
+    directory_mode: FileMode,
 ) -> Result<std::fs::File> {
     #[cfg(unix)]
     {
@@ -255,6 +260,8 @@ fn write_file_no_follow_with_mode(
     #[cfg(not(unix))]
     {
         use std::io::Write;
+
+        let _ = (file_mode, directory_mode);
 
         let absolute = if path.is_absolute() {
             path.to_path_buf()


### PR DESCRIPTION
## Summary

- keep Unix file-mode parameters behind a platform-specific type alias
- explicitly consume those parameters on non-Unix targets
- add a Windows all-features check to PR and main CI

## Root cause

The release build exposed `libc::mode_t` in a function signature compiled on every platform. The Windows `libc` target does not define that Unix type, so the signed Windows release binary could not compile.

## Verification

- reproduced in the v0.25.1 Windows release job: `cannot find type mode_t in crate libc`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUST_LOG=off cargo test --all-features utils::helpers -- --test-threads=1`
- new `Windows All-Features Check` CI job

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted portability fix for file helpers and CI only; Unix permission behavior is unchanged.
> 
> **Overview**
> Fixes Windows release builds that failed because **`write_file_no_follow_with_mode`** exposed **`libc::mode_t`** in a signature compiled on every target; Windows’s **`libc`** does not define that type.
> 
> **`helpers.rs`** now uses a **`FileMode`** alias (`libc::mode_t` on Unix, **`u32`** elsewhere) for the mode parameters, and the non-Unix implementation explicitly ignores those args so callers can still pass octal modes for **`atomic_write_file_no_follow`** without platform-specific call sites.
> 
> **CI** adds a **`windows-check`** job on **`windows-latest`** that runs **`cargo check --all-features`** so all-feature Windows compile regressions are caught on PRs and **`main`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634217e4a120332a1196ddcaf9dc0fd01a8ddbeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->