### PR TITLE
chore: bump version to 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.26.1 — Windows upgrade and bare-update prompt fixes (2026-07-15)
+
+### Fixed
+
+- **`xv upgrade` failed on Windows with ERROR_SHARING_VIOLATION (os error 32).**
+  The updater spawned the downloaded binary for `--version` validation while
+  its write handle was still open, which Windows rejects. The handle is now
+  synced and closed before the validation spawn; the sync also surfaces write
+  errors previously swallowed at implicit close.
+- **Bare `xv update NAME` silently did nothing.** Despite the documented
+  "if not provided, will prompt" behavior, no prompt existed — the command
+  reported success without changing anything. It now prompts for the new
+  value (hidden input, same as `xv set`) when no value, `--stdin`, or other
+  update flag is supplied; a prompted value on a typed record updates the
+  primary field, and empty input is rejected.
+
 ## v0.26.0 — Web UI UX and visual refresh (2026-07-14)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.26.0"
+version = "0.26.1"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Patch release for the two fixes in #369:

- `xv upgrade` ERROR_SHARING_VIOLATION on Windows (open write handle before validation spawn)
- bare `xv update NAME` now prompts for the new value instead of silently succeeding

Bumps Cargo.toml/Cargo.lock to 0.26.1 and adds the CHANGELOG section. Tag `v0.26.1` follows after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata-only change (version strings and changelog); no application code in this diff.
> 
> **Overview**
> **Patch release v0.26.1** — bumps `crosstache` from **0.26.0** to **0.26.1** in `Cargo.toml` and `Cargo.lock`, and documents the release in **CHANGELOG.md**.
> 
> The new changelog section records two fixes already landed elsewhere (#369): Windows **`xv upgrade`** no longer hits ERROR_SHARING_VIOLATION because the downloaded binary’s write handle is synced and closed before `--version` validation, and bare **`xv update NAME`** now prompts for a new value (hidden input like `xv set`) instead of reporting success with no change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffb6355f836ddd3a78f86a2425bd6a5e9ea7cab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->