### PR TITLE
fix(install): support Windows bash shells and CRLF minisig comments

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -352,7 +352,7 @@ function Install-crosstache {
 
         $minisign = Get-Command minisign -ErrorAction SilentlyContinue
         if (-not $minisign) {
-            throw "minisign is required to authenticate releases. Install minisign and retry."
+            throw "minisign is required to authenticate releases. Install it with 'winget install jedisct1.minisign' (or 'scoop install minisign' / 'choco install minisign') and retry."
         }
         $releaseSigningKey = "RWRuXFh34rB613dgsXyAMmtKvYK0SFwxq4i44dhGFXVTrhAQ7hJXf6Ym"
         & $minisign.Source -Vm $archivePath -x $signaturePath -P $releaseSigningKey | Out-Null

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# crosstache (xv) installer for Unix systems (Linux/macOS)
+# crosstache (xv) installer for Linux, macOS, and Windows bash
+# environments (Git Bash / MSYS2 / Cygwin)
 # https://github.com/bziobnic/crosstache
 
 set -e
@@ -111,6 +112,14 @@ install_azure_cli() {
                 curl -L https://aka.ms/InstallAzureCli | bash
             fi
             ;;
+        mingw*|msys*|cygwin*|windows_nt*)
+            if command -v winget.exe >/dev/null 2>&1; then
+                info "Installing Azure CLI via winget..."
+                winget.exe install --exact --id Microsoft.AzureCLI || error "winget installation failed. Install Azure CLI manually from https://learn.microsoft.com/cli/azure/install-azure-cli-windows"
+            else
+                error "Automatic Azure CLI installation requires winget. Install Azure CLI manually from https://learn.microsoft.com/cli/azure/install-azure-cli-windows"
+            fi
+            ;;
         *)
             error "Unsupported operating system for automatic Azure CLI installation: $os"
             ;;
@@ -146,6 +155,12 @@ detect_platform() {
                 *) error "Unsupported architecture: $arch" ;;
             esac
             ;;
+        mingw*|msys*|cygwin*|windows_nt*)
+            case "$arch" in
+                x86_64|amd64) echo "windows-x64" ;;
+                *) error "Unsupported architecture: $arch" ;;
+            esac
+            ;;
         *)
             error "Unsupported operating system: $os"
             ;;
