### PR TITLE
chore: bump version to 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.28.0 — Web UI attachment links (2026-07-22)
+
+### Added
+
+- The web UI's secret detail drawer now lists a secret's attachments as
+  clickable links (base filename + size) that download through the
+  authenticated session, backed by a new `GET /api/secrets/{name}/attachments`
+  endpoint.
+
+### Fixed
+
+- Web UI file downloads now decrypt age-encrypted content flagged
+  `xv_encrypted` — parity with `xv file download`. Previously the UI served
+  attachment ciphertext; unflagged files (including foreign `.age` files)
+  still pass through untouched.
+
 ## v0.27.1 — Azure attachment upload fix (2026-07-21)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.27.1"
+version = "0.28.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.27.1"
+version = "0.28.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Version bump for the v0.28.0 release: web UI secret attachment links (#379).

- Cargo.toml 0.27.1 → 0.28.0 (+ Cargo.lock)
- CHANGELOG.md: new v0.28.0 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only change with no runtime or dependency logic updates beyond the lockfile package version entry.
> 
> **Overview**
> Bumps the crate from **0.27.1** to **0.28.0** in `Cargo.toml` and `Cargo.lock` (no other source changes in this diff).
> 
> Adds a **v0.28.0** `CHANGELOG.md` section for the release already described in the PR title: web UI secret drawer **attachment download links** via `GET /api/secrets/{name}/attachments`, and a fix so UI downloads **decrypt `xv_encrypted`** age content like `xv file download`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23dfca159e049d764a3efe6c1d876ecc68ddec0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->