### PR TITLE
chore: bump version to 0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.26.2 — Tauri secret and file table polish (2026-07-16)
+
+### Added
+
+- Sortable, resizable table columns with per-table width persistence while
+  retaining folder groups and sorting rows within each group.
+- Authenticated file-name links that download directly from the file table.
+
+### Changed
+
+- File deletion is available only from the top selection toolbar; per-row
+  download and delete actions were removed.
+- Every protected field now uses the same fixed-length mask and Reveal/Hide
+  behavior, including protected fields in typed records.
+
+### Fixed
+
+- Missing expirations remain visibly blank, stored expirations display as
+  `YYYY-MM-DD`, and Updated values no longer include a time.
+- Protected-value loads cannot overwrite newer edits, and the secret drawer
+  supports both textarea and record-input controls without runtime errors.
+
 ## v0.26.1 — Windows upgrade and bare-update prompt fixes (2026-07-15)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "age",
  "aho-corasick",
@@ -9393,7 +9393,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xv-desktop"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "crosstache",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.26.1"
+version = "0.26.2"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xv-desktop"
-version = "0.26.1"
+version = "0.26.2"
 description = "macOS desktop proof of concept for Crosstache Vault"
 authors = ["crosstache Team"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Crosstache Vault",
-  "version": "0.26.0",
+  "version": "0.26.2",
   "identifier": "com.crosstache.xv",
   "build": {
     "frontendDist": "../frontend"


### PR DESCRIPTION
## Summary

- bump the root crate and desktop package to `0.26.2`
- synchronize the Tauri bundle version and workspace lockfile
- add the `v0.26.2` changelog entry for the Tauri table, protected-field, date, and file workflow improvements

## Validation

- frontend Node tests: 11 passed
- focused web/API Rust tests: 64 passed
- `cargo check --workspace --all-features`
- `cargo fmt --all -- --check`
- release workflow version guard: Cargo and intended tag both report `0.26.2`

After merge, the annotated `v0.26.2` tag will be created from the merge commit to trigger the release workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile metadata only; no runtime code changes in the diff.
> 
> **Overview**
> Release **v0.26.2** by aligning workspace versions and documenting the Tauri desktop polish shipped in this line.
> 
> **Version bumps:** `crosstache` and `xv-desktop` go from `0.26.1` to `0.26.2` in their `Cargo.toml` files; `Cargo.lock` is updated for both packages. The Tauri bundle version in `tauri.conf.json` is brought in sync (`0.26.0` → `0.26.2`).
> 
> **Changelog:** A new `v0.26.2` section records Tauri UI changes—sortable/resizable tables with persisted column widths, authenticated file download links, toolbar-only file deletion, unified protected-field masking, date display fixes, and secret-drawer race/error fixes—without altering application source in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36f3692f721d47e299d52a9038611b00d36e7a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->