@@ -170,7 +185,10 @@ download_and_install() {
     local platform version download_url archive_name
     
     platform=$(detect_platform)
-    
+    if [ "$platform" = "windows-x64" ]; then
+        BINARY_NAME="xv.exe"
+    fi
+
     if [ "$VERSION" = "latest" ]; then
         version=$(get_latest_version)
         if [ -z "$version" ]; then
@@ -183,7 +201,11 @@ download_and_install() {
     # Remove 'v' prefix if present
     version_clean=${version#v}
     
-    archive_name="xv-${platform}.tar.gz"
+    if [ "$platform" = "windows-x64" ]; then
+        archive_name="xv-${platform}.zip"
+    else
+        archive_name="xv-${platform}.tar.gz"
+    fi
     download_url="https://github.com/$GITHUB_REPO/releases/download/$version/$archive_name"
     checksum_url="https://github.com/$GITHUB_REPO/releases/download/$version/$archive_name.sha256"
     signature_url="https://github.com/$GITHUB_REPO/releases/download/$version/$archive_name.minisig"
@@ -210,12 +232,14 @@ download_and_install() {
     fi
 
     if ! command -v minisign >/dev/null 2>&1; then
-        error "minisign is required to authenticate releases. Install minisign and retry."
+        error "minisign is required to authenticate releases. Install minisign (e.g. 'brew install minisign', 'apt install minisign', or 'scoop install minisign' on Windows) and retry."
     fi
     if ! minisign -Vm "$archive_name" -x "$archive_name.minisig" -P "$RELEASE_SIGNING_KEY" >/dev/null; then
         error "Release signature verification failed. Refusing to install."
     fi
-    trusted_comment=$(sed -n '3s/^trusted comment: //p' "$archive_name.minisig")
+    # Windows-built minisig files have CRLF line endings; strip the CR so the
+    # comparison below doesn't fail on an invisible trailing '\r'.
+    trusted_comment=$(sed -n '3s/^trusted comment: //p' "$archive_name.minisig" | tr -d '\r')
     if [ "$trusted_comment" != "crosstache $version" ]; then
         error "Release signature belongs to '$trusted_comment', not 'crosstache $version'. Refusing a replayed archive."
     fi
@@ -251,7 +275,20 @@ download_and_install() {
     
     # Extract archive
     info "Extracting archive..."
-    tar -xzf "$archive_name" || error "Failed to extract archive"
+    case "$archive_name" in
+        *.zip)
+            if command -v unzip >/dev/null 2>&1; then
+                unzip -oq "$archive_name" || error "Failed to extract archive"
+            elif command -v powershell.exe >/dev/null 2>&1 && command -v cygpath >/dev/null 2>&1; then
+                powershell.exe -NoProfile -Command "Expand-Archive -Force -Path '$(cygpath -w "$archive_name")' -DestinationPath '$(cygpath -w .)'" || error "Failed to extract archive"
+            else
+                error "unzip is required to extract the archive but was not found"
+            fi
+            ;;
+        *)
+            tar -xzf "$archive_name" || error "Failed to extract archive"
+            ;;
+    esac
     
     # Create install directory
     mkdir -p "$INSTALL_DIR" || error "Failed to create installation directory: $INSTALL_DIR"
@@ -389,8 +426,12 @@ main() {
     info "Repository: https://github.com/$GITHUB_REPO"
     echo ""
     
-    # Check dependencies
-    if ! command -v tar >/dev/null 2>&1; then
+    # Check dependencies (Windows archives are .zip; everything else .tar.gz)
+    if [ "$(detect_platform)" = "windows-x64" ]; then
+        if ! command -v unzip >/dev/null 2>&1 && ! command -v powershell.exe >/dev/null 2>&1; then
+            error "unzip (or powershell.exe) is required but not installed"
+        fi
+    elif ! command -v tar >/dev/null 2>&1; then
         error "tar is required but not installed"
     fi
     


### PR DESCRIPTION
## Summary

- `install.sh` now supports Windows bash environments (Git Bash / MSYS2 / Cygwin / `windows_nt`): detects `windows-x64`, downloads the `.zip` release artifact, extracts via `unzip` (with a `powershell.exe Expand-Archive` fallback), installs `xv.exe`, and offers Azure CLI via winget.
- Fixes a latent replay-check bug: Windows-built `.minisig` files have CRLF endings, so the trusted comment carried a trailing `\r` and `install.sh` rejected every valid Windows archive ("belongs to 'crosstache v0.26.1', not 'crosstache v0.26.1'"). The CR is now stripped before comparison. `install.ps1` (`Get-Content`) and the Rust upgrader (`minisign_verify`) already handle CRLF.
- Both installers' minisign-missing errors now name concrete install commands (winget/scoop/choco/brew/apt).

## Testing

- `bash -n` syntax check
- Simulated Git Bash run on macOS (uname/minisign shims, real release artifacts): platform detected, real CRLF `.minisig` trusted comment accepted, checksum verified, zip extracted, `xv.exe` installed
- Native macOS run: full flow succeeds, installed binary reports `xv 0.26.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Installer-only changes that preserve mandatory checksum and minisign verification while fixing Windows bash support and a CRLF parsing bug.
> 
> **Overview**
> Extends **`install.sh`** so Git Bash, MSYS2, Cygwin, and similar environments install **`xv.exe`** from the Windows **`.zip`** release (with **`unzip`** or a **`powershell.exe Expand-Archive`** fallback), detect **`windows-x64`**, and can pull in Azure CLI via **`winget`**. Up-front dependency checks require **`unzip`** or PowerShell on Windows instead of **`tar`**.
> 
> Fixes a replay-trusted-comment check that falsely rejected valid Windows releases because CRLF **`.minisig`** files left a trailing **`\\r`** on the trusted comment; the comment is now normalized before comparison.
> 
> **`install.ps1`** and **`install.sh`** minisign-missing errors now list concrete install commands (e.g. winget/scoop/choco on Windows, brew/apt elsewhere).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880bf8945b44c2ca9f08d9bf9825535b7a79747d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->