### PR TITLE
feat(ui): add bulk selection mode and indent expanded folders.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,19 +1,14 @@
-# Documentation automation plan
+# Web UI selection and indentation
 
-## Goal
-
-Keep engineering and user-facing documentation aligned with recently shipped
-changes without adding redundant pages.
+Detailed plan:
+`docs/superpowers/plans/2026-07-14-web-ui-selection.md`
 
 ## Steps
 
-- [x] Refresh README multi-vault workspace docs for the v0.22 alias UX:
-      `cx add --alias`, `cx alias`, `cx alias --reset`, and long-list backing
-      vault suffixes.
-- [x] Correct README file-storage notes for v0.21 default-entry routing and
-      local backend file/sync support while preserving the AWS sync limitation.
-- [x] Update `docs/FEATURES.md` capability and command-reference rows so local
-      file operations and workspace context commands match shipped behavior.
-- [x] Verify changed docs against source/tests and run an appropriate
-      docs-only validation command.
-- [x] Prepare the branch handoff after verification.
+- [x] Add failing embedded-asset contract tests.
+- [x] Indent expanded folder children in both tables.
+- [x] Add explicit selection mode and visible-only select-all.
+- [x] Add bounded bulk delete for secrets and files.
+- [x] Add bounded bulk move for secrets.
+- [x] Update web UI documentation.
+- [x] Run formatting, clippy, and UI-feature tests.

