### PR TITLE
chore: bump version to 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.27.0 — Secret file attachments (2026-07-21)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.26.2"
+version = "0.27.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Release prep for v0.27.0 — secret file attachments (#375) plus the clap-derive test stack-overflow fix.

Changelog: `Unreleased` renamed to `v0.27.0 — Secret file attachments (2026-07-21)`.

After merge, main will be tagged `v0.27.0` to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no runtime or behavioral code modifications.
> 
> **Overview**
> Prepares **v0.27.0** by aligning the package version in `Cargo.toml` / `Cargo.lock` with the changelog heading.
> 
> The former **Unreleased** section is renamed to **`v0.27.0 — Secret file attachments (2026-07-21)`**; the listed feature content is unchanged from what was already documented there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 399b5a4a8076411bf066496b132f64d0a083b997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->