### PR TITLE
feat(ui): list secret attachments as download links in the detail drawer

### DIFF
--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -398,6 +398,22 @@ pub(crate) mod files {
         ))
     }
 
+    /// List a secret's attachments (blobs under `attachments/<secret>/`).
+    pub(crate) async fn list_attachments(
+        State(state): State<Arc<WebState>>,
+        Path(name): Path<String>,
+        Query(q): Query<VaultQuery>,
+    ) -> Result<Json<Vec<crate::blob::models::FileInfo>>, ApiError> {
+        Ok(Json(
+            crate::secret::attachments::list_attachments(
+                files_backend(&state)?,
+                q.vault(&state),
+                &name,
+            )
+            .await?,
+        ))
+    }
+
     pub(crate) async fn upload_file(
         State(state): State<Arc<WebState>>,
         Query(q): Query<VaultQuery>,
@@ -449,7 +465,18 @@ pub(crate) mod files {
         let vault = q.vault(&state);
         let backend = files_backend(&state)?;
         let info = backend.get_file_info(vault, &name).await?;
-        let bytes = backend.download_file(vault, &name, None).await?;
+        // Same transparent decryption as `xv file download`: content flagged
+        // `xv_encrypted: age` (secret attachments, `xv file upload --encrypt`)
+        // is decrypted with the vault's attachment key; everything else passes
+        // through untouched.
+        let bytes = crate::secret::attachments::download_decrypted(
+            state.backend.secrets(),
+            backend,
+            vault,
+            &name,
+            None,
+        )
+        .await?;
         // Escape \ then " so an untrusted filename can't break out of the
         // quoted-string and forge extra header parameters. CRLF is already
         // rejected by HeaderValue parsing.
@@ -570,6 +597,76 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[cfg(feature = "file-ops")]
+    #[tokio::test]
+    async fn secret_attachments_list_and_decrypt_on_download() {
+        use crate::secret::attachments;
+
+        let state = testutil::test_state();
+        let files = state.backend.files().unwrap();
+        // One encrypted attachment for db-cert + an unrelated plain file that
+        // must not leak into the attachment listing.
+        attachments::upload_encrypted(
+            state.backend.secrets(),
+            files,
+            "default",
+            crate::blob::models::FileUploadRequest {
+                name: attachments::attachment_blob_name("db-cert", "cert.pem"),
+                content: b"BEGIN CERT".to_vec(),
+                content_type: Some("application/x-pem-file".to_string()),
+                groups: Vec::new(),
+                metadata: std::collections::HashMap::new(),
+                tags: std::collections::HashMap::new(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        files
+            .upload_file(
+                "default",
+                crate::blob::models::FileUploadRequest {
+                    name: "notes.txt".to_string(),
+                    content: b"plain".to_vec(),
+                    content_type: None,
+                    groups: Vec::new(),
+                    metadata: std::collections::HashMap::new(),
+                    tags: std::collections::HashMap::new(),
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        let app = crate::web::build_router(state);
+
+        let (status, json_body) =
+            get_json(app.clone(), "GET", "/api/secrets/db-cert/attachments", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json_body.as_array().unwrap().len(), 1);
+        assert_eq!(json_body[0]["name"], "attachments/db-cert/cert.pem");
+
+        // No attachments → empty list, not an error.
+        let (status, json_body) =
+            get_json(app.clone(), "GET", "/api/secrets/other/attachments", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json_body.as_array().unwrap().len(), 0);
+
+        // Downloading the attachment returns plaintext, not age ciphertext.
+        let res = app
+            .oneshot(
+                Request::get("/api/files/attachments%2Fdb-cert%2Fcert.pem")
+                    .header(header::HOST, "127.0.0.1:1")
+                    .header(header::AUTHORIZATION, "Bearer test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let bytes = res.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&bytes[..], b"BEGIN CERT");
     }
 
     #[tokio::test]

--- a/src/web/assets/app.js
+++ b/src/web/assets/app.js
@@ -872,6 +872,8 @@ async function openDrawer(name) {
   $('#record-section').hidden = true;
   $('#value-section').hidden = false;
   $('#record-fields').innerHTML = '';
+  $('#attachments-section').hidden = true;
+  $('#attachments-list').innerHTML = '';
   $('#save').disabled = false;
   $('#type-picker-label').hidden = !!name; // type is chosen at creation only
   $('#type-picker').value = '';
@@ -898,6 +900,8 @@ async function openDrawer(name) {
         not_before: meta.not_before || null,
       };
       if (isRecordMeta(meta)) await openRecord(name, meta, tags, generation);
+      if (generation !== drawerGeneration) return;
+      await loadAttachments(name, generation);
       if (generation !== drawerGeneration) return;
     } catch (e) {
       if (generation !== drawerGeneration) return;
@@ -943,6 +947,43 @@ async function openRecord(name, meta, tags, generation) {
   // Whole-value reveal/copy would expose the raw envelope JSON.
   $('#reveal').hidden = $('#copy').hidden = true;
   renderRecordFields(recordState.typeName, secretFields, metaFields, false);
+}
+
+// Non-fatal: a failed attachment listing toasts but still opens the drawer —
+// the secret's own metadata is already loaded and editable.
+async function loadAttachments(name, generation) {
+  if (!ctx.capabilities.files) return;
+  let attachments;
+  try {
+    attachments = await api('GET', `/api/secrets/${encodeURIComponent(name)}/attachments${vaultQS(currentVault)}`);
+  } catch (e) {
+    if (generation !== drawerGeneration) return;
+    toast(`could not load attachments: ${e.message}`, true);
+    return;
+  }
+  if (generation !== drawerGeneration || !attachments.length) return;
+  const list = $('#attachments-list');
+  list.innerHTML = '';
+  for (const f of attachments) {
+    const base = f.name.slice(f.name.lastIndexOf('/') + 1);
+    const li = document.createElement('li');
+    const link = document.createElement('a');
+    link.className = 'attachment-link';
+    link.href = `/api/files/${encodeURIComponent(f.name)}${vaultQS(currentVault)}`;
+    link.download = base;
+    link.appendChild(icon('file'));
+    const label = document.createElement('span');
+    label.textContent = base;
+    link.appendChild(label);
+    link.onclick = (event) => { event.preventDefault(); downloadFile(f.name, base); };
+    li.appendChild(link);
+    const size = document.createElement('span');
+    size.className = 'attachment-size';
+    size.textContent = fmtSize(f.size);
+    li.appendChild(size);
+    list.appendChild(li);
+  }
+  $('#attachments-section').hidden = false;
 }
 
 $('#close-drawer').onclick = closeDrawer;
@@ -1355,13 +1396,13 @@ $('#bulk-delete-secrets').onclick = () => bulkDelete('secrets').catch(fail);
 $('#bulk-delete-files').onclick = () => bulkDelete('files').catch(fail);
 $('#bulk-move-secrets').onclick = () => bulkMoveSecrets().catch(fail);
 
-async function downloadFile(name) {
+async function downloadFile(name, saveAs = name) {
   try {
     const res = await api('GET', `/api/files/${encodeURIComponent(name)}${vaultQS(currentVault)}`, undefined, true);
     const blob = await res.blob();
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
-    a.download = name;
+    a.download = saveAs;
     a.click();
     URL.revokeObjectURL(a.href);
   } catch (e) { fail(e); }

--- a/src/web/assets/index.html
+++ b/src/web/assets/index.html
@@ -125,6 +125,10 @@
         <div id="record-type"></div>
         <div id="record-fields"></div>
       </div>
+      <div id="attachments-section" class="form-field" hidden>
+        <span class="field-label">Attachments</span>
+        <ul id="attachments-list" class="attachment-list"></ul>
+      </div>
       <label class="form-field"><span class="field-label">Folder</span><input name="folder"></label>
       <label class="form-field"><span class="field-label">Groups</span><input name="groups" placeholder="Comma-separated"></label>
       <label class="form-field"><span class="field-label">Note</span><input name="note"></label>

--- a/src/web/assets/style.css
+++ b/src/web/assets/style.css
@@ -188,6 +188,15 @@ input:focus-visible, select:focus-visible, textarea:focus-visible { outline:0; b
   border-top:1px solid var(--color-border); background:color-mix(in srgb, var(--color-surface-subtle) 94%, transparent); }
 .drawer-footer-spacer { flex:1; }
 #record-type { margin-bottom:.75rem; color:var(--color-text-muted); font-size:.75rem; }
+.attachment-list { list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:.35rem; }
+.attachment-list li { display:flex; align-items:center; justify-content:space-between; gap:.75rem; font-size:.82rem; }
+.attachment-link { display:inline-flex; align-items:center; gap:.4rem; min-width:0;
+  color:var(--color-accent); text-decoration:none; }
+.attachment-link span { overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+  text-decoration:underline; text-underline-offset:.18em; }
+.attachment-link:hover { color:var(--color-accent-hover); }
+.attachment-link:focus-visible { outline:2px solid var(--color-accent); outline-offset:2px; border-radius:.25rem; }
+.attachment-size { flex-shrink:0; color:var(--color-text-muted); font-size:.75rem; }
 .toolbar { display:flex; align-items:center; gap:.55rem; margin-bottom:.875rem; }
 .toolbar-spacer { flex:1; }
 .search-field { min-height:2.375rem; flex:1; display:flex; align-items:center; gap:.55rem; padding:0 .7rem;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -93,6 +93,10 @@ pub(crate) fn build_router(state: Arc<WebState>) -> Router {
         .route(
             "/files/{name}",
             get(api::files::download_file).delete(api::files::delete_file),
+        )
+        .route(
+            "/secrets/{name}/attachments",
+            get(api::files::list_attachments),
         );
 
     let api = api
@@ -498,6 +502,15 @@ mod tests {
         ] {
             assert!(INDEX_HTML.contains(&format!("id=\"{id}\"")), "{id}");
         }
+    }
+
+    #[test]
+    fn ui_secret_drawer_lists_attachments_as_links() {
+        assert!(INDEX_HTML.contains("id=\"attachments-section\""));
+        assert!(INDEX_HTML.contains("id=\"attachments-list\""));
+        assert!(APP_JS.contains("/attachments${vaultQS(currentVault)}"));
+        assert!(APP_JS.contains("downloadFile(f.name, base)"));
+        assert!(STYLE_CSS.contains(".attachment-link"));
     }
 
     #[test]

--- a/src/web/testutil.rs
+++ b/src/web/testutil.rs
@@ -29,10 +29,14 @@ pub(crate) mod stub {
         SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest,
     };
 
+    /// Stored file entry: (content, content_type, metadata).
+    #[cfg(feature = "file-ops")]
+    type StoredFile = (Vec<u8>, String, HashMap<String, String>);
+
     pub(crate) struct StubBackend {
         pub secrets: Mutex<HashMap<String, SecretRequest>>,
         #[cfg(feature = "file-ops")]
-        pub files: Mutex<HashMap<String, (Vec<u8>, String)>>,
+        pub files: Mutex<HashMap<String, StoredFile>>,
     }
 
     impl StubBackend {
@@ -258,10 +262,11 @@ pub(crate) mod stub {
                     .content_type
                     .as_deref()
                     .unwrap_or("application/octet-stream"),
+                request.metadata.clone(),
             );
             self.files.lock().unwrap().insert(
                 request.name.clone(),
-                (request.content, info.content_type.clone()),
+                (request.content, info.content_type.clone(), request.metadata),
             );
             Ok(info)
         }
@@ -276,7 +281,7 @@ pub(crate) mod stub {
                 .lock()
                 .unwrap()
                 .get(name)
-                .map(|(b, _)| b.clone())
+                .map(|(b, _, _)| b.clone())
                 .ok_or_else(|| BackendError::NotFound {
                     name: name.to_string(),
                     suggestion: None,
@@ -294,7 +299,7 @@ pub(crate) mod stub {
                 .unwrap()
                 .iter()
                 .filter(|(n, _)| request.prefix.as_deref().is_none_or(|p| n.starts_with(p)))
-                .map(|(n, (b, ct))| file_info(n, b.len() as u64, ct))
+                .map(|(n, (b, ct, m))| file_info(n, b.len() as u64, ct, m.clone()))
                 .collect())
         }
 
@@ -319,7 +324,7 @@ pub(crate) mod stub {
                 .lock()
                 .unwrap()
                 .get(name)
-                .map(|(b, ct)| file_info(name, b.len() as u64, ct))
+                .map(|(b, ct, m)| file_info(name, b.len() as u64, ct, m.clone()))
                 .ok_or_else(|| BackendError::NotFound {
                     name: name.to_string(),
                     suggestion: None,
@@ -328,7 +333,12 @@ pub(crate) mod stub {
     }
 
     #[cfg(feature = "file-ops")]
-    fn file_info(name: &str, size: u64, content_type: &str) -> crate::blob::models::FileInfo {
+    fn file_info(
+        name: &str,
+        size: u64,
+        content_type: &str,
+        metadata: HashMap<String, String>,
+    ) -> crate::blob::models::FileInfo {
         crate::blob::models::FileInfo {
             name: name.to_string(),
             size,
@@ -336,7 +346,7 @@ pub(crate) mod stub {
             last_modified: chrono::Utc::now(),
             etag: String::new(),
             groups: Vec::new(),
-            metadata: std::collections::HashMap::new(),
+            metadata,
             tags: std::collections::HashMap::new(),
         }
     }


### PR DESCRIPTION
## Summary
- The secret detail drawer in `xv ui` now shows an **Attachments** section: each blob under `attachments/<secret>/` renders as a clickable link with its base filename and size. The section is hidden for new secrets and secrets without attachments, and a failed listing toasts without blocking the drawer.
- New `file-ops`-gated endpoint `GET /api/secrets/{name}/attachments` backed by the existing `attachments::list_attachments` helper.
- The web `GET /api/files/{name}` download handler now routes through `attachments::download_decrypted` for parity with `xv file download` — content flagged `xv_encrypted: age` (secret attachments, `xv file upload --encrypt`) decrypts with the vault's attachment key; unflagged files, including foreign `.age` files, pass through untouched. Previously the UI served attachment ciphertext.
- Clicking a link downloads through the authenticated fetch path and saves under the base name (`cert.pem`, not `attachments/db-cert/cert.pem`).

## Test plan
- New API test seeds an age-encrypted attachment plus an unrelated plain file, then asserts the listing filters to the secret's attachments, an attachment-less secret returns an empty list, and downloading returns plaintext.
- Web test stub now persists file metadata so the encryption flag survives round-trip.
- Asset test pins the drawer wiring (section markup, fetch path, download call, styles).
- `cargo test --features ui --lib`: 905 passed; `cargo clippy --features ui --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches file download and vault attachment-key decryption paths; behavior change for encrypted attachments in the web UI, with new API surface and tests.
> 
> **Overview**
> The secret detail drawer in **`xv ui`** now loads **`GET /api/secrets/{name}/attachments`** (when file storage is enabled) and shows an **Attachments** section with filename, size, and authenticated download links. Listing failures only toast; the drawer still opens. Downloads save under the base filename (e.g. `cert.pem`), not the full blob path.
> 
> **`GET /api/files/{name}`** now uses **`attachments::download_decrypted`** so blobs flagged **`xv_encrypted: age`** return plaintext (matching **`xv file download`**); other files are unchanged. Previously the UI could serve raw ciphertext for secret attachments.
> 
> The web test stub persists file **metadata** on upload so encryption flags round-trip in API tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a30a478f6dde6435fb4d0ac1d6bd8b3eef5eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->