--- a/docs/superpowers/plans/2026-07-14-web-ui-selection.md
+++ b/docs/superpowers/plans/2026-07-14-web-ui-selection.md
@@ -1,0 +1,252 @@
+# Web UI Selection and Folder Indentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Indent expanded folder children and add accessible selection mode with visible-only select-all, bulk delete for secrets/files, and bulk secret move.
+
+**Architecture:** Keep the feature inside the embedded vanilla HTML/JS/CSS frontend and reuse existing per-item API routes. Shared selection helpers own checkbox state and bounded bulk execution; table-specific renderers supply identifiers and operations.
+
+**Tech Stack:** Rust embedded-asset tests, vanilla JavaScript, HTML, CSS, existing axum API routes.
+
+## Global Constraints
+
+- No new frontend framework, build step, or dependency.
+- `Select all` affects only currently visible rows.
+- Bulk file move is out of scope because `FileBackend` has no move operation.
+- At most four bulk requests may be in flight.
+- Changing vaults or tabs clears selection.
+
+---
+
+### Task 1: Lock the UI contract with failing tests
+
+**Files:**
+- Modify: `src/web/mod.rs`
+
+**Interfaces:**
+- Consumes: embedded constants `INDEX_HTML`, `APP_JS`, and `STYLE_CSS`.
+- Produces: regression tests for selection controls, grouped indentation hooks,
+  bounded execution, and bulk endpoint usage.
+
+- [ ] **Step 1: Add failing embedded-asset tests**
+
+Add tests asserting:
+
+```rust
+#[test]
+fn ui_exposes_selection_controls_for_both_tables() {
+    for id in [
+        "select-secrets",
+        "select-files",
+        "select-all-secrets",
+        "select-all-files",
+        "secret-bulk-bar",
+        "file-bulk-bar",
+    ] {
+        assert!(INDEX_HTML.contains(&format!("id=\"{id}\"")), "{id}");
+    }
+}
+
+#[test]
+fn ui_marks_group_children_for_indentation() {
+    assert!(APP_JS.contains("renderRow(it, true)"));
+    assert!(APP_JS.contains("tr.classList.add('folder-child')"));
+    assert!(APP_JS.contains("td.classList.add('item-name')"));
+    assert!(STYLE_CSS.contains(".folder-child .item-name"));
+}
+
+#[test]
+fn ui_bulk_actions_are_bounded_and_reuse_item_routes() {
+    assert!(APP_JS.contains("async function runBounded(items, limit, operation)"));
+    assert!(APP_JS.contains("runBounded(items, 4"));
+    assert!(APP_JS.contains("api('DELETE', `/api/secrets/"));
+    assert!(APP_JS.contains("api('DELETE', `/api/files/"));
+    assert!(APP_JS.contains("/move${vaultQS(vault)}`, { folder }"));
+}
+```
+
+Add companion assertions for visible identifiers driving select-all, the
+indeterminate header state, selection reset on vault/tab changes, and the
+two-click bulk-delete confirmation labels.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+cargo test --features ui web::tests::ui_exposes_selection_controls_for_both_tables
+cargo test --features ui web::tests::ui_marks_group_children_for_indentation
+cargo test --features ui web::tests::ui_bulk_actions_are_bounded_and_reuse_item_routes
+```
+
+Expected: each test fails because the controls and JavaScript/CSS hooks do not
+exist.
+
+### Task 2: Add semantic controls and folder indentation
+
+**Files:**
+- Modify: `src/web/assets/index.html`
+- Modify: `src/web/assets/app.js`
+- Modify: `src/web/assets/style.css`
+
+**Interfaces:**
+- Produces: `renderGrouped(... renderRow(item, grouped))`; `.folder-child`
+  rows; `.item-name` cells; selection toggles, bulk bars, and select-all inputs.
+
+- [ ] **Step 1: Add HTML controls**
+
+Add `Select` buttons to both normal toolbars, hidden checkbox header cells, and
+hidden bulk bars. The secret bar contains selected count, destination-folder
+input, `Move`, `Delete`, and `Cancel`; the file bar contains selected count,
+`Delete`, and `Cancel`.
+
+- [ ] **Step 2: Mark grouped child rows**
+
+Change grouped rendering to call `renderRow(it, true)` for folder members and
+`renderRow(it, false)` for loose items. In `secretRow` and `fileRow`, add
+`folder-child` to grouped rows and `item-name` to the name cell.
+
+- [ ] **Step 3: Add hierarchy and selection styling**
+
+Style `.folder-child .item-name` with extra inline-start padding and a subtle
+guide line. Add compact checkbox-column, bulk-toolbar, pending, and responsive
+styles without changing the existing light/dark color variables.
+
+- [ ] **Step 4: Run the first two contract tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test --features ui web::tests::ui_exposes_selection_controls_for_both_tables
+cargo test --features ui web::tests::ui_marks_group_children_for_indentation
+```
+
+Expected: PASS.
+
+### Task 3: Implement selection state and visible-only select-all
+
+**Files:**
+- Modify: `src/web/assets/app.js`
+
+**Interfaces:**
+- Produces: `secretSelection`, `fileSelection`, mode flags,
+  `setSelectionMode(kind, enabled)`, `selectionCell(...)`,
+  `syncSelectionUi(...)`, and visible identifier lists.
+
+- [ ] **Step 1: Add per-table selection state**
+
+Use `Set<string>` instances for selected identifiers and booleans for mode.
+Central helpers toggle the checkbox columns and bulk bars, update count labels,
+and reset confirmation buttons.
+
+- [ ] **Step 2: Render row checkboxes**
+
+In selection mode prepend a checkbox cell with an item-specific `aria-label`.
+Stop checkbox click propagation. Secret row clicks toggle selection rather than
+opening the drawer; file per-item action buttons are omitted.
+
+- [ ] **Step 3: Synchronize select-all**
+
+Have `renderSecrets` and `renderFiles` compute visible identifiers. Set the
+header checkbox's `checked` and `indeterminate` properties from only those
+identifiers. Its change handler adds/removes only visible identifiers.
+
+- [ ] **Step 4: Reset and prune state**
+
+Clear both modes and sets on vault and tab changes. After list reloads, remove
+selected identifiers absent from the new dataset.
+
+- [ ] **Step 5: Run selection tests**
+
+Run:
+
+```bash
+cargo test --features ui web::tests::ui_selection
+```
+
+Expected: all selection contract tests PASS.
+
+### Task 4: Implement bounded bulk actions
+
+**Files:**
+- Modify: `src/web/assets/app.js`
+
+**Interfaces:**
+- Produces: `runBounded(items, limit, operation) -> Promise<Result[]>`,
+  bulk delete handlers for both tables, and bulk secret move handler.
+
+- [ ] **Step 1: Implement bounded execution**
+
+Create up to `Math.min(limit, items.length)` workers sharing an index. Each
+worker records `{ item, ok, error }` so one rejection never stops remaining
+items.
+
+- [ ] **Step 2: Implement bulk secret move**
+
+Validate the destination input, capture vault and generation, POST each selected
+name to its existing move route with `{ folder }`, retain failed names, reload
+the current vault, and summarize successes/failures.
+
+- [ ] **Step 3: Implement confirmed bulk deletion**
+
+Use `armConfirmation` for `Delete N secrets?` / `Delete N files?`. Disable
+selection controls while pending, run at concurrency four, retain failed names,
+reload, restore controls, and emit a summary toast.
+
+- [ ] **Step 4: Guard stale UI continuations**
+
+Increment a selection action generation on vault switch, tab switch, or cancel.
+Requests may finish against their captured vault, but stale completions must not
+modify the current selection UI.
+
+- [ ] **Step 5: Run bulk-action tests**
+
+Run:
+
+```bash
+cargo test --features ui web::tests::ui_bulk
+```
+
+Expected: all bulk contract tests PASS.
+
+### Task 5: Document and verify the feature
+
+**Files:**
+- Modify: `docs/web-ui.md`
+- Modify: `TODO.md`
+
+**Interfaces:**
+- Produces: user-facing behavior documentation and completed execution record.
+
+- [ ] **Step 1: Update web UI documentation**
+
+Document indented expanded rows, explicit selection mode, visible-only
+select-all, bulk delete for both tables, and secret-only bulk move.
+
+- [ ] **Step 2: Run formatting and focused tests**
+
+Run:
+
+```bash
+cargo fmt --check
+cargo test --features ui web::tests
+```
+
+Expected: PASS with no warnings or failures.
+
+- [ ] **Step 3: Run full feature verification**
+
+Run:
+
+```bash
+cargo clippy --features ui --all-targets
+cargo test --features ui
+```
+
+Expected: PASS with no clippy warnings or test failures.
+
+- [ ] **Step 4: Review the final diff**
+
+Confirm no unrelated files, secrets, generated browser data, or dependency
+changes are present.
+

--- a/docs/superpowers/specs/2026-07-14-web-ui-selection-design.md
+++ b/docs/superpowers/specs/2026-07-14-web-ui-selection-design.md
@@ -1,0 +1,90 @@
+# Web UI Selection and Folder Indentation Design
+
+**Date:** 2026-07-14  
+**Status:** Approved
+
+## Goal
+
+Make grouped tables visually hierarchical and add an explicit, accessible
+selection mode for bulk secret and file operations.
+
+## Scope
+
+- Expanded folder contents are indented beneath their folder header in both the
+  Secrets and Files tables.
+- Each table gains a `Select` control that enables per-item checkboxes.
+- The table-header checkbox selects or clears only the currently visible items.
+- Both tables support bulk deletion.
+- Secrets additionally support bulk movement to a destination folder.
+- File movement is not included because `FileBackend` has no rename/move
+  operation.
+
+## Interaction design
+
+Selection mode is explicit so ordinary secret-row clicks continue to open the
+drawer and the tables remain uncluttered during normal browsing. Entering the
+mode reveals a checkbox column and a compact action bar. The action bar shows
+the selected count, destructive or move actions, and `Cancel`.
+
+Checkbox clicks stop row activation. Secret rows do not open the drawer while
+selection mode is active; clicking a row toggles its selection instead. File
+download and per-file delete controls are hidden in selection mode to keep the
+interaction unambiguous.
+
+The header checkbox reflects the visible rows:
+
+- checked when every visible item is selected;
+- indeterminate when only some visible items are selected;
+- unchecked when none are selected.
+
+When a secret search is active, `Select all` affects only matching rows.
+Selections outside the filter remain selected and are included in the selected
+count and subsequent bulk action.
+
+Selection is cleared when changing vaults, switching tabs, or cancelling
+selection mode. Reloading a table prunes identifiers that no longer exist.
+
+## Folder hierarchy
+
+`renderGrouped` marks rows emitted beneath an expanded folder as folder
+children. The item-name cell receives additional left padding and a subtle
+guide line. Loose items are not indented. Existing grouping remains flat:
+folder strings such as `proj/db` are still one group, not a nested tree.
+
+## Bulk operations
+
+Bulk operations reuse existing per-item API routes with at most four requests
+in flight:
+
+- secret delete: `DELETE /api/secrets/:name`;
+- file delete: `DELETE /api/files/:name`;
+- secret move: `POST /api/secrets/:name/move` with `{ "folder": "..." }`.
+
+Bulk deletion uses the existing two-click confirmation pattern. Controls are
+disabled while an operation is pending. After completion, successful items are
+removed from selection, failed items remain selected, and the current table is
+reloaded. A summary toast reports the success count and names each failure.
+
+## Accessibility
+
+- Selection checkboxes have item-specific accessible labels.
+- Header checkboxes identify their visible-item scope.
+- Selection counts use an `aria-live` region.
+- Indentation is visual only; folder disclosure rows retain their existing
+  keyboard behavior and `aria-expanded` state.
+- Pending actions expose visible text and disabled state.
+
+## Testing
+
+Implementation proceeds test-first. Embedded-asset contract tests cover the
+new controls, selection state, visible-only select-all behavior, folder-child
+styling hooks, bounded bulk execution, bulk API routes, and confirmation.
+Existing UI tests continue to cover authentication, stale response guards, and
+single-item destructive actions.
+
+Final verification runs:
+
+- `cargo fmt --check`
+- `cargo clippy --features ui --all-targets`
+- `cargo test --features ui`
+

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -12,7 +12,14 @@ secret" drawer or open an existing one to edit it field-by-field, with
 secret-kind fields masked and individually revealable/copyable.
 
 Entries in both tables are grouped by folder into collapsible sections
-(collapsed by default), with file sizes shown in human-readable units.
+(collapsed by default). Expanded contents are indented beneath their folder
+header, and file sizes use human-readable units.
+
+Use **Select** to reveal per-item checkboxes. The header checkbox selects only
+items currently visible (including the active secret filter and expanded
+folders). Both tables support bulk deletion; selected secrets can also be moved
+to another folder. Bulk file moves are not available because file backends do
+not expose a portable move operation.
 
 The URL token is copied into per-tab `sessionStorage`, so reloads in that tab
 remain authenticated while the server is running. Closing the tab discards the
@@ -32,4 +39,5 @@ values only in POST bodies; `Cache-Control: no-store`. There is no TLS and no
 login — if you need network access to your vaults from another device, this is
 deliberately not the tool.
 
-Design: `docs/superpowers/specs/2026-07-08-web-ui-design.md`.
+Designs: `docs/superpowers/specs/2026-07-08-web-ui-design.md` and
+`docs/superpowers/specs/2026-07-14-web-ui-selection-design.md`.

--- a/src/web/assets/app.js
+++ b/src/web/assets/app.js
@@ -52,6 +52,7 @@ function resetConfirmation(button, label) {
   button._confirmTimer = null;
   button.dataset.armed = '';
   button.disabled = false;
+  button.classList.remove('pending');
   button.textContent = label;
 }
 
@@ -60,6 +61,7 @@ function beginPendingAction(button, label) {
   button._confirmTimer = null;
   button.dataset.armed = '';
   button.disabled = true;
+  button.classList.add('pending');
   button.textContent = label;
 }
 
@@ -111,6 +113,133 @@ function showPlaceholder(tbody, text, cols) {
 const expandedSecretFolders = new Set();
 const expandedFileFolders = new Set();
 
+const secretSelection = { enabled: false, pending: false, ids: new Set(), visibleIds: [], generation: 0 };
+const fileSelection = { enabled: false, pending: false, ids: new Set(), visibleIds: [], generation: 0 };
+
+function selectionState(kind) {
+  return kind === 'secrets' ? secretSelection : fileSelection;
+}
+
+function selectionElements(kind) {
+  const singular = kind === 'secrets' ? 'secret' : 'file';
+  return {
+    table: $(`#${kind}-table`),
+    toggle: $(`#select-${kind}`),
+    selectAll: $(`#select-all-${kind}`),
+    bulkBar: $(`#${singular}-bulk-bar`),
+    count: $(`#${singular}-selection-count`),
+    deleteButton: $(`#bulk-delete-${kind}`),
+  };
+}
+
+function resetBulkConfirmation(kind) {
+  const state = selectionState(kind);
+  if (!state.pending) resetConfirmation(selectionElements(kind).deleteButton, 'Delete');
+}
+
+function renderSelectionKind(kind) {
+  if (kind === 'secrets') renderSecrets();
+  else renderFiles();
+}
+
+function resetSelectionControls(kind) {
+  const singular = kind === 'secrets' ? 'secret' : 'file';
+  const cancelButton = $(`#cancel-${singular}-selection`);
+  cancelButton.disabled = false;
+  if (kind === 'secrets') {
+    const moveButton = $('#bulk-move-secrets');
+    resetConfirmation(moveButton, 'Move');
+    $('#secret-move-folder').disabled = false;
+  }
+}
+
+function setSelectionMode(kind, enabled) {
+  const state = selectionState(kind);
+  const elements = selectionElements(kind);
+  state.enabled = enabled;
+  state.generation++;
+  if (!enabled) {
+    resetSelectionControls(kind);
+    state.pending = false;
+    state.ids.clear();
+    state.visibleIds = [];
+    resetConfirmation(elements.deleteButton, 'Delete');
+  }
+  elements.toggle.hidden = enabled;
+  elements.bulkBar.hidden = !enabled;
+  elements.table.querySelector('thead .selection-column').hidden = !enabled;
+  elements.table.classList.toggle('selection-mode', enabled);
+  renderSelectionKind(kind);
+}
+
+function clearSelection(kind) {
+  setSelectionMode(kind, false);
+}
+
+function syncSelectionUi(kind, visibleIds) {
+  const state = selectionState(kind);
+  state.visibleIds = visibleIds;
+  const available = new Set(
+    (kind === 'secrets' ? secrets : files).map((item) => (
+      kind === 'secrets' ? (item.original_name || item.name) : item.name
+    )),
+  );
+  let selectionChanged = false;
+  for (const id of [...state.ids]) {
+    if (!available.has(id)) {
+      state.ids.delete(id);
+      selectionChanged = true;
+    }
+  }
+  if (selectionChanged) resetBulkConfirmation(kind);
+  updateSelectionControls(kind);
+}
+
+function updateSelectionControls(kind) {
+  const state = selectionState(kind);
+  const elements = selectionElements(kind);
+  const visibleIds = state.visibleIds;
+  const selectedVisible = visibleIds.filter((id) => state.ids.has(id)).length;
+  const allVisible = visibleIds.length > 0 && selectedVisible === visibleIds.length;
+  elements.selectAll.checked = allVisible;
+  elements.selectAll.indeterminate = selectedVisible > 0 && !allVisible;
+  elements.selectAll.disabled = visibleIds.length === 0;
+  elements.count.textContent = `${state.ids.size} selected`;
+  elements.deleteButton.disabled = state.pending || state.ids.size === 0;
+  elements.selectAll.disabled = state.pending || visibleIds.length === 0;
+  if (kind === 'secrets') $('#bulk-move-secrets').disabled = state.pending || state.ids.size === 0;
+}
+
+function selectionCell(kind, id) {
+  const state = selectionState(kind);
+  const td = document.createElement('td');
+  td.className = 'selection-column';
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.checked = state.ids.has(id);
+  checkbox.disabled = state.pending;
+  checkbox.setAttribute('aria-label', `Select ${kind === 'secrets' ? 'secret' : 'file'} ${id}`);
+  checkbox.onclick = (e) => e.stopPropagation();
+  checkbox.onchange = () => {
+    if (checkbox.checked) state.ids.add(id);
+    else state.ids.delete(id);
+    resetBulkConfirmation(kind);
+    renderSelectionKind(kind);
+  };
+  td.onclick = (e) => e.stopPropagation();
+  td.appendChild(checkbox);
+  return td;
+}
+
+function toggleSelected(kind, id) {
+  const state = selectionState(kind);
+  if (state.pending) return;
+  if (state.ids.has(id)) state.ids.delete(id);
+  else state.ids.add(id);
+  resetBulkConfirmation(kind);
+  renderSelectionKind(kind);
+}
+
 // Renders `items` into `tbody` as collapsible folder groups (sorted,
 // listed first) followed by loose items (folderOf(item) === '').
 // forceExpand shows every group open without mutating `expanded` —
