### PR TITLE
chore: bump version to 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v0.29.0 — App UX modernization (2026-07-24)
+
+### Added
+
+- Added first-run desktop setup and actionable startup recovery for local,
+  Azure, and AWS backends, including safe previews, retry, configuration
+  access, and redacted diagnostics.
+- Added recoverable Trash and Undo workflows, typed secret editing, global
+  command search, structured filters, managed upload queues, and persistent
+  Settings and Help surfaces.
+- Added time-bounded reveal and clipboard protection, workspace-aware context,
+  hierarchical folders, and responsive stacked content layouts down to 390 px.
+
+### Changed
+
+- Reworked core secret and file workflows for keyboard and screen-reader use,
+  with modal focus management, ARIA tabs and trees, durable errors, explicit
+  operation status, and safer destructive confirmations.
+- Made navigation, vault switching, window closing, and setup application
+  respect dirty drafts and in-flight saves without silently losing work.
+
+### Fixed
+
+- Prevented stale asynchronous results from replacing newer workspace, list,
+  upload, setup, and protected-value state.
+- Preserved unreadable existing configuration during desktop setup and granted
+  the startup shell only its explicit Tauri command permissions.
+
 ## v0.28.0 — Web UI attachment links (2026-07-22)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
## Summary

- bump the Crosstache package and lockfile to `0.29.0`
- add the App UX modernization release notes to `CHANGELOG.md`

## Validation

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test --test version_history_tests` (22 passed)
- `cargo run --quiet -- --version` → `xv 0.29.0`

After this PR merges, an annotated `v0.29.0` tag on the merge commit will trigger the release workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only change with no runtime code modifications.
> 
> **Overview**
> Prepares the **v0.29.0** release by bumping the crate version from `0.28.0` to `0.29.0` in `Cargo.toml` and syncing the `crosstache` entry in `Cargo.lock`.
> 
> Adds a new **v0.29.0 — App UX modernization** section at the top of `CHANGELOG.md`, summarizing the desktop app work already landed elsewhere: first-run setup and startup recovery, Trash/Undo, command search, accessibility and responsive layout improvements, dirty-draft handling, and fixes for stale async state and setup permissions.
> 
> No application or library code changes in this diff—only release metadata and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 697e54c1ab55ef4f572ac592444d0d5cffb2cf6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->