### PR TITLE
fix: Windows upgrade sharing violation and missing bare-update prompt

### DIFF
--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -3820,6 +3820,44 @@ pub(crate) async fn execute_secret_update_direct(
         let local_registry = BackendRegistry::new(resolved_backend);
         let reg = &local_registry;
 
+        // A bare `xv update NAME` — no value, no --stdin, and no other
+        // update flag — prompts for the new value, matching the `value`
+        // arg's documented "if not provided, will prompt" and `xv set`.
+        // Without this it fell through to the all-unchanged update call
+        // below and reported success without changing anything.
+        let mut value = value;
+        if value.is_none()
+            && !stdin
+            && type_name.is_none()
+            && !untype
+            && fields.is_empty()
+            && secret_fields.is_empty()
+            && classic_flags_present(
+                &tags,
+                &groups,
+                &rename,
+                &note,
+                &folder,
+                replace_tags,
+                replace_groups,
+                &expires,
+                &not_before,
+                clear_expires,
+                clear_not_before,
+                clear_note,
+                clear_folder,
+                enabled,
+            )
+            .is_empty()
+        {
+            let prompted =
+                rpassword::prompt_password(format!("Enter new value for secret '{name}': "))?;
+            if prompted.is_empty() {
+                return Err(CrosstacheError::config("Secret value cannot be empty"));
+            }
+            value = Some(prompted);
+        }
+
         // Record-types edit/conversion paths (record-types plan Tasks 8/9)
         // take over completely — clap's `conflicts_with_all` on --type/
         // --untype/--field/--field-secret already guarantees at most one

--- a/src/cli/upgrade_ops.rs
+++ b/src/cli/upgrade_ops.rs
@@ -463,6 +463,14 @@ fn replace_binary(new_binary: &[u8], expected_version: &semver::Version) -> Resu
         let _ = fs::remove_file(&temp_path);
         CrosstacheError::upgrade(format!("Failed to write new binary: {e}"))
     })?;
+    temp_file.sync_all().map_err(|e| {
+        let _ = fs::remove_file(&temp_path);
+        CrosstacheError::upgrade(format!("Failed to flush new binary: {e}"))
+    })?;
+    // Close the write handle before the `--version` spawn below: Windows
+    // refuses to execute a file with an open write handle
+    // (ERROR_SHARING_VIOLATION, os error 32).
+    drop(temp_file);
 
     // Set executable permissions on Unix
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

Two bug fixes reported on Windows:

- **`xv upgrade` failed with ERROR_SHARING_VIOLATION (os error 32)**: the updater wrote the downloaded binary to a temp file and spawned it with `--version` to validate it while the write handle was still open. Windows refuses to execute a file with an open write handle, so CreateProcess failed on every upgrade. Fix: `sync_all` + explicitly `drop` the handle before the spawn (`src/cli/upgrade_ops.rs`). `sync_all` also surfaces write errors previously swallowed at implicit close.
- **Bare `xv update NAME` silently did nothing**: the `value` arg help has always promised "if not provided, will prompt", but no prompt existed — the command fell through to the all-unchanged update call and printed "Successfully updated" without changing anything (all platforms, not just Windows). Fix: prompt via `rpassword` (same mechanism as `xv set`), only when the update is truly bare — no value, no `--stdin`, and none of the metadata/record flags present, reusing `classic_flags_present` so the flag list can't drift. A prompted value on a typed record routes through the primary-field write path; empty input is rejected, matching `xv set`.

## Testing

- `cargo test --lib`: 817 passed
- `cargo test --test e2e_local_backend --test e2e_workspaces --test cli_integration_tests`: all passed
- `cargo clippy --all-targets`: clean
- Manual e2e against the local backend with a pseudo-TTY: bare `xv update foo` prompts and updates the value; `--note`, positional-value, and `--stdin` variants show no spurious prompt; empty prompted value rejected
- The upgrade fix is platform-neutral; the Windows spawn path itself was not executable from macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI bug fixes in upgrade I/O and update value handling; no auth, persistence, or API contract changes beyond correcting broken behavior.
> 
> **Overview**
> **`xv upgrade`** now **flushes and closes** the temp downloaded binary (`sync_all` + dropping the write handle) **before** spawning it with `--version`. On Windows, executing a file still held open for writing caused **ERROR_SHARING_VIOLATION (os error 32)** on every upgrade.
> 
> **Bare `xv update NAME`** (no value, `--stdin`, or metadata/record flags) **prompts** for the new value via `rpassword`, aligned with **`xv set`** and the documented “if not provided, will prompt” behavior. Previously it hit an all-unchanged update and reported success without changing anything. **Empty** prompted input is rejected; the “truly bare” check reuses **`classic_flags_present`** so the flag list stays in sync with other update paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 018c31876dab86d81e7d685e218bc38b9f879099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->