### PR TITLE
fix(attachments): use Azure-valid metadata key xv_encrypted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `xv attach` and `xv file upload --encrypt` failed on Azure with a 400 error:
+  the `xv-encrypted` metadata flag is not a valid Azure blob metadata key
+  (hyphens are rejected). The flag is now `xv_encrypted`.
+
 ## v0.27.0 — Secret file attachments (2026-07-21)
 
 ### Added

--- a/src/cli/file_ops.rs
+++ b/src/cli/file_ops.rs
@@ -1858,7 +1858,7 @@ fn strip_encrypted_attachments(
 }
 
 /// Local-side counterpart of [`strip_encrypted_attachments`]: local files
-/// have no `xv-encrypted` metadata to check, so this matches on the
+/// have no `xv_encrypted` metadata to check, so this matches on the
 /// `attachments/` name prefix alone (same convention, see
 /// [`crate::secret::attachments::is_encrypted_attachment`]).
 fn strip_encrypted_attachments_local(
@@ -2715,7 +2715,10 @@ mod tests {
     fn remote_file(name: &str, encrypted: bool) -> crate::blob::models::FileInfo {
         let mut metadata = std::collections::HashMap::new();
         if encrypted {
-            metadata.insert("xv-encrypted".to_string(), "age".to_string());
+            metadata.insert(
+                crate::secret::attachments::ENC_METADATA_KEY.to_string(),
+                crate::secret::attachments::ENC_METADATA_VALUE.to_string(),
+            );
         }
         crate::blob::models::FileInfo {
             name: name.to_string(),

--- a/src/secret/attachments.rs
+++ b/src/secret/attachments.rs
@@ -18,9 +18,11 @@ use crate::secret::manager::SecretRequest;
 
 /// Reserved per-vault secret holding the age identity for attachments.
 pub const ATTACHMENT_KEY_SECRET: &str = "xv-attachment-key";
-/// File-metadata key marking client-side-encrypted content.
+/// File-metadata key marking client-side-encrypted content. Underscore, not
+/// hyphen: Azure Blob metadata keys must be valid C# identifiers, and a
+/// hyphenated key fails the whole upload with 400 InvalidMetadata.
 #[allow(dead_code)] // Consumed by attachment CLI/encryption tasks (Tasks 2-4)
-pub const ENC_METADATA_KEY: &str = "xv-encrypted";
+pub const ENC_METADATA_KEY: &str = "xv_encrypted";
 /// File-metadata value for age encryption.
 #[allow(dead_code)] // Consumed by attachment CLI/encryption tasks (Tasks 2-4)
 pub const ENC_METADATA_VALUE: &str = "age";
@@ -47,7 +49,7 @@ pub fn attachment_blob_name(secret_name: &str, attachment: &str) -> String {
 
 /// True if a blob is a client-side-encrypted attachment: reserved-namespace
 /// name convention (anything under `attachments/`) OR explicit
-/// `xv-encrypted: age` metadata flag. `metadata` may be empty (e.g. for a
+/// `xv_encrypted: age` metadata flag. `metadata` may be empty (e.g. for a
 /// local file that hasn't been uploaded yet) — the name check alone still
 /// catches the reserved namespace.
 ///
@@ -160,7 +162,7 @@ use crate::blob::models::{FileInfo, FileListRequest, FileUploadRequest};
 use crate::utils::progress::ProgressReporter;
 
 /// Age-encrypt `request.content` with the vault's attachment key (created on
-/// first use) and upload the ciphertext, flagged `xv-encrypted: age`.
+/// first use) and upload the ciphertext, flagged `xv_encrypted: age`.
 #[cfg(feature = "file-ops")]
 pub async fn upload_encrypted(
     secrets: &dyn SecretBackend,
@@ -182,7 +184,7 @@ pub async fn upload_encrypted(
 }
 
 /// Download a file, transparently decrypting it when it carries the
-/// `xv-encrypted: age` metadata flag. Unflagged files (including user-supplied
+/// `xv_encrypted: age` metadata flag. Unflagged files (including user-supplied
 /// `.age` files encrypted with foreign keys) pass through untouched.
 #[cfg(feature = "file-ops")]
 pub async fn download_decrypted(
@@ -683,6 +685,20 @@ mod tests {
         assert!(!is_valid_path_component(".."));
         assert!(is_valid_path_component("db-cert"));
         assert!(is_valid_path_component("normal_name.txt"));
+    }
+
+    #[test]
+    fn enc_metadata_key_is_a_valid_azure_metadata_identifier() {
+        // Azure Blob metadata keys travel as `x-ms-meta-<key>` headers and
+        // must be valid C# identifiers; a hyphen makes every upload fail
+        // with 400 InvalidMetadata.
+        let mut chars = ENC_METADATA_KEY.chars();
+        let first = chars.next().expect("key must be non-empty");
+        assert!(first.is_ascii_alphabetic() || first == '_');
+        assert!(
+            chars.all(|c| c.is_ascii_alphanumeric() || c == '_'),
+            "ENC_METADATA_KEY '{ENC_METADATA_KEY}' contains characters Azure rejects in metadata keys"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`xv attach` failed on Azure with `400` because the `xv-encrypted` blob metadata flag is not a valid Azure metadata key (keys travel as `x-ms-meta-<key>` headers and must be C# identifiers — no hyphens).

- Renamed the flag to `xv_encrypted` (constant `ENC_METADATA_KEY`)
- Routed the one hardcoded copy (file_ops sync test helper) through the constant
- Added a unit test pinning the key to Azure's allowed charset

Verified against real Azure: `xv attach test-delete-one ./AGENTS.md` succeeds, listing shows the ciphertext blob, and `--get` downloads a byte-identical decrypted copy.

No migration concern: uploads with the old key always failed on Azure, so no Azure blobs carry it; the feature shipped hours ago (#375).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small constant rename and test/doc updates; behavior unchanged on backends that already accepted the flag, with no data migration required.
> 
> **Overview**
> Fixes **Azure HTTP 400** on encrypted uploads (`xv attach`, `xv file upload --encrypt`) by changing the blob metadata flag from **`xv-encrypted`** to **`xv_encrypted`**. Azure rejects hyphenated `x-ms-meta-*` keys as invalid C# identifiers.
> 
> **`ENC_METADATA_KEY`** in `attachments.rs` is the single source of truth; upload/decrypt/sync detection and docs/comments follow it. The file-sync test helper now uses that constant instead of a hardcoded key. A unit test asserts the key matches Azure’s allowed charset.
> 
> No migration: uploads with the old key never succeeded on Azure, so no blobs should carry it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e99d2eca274cd9ac5f942159ff4541d8487cc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->