### PR TITLE
chore: bump version to 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v0.26.0 — Web UI UX and visual refresh (2026-07-14)
+
+### Added
+
+- **Bulk selection for secrets and files.** Selection mode adds visible-only
+  select-all, bounded-concurrency bulk delete, and bulk folder moves for
+  secrets. Expanded folder members are indented for clearer hierarchy.
+- **Responsive, accessible visual system.** The embedded UI now uses a refined
+  app shell, semantic data surfaces, consistent action and feedback styles,
+  purposeful loading/empty/error states, automatic light/dark theming, and
+  keyboard-operable controls across desktop, tablet, and phone layouts.
+
+### Changed
+
+- **Polished primary workflows.** Vault tables, the secret editor drawer,
+  file uploads, destructive confirmations, and toasts have clearer hierarchy,
+  stronger status feedback, and more consistent interaction targets.
+- **Reload-safe per-tab sessions.** The UI preserves its bearer token in
+  `sessionStorage`, scrubs it from the URL, and presents a persistent recovery
+  state when a valid session link is unavailable.
+
+### Fixed
+
+- Prevented stale vault, list, drawer, bulk-action, and delete responses from
+  overwriting newer UI state or acting on the wrong secret, file, or vault.
+- Made destructive actions non-repeatable while pending and resilient to list
+  rerenders, tab changes, vault switches, and reconciliation failures.
+
 ## v0.25.1 — Security hardening (2026-07-11)
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.25.1"
+version = "0.26.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
## Summary

- bump the crate version from `0.25.1` to `0.26.0` in `Cargo.toml` and `Cargo.lock`
- add `v0.26.0` changelog notes for the web UI session/async hardening, bulk selection, and visual refresh merged since `v0.25.1`
- prepare the merge commit for the annotated `v0.26.0` tag that triggers the release workflow

## Why

The changes since `v0.25.1` add user-facing web UI features and substantial UX improvements, so this is a SemVer minor release.

## User impact

Release binaries will include reload-safe per-tab web sessions, stale-response protections, bulk secret/file selection, and the responsive visual refresh across desktop, tablet, and phone layouts.

## Validation

- `env -u RUST_LOG cargo test --all-features -- --test-threads=1`
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `node --check src/web/assets/app.js`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1` resolves `crosstache 0.26.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version and documentation updates with no runtime code changes.
> 
> **Overview**
> Prepares the **v0.26.0** minor release by bumping the crate from `0.25.1` to `0.26.0` in `Cargo.toml` and `Cargo.lock`, and adding a **v0.26.0** section to `CHANGELOG.md`.
> 
> The new changelog entry documents the web UI work shipped since v0.25.1: bulk secret/file selection, responsive visual refresh, reload-safe per-tab sessions, and fixes for stale async responses and destructive-action races. There are no application or UI code changes in this diff—only version and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22389d4869e80273a9f9626fdfe263a1720a2d17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->