@@ -118,6 +247,7 @@ const expandedFileFolders = new Set();
 function renderGrouped(tbody, items, folderOf, expanded, cols, renderRow, forceExpand, rerender) {
   const groups = new Map();
   const loose = [];
+  const rendered = [];
   for (const it of items) {
     const f = folderOf(it);
     if (f) {
@@ -156,9 +286,18 @@ function renderGrouped(tbody, items, folderOf, expanded, cols, renderRow, forceE
     }
     tr.appendChild(td);
     tbody.appendChild(tr);
-    if (open) for (const it of rows) tbody.appendChild(renderRow(it));
+    if (open) {
+      for (const it of rows) {
+        rendered.push(it);
+        tbody.appendChild(renderRow(it, true));
+      }
+    }
   }
-  for (const it of loose) tbody.appendChild(renderRow(it));
+  for (const it of loose) {
+    rendered.push(it);
+    tbody.appendChild(renderRow(it, false));
+  }
+  return rendered;
 }
 
 // ---- state ----
@@ -332,6 +471,8 @@ async function init() {
     // Close the drawer: anything open in it belongs to the previous vault,
     // and saving/deleting it against the new vault would hit the wrong secret.
     closeDrawer();
+    clearSelection('secrets');
+    clearSelection('files');
     expandedSecretFolders.clear();
     expandedFileFolders.clear();
     loadSecrets(vault).catch(fail);
@@ -351,7 +492,7 @@ let secretLoadGeneration = 0;
 async function loadSecrets(vault) {
   const generation = ++secretLoadGeneration;
   secretsState = 'loading';
-  showPlaceholder($('#secrets-table tbody'), 'Loading secrets…', 5);
+  showPlaceholder($('#secrets-table tbody'), 'Loading secrets…', secretSelection.enabled ? 6 : 5);
   try {
     const loadedSecrets = await api('GET', `/api/secrets${vaultQS(vault)}`);
     if (generation !== secretLoadGeneration) return false;
@@ -360,7 +501,7 @@ async function loadSecrets(vault) {
     if (generation !== secretLoadGeneration) return false;
     secretsState = 'failed';
     secrets = [];
-    showPlaceholder($('#secrets-table tbody'), 'failed to load', 5);
+    showPlaceholder($('#secrets-table tbody'), 'failed to load', secretSelection.enabled ? 6 : 5);
     throw e;
   }
   secretsState = 'ready';
@@ -382,21 +523,39 @@ function renderSecrets() {
   // While filtering, collapse state is ignored so matches are never
   // hidden inside a collapsed folder; empty groups drop out because
   // their rows are filtered before grouping.
-  renderGrouped(tbody, visible, (s) => s.folder || '', expandedSecretFolders, 5, secretRow, !!filter, renderSecrets);
+  const cols = secretSelection.enabled ? 6 : 5;
+  const rendered = renderGrouped(
+    tbody,
+    visible,
+    (s) => s.folder || '',
+    expandedSecretFolders,
+    cols,
+    secretRow,
+    !!filter,
+    renderSecrets,
+  );
+  syncSelectionUi('secrets', rendered.map((s) => s.original_name || s.name));
   if (!tbody.children.length) {
-    showPlaceholder(tbody, secrets.length ? 'no matching secrets' : 'no secrets', 5);
+    showPlaceholder(tbody, secrets.length ? 'no matching secrets' : 'no secrets', cols);
   }
 }
 
-function secretRow(s) {
+function secretRow(s, grouped = false) {
   const name = s.original_name || s.name;
   const tr = document.createElement('tr');
-  for (const cell of [name, s.folder, s.groups, s.note, fmtDate(s.updated_on)]) {
+  if (grouped) tr.classList.add('folder-child');
+  if (secretSelection.ids.has(name)) tr.classList.add('selected-row');
+  if (secretSelection.enabled) tr.appendChild(selectionCell('secrets', name));
+  for (const [index, cell] of [name, s.folder, s.groups, s.note, fmtDate(s.updated_on)].entries()) {
     const td = document.createElement('td');
+    if (index === 0) td.classList.add('item-name');
     td.textContent = cell || '';
     tr.appendChild(td);
   }
-  tr.onclick = () => openDrawer(name);
+  tr.onclick = () => {
+    if (secretSelection.enabled) toggleSelected('secrets', name);
+    else openDrawer(name);
+  };
   return tr;
 }
 
@@ -639,8 +798,14 @@ $('#delete').onclick = async () => {
 // ---- tabs ----
 $('#tab-secrets').onclick = () => switchTab('secrets');
 $('#tab-files').onclick = () => switchTab('files');
+let activeTab = 'secrets';
 function switchTab(which) {
   if (authRecoveryActive) return;
+  if (which !== activeTab) {
+    clearSelection('secrets');
+    clearSelection('files');
+    activeTab = which;
+  }
   $('#secrets-view').hidden = which !== 'secrets';
   $('#files-view').hidden = which !== 'files';
   $('#tab-secrets').classList.toggle('active', which === 'secrets');
@@ -649,6 +814,7 @@ function switchTab(which) {
 
 // ---- files ----
 let files = [];
+let filesState = 'ready';
 let fileLoadGeneration = 0;
 let fileActionGeneration = 0;
 const pendingFileDeletes = new Map();
@@ -672,27 +838,33 @@ function clearFileDeletePending(vault, name, generation) {
 async function loadFiles(vault) {
   const generation = ++fileLoadGeneration;
   if (!ctx.capabilities.files) return false;
-  showPlaceholder($('#files-table tbody'), 'Loading files…', 5);
+  filesState = 'loading';
+  showPlaceholder($('#files-table tbody'), 'Loading files…', fileSelection.enabled ? 6 : 5);
   try {
     const loadedFiles = await api('GET', `/api/files${vaultQS(vault)}`);
     if (generation !== fileLoadGeneration) return false;
     files = loadedFiles;
   } catch (e) {
     if (generation !== fileLoadGeneration) return false;
+    filesState = 'failed';
     files = [];
-    showPlaceholder($('#files-table tbody'), 'failed to load', 5);
+    showPlaceholder($('#files-table tbody'), 'failed to load', fileSelection.enabled ? 6 : 5);
     throw e;
   }
+  filesState = 'ready';
   renderFiles();
   return true;
 }
 
 function renderFiles() {
+  if (filesState !== 'ready') return;
   const tbody = $('#files-table tbody');
   tbody.innerHTML = '';
   const dirOf = (f) => (f.name.includes('/') ? f.name.slice(0, f.name.lastIndexOf('/')) : '');
-  renderGrouped(tbody, files, dirOf, expandedFileFolders, 5, fileRow, false, renderFiles);
-  if (!tbody.children.length) showPlaceholder(tbody, 'no files', 5);
+  const cols = fileSelection.enabled ? 6 : 5;
+  const rendered = renderGrouped(tbody, files, dirOf, expandedFileFolders, cols, fileRow, false, renderFiles);
+  syncSelectionUi('files', rendered.map((f) => f.name));
+  if (!tbody.children.length) showPlaceholder(tbody, 'no files', cols);
 }
 
 function isCurrentFileAction(generation, vault) {
@@ -717,18 +889,27 @@ async function reconcileFilesAfterDelete(generation, vault) {
   }
 }
 
-function fileRow(f) {
+function fileRow(f, grouped = false) {
   const vault = currentVault;
   const name = f.name;
   const tr = document.createElement('tr');
+  if (grouped) tr.classList.add('folder-child');
+  if (fileSelection.ids.has(name)) tr.classList.add('selected-row');
+  if (fileSelection.enabled) tr.appendChild(selectionCell('files', name));
   const cells = [f.name, fmtSize(f.size), f.content_type, fmtDate(f.last_modified)];
-  for (const c of cells) {
+  for (const [index, c] of cells.entries()) {
     const td = document.createElement('td');
+    if (index === 0) td.classList.add('item-name');
     td.textContent = c || '';
     tr.appendChild(td);
   }
   const td = document.createElement('td');
   td.className = 'file-actions';
+  if (fileSelection.enabled) {
+    tr.onclick = () => toggleSelected('files', name);
+    tr.appendChild(td);
+    return tr;
+  }
   const dl = document.createElement('button');
   dl.textContent = 'Download';
   dl.onclick = () => downloadFile(f.name);
@@ -764,6 +945,163 @@ function fileRow(f) {
   tr.appendChild(td);
   return tr;
 }
+
+function setVisibleSelection(kind, checked) {
+  const state = selectionState(kind);
+  const visibleIds = state.visibleIds;
+  for (const id of visibleIds) {
+    if (checked) state.ids.add(id);
+    else state.ids.delete(id);
+  }
+  resetBulkConfirmation(kind);
+  renderSelectionKind(kind);
+}
+
+async function runBounded(items, limit, operation) {
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const index = next++;
+      const item = items[index];
+      try {
+        await operation(item);
+        results[index] = { item, ok: true };
+      } catch (error) {
+        results[index] = { item, ok: false, error };
+      }
+    }
+  }
+  const workerCount = Math.min(limit, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
+function reportBulkResults(verb, results) {
+  const succeeded = results.filter((result) => result.ok).length;
+  const failures = results.filter((result) => !result.ok);
+  if (!failures.length) {
+    toast(`${verb} ${succeeded} item${succeeded === 1 ? '' : 's'}`);
+    return;
+  }
+  const details = failures
+    .map(({ item, error }) => `${item}: ${error.message}`)
+    .join('; ');
+  toast(`${verb} ${succeeded}; ${failures.length} failed — ${details}`, true);
+}
+
+function setBulkPending(kind, pending, label) {
+  const state = selectionState(kind);
+  const elements = selectionElements(kind);
+  state.pending = pending;
+  const singular = kind === 'secrets' ? 'secret' : 'file';
+  $(`#cancel-${singular}-selection`).disabled = pending;
+  if (kind === 'secrets') {
+    $('#secret-move-folder').disabled = pending;
+    $('#bulk-move-secrets').disabled = pending || state.ids.size === 0;
+  }
+  if (pending) beginPendingAction(elements.deleteButton, label);
+  else resetConfirmation(elements.deleteButton, 'Delete');
+  updateSelectionControls(kind);
+  renderSelectionKind(kind);
+}
+
+async function bulkDelete(kind) {
+  const state = selectionState(kind);
+  const items = [...state.ids];
+  if (!items.length || state.pending) return;
+  const button = selectionElements(kind).deleteButton;
+  if (kind === 'secrets') {
+    if (!armConfirmation(button, `Delete ${items.length} secrets?`)) return;
+  } else if (!armConfirmation(button, `Delete ${items.length} files?`)) {
+    return;
+  }
+
+  const generation = state.generation;
+  const vault = currentVault;
+  setBulkPending(kind, true, 'Deleting…');
+  const results = await runBounded(items, 4, (item) => {
+    if (kind === 'secrets') {
+      return api('DELETE', `/api/secrets/${encodeURIComponent(item)}${vaultQS(vault)}`);
+    }
+    return api('DELETE', `/api/files/${encodeURIComponent(item)}${vaultQS(vault)}`);
+  });
+  if (vault !== currentVault) return;
+
+  const selectionIsCurrent = generation === state.generation;
+  if (selectionIsCurrent) {
+    for (const result of results) {
+      if (result.ok) state.ids.delete(result.item);
+    }
+    state.pending = false;
+  }
+  try {
+    if (kind === 'secrets') await loadSecrets(vault);
+    else await loadFiles(vault);
+  } catch (e) {
+    fail(e);
+  }
+  if (vault !== currentVault) return;
+  if (!selectionIsCurrent || generation !== state.generation) return;
+  setBulkPending(kind, false, '');
+  reportBulkResults('Deleted', results);
+}
+
+async function bulkMoveSecrets() {
+  const state = secretSelection;
+  const items = [...state.ids];
+  if (!items.length || state.pending) return;
+  const folder = $('#secret-move-folder').value.trim();
+  if (!folder) {
+    toast('enter a destination folder', true);
+    return;
+  }
+
+  const generation = state.generation;
+  const vault = currentVault;
+  const moveButton = $('#bulk-move-secrets');
+  state.pending = true;
+  $('#cancel-secret-selection').disabled = true;
+  $('#secret-move-folder').disabled = true;
+  $('#bulk-delete-secrets').disabled = true;
+  beginPendingAction(moveButton, 'Moving…');
+  renderSecrets();
+  const results = await runBounded(items, 4, (item) => (
+    api('POST', `/api/secrets/${encodeURIComponent(item)}/move${vaultQS(vault)}`, { folder })
+  ));
+  if (vault !== currentVault) return;
+
+  const selectionIsCurrent = generation === state.generation;
+  if (selectionIsCurrent) {
+    for (const result of results) {
+      if (result.ok) state.ids.delete(result.item);
+    }
+    state.pending = false;
+  }
+  try {
+    await loadSecrets(vault);
+  } catch (e) {
+    fail(e);
+  }
+  if (vault !== currentVault) return;
+  if (!selectionIsCurrent || generation !== state.generation) return;
+  $('#cancel-secret-selection').disabled = false;
+  $('#secret-move-folder').disabled = false;
+  resetConfirmation(moveButton, 'Move');
+  updateSelectionControls('secrets');
+  renderSecrets();
+  reportBulkResults('Moved', results);
+}
+
+$('#select-secrets').onclick = () => setSelectionMode('secrets', true);
+$('#select-files').onclick = () => setSelectionMode('files', true);
+$('#cancel-secret-selection').onclick = () => clearSelection('secrets');
+$('#cancel-file-selection').onclick = () => clearSelection('files');
+$('#select-all-secrets').onchange = (e) => setVisibleSelection('secrets', e.target.checked);
+$('#select-all-files').onchange = (e) => setVisibleSelection('files', e.target.checked);
+$('#bulk-delete-secrets').onclick = () => bulkDelete('secrets').catch(fail);
+$('#bulk-delete-files').onclick = () => bulkDelete('files').catch(fail);
+$('#bulk-move-secrets').onclick = () => bulkMoveSecrets().catch(fail);
 
 async function downloadFile(name) {
   try {

--- a/src/web/assets/index.html
+++ b/src/web/assets/index.html
@@ -27,18 +27,35 @@
   <section id="secrets-view">
     <div class="toolbar">
       <input id="search" type="search" placeholder="filter secrets…">
+      <button id="select-secrets" type="button">Select</button>
       <button id="new-secret">+ New secret</button>
     </div>
+    <div id="secret-bulk-bar" class="bulk-toolbar" hidden>
+      <span id="secret-selection-count" aria-live="polite">0 selected</span>
+      <input id="secret-move-folder" placeholder="destination folder" aria-label="Destination folder">
+      <button id="bulk-move-secrets" type="button">Move</button>
+      <button id="bulk-delete-secrets" type="button" class="danger" data-default-label="Delete">Delete</button>
+      <button id="cancel-secret-selection" type="button">Cancel</button>
+    </div>
     <table id="secrets-table">
-      <thead><tr><th>Name</th><th>Folder</th><th>Groups</th><th>Note</th><th>Updated</th></tr></thead>
+      <thead><tr><th class="selection-column" hidden><input id="select-all-secrets" type="checkbox" aria-label="Select all visible secrets"></th><th>Name</th><th>Folder</th><th>Groups</th><th>Note</th><th>Updated</th></tr></thead>
       <tbody></tbody>
     </table>
   </section>
 
   <section id="files-view" hidden>
+    <div class="toolbar file-toolbar">
+      <span class="toolbar-spacer"></span>
+      <button id="select-files" type="button">Select</button>
+    </div>
+    <div id="file-bulk-bar" class="bulk-toolbar" hidden>
+      <span id="file-selection-count" aria-live="polite">0 selected</span>
+      <button id="bulk-delete-files" type="button" class="danger" data-default-label="Delete">Delete</button>
+      <button id="cancel-file-selection" type="button">Cancel</button>
+    </div>
     <div id="dropzone">Drop files here or <label class="linkish">browse<input id="file-input" type="file" multiple hidden></label></div>
     <table id="files-table">
-      <thead><tr><th>Name</th><th>Size</th><th>Type</th><th>Modified</th><th></th></tr></thead>
+      <thead><tr><th class="selection-column" hidden><input id="select-all-files" type="checkbox" aria-label="Select all visible files"></th><th>Name</th><th>Size</th><th>Type</th><th>Modified</th><th></th></tr></thead>
       <tbody></tbody>
     </table>
   </section>

--- a/src/web/assets/style.css
+++ b/src/web/assets/style.css
@@ -14,10 +14,19 @@ header nav { margin-left:auto; }
 .tab.active { color:var(--accent); border-bottom:2px solid var(--accent); }
 main { padding:1rem; max-width:70rem; }
 .recovery { max-width:36rem; margin:2rem 0; }
-.toolbar { display:flex; gap:.5rem; margin-bottom:.75rem; }
+.toolbar { display:flex; gap:.5rem; align-items:center; margin-bottom:.75rem; }
+.toolbar-spacer { flex:1; }
 #search { flex:1; padding:.4rem; }
+.bulk-toolbar { display:flex; flex-wrap:wrap; gap:.5rem; align-items:center; margin-bottom:.75rem;
+  padding:.55rem .65rem; border:1px solid var(--line); border-radius:6px;
+  background:color-mix(in srgb, var(--accent) 5%, transparent); }
+.bulk-toolbar span { min-width:6.5rem; font-weight:600; }
+.bulk-toolbar input { min-width:10rem; flex:1; padding:.35rem .5rem; font:inherit;
+  color:var(--fg); background:var(--bg); border:1px solid var(--line); border-radius:4px; }
 table { width:100%; border-collapse:collapse; }
 th, td { text-align:left; padding:.4rem .6rem; border-bottom:1px solid var(--line); }
+.selection-column { width:2.5rem; text-align:center; padding-inline:.35rem; }
+.selection-column input { width:1rem; height:1rem; margin:0; vertical-align:middle; accent-color:var(--accent); }
 .file-actions { display:flex; flex-wrap:wrap; gap:.25rem; }
 #secrets-table tbody tr { cursor:pointer; }
 #secrets-table tbody tr:hover { background:color-mix(in srgb, var(--accent) 8%, transparent); }
@@ -30,6 +39,8 @@ th, td { text-align:left; padding:.4rem .6rem; border-bottom:1px solid var(--lin
 button { font:inherit; padding:.35rem .8rem; border:1px solid var(--line); border-radius:4px;
   background:var(--bg); color:var(--fg); cursor:pointer; }
 button:hover { border-color:var(--accent); }
+button:disabled { cursor:not-allowed; opacity:.65; }
+button.pending:disabled { cursor:wait; }
 button.danger { color:var(--danger); }
 #dropzone { border:2px dashed var(--line); border-radius:8px; padding:2rem; text-align:center;
   color:var(--muted); margin-bottom:1rem; }
@@ -48,3 +59,10 @@ tr.folder-row td { cursor:pointer; font-weight:600; color:var(--muted);
   background:color-mix(in srgb, var(--fg) 4%, transparent); }
 tr.folder-row:not(.static):hover td { color:var(--fg); }
 tr.folder-row.static td { cursor:default; }
+.folder-child .item-name { position:relative; padding-inline-start:2rem; }
+.folder-child .item-name::before { content:""; position:absolute; inset-block:0; inset-inline-start:1rem;
+  width:1px; background:var(--line); }
+tr.selected-row { background:color-mix(in srgb, var(--accent) 12%, transparent); }
+@media (max-width: 42rem) {
+  .bulk-toolbar input { flex-basis:100%; }
+}

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -289,4 +289,112 @@ mod tests {
         ));
         assert!(APP_JS.contains("function clearDrawerState()"));
     }
+
+    #[test]
+    fn ui_exposes_selection_controls_for_both_tables() {
+        for id in [
+            "select-secrets",
+            "select-files",
+            "select-all-secrets",
+            "select-all-files",
+            "secret-bulk-bar",
+            "file-bulk-bar",
+        ] {
+            assert!(INDEX_HTML.contains(&format!("id=\"{id}\"")), "{id}");
+        }
+    }
+
+    #[test]
+    fn ui_marks_group_children_for_indentation() {
+        assert!(APP_JS.contains("renderRow(it, true)"));
+        assert!(APP_JS.contains("tr.classList.add('folder-child')"));
+        assert!(APP_JS.contains("td.classList.add('item-name')"));
+        assert!(STYLE_CSS.contains(".folder-child .item-name"));
+    }
+
+    #[test]
+    fn ui_selection_uses_visible_items_and_mixed_header_state() {
+        assert!(APP_JS.contains("function syncSelectionUi(kind, visibleIds)"));
+        assert!(APP_JS.contains("selectAll.indeterminate = selectedVisible > 0 && !allVisible"));
+        assert!(APP_JS.contains("for (const id of visibleIds)"));
+        assert!(APP_JS.contains("clearSelection('secrets')"));
+        assert!(APP_JS.contains("clearSelection('files')"));
+    }
+
+    #[test]
+    fn ui_bulk_actions_are_bounded_and_reuse_item_routes() {
+        assert!(APP_JS.contains("async function runBounded(items, limit, operation)"));
+        assert!(APP_JS.contains("runBounded(items, 4"));
+        assert!(APP_JS.contains("api('DELETE', `/api/secrets/"));
+        assert!(APP_JS.contains("api('DELETE', `/api/files/"));
+        assert!(APP_JS.contains("/move${vaultQS(vault)}`, { folder }"));
+    }
+
+    #[test]
+    fn ui_bulk_deletes_require_confirmation() {
+        assert!(APP_JS.contains("armConfirmation(button, `Delete ${items.length} secrets?`)"));
+        assert!(APP_JS.contains("armConfirmation(button, `Delete ${items.length} files?`)"));
+    }
+
+    #[test]
+    fn ui_cancelling_selection_restores_bulk_controls() {
+        assert!(APP_JS.contains("function resetSelectionControls(kind)"));
+        assert!(APP_JS.contains("if (!enabled) {\n    resetSelectionControls(kind);"));
+        assert!(APP_JS.contains("resetConfirmation(moveButton, 'Move');"));
+        assert!(APP_JS.contains("cancelButton.disabled = false;"));
+    }
+
+    #[test]
+    fn ui_selection_changes_reset_bulk_confirmation() {
+        assert!(APP_JS.contains("function resetBulkConfirmation(kind)"));
+        assert!(
+            APP_JS.matches("resetBulkConfirmation(kind);").count() >= 4,
+            "every selection mutation path must disarm bulk delete"
+        );
+    }
+
+    #[test]
+    fn ui_bulk_actions_reconcile_same_vault_after_tab_switch() {
+        assert!(APP_JS.contains("const selectionIsCurrent = generation === state.generation;"));
+        assert!(
+            APP_JS
+                .matches("if (vault !== currentVault) return;")
+                .count()
+                >= 4,
+            "bulk delete and move must reconcile same-vault data independently of selection state"
+        );
+        assert!(!APP_JS
+            .contains("if (generation !== state.generation || vault !== currentVault) return;"));
+    }
+
+    #[test]
+    fn ui_preserves_failed_file_load_state_during_bulk_recovery() {
+        assert!(APP_JS.contains("let filesState = 'ready';"));
+        assert!(APP_JS.contains("filesState = 'loading';"));
+        assert!(APP_JS.contains("filesState = 'failed';"));
+        assert!(APP_JS.contains("function renderFiles() {\n  if (filesState !== 'ready') return;"));
+    }
+
+    #[test]
+    fn ui_uses_wait_cursor_only_for_pending_buttons() {
+        assert!(APP_JS.contains("button.classList.add('pending');"));
+        assert!(APP_JS.contains("button.classList.remove('pending');"));
+        assert!(STYLE_CSS.contains("button:disabled { cursor:not-allowed;"));
+        assert!(STYLE_CSS.contains("button.pending:disabled { cursor:wait;"));
+    }
+
+    #[test]
+    fn ui_bulk_move_uses_pending_button_state() {
+        assert!(APP_JS.contains("beginPendingAction(moveButton, 'Moving…');"));
+        assert!(APP_JS.contains("resetConfirmation(moveButton, 'Move');"));
+    }
+
+    #[test]
+    fn ui_bulk_toolbar_sync_does_not_depend_on_table_render() {
+        assert!(APP_JS.contains("function updateSelectionControls(kind)"));
+        assert!(APP_JS.contains(
+            "function setBulkPending(kind, pending, label) {\n  const state = selectionState(kind);"
+        ));
+        assert!(APP_JS.contains("updateSelectionControls(kind);\n  renderSelectionKind(kind);"));
+    }
 }


### PR DESCRIPTION
Selection mode enables visible-only select-all, bounded bulk delete/move, and safer async recovery for the embedded web UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk delete and secret move are destructive vault operations, though they use existing routes, confirmation, and concurrency limits; risk is mainly UX/async edge cases rather than new server surface.
> 
> **Overview**
> Adds **explicit selection mode** to the embedded Secrets and Files tables: **Select** toggles checkboxes and bulk toolbars, header **select-all** applies only to **currently visible** rows (filter + expanded folders), and selection clears on vault/tab change or cancel.
> 
> **Visual hierarchy:** expanded folder members render as `.folder-child` rows with indented name cells.
> 
> **Bulk operations** reuse existing per-item APIs with **at most four concurrent** requests: delete for secrets and files (two-click confirm), move to folder for secrets only. Generation/vault guards prevent stale bulk completions from updating the wrong UI; file list loading gains a `filesState` guard like secrets.
> 
> **Tests & docs:** new embedded-asset contract tests in `src/web/mod.rs`; `docs/web-ui.md`, design/plan specs, and `TODO.md` updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d4676638f4d9eedd6d393f532e965487413a9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->