### PR TITLE
chore: bump version to 0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.27.1 — Azure attachment upload fix (2026-07-21)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.27.0"
+version = "0.27.1"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Patch release: v0.27.0's `xv attach` / `xv file upload --encrypt` were broken on Azure (400 InvalidMetadata); fixed in #377 (`xv_encrypted` metadata key).

After merge, main will be tagged `v0.27.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only change with no runtime code paths modified in this PR.
> 
> **Overview**
> **Release housekeeping for v0.27.1** — no application code in this diff; it prepares to tag main after the Azure attachment fix merged elsewhere (#377).
> 
> `Cargo.toml` and `Cargo.lock` move **0.27.0 → 0.27.1**. **CHANGELOG** adds a **v0.27.1** section documenting that **`xv attach`** and **`xv file upload --encrypt`** failed on Azure (400 **InvalidMetadata**) because blob metadata used **`xv-encrypted`**, which Azure rejects; uploads now use **`xv_encrypted`** instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 249202e344962b5f78e710a99fb5a014e36d83b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->