### PR TITLE
feat: rotation policies, local audit trail, git-native versioning, first-party CI/CD

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -1,0 +1,110 @@
+name: Action Smoke Test
+
+# Exercises the install path of `action.yml` on every runner we publish
+# binaries for. The action's shell logic is unit-tested in
+# `tests/action_yml_tests.rs`; what only a real runner can prove is that the
+# platform→archive mapping, checksum verification, unpack, and PATH export
+# actually work on each OS.
+#
+# Deliberately does not authenticate or read secrets: that needs a federated
+# app registration and a live vault, which a public smoke test should not
+# depend on. `auth: none` covers everything up to the point where credentials
+# would be required.
+
+on:
+  pull_request:
+    paths:
+      - 'action.yml'
+      - '.github/workflows/action-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'action.yml'
+      - '.github/workflows/action-test.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    name: Install via action (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # macos-latest is ARM64, macos-13 is Intel — both archives get exercised.
+        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xv through the action
+        id: setup
+        uses: ./
+        with:
+          auth: none
+
+      - name: Verify the binary is on PATH and runnable
+        shell: bash
+        # Step outputs are passed through env rather than interpolated into the
+        # script body — the safe default for any `${{ }}` value in a `run:`.
+        env:
+          XV_VERSION: ${{ steps.setup.outputs.version }}
+          XV_PATH: ${{ steps.setup.outputs.path }}
+        run: |
+          set -euo pipefail
+          xv --version
+          test -n "${XV_VERSION}"
+          test -x "${XV_PATH}"
+          echo "Installed ${XV_VERSION}"
+
+      - name: Verify the second run hits the tool cache
+        uses: ./
+        with:
+          auth: none
+
+  local-backend-round-trip:
+    name: Local-backend round trip via action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xv through the action
+        uses: ./
+        with:
+          backend: local
+          auth: none
+
+      - name: Write and read a secret with no cloud credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          export XDG_CONFIG_HOME="${RUNNER_TEMP}/config"
+          mkdir -p "${XDG_CONFIG_HOME}/xv"
+          cat > "${XDG_CONFIG_HOME}/xv/xv.conf" <<EOF
+          backend = "local"
+          debug = false
+          subscription_id = ""
+          default_vault = "default"
+          default_resource_group = ""
+          default_location = ""
+          tenant_id = ""
+          output_json = false
+          no_color = true
+          cache_enabled = false
+          cache_ttl_secs = 0
+          clipboard_timeout = 0
+
+          [local]
+          store_path = "${RUNNER_TEMP}/store"
+          key_file = "${RUNNER_TEMP}/key.txt"
+          default_vault = "default"
+          EOF
+
+          xv set CI_TOKEN --value "round-trip-value"
+          got="$(xv get CI_TOKEN --raw)"
+          if [[ "${got}" != "round-trip-value" ]]; then
+            echo "::error::expected 'round-trip-value', got '${got}'" >&2
+            exit 1
+          fi
+          echo "Local backend round trip succeeded"

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -33,8 +33,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-latest is ARM64, macos-13 is Intel — both archives get exercised.
-        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+        # macos-latest is ARM64. Intel macOS (macos-13) is deliberately absent:
+        # GitHub retired its Intel hosted runners, so a macos-13 job queues
+        # forever and can never be scheduled. The xv-macos-intel.tar.gz mapping
+        # stays covered by tests/action_yml_tests.rs; only the on-runner install
+        # of that one archive is unverifiable now.
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,9 +104,11 @@
   becomes a real git repository committed after every mutation, so `git log`,
   `git diff`, `git bisect`, and `git push` operate on actual history.
   `xv git init|log|status|diff|push|pull`. Only age **ciphertext** and metadata
-  are committed; the age identity and recipients files are excluded by a managed
-  `.gitignore` *and* by a pre-commit staged-path check that refuses the commit
-  outright (`.gitignore` alone is defeatable with `git add -f`). `xv git diff`
+  are committed; the age identity is excluded by a managed `.gitignore`, by a
+  pre-commit **content scan** of the staged index for the `AGE-SECRET-KEY-1`
+  identity marker (catches a key at any path under any name, in every layout,
+  surviving `git add -f` and renames), and by a path check for the configured
+  key/recipients files when they resolve inside the store. `xv git diff`
   reports names only, never contents. `xv git pull` is fast-forward only, since a
   merge conflict inside age ciphertext is unresolvable. Additive:
   `xv history`/`xv rollback` are unchanged on every backend. Azure and AWS are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,135 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **First-party GitHub Action** (`action.yml`): `uses: bziobnic/crosstache@v1`
+  installs the CLI (per-platform release archive, SHA-256 verified fail-closed,
+  cached in the runner tool cache) and optionally fetches secrets into
+  `GITHUB_ENV` with `::add-mask::` applied per line before anything logs.
+  Optional `verify-signature: true` checks the release `.minisig` against the
+  same minisign key embedded in `xv upgrade`. Outputs `version` and `path`.
+  Guide: `docs/ci-cd.md`.
+
+- **OIDC-native Azure authentication**: `AZURE_CREDENTIAL_PRIORITY=oidc` (or
+  `--credential-type oidc`) federates a GitHub Actions OIDC token into Azure AD
+  as a `client_assertion`, so CI needs no stored client secret and no
+  `azure/login` step. The `default` credential chain now also prefers OIDC when
+  the Actions runtime variables are present, falling back silently if federation
+  is incompletely configured; the explicit `oidc` selection never falls back, so
+  a misconfiguration cannot authenticate as a different identity. Azure AD
+  rejections surface the `AADSTS…` description with the actionable first line.
+
+- **Rotation policies on every backend** (closes the Azure/local rotation gap):
+  a policy is stored with the secret as the `xv:rotate_every` interval plus
+  `xv:rotated_at` timestamp.
+  - `xv update <name> --rotate-every 90d` sets a policy without rotating (clock
+    starts now); `--clear-rotate-every` removes it. Standalone, like `--field`.
+  - `xv rotate <name> --every 90d` rotates and sets/refreshes the policy.
+  - `xv rotate --due` rotates everything currently due; `--force` for cron/CI.
+  - `xv rotate --check` reports status and changes nothing, exiting **51**
+    (`xv-rotation-due`) when any secret is due, so a pipeline can gate on
+    staleness. Honors `--format`.
+  - Every rotation, `--every` or not, restamps `xv:rotated_at`, so `--due` cannot
+    re-rotate the same secret on every run.
+  - An unparseable interval is reported as `invalid` by `--check` and **fails**
+    `--due` rather than being skipped: unknown due-ness must not look like a
+    clean run. Intervals require a unit (`m`/`h`/`d`/`w`); a bare `90` is
+    rejected rather than guessed. Guide: `docs/rotation.md`.
+  - Not a scheduler: nothing rotates unless cron, a systemd timer, or CI invokes
+    `xv`. `--native` (AWS server-side Lambda rotation) is unchanged.
+
+- **Automatic rotation scheduling** (`xv schedule install|status|uninstall`):
+  installs and manages a **per-user** job in the platform's own scheduler that
+  runs `xv rotate --due --force` on a cadence — launchd agent on macOS, systemd
+  **user** timer on Linux, Task Scheduler task on Windows. Nothing system-wide,
+  no root, and no daemon: a resident process would reimplement reboot survival,
+  sleep catch-up, and log capture worse than the OS already does, while holding
+  decryption credentials for its whole lifetime.
+  - `--interval hourly|daily|weekly` and `--at HH:MM` (default daily 03:00);
+    `HH:MM` is strict, so `3:0` is rejected rather than landing an hour off.
+  - `--print` renders the unit and the exact command line without writing or
+    registering anything — also how to drive a scheduler `xv` does not manage
+    (cron, Kubernetes CronJob, CI schedule).
+  - `--vault` pins the target; without it the scheduled run re-resolves whatever
+    context it finds at fire time, and install warns about that.
+  - Units carry only an absolute binary path, the rotate arguments, a log path,
+    and `HOME`/`XDG_CONFIG_HOME` — **never credentials or secret values**. The env
+    pair is what stops a scheduled run from resolving a different config than the
+    user tested against.
+  - The scheduled command is always `rotate --due --force`: bounded to secrets
+    that already carry a policy and are already past it, and `--every` is never
+    passed, so a schedule cannot redefine what it sweeps.
+  - Install requires confirmation (or `--force`) and states plainly that
+    unattended rotation breaks anything that does not re-read its secrets. On a
+    non-TTY without `--force` it errors naming `--force`/`--print` instead of
+    surfacing a generic "not a terminal" I/O failure.
+  - Output is captured to `$XDG_STATE_HOME/xv/rotate.log` (else
+    `~/.local/state/xv/rotate.log`) on every platform. Reinstall is idempotent;
+    uninstall converges on "absent" and succeeds when nothing was installed.
+  - A Linux host with no systemd gets a diagnostic error plus the cron line to
+    use, not a silently-absent schedule. Guide: `docs/rotation.md`.
+
+- **Failed local operations are now audited.** The local trail records attempts,
+  not just outcomes: a missing secret, a denied path, or ciphertext that would not
+  decrypt each produce a record. Status tokens come from a **closed set** derived
+  from the error's variant, never its message, so no future error string can widen
+  what the log captures. Secret values never appear; secret *names* do, exactly as
+  for successful operations.
+  - New `BackendError::Decryption` variant, so a read that reached a secret's
+    ciphertext and could not open it records as `DecryptionFailed` rather than
+    collapsing into a generic internal error. That is the one status worth
+    alerting on — it means the wrong age identity, or altered material.
+  - Metadata-only probes stay unlogged on the failure path too, matching the
+    success path: a `NotFound` from an existence check is normal listing traffic.
+  - If the audit append for a failure itself fails, both failures are reported
+    rather than the original error being replaced or the record silently dropped.
+
+- **Audit trail for the local backend** (`[local].audit = true`): append-only
+  hash-chained log at `<store>/vaults/<vault>/.audit/log.jsonl`, surfaced through
+  the existing `xv audit`. Records `PutSecretValue`, `GetSecretValue`,
+  `UpdateSecret`, `DeleteSecret`, `RestoreSecret`, `PurgeSecret`,
+  `RollbackSecret`, and vault-wide `ListSecrets`; only reads that actually
+  decrypt a value count as `GetSecretValue`. Each record carries
+  `HMAC-SHA256(chain_key, prev_mac || record)` with the key HKDF-derived from the
+  age identity, and `xv audit --verify` recomputes the chain and exits non-zero
+  on a break. Fail-closed: a failed append fails the triggering operation.
+  `has_audit` is true only when the log is actually being written.
+  **Tamper-evident, not tamper-proof** — anyone holding the age identity can
+  rewrite the chain, and anyone who can write the file can truncate it; push the
+  store to a remote for off-box copies. Guide: `docs/git-versioning.md`.
+
+- **Git-native versioning for the local store** (`[local].git = true`): the store
+  becomes a real git repository committed after every mutation, so `git log`,
+  `git diff`, `git bisect`, and `git push` operate on actual history.
+  `xv git init|log|status|diff|push|pull`. Only age **ciphertext** and metadata
+  are committed; the age identity and recipients files are excluded by a managed
+  `.gitignore` *and* by a pre-commit staged-path check that refuses the commit
+  outright (`.gitignore` alone is defeatable with `git add -f`). `xv git diff`
+  reports names only, never contents. `xv git pull` is fast-forward only, since a
+  merge conflict inside age ciphertext is unresolvable. Additive:
+  `xv history`/`xv rollback` are unchanged on every backend. Azure and AWS are
+  excluded by design — mirroring cloud secret values into git would create a
+  second, effectively permanent copy of every version.
+
+### Changed
+
+- `xv rotate`'s secret name is now optional, since `--due` and `--check` are
+  vault-scoped. Invoking `xv rotate` with neither a name nor a mode flag errors
+  and names the alternatives.
+- The local backend's `has_audit` capability reflects `[local].audit` rather than
+  being hard-coded `false`.
+- New `[local]` config keys: `audit`, `git` (both default `false`, so existing
+  stores are byte-for-byte unchanged until opted in).
+- New `AzureCredentialType::Oidc` variant (`oidc`, `github-oidc`,
+  `workload-identity`).
+- New `BackendError::Decryption` variant, split out of `Internal`, so decryption
+  failures are distinguishable by callers and by the audit trail. It converts to
+  `CrosstacheError::Unknown` with a message naming the two likely causes.
+- New exit code **52** (`xv-audit-chain-broken`) for `xv audit --verify` on an
+  altered chain. It previously reported as `xv-config-invalid` (exit 3), which
+  misdescribed an integrity failure as a configuration problem.
 ## v0.29.0 — App UX modernization (2026-07-24)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,10 +222,20 @@ As of `v0.14.0` plus current `main`:
 - **Leak Scanner**: `xv scan` pre-commit scanner, shipped v0.7.0-rc.1.
 - **Self-update**: `xv upgrade`, shipped v0.5.1.
 - **Secret File Attachments**: `xv attach`/`xv attachments`/`xv detach` plus `xv file upload --encrypt` — client-side age encryption with per-vault key custody in the vault's secret store (`xv-attachment-key`); see `docs/superpowers/specs/2026-07-21-secret-file-attachments-design.md`.
+- **Rotation policies (all backends)**: `xv:rotate_every` + `xv:rotated_at` tags, `xv update --rotate-every`, `xv rotate --every/--due/--check` (exit 51 `xv-rotation-due`). AWS `--native` is still the only *server-side* rotation. See `src/secret/rotation.rs`, `docs/rotation.md`.
+- **Automatic rotation scheduling**: `xv schedule install|status|uninstall` manages a per-user job in the OS scheduler (launchd / systemd user timer / Task Scheduler) running `xv rotate --due --force`. No daemon, nothing system-wide. `--print` renders without installing. Units carry no credentials; `HOME`/`XDG_CONFIG_HOME` are pinned so the scheduled run resolves the same config. Lifecycle logic is tested against a fake `CommandRunner` — no test registers a real job. See `src/schedule/mod.rs`, `src/cli/schedule_ops.rs`.
+- **Local audit trail** (`[local].audit`): hash-chained append-only JSONL, `xv audit --verify` (exit 52 `xv-audit-chain-broken`). Fail-closed appends; `has_audit` reflects the flag. Tamper-*evident* only — the age-identity holder can rewrite it. Records **failures as well as successes**, with status tokens from a closed set keyed off the error variant (`DecryptionFailed`, `NotFound`, …) — never from error messages. `BackendError::Decryption` exists to make failed decryption its own status. See `src/backend/local/audit.rs`, `docs/git-versioning.md`.
+- **Git-native versioning** (`[local].git`, local backend only): store is a real git repo, auto-commit per mutation, `xv git init/log/status/diff/push/pull`. Age identity protected by a managed `.gitignore` **and** a pre-commit staged-path refusal. Azure/AWS excluded by design (would create a permanent second copy of every cloud secret). See `src/backend/local/git.rs`.
+- **First-party CI/CD**: root `action.yml` composite GitHub Action (per-OS release archive, fail-closed SHA-256, tool cache, masked secret export to `GITHUB_ENV`) plus OIDC-native Azure auth (`AZURE_CREDENTIAL_PRIORITY=oidc`) federating a GitHub OIDC token as a `client_assertion` — no stored secret, no `azure/login`. See `src/backend/azure/oidc.rs`, `docs/ci-cd.md`, `.github/workflows/action-test.yml`.
 
 Known partial / known limitations (tracked in `ROADMAP.md`):
 
 - **Azure Secret Backup/Restore**: stub on Azure backend (`src/backend/azure/secrets.rs`).
 - **AWS capability gap**: `xv file sync` is not supported on AWS S3 storage yet.
+- **Local audit trail has no off-box sink** (a git remote is the current answer); the chain is tamper-evident, not tamper-proof.
+- **Rotation has no external-system hook** (`--generator` or AWS `--native` are the escape hatches) and no rollout coordination — a rotated credential still needs the consumer to re-read it.
+- **Scheduler lifecycle is untested on a real runner** (rendering + command sequencing are tested against a fake runner; macOS was verified manually). systemd-less Linux gets a diagnostic error with the cron line, not an auto-installed fallback.
+- **CI/CD is GitHub-only** as a first-party integration; GitLab/CircleCI use a documented plain install step.
+- **`xv rotate --check --format json` emits two JSON documents on stdout** when something is due (rows + the error envelope) — same shape `xv scan --format json` has always had; the framework's error path owns this.
 
 For open work items, see `ROADMAP.md` at the repo root. Implementation history is in `CHANGELOG.md`; shipped designs live under `docs/superpowers/specs/` with version banners.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,14 @@ pre-commit leak scanner that matches files against your *actual* vault values.
 - [Vault management](#vault-management)
 - [Cross-vault operations — diff, copy, move](#cross-vault-operations--diff-copy-move)
 - [Files (blob storage)](#files-blob-storage)
+- [Rotation & rotation policies](#rotation--rotation-policies) — `xv schedule` for automatic sweeps
+- [Git-native versioning & local audit trail](#git-native-versioning--local-audit-trail)
 - [Pre-commit leak scanner — `xv scan`](#pre-commit-leak-scanner--xv-scan)
 - [Terminal UI — `xv tui`](#terminal-ui--xv-tui)
 - [Web UI — `xv ui`](#web-ui--xv-ui)
 - [Desktop app](#desktop-app)
 - [Scripting & CI](#scripting--ci) — exit codes, JSON envelope, examples
+- [GitHub Action & OIDC](#github-action--oidc) — no stored credentials in CI
 - [Configuration](#configuration)
 - [Authentication](#authentication)
 - [Troubleshooting](#troubleshooting)
@@ -161,8 +164,12 @@ backend = "local"
 
 [local]
 store_path = "~/.xv/store"
-key_file = "~/.xv/key.txt"
+key_file = "~/.xv/key.txt"     # keep this OUTSIDE store_path
 default_vault = "default"
+encrypt_metadata = false       # `xv local encrypt-metadata` after enabling
+opaque_filenames = false       # `xv local migrate` after enabling
+audit = false                  # hash-chained audit log; `xv audit --verify`
+git = false                    # commit the store on every write; `xv git init` first
 # Encrypt secret metadata (notes, tags, folders, expiry) at rest with the
 # same age key as the values. Default false. Secret *names* stay visible as
 # on-disk filenames unless opaque_filenames is also enabled. After enabling on
@@ -526,6 +533,9 @@ xv rotate API_KEY --charset hex              # hex / base64 / numeric / uppercas
 xv rotate API_KEY --generator ./mygen.sh     # custom generator (validated for ownership + 0700 perms)
 xv rotate API_KEY --show-value               # echo the new value to stdout (otherwise silent)
 ```
+
+See [Rotation & rotation policies](#rotation--rotation-policies) for scheduling
+rotation across a vault.
 
 ---
 
@@ -1271,6 +1281,139 @@ xv file sync ./mydir --prefix backup/ --delete   # mirror; remove extra remote b
 
 ---
 
+## Rotation & rotation policies
+
+`xv rotate NAME` replaces a value. A **rotation policy** records how often that
+should happen, so a vault can be swept in one command.
+
+```bash
+xv update DB_PASSWORD --rotate-every 90d   # set a policy; does NOT rotate. Clock starts now.
+xv rotate DB_PASSWORD --every 90d          # rotate now AND set the policy
+xv update DB_PASSWORD --clear-rotate-every # remove the policy
+
+xv rotate --check                          # report what is due; changes nothing; exits 51 if any is due
+xv rotate --due --force                    # rotate everything due (cron/CI)
+```
+
+```console
+$ xv rotate --check
+ Name          Status  Interval  Due
+ API_KEY       ok                in 74 days (2026-10-07)
+ DB_PASSWORD   due               12 days ago (2026-07-13)
+```
+
+Works on **every backend** — the policy is two tags on the secret
+(`xv:rotate_every`, `xv:rotated_at`), so it travels with the secret and is
+visible to anything else reading its metadata. Intervals are `<n>m|h|d|w`; the
+unit is required, because guessing minutes vs. days is the difference between
+rotating constantly and never rotating.
+
+Azure Key Vault has no server-side rotation for secret values, and a local
+directory has no scheduler at all, so the cadence has to come from outside the
+vault. `xv schedule` puts it in the host's scheduler:
+
+```bash
+xv schedule install --vault myproj-prod-kv       # daily at 03:00
+xv schedule install --vault v --interval hourly --at 00:15
+xv schedule status
+xv schedule uninstall
+```
+
+`xv schedule` installs a **per-user** job in the platform's own scheduler —
+launchd on macOS, a systemd user timer on Linux, Task Scheduler on Windows — that
+runs `xv rotate --due --force`. No daemon, nothing system-wide, no root. The unit
+holds only a binary path, those arguments, a log path, and `HOME`/`XDG_CONFIG_HOME`
+— never credentials.
+
+```bash
+xv schedule install --vault v --print   # render the unit, write nothing
+```
+
+`--print` also gives you the exact command line for a scheduler `xv` does not
+manage (cron, a Kubernetes CronJob, a CI schedule).
+
+One thing to plan around: a scheduled run has no terminal, so a credential that
+needs interaction fails there even though it works for you now. Verify with
+`xv rotate --due --force` in a clean shell, then watch
+`~/.local/state/xv/rotate.log` after the first firing.
+
+On AWS, `xv rotate --native` instead hands the whole job to Secrets Manager's
+rotation Lambda, which *is* server-side.
+
+Also worth knowing: rotation replaces the stored value, not the password on the
+database, and an app that read the secret at startup keeps the old value until
+it restarts. Full detail, including the `--due` fail-closed behavior on an
+unparseable policy, in [`docs/rotation.md`](docs/rotation.md).
+
+---
+
+## Git-native versioning & local audit trail
+
+Two opt-in features for the local age-encrypted backend.
+
+### Git-native versioning
+
+```toml
+[local]
+git = true
+```
+
+```bash
+xv git init                    # create the repo (works before the flag is on)
+xv set DB_PASSWORD --value x   # → commit "set DB_PASSWORD"
+xv git log DB_PASSWORD         # one secret's timeline
+xv git push origin --branch main
+```
+
+The store becomes a real git repository, so `git log`, `git diff`, `git bisect`,
+and `git push` operate on actual history — the `pass` model. Only age
+**ciphertext** and metadata are committed. The age identity is protected twice:
+a managed `.gitignore`, *and* a pre-commit check that refuses the commit outright
+if key material is staged (`.gitignore` alone is defeatable with `git add -f`).
+
+Additive — `xv history` and `xv rollback` are unchanged on every backend.
+`xv git pull` is fast-forward only, because a merge conflict inside age
+ciphertext is not resolvable.
+
+Local backend only, deliberately: mirroring Azure or AWS secret values into a git
+history would create a second, effectively permanent copy of every version.
+
+### Local audit trail
+
+```toml
+[local]
+audit = true
+```
+
+```bash
+xv audit --vault default    # same output as the Azure/AWS trails
+xv audit --verify           # recompute the hash chain; non-zero on tampering
+```
+
+An append-only log at `<store>/vaults/<vault>/.audit/log.jsonl`, each record
+chained by `HMAC-SHA256(key, prev_mac || record)` with the key derived from the
+age identity. Fail-closed: if the append fails, the operation fails.
+
+Failed attempts are recorded too, with a status token from a closed set
+(`NotFound`, `AccessDenied`, `DecryptionFailed`, …) derived from the error type
+rather than its message. `DecryptionFailed` is the one to watch — someone reached
+a secret's ciphertext and could not open it. Secret values never appear in a
+record; names do, exactly as for successful operations.
+
+```bash
+xv audit --operation DecryptionFailed
+```
+
+**Tamper-evident, not tamper-proof.** It detects edits, reordering, and deletions.
+It cannot stop someone holding the age identity from rewriting the chain, or
+anyone who can write the file from truncating it — unlike Azure Activity Log and
+CloudTrail, which the platform holds rather than the caller. Pushing the store to
+a git remote gets you off-box copies a local attacker cannot reach.
+
+Full detail in [`docs/git-versioning.md`](docs/git-versioning.md).
+
+---
+
 ## Pre-commit leak scanner — `xv scan`
 
 `xv scan` is unique because it matches files against your **actual vault values**, not just generic regex patterns. When you accidentally paste `DB_PASSWORD`'s real value into a config file, it tells you *"this file contains the value of secret DB_PASSWORD from vault dev-kv"* — not just "high-entropy string."
@@ -1565,6 +1708,42 @@ token=$(xv get DEPLOY_TOKEN --raw 2>&1) || {
 }
 ```
 
+### GitHub Action & OIDC
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write        # required for OIDC
+      contents: read
+    steps:
+      - uses: bziobnic/crosstache@v1
+        with:
+          version: v0.28.0
+          vault: myproj-prod-kv
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          secrets: |
+            DEPLOY_TOKEN=deploy-token
+      - run: ./scripts/deploy.sh     # $DEPLOY_TOKEN is set and masked
+```
+
+No client secret is stored anywhere: the job's OIDC token is federated into
+Azure AD as a `client_assertion`, and no `azure/login` step is needed. The action
+verifies the release archive's SHA-256 fail-closed and caches the binary in the
+runner tool cache.
+
+Outside the action, the same credential is selected with:
+
+```bash
+export AZURE_CREDENTIAL_PRIORITY=oidc
+export AZURE_CLIENT_ID=<app-id> AZURE_TENANT_ID=<tenant-id>
+```
+
+Federated-credential setup, subject scoping, what the checksum does and does not
+prove, and troubleshooting for the `AADSTS…` errors: [`docs/ci-cd.md`](docs/ci-cd.md).
+
 ### `xv scan` in CI
 
 ```bash
@@ -1615,7 +1794,7 @@ configuration error.
 | `AZURE_SUBSCRIPTION_ID` | Azure subscription |
 | `AZURE_TENANT_ID` | Azure tenant |
 | `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` | Service-principal auth |
-| `AZURE_CREDENTIAL_PRIORITY` | `cli` / `managed_identity` / `environment` / `default` |
+| `AZURE_CREDENTIAL_PRIORITY` | `cli` / `managed_identity` / `environment` / `oidc` / `default` |
 | `DEFAULT_VAULT` | Default vault name |
 | `DEFAULT_RESOURCE_GROUP` | Default resource group |
 | `DEFAULT_LOCATION` | Default Azure location (e.g., `eastus`) |
@@ -1643,7 +1822,7 @@ These work with any command:
 |------|---------|
 | `--format <FORMAT>` | `table` / `json` / `yaml` / `csv` / `plain` / `raw` / `template` (default: `auto` — table on TTY, json for pipes) |
 | `--columns <COLS>` | Comma-separated column names for `table`/`plain`/`csv` output, in order (case-insensitive, e.g. `--columns Name,Updated`); unknown names error |
-| `--credential-type <TYPE>` | Azure credential type (`cli`, `managed_identity`, `environment`, `default`) |
+| `--credential-type <TYPE>` | Azure credential type (`cli`, `managed_identity`, `environment`, `oidc`, `default`) |
 | `--template <TEMPLATE>` | Custom template string for template format |
 | `--no-color` | Disable colored output (same effect as the `NO_COLOR` env var) |
 | `--env <NAME>` | Active env from `.xv.toml` (overridden by `XV_ENV`) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,6 +117,77 @@ low-confidence (`src/scan/patterns.rs:62`).
 
 ---
 
+## Rotation, audit, and CI/CD (2026-07-24)
+
+Four capability gaps from the competitive feature review closed this pass; see
+`CHANGELOG.md` § Unreleased for the user-visible list. Remaining follow-ups:
+
+### ~~P2 — Local audit log records successes only~~ — closed
+✅ **Closed 2026-07-24.** All nine audited operations now record failures as well
+as successes, with status tokens from a closed set keyed off the error variant
+(`failure_status`). `BackendError::Decryption` was split out of `Internal` so a
+failed decryption is its own status. Metadata-only probes remain unlogged on both
+paths.
+
+### P2 — No off-box audit sink
+The hash chain is tamper-evident but not tamper-proof: whoever holds the age
+identity can rewrite it wholesale, and anyone who can write the file can truncate
+the tail. `[local].git` plus a remote is the current answer (the remote holds
+copies a local attacker cannot reach), which requires the operator to push.
+A native append-only sink (syslog, an HTTP endpoint, a WORM bucket) would close
+it properly.
+
+### ~~P2 — No first-party scheduling for due rotation~~ — closed
+✅ **Closed 2026-07-24.** `xv schedule install|status|uninstall` manages a
+per-user job in the platform scheduler (launchd / systemd user timer / Task
+Scheduler). See `src/schedule/mod.rs`. Remaining: no cron fallback is installed
+automatically on systemd-less Linux (a diagnostic error prints the line to add),
+and lifecycle verification on Windows and systemd is untested in CI — the unit
+tests cover rendering and command sequencing against a fake runner, but no test
+registers a real job, by design.
+
+### P2 — Rotation policy has no external-system hook
+`xv rotate` replaces the stored value; it does not change the password on the
+database. `--generator` can wrap a script that does both, and AWS `--native`
+delegates to a Lambda, but there is no first-class "rotate this, then run this"
+step, and no rollout coordination — a rotated credential that an app read at
+startup needs a restart. Worth a design pass before adding surface.
+
+### P3 — Scheduler lifecycle is not exercised on a real runner
+`src/schedule/mod.rs` unit-tests rendering and command sequencing against a fake
+`CommandRunner`, and `tests/schedule_cli_tests.rs` covers `--print` and argument
+validation. Nothing installs a real job: `launchctl`, `systemctl --user`, and
+`schtasks` act on the invoking user's live session regardless of `HOME`, so a test
+that installed would leave a rotation job on the developer's machine. A container
+or VM job could cover systemd end-to-end; launchd and Task Scheduler would need
+dedicated runners. The macOS path was verified manually (install → reinstall →
+status → uninstall, with `plutil -lint` on the plist).
+
+### P3 — `xv rotate --check` emits two JSON documents on stdout
+With an explicit `--format json`, a non-zero exit also writes the machine-readable
+error envelope to stdout (`print_user_friendly_error`), so `--check` output is
+rows followed by the envelope and `| jq` sees two documents. This matches
+`xv scan --format json`, which has behaved this way since it shipped — the
+inconsistency is in the framework's error path, not in either command, so fixing
+it means deciding the contract for the whole 50–59 exit-code family at once
+rather than special-casing one command.
+
+### P3 — No first-party GitLab / CircleCI integration
+`action.yml` covers GitHub. GitLab and CircleCI work via a documented plain
+install step (`docs/ci-cd.md`), but there is no CI component or orb, and no
+OIDC-native path for GitLab's `CI_JOB_JWT_V2` (the exchange in
+`src/backend/azure/oidc.rs` is generic; only the token-fetch step is
+GitHub-specific, so this is a small addition).
+
+### P3 — Git versioning is local-only by design
+Deliberate, not an omission: mirroring Azure/AWS secret values into a git history
+would create a second, effectively permanent copy of every secret version. If a
+cloud mirror is ever wanted, it needs its own design pass covering key custody
+for the mirror and a redaction story — not a straight extension of the local
+implementation.
+
+---
+
 ## Backend ecosystem
 
 ### P1 — AWS capability matrix gaps (deferred from v0.10.0)
@@ -154,6 +225,16 @@ manager retirement (see § above). Azure `xv audit`/`--resource-group` now
 dispatches through the `AuditBackend` trait exactly like AWS; the legacy
 Activity Log client is deleted, so `has_audit: true` for Azure is no longer a
 lie. Retained here for traceability; details in `CHANGELOG.md` § Unreleased.
+
+### ~~P1 — Rotation limited to AWS native / manual value replacement~~ — closed
+✅ **Closed 2026-07-24.** Rotation policies (`xv:rotate_every` +
+`xv:rotated_at`), `xv rotate --due`, and `xv rotate --check` work on Azure, AWS,
+and local; `--native` remains the AWS server-side path. See § Rotation, audit,
+and CI/CD above for remaining follow-ups.
+
+### ~~P2 — Local backend has no audit trail~~ — closed
+✅ **Closed 2026-07-24.** `[local].audit` writes a hash-chained log verified by
+`xv audit --verify`. Scope limits and the missing off-box sink are tracked above.
 
 ### P3 — Additional backends
 Open ground from `2026-04-29-strategic-improvements-phase-1-design.md`:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,315 @@
+name: 'Setup crosstache (xv)'
+description: 'Install the xv secrets CLI and optionally fetch secrets into the environment using OIDC — no stored credentials required.'
+author: 'crosstache'
+
+branding:
+  icon: 'lock'
+  color: 'purple'
+
+inputs:
+  version:
+    description: >-
+      Release to install: a tag like `v0.28.0`, or `latest`. Pin an exact tag for
+      reproducible builds — `latest` changes what it installs over time.
+    required: false
+    default: 'latest'
+
+  backend:
+    description: 'Secrets backend: azure, aws, or local.'
+    required: false
+    default: 'azure'
+
+  vault:
+    description: 'Vault to read from. Defaults to whatever the resolved config selects.'
+    required: false
+    default: ''
+
+  secrets:
+    description: >-
+      Secrets to fetch, one `ENV_NAME=secret-name` pair per line. Each value is
+      registered as a masked value and exported to `GITHUB_ENV`, so later steps
+      in the job can read it as an environment variable. Omit to install the CLI
+      without reading anything.
+    required: false
+    default: ''
+
+  auth:
+    description: >-
+      How to authenticate. `oidc` federates this job's GitHub OIDC token into
+      Azure AD — no stored secret, and no separate `azure/login` step. Requires
+      `permissions: id-token: write` on the job plus a federated credential on
+      the app registration. `default` uses the standard credential chain (which
+      picks up whatever `azure/login` or the AWS credentials action already set
+      up). `none` skips auth configuration entirely.
+    required: false
+    default: 'oidc'
+
+  client-id:
+    description: 'Azure app registration (client) ID. Required for auth=oidc.'
+    required: false
+    default: ''
+
+  tenant-id:
+    description: 'Azure tenant ID. Required for auth=oidc.'
+    required: false
+    default: ''
+
+  subscription-id:
+    description: 'Azure subscription ID.'
+    required: false
+    default: ''
+
+  verify-signature:
+    description: >-
+      Also verify the release archive's minisign signature. Requires `minisign`
+      on PATH (install it in a prior step). The SHA-256 digest published with the
+      release is ALWAYS verified regardless of this setting; see the README for
+      exactly what each check does and does not prove.
+    required: false
+    default: 'false'
+
+outputs:
+  version:
+    description: 'The release tag that was installed.'
+    value: ${{ steps.install.outputs.version }}
+  path:
+    description: 'Absolute path to the installed xv binary.'
+    value: ${{ steps.install.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install xv
+      id: install
+      shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_VERIFY_SIGNATURE: ${{ inputs.verify-signature }}
+        # Used only for the release API lookup and archive download. Falls back
+        # to unauthenticated requests, which are rate-limited on busy runners.
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        REPO="bziobnic/crosstache"
+
+        # ── Resolve the platform to a published archive name ───────────────
+        case "${RUNNER_OS}:${RUNNER_ARCH}" in
+          Linux:X64)    ARCHIVE="xv-linux-x64.tar.gz" ;;
+          macOS:X64)    ARCHIVE="xv-macos-intel.tar.gz" ;;
+          macOS:ARM64)  ARCHIVE="xv-macos-apple-silicon.tar.gz" ;;
+          Windows:X64)  ARCHIVE="xv-windows-x64.zip" ;;
+          *)
+            echo "::error::crosstache publishes no release binary for ${RUNNER_OS}/${RUNNER_ARCH}." >&2
+            echo "Supported: Linux/X64, macOS/X64, macOS/ARM64, Windows/X64. Build from source with cargo for other targets." >&2
+            exit 1
+            ;;
+        esac
+
+        # ── Resolve the version ───────────────────────────────────────────
+        if [[ "${INPUT_VERSION}" == "latest" ]]; then
+          VERSION="$(curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            ${GH_TOKEN:+-H "Authorization: Bearer ${GH_TOKEN}"} \
+            "https://api.github.com/repos/${REPO}/releases/latest" \
+            | grep -o '"tag_name": *"[^"]*"' | head -1 | cut -d'"' -f4)"
+          if [[ -z "${VERSION}" ]]; then
+            echo "::error::Could not determine the latest crosstache release. Pin an explicit version instead." >&2
+            exit 1
+          fi
+        else
+          VERSION="${INPUT_VERSION}"
+        fi
+        echo "Installing crosstache ${VERSION} (${ARCHIVE})"
+
+        # ── Cache lookup ──────────────────────────────────────────────────
+        # Keyed by version AND platform so a cache restored on one runner can
+        # never hand a foreign binary to another.
+        CACHE_ROOT="${RUNNER_TOOL_CACHE:-${HOME}/.cache}/crosstache/${VERSION}/${RUNNER_OS}-${RUNNER_ARCH}"
+        BIN_NAME="xv"
+        [[ "${RUNNER_OS}" == "Windows" ]] && BIN_NAME="xv.exe"
+        BIN_PATH="${CACHE_ROOT}/${BIN_NAME}"
+
+        if [[ ! -x "${BIN_PATH}" ]]; then
+          WORK="$(mktemp -d)"
+          trap 'rm -rf "${WORK}"' EXIT
+          BASE="https://github.com/${REPO}/releases/download/${VERSION}"
+
+          echo "Downloading ${BASE}/${ARCHIVE}"
+          curl -fsSL -o "${WORK}/${ARCHIVE}" "${BASE}/${ARCHIVE}"
+          curl -fsSL -o "${WORK}/${ARCHIVE}.sha256" "${BASE}/${ARCHIVE}.sha256"
+
+          # ── Integrity: always, fail-closed ──────────────────────────────
+          EXPECTED="$(tr -d ' \t\r\n*' < "${WORK}/${ARCHIVE}.sha256" | tr 'A-Z' 'a-z')"
+          # The published file may be a bare digest or `digest  filename`; the
+          # trim above collapses both, so take the leading 64 hex chars.
+          EXPECTED="${EXPECTED:0:64}"
+          if [[ ! "${EXPECTED}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::Published checksum for ${ARCHIVE} is not a SHA-256 digest; refusing to install." >&2
+            exit 1
+          fi
+          if command -v sha256sum >/dev/null 2>&1; then
+            ACTUAL="$(sha256sum "${WORK}/${ARCHIVE}" | cut -d' ' -f1)"
+          else
+            ACTUAL="$(shasum -a 256 "${WORK}/${ARCHIVE}" | cut -d' ' -f1)"
+          fi
+          if [[ "${ACTUAL}" != "${EXPECTED}" ]]; then
+            echo "::error::Checksum mismatch for ${ARCHIVE}. Expected ${EXPECTED}, got ${ACTUAL}. Refusing to install." >&2
+            exit 1
+          fi
+          echo "SHA-256 verified: ${ACTUAL}"
+
+          # ── Authenticity: opt-in, needs minisign on PATH ────────────────
+          if [[ "${INPUT_VERIFY_SIGNATURE}" == "true" ]]; then
+            if ! command -v minisign >/dev/null 2>&1; then
+              echo "::error::verify-signature was requested but minisign is not on PATH. Install it in a prior step." >&2
+              exit 1
+            fi
+            curl -fsSL -o "${WORK}/${ARCHIVE}.minisig" "${BASE}/${ARCHIVE}.minisig"
+            # Public key is the one embedded in `xv upgrade` (generated 2026-05-04).
+            minisign -Vm "${WORK}/${ARCHIVE}" \
+              -P 'RWRuXFh34rB613dgsXyAMmtKvYK0SFwxq4i44dhGFXVTrhAQ7hJXf6Ym' \
+              -x "${WORK}/${ARCHIVE}.minisig"
+            echo "minisign signature verified"
+          fi
+
+          # ── Unpack ─────────────────────────────────────────────────────
+          mkdir -p "${CACHE_ROOT}"
+          if [[ "${ARCHIVE}" == *.zip ]]; then
+            unzip -q -o "${WORK}/${ARCHIVE}" -d "${WORK}/out"
+          else
+            mkdir -p "${WORK}/out"
+            tar xzf "${WORK}/${ARCHIVE}" -C "${WORK}/out"
+          fi
+          if [[ ! -f "${WORK}/out/${BIN_NAME}" ]]; then
+            echo "::error::Release archive did not contain ${BIN_NAME}." >&2
+            exit 1
+          fi
+          mv "${WORK}/out/${BIN_NAME}" "${BIN_PATH}"
+          chmod +x "${BIN_PATH}"
+        else
+          echo "Using cached ${BIN_PATH}"
+        fi
+
+        echo "${CACHE_ROOT}" >> "${GITHUB_PATH}"
+        echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+        echo "path=${BIN_PATH}" >> "${GITHUB_OUTPUT}"
+        "${BIN_PATH}" --version || true
+
+    - name: Configure authentication
+      if: inputs.auth != 'none'
+      shell: bash
+      env:
+        INPUT_AUTH: ${{ inputs.auth }}
+        INPUT_BACKEND: ${{ inputs.backend }}
+        INPUT_CLIENT_ID: ${{ inputs.client-id }}
+        INPUT_TENANT_ID: ${{ inputs.tenant-id }}
+        INPUT_SUBSCRIPTION_ID: ${{ inputs.subscription-id }}
+        INPUT_VAULT: ${{ inputs.vault }}
+      run: |
+        set -euo pipefail
+
+        # `XV_BACKEND` is read during config load, unlike the `--backend` flag,
+        # which resolves too late to affect early validation.
+        echo "XV_BACKEND=${INPUT_BACKEND}" >> "${GITHUB_ENV}"
+        [[ -n "${INPUT_VAULT}" ]] && echo "DEFAULT_VAULT=${INPUT_VAULT}" >> "${GITHUB_ENV}"
+        [[ -n "${INPUT_TENANT_ID}" ]] && echo "AZURE_TENANT_ID=${INPUT_TENANT_ID}" >> "${GITHUB_ENV}"
+        [[ -n "${INPUT_CLIENT_ID}" ]] && echo "AZURE_CLIENT_ID=${INPUT_CLIENT_ID}" >> "${GITHUB_ENV}"
+        [[ -n "${INPUT_SUBSCRIPTION_ID}" ]] && echo "AZURE_SUBSCRIPTION_ID=${INPUT_SUBSCRIPTION_ID}" >> "${GITHUB_ENV}"
+
+        case "${INPUT_AUTH}" in
+          oidc)
+            if [[ "${INPUT_BACKEND}" != "azure" ]]; then
+              echo "::error::auth=oidc federates into Azure AD and requires backend=azure. For AWS, use aws-actions/configure-aws-credentials (which is itself OIDC-based) with auth=default." >&2
+              exit 1
+            fi
+            if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+              echo "::error::auth=oidc needs an OIDC token, but this job cannot request one. Add:" >&2
+              echo "    permissions:" >&2
+              echo "      id-token: write" >&2
+              echo "  to the job (or workflow) definition." >&2
+              exit 1
+            fi
+            if [[ -z "${INPUT_CLIENT_ID}" || -z "${INPUT_TENANT_ID}" ]]; then
+              echo "::error::auth=oidc requires both client-id and tenant-id, naming an app registration with a federated credential for this repository." >&2
+              exit 1
+            fi
+            echo "AZURE_CREDENTIAL_PRIORITY=oidc" >> "${GITHUB_ENV}"
+            echo "Configured OIDC federation for client ${INPUT_CLIENT_ID} in tenant ${INPUT_TENANT_ID}"
+            ;;
+          default)
+            echo "Using the default credential chain"
+            ;;
+          *)
+            echo "::error::Unknown auth mode '${INPUT_AUTH}'. Valid values: oidc, default, none." >&2
+            exit 1
+            ;;
+        esac
+
+    - name: Fetch secrets
+      if: inputs.secrets != ''
+      shell: bash
+      env:
+        INPUT_SECRETS: ${{ inputs.secrets }}
+        INPUT_VAULT: ${{ inputs.vault }}
+      run: |
+        set -euo pipefail
+
+        VAULT_ARGS=()
+        [[ -n "${INPUT_VAULT}" ]] && VAULT_ARGS=(--vault "${INPUT_VAULT}")
+
+        COUNT=0
+        while IFS= read -r LINE; do
+          LINE="${LINE%%$'\r'}"                      # tolerate CRLF workflows
+          LINE="$(printf '%s' "${LINE}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          [[ -z "${LINE}" || "${LINE}" == \#* ]] && continue
+
+          if [[ "${LINE}" != *=* ]]; then
+            echo "::error::Malformed secrets entry '${LINE}'. Use ENV_NAME=secret-name, one per line." >&2
+            exit 1
+          fi
+          ENV_NAME="${LINE%%=*}"
+          SECRET_NAME="${LINE#*=}"
+
+          # A bad env name would corrupt GITHUB_ENV rather than fail cleanly.
+          if [[ ! "${ENV_NAME}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            echo "::error::'${ENV_NAME}' is not a valid environment variable name." >&2
+            exit 1
+          fi
+          if [[ -z "${SECRET_NAME}" ]]; then
+            echo "::error::No secret name given for ${ENV_NAME}." >&2
+            exit 1
+          fi
+
+          # `--raw` writes the bare value to stdout; status chrome goes to stderr.
+          if ! VALUE="$(xv get "${SECRET_NAME}" --raw "${VAULT_ARGS[@]+"${VAULT_ARGS[@]}"}")"; then
+            echo "::error::Failed to read secret '${SECRET_NAME}'." >&2
+            exit 1
+          fi
+
+          # Mask BEFORE the value can reach any later log line. Mask each line
+          # separately: the runner matches masks per line, so a multi-line
+          # secret registered whole would still leak line by line.
+          while IFS= read -r MASK_LINE; do
+            [[ -n "${MASK_LINE}" ]] && echo "::add-mask::${MASK_LINE}"
+          done <<< "${VALUE}"
+
+          # Heredoc form so multi-line values survive. The delimiter is random
+          # per value, and a value containing it is rejected rather than
+          # allowed to terminate the block early and inject arbitrary env vars.
+          DELIM="XV_EOF_$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+          if printf '%s' "${VALUE}" | grep -qF "${DELIM}"; then
+            echo "::error::Secret '${SECRET_NAME}' contains the generated delimiter; refusing to write it to GITHUB_ENV." >&2
+            exit 1
+          fi
+          {
+            printf '%s<<%s\n' "${ENV_NAME}" "${DELIM}"
+            printf '%s\n' "${VALUE}"
+            printf '%s\n' "${DELIM}"
+          } >> "${GITHUB_ENV}"
+
+          COUNT=$((COUNT + 1))
+          echo "Exported ${ENV_NAME} from secret '${SECRET_NAME}'"
+        done <<< "${INPUT_SECRETS}"
+
+        echo "Fetched ${COUNT} secret(s)"

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -12,8 +12,11 @@
 |------|-------|-----|-------|
 | Secrets CRUD, groups, notes, folders, expiry | Native Key Vault secrets + tags | Secrets Manager + tags/description | age-encrypted files |
 | Vaults | Azure Key Vault resources | Prefix-based virtual vaults (`<vault>/.xv-vault`) | Directories under the local store |
-| Audit | Azure Activity Log path | CloudTrail `LookupEvents` (`cloudtrail:LookupEvents` required) | Unsupported |
+| Audit | Azure Activity Log path | CloudTrail `LookupEvents` (`cloudtrail:LookupEvents` required) | Opt-in hash-chained log (`[local].audit`), verify with `xv audit --verify` |
 | Native rotation | Unsupported (`xv rotate` generates a new value) | `xv rotate --native` calls `RotateSecret` and requires a rotation Lambda | Unsupported |
+| Rotation policies | `xv:rotate_every` tag + `xv rotate --due`/`--check` | Same, plus native rotation | Same |
+| Automatic rotation | `xv schedule` (OS scheduler) | `xv schedule`, or AWS server-side `--native` | `xv schedule` |
+| Git-native versioning | Unsupported by design (would mirror cloud secrets into permanent git history) | Unsupported by design | `[local].git` + `xv git log/diff/push/pull` |
 | Sharing / RBAC commands | Azure RBAC | Unsupported; commands return IAM resource-policy hints | Unsupported |
 | File storage | Azure Blob Storage; includes `xv file sync` | S3 when `[aws].s3_bucket` or `XV_AWS_S3_BUCKET` is set; sync unsupported | age-encrypted per-vault files; includes `xv file sync` |
 
@@ -28,13 +31,19 @@
 | `xv get <name>` | Retrieve a secret (clipboard by default; `--raw` for stdout) |
 | `xv list` (alias `xv ls`) | List secrets. Default TTY output is a folder-aware grid (folders first, shown as `prod/`); pass a `[FOLDER]` positional to list inside a folder. `-l` for a long listing (name, updated, groups, note), `-r` to recurse (folder-qualified names in the grid/long/`--names-only` views), `--format table` for the classic table. Filters: `--group`, `--all` (include disabled), `--expiring <period>`, `--expired`, `--deleted` (soft-deleted secrets; conflicts with `FOLDER`, `-r`, `--group`, `--all`, `--expiring`, `--expired`). `--sort name\|updated` (default `name`). `--names-only`, `--page-size`, `--page`, `--pager [auto\|always\|never]`, `--no-cache` |
 | `xv delete <name>` | Soft-delete a secret (`--force` to skip confirmation) |
+| `xv update <name> --rotate-every <interval>` | Set a rotation policy without rotating the value; the clock starts now. `--clear-rotate-every` removes it. Standalone, like `--field`. See [rotation.md](rotation.md) |
 | `xv update <name>` | Update value, groups, folder, note, tags, expiry; supports `--rename`, `--tag`/`--tags`, `--enabled <true\|false>` (disable/enable — disabled secrets are excluded from `xv ls` and `xv group list` by default, `--all` reveals them), and clear flags such as `--clear-note` |
 | `xv update <name> --rename <new>` | Rename a secret on any backend: creates `<new>` with the current value and metadata (tags, groups, note, folder, content type, expiry — not version history), then deletes `<name>` via the backend's normal delete (Azure: soft-deleted; AWS: 30-day recovery window; local: trash). Combined with other update flags, in-place updates apply first, then the rename. Renaming onto an existing name is refused (`xv-conflict`). Partial failure (new secret created, old one not deleted) exits `43` (`xv-rename-incomplete`) and never rolls back the new secret. Combining `--enabled false` with `--rename` fails on Azure (the disable applies first, then the rename's read gets a 403) — re-enable first or rename before disabling |
 | `xv purge <name>` | Permanently delete a soft-deleted secret |
 | `xv restore <name>` | Restore a soft-deleted secret |
 | `xv history <name>` | Show version history |
 | `xv rollback <name>` | Restore a previous version (`--version <id>`) |
-| `xv rotate <name>` | Generate new random value (`--length`, `--charset`, `--generator`); `--native` triggers AWS Secrets Manager rotation |
+| `xv rotate <name>` | Generate new random value (`--length`, `--charset`, `--generator`); `--native` triggers AWS Secrets Manager rotation; `--every <interval>` also sets the rotation policy |
+| `xv rotate --check` | Report which secrets are past their rotation policy, changing nothing. Exits `51` when any is due, so CI can gate on staleness. Honors `--format` |
+| `xv rotate --due` | Rotate every secret whose rotation policy has come due (`--force` for unattended cron/CI). Fails rather than skipping when a policy tag is unparseable |
+| `xv schedule install` | Install a per-user job in the OS scheduler (launchd / systemd user timer / Task Scheduler) that runs `xv rotate --due --force` on a cadence. `--interval hourly\|daily\|weekly`, `--at HH:MM`, `--vault`, `--log-file`, `--print` to render without installing, `--force` to skip confirmation. No daemon; nothing system-wide |
+| `xv schedule status` | Whether a schedule is installed, what the scheduler reports, and where the log is |
+| `xv schedule uninstall` | Remove the schedule; succeeds when none is installed |
 | `xv copy <name>` | Copy a secret between vaults (`--from`, `--to`) |
 | `xv move <name>` | Move a secret between vaults (`--from`, `--to`) |
 | `xv group list` | List secret groups with member counts, derived from the `groups` metadata (`--no-cache`; full `--format`/`--columns` support) |
@@ -274,11 +283,54 @@ JSON/YAML keep the full-fidelity serialization (etags, raw byte sizes, extra met
 | Command | Description |
 |---------|-------------|
 | `xv whoami` | Show authenticated identity and context |
-| `xv audit <name>` | Access/change history for a secret or vault (Azure Activity Log or AWS CloudTrail; unsupported on local); `--vault`, `--days`, `--operation`; honors the global `--format` (JSON = array of `{timestamp, operation, resource, caller, status}` rows). |
+| `xv audit <name>` | Access/change history for a secret or vault (Azure Activity Log, AWS CloudTrail, or the local hash-chained log when `[local].audit` is on); `--vault`, `--days`, `--operation`; honors the global `--format` (JSON = array of `{timestamp, operation, resource, caller, status}` rows). |
+| `xv audit --operation DecryptionFailed` | Filter the local trail to failed decryptions — a caller that reached a secret's ciphertext and could not open it (wrong age identity, or altered material) |
+| `xv audit --verify` | Recompute the local audit log's hash chain and report the first break; exits non-zero when it has been altered. Local backend only — cloud trails are held by the platform, so there is no client-side chain to verify. See [git-versioning.md](git-versioning.md) |
 | `xv info <resource>` | Auto-detect and display info for a vault or secret |
 | `xv parse <conn-string>` | Parse and display connection string components |
 | `xv completion <shell>` | Generate shell completions (bash, zsh, fish, powershell) |
 | `xv version` | Build info (version, git hash, target) |
+
+## Git-native versioning (local backend)
+
+Enable with `git = true` under `[local]`. Every mutation commits the store, so
+`git log`/`git diff`/`git push` work on real history. Only age **ciphertext** and
+metadata are committed — the identity and recipients files are excluded by a
+managed `.gitignore` *and* by a pre-commit check that refuses the commit outright.
+Additive: `xv history`/`xv rollback` are unchanged on every backend.
+
+| Command | Description |
+|---------|-------------|
+| `xv git init` | Create the repository and write the managed `.gitignore`. Works before `git = true` is set; idempotent |
+| `xv git log [secret]` | Commit history, newest first; a secret name filters to commits touching it (`--limit`, `--format`) |
+| `xv git status` | Uncommitted changes in the store |
+| `xv git diff [rev]` | Which files a commit changed — names only, never contents |
+| `xv git push [remote]` | Push the store to a remote (`--branch`) |
+| `xv git pull [remote]` | Pull from a remote, fast-forward only (`--branch`) |
+
+Azure and AWS are excluded by design: mirroring cloud secret values into git
+would create a second, effectively permanent copy of every version. Full guide in
+[git-versioning.md](git-versioning.md).
+
+## CI/CD
+
+A first-party GitHub Action installs the CLI and can fetch secrets with no stored
+credential, federating the job's OIDC token into Azure AD:
+
+```yaml
+- uses: bziobnic/crosstache@v1
+  with:
+    version: v0.28.0
+    vault: myproj-prod-kv
+    client-id: ${{ vars.AZURE_CLIENT_ID }}
+    tenant-id: ${{ vars.AZURE_TENANT_ID }}
+    secrets: |
+      DEPLOY_TOKEN=deploy-token
+```
+
+`AZURE_CREDENTIAL_PRIORITY=oidc` selects the same credential outside the Action.
+Full guide, federated-credential setup, and troubleshooting in
+[ci-cd.md](ci-cd.md).
 
 ### Local backend maintenance
 
@@ -350,6 +402,8 @@ key_file = "~/.xv/key.txt"
 default_vault = "default"
 encrypt_metadata = false   # when true, run `xv local encrypt-metadata`
 opaque_filenames = false   # when true, run `xv local migrate` to hide names on disk
+audit = false              # hash-chained audit log; verify with `xv audit --verify`
+git = false                # commit the store on every write; run `xv git init` first
 ```
 
 ---

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -302,7 +302,7 @@ Additive: `xv history`/`xv rollback` are unchanged on every backend.
 | Command | Description |
 |---------|-------------|
 | `xv git init` | Create the repository and write the managed `.gitignore`. Works before `git = true` is set; idempotent |
-| `xv git log [secret]` | Commit history, newest first; a secret name filters to commits touching it (`--limit`, `--format`) |
+| `xv git log [secret]` | Commit history, newest first; a secret name filters to the commits recorded for it — subject-matched, so opaque filenames do not hide history (`--limit`, `--format`) |
 | `xv git status` | Uncommitted changes in the store |
 | `xv git diff [rev]` | Which files a commit changed — names only, never contents |
 | `xv git push [remote]` | Push the store to a remote (`--branch`) |

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,0 +1,277 @@
+# CI/CD integration
+
+crosstache ships a first-party GitHub Action and can authenticate to Azure
+directly from a workflow's OIDC token — no client secret stored anywhere, and no
+separate `azure/login` step.
+
+- [Quick start](#quick-start)
+- [Action inputs and outputs](#action-inputs-and-outputs)
+- [OIDC setup (Azure)](#oidc-setup-azure)
+- [What the install step verifies](#what-the-install-step-verifies)
+- [Other platforms](#other-platforms)
+- [Rotation gates in CI](#rotation-gates-in-ci)
+
+---
+
+## Quick start
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write        # required for OIDC
+      contents: read
+    steps:
+      - uses: bziobnic/crosstache@v1
+        with:
+          version: v0.28.0                       # pin for reproducible builds
+          vault: myproj-prod-kv
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          secrets: |
+            DEPLOY_TOKEN=deploy-token
+            DATABASE_URL=prod-database-url
+
+      - run: ./scripts/deploy.sh     # $DEPLOY_TOKEN and $DATABASE_URL are set
+```
+
+`client-id` and `tenant-id` are identifiers, not secrets — `vars` is the right
+home for them, though `secrets` works too.
+
+Install the CLI without reading anything by omitting `secrets`:
+
+```yaml
+      - uses: bziobnic/crosstache@v1
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      - run: xv ls --format json | jq -r '.[].name'
+```
+
+---
+
+## Action inputs and outputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | Release tag (`v0.28.0`) or `latest`. **Pin it** — `latest` changes over time. |
+| `backend` | `azure` | `azure`, `aws`, or `local`. |
+| `vault` | — | Vault to read from. |
+| `secrets` | — | `ENV_NAME=secret-name` per line. Each value is masked and exported to `GITHUB_ENV`. |
+| `auth` | `oidc` | `oidc`, `default`, or `none`. See below. |
+| `client-id` | — | Azure app registration ID. Required for `auth: oidc`. |
+| `tenant-id` | — | Azure tenant ID. Required for `auth: oidc`. |
+| `subscription-id` | — | Azure subscription ID. |
+| `verify-signature` | `false` | Also verify the release's minisign signature. Requires `minisign` on `PATH`. |
+
+| Output | Description |
+|--------|-------------|
+| `version` | The release tag that was installed. |
+| `path` | Absolute path to the `xv` binary. |
+
+### `auth` modes
+
+- **`oidc`** — federates this job's GitHub OIDC token into Azure AD. Nothing is
+  stored; the token is minted per job and expires in minutes. Azure only.
+- **`default`** — uses the standard credential chain, which picks up whatever a
+  prior step configured (`azure/login`, `aws-actions/configure-aws-credentials`,
+  a managed identity on a self-hosted runner). Use this for AWS.
+- **`none`** — installs the CLI and configures nothing. Useful for the local
+  backend, or when a later step handles auth itself.
+
+### Secrets land in `GITHUB_ENV`
+
+Fetched values become environment variables for **every later step in the job**.
+That is the point, but it is worth stating plainly: any later step, including a
+third-party action, can read them. Fetch only what the job needs, and put the
+`uses:` for this action as late in the job as you can.
+
+Values are registered with `::add-mask::` before anything else logs, line by line
+for multi-line values (the runner matches masks per line, so a PEM key registered
+as one blob would still leak line by line). Masking is best-effort by nature — it
+redacts values it recognizes in log output; it cannot stop a step that
+deliberately exfiltrates them.
+
+---
+
+## OIDC setup (Azure)
+
+One-time setup on the app registration. Replace `OWNER/REPO` and the branch.
+
+```bash
+# 1. Create an app registration (or reuse one) and note its appId + tenant.
+az ad app create --display-name crosstache-ci
+APP_ID=$(az ad app list --display-name crosstache-ci --query '[0].appId' -o tsv)
+
+# 2. Add a federated credential for the workflow that should be trusted.
+az ad app federated-credential create --id "$APP_ID" --parameters '{
+  "name": "github-main",
+  "issuer": "https://token.actions.githubusercontent.com",
+  "subject": "repo:OWNER/REPO:ref:refs/heads/main",
+  "audiences": ["api://AzureADTokenExchange"]
+}'
+
+# 3. Give its service principal read access to the vault.
+az role assignment create \
+  --assignee "$APP_ID" \
+  --role "Key Vault Secrets User" \
+  --scope "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>"
+```
+
+The `subject` is what pins *which* workflow can authenticate. Scope it as
+narrowly as the job allows:
+
+| Trust | `subject` |
+|-------|-----------|
+| A branch | `repo:OWNER/REPO:ref:refs/heads/main` |
+| A tag | `repo:OWNER/REPO:ref:refs/tags/v1.0.0` |
+| An environment | `repo:OWNER/REPO:environment:production` |
+| Any PR | `repo:OWNER/REPO:pull_request` |
+
+Prefer an **environment** subject for anything that touches production: GitHub
+environments support required reviewers, so a fork PR cannot reach the
+credential. A bare `repo:OWNER/REPO:pull_request` subject trusts every pull
+request that can trigger the workflow.
+
+### Using OIDC without the Action
+
+The credential works from any OIDC-capable runner, not just through the Action:
+
+```bash
+export AZURE_CREDENTIAL_PRIORITY=oidc
+export AZURE_CLIENT_ID=<app-id>
+export AZURE_TENANT_ID=<tenant-id>
+xv get DEPLOY_TOKEN --raw
+```
+
+`xv` reads GitHub's `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN`
+pair, requests an ID token for the `api://AzureADTokenExchange` audience, and
+presents it to Azure AD as a `client_assertion`. With
+`AZURE_CREDENTIAL_PRIORITY` unset, OIDC is tried first automatically *when those
+variables are present*, then the normal chain.
+
+Set it explicitly (`oidc`) when you want a hard failure rather than a silent
+fallback to some other identity — worth doing in production pipelines, where
+authenticating as the wrong principal is worse than not authenticating.
+
+### Troubleshooting
+
+| Symptom | Cause |
+|---------|-------|
+| `ACTIONS_ID_TOKEN_REQUEST_URL is not set` | The job lacks `permissions: id-token: write`. |
+| `AADSTS700213: No matching federated identity record found` | The `subject` on the federated credential does not match this workflow's ref/environment. |
+| `AADSTS700016: Application not found` | Wrong `client-id`, or the app lives in a different tenant. |
+| `Forbidden` / `403` from Key Vault | Federation worked; the service principal has no RBAC role on the vault. |
+
+The first three come from Azure AD and are reported verbatim, minus the trace
+IDs. The fourth means auth succeeded — fix the role assignment, not the
+credential.
+
+---
+
+## What the install step verifies
+
+The action always verifies the release archive's **SHA-256** against the
+`.sha256` published beside it, and refuses to install on a mismatch.
+
+Be clear about what that does and does not prove:
+
+- ✅ Catches a corrupted or truncated download.
+- ✅ Catches an archive swapped without also swapping the digest.
+- ❌ Does **not** prove authorship. Both files come from the same release, so an
+  attacker who can publish releases can publish a matching digest.
+
+For authorship, set `verify-signature: true`. It verifies the `.minisig` against
+the same minisign public key embedded in `xv upgrade`, which is held outside the
+release pipeline. It needs `minisign` on `PATH`:
+
+```yaml
+      - run: sudo apt-get install -y minisign
+      - uses: bziobnic/crosstache@v1
+        with:
+          verify-signature: true
+          version: v0.28.0
+```
+
+Independently of both: **pin the action to a commit SHA** (`uses:
+bziobnic/crosstache@<sha>`) if you want the action's own code to be immutable.
+A tag like `@v1` can be moved.
+
+---
+
+## Other platforms
+
+There is no first-party GitLab component or CircleCI orb yet. Both work fine
+with a plain install step:
+
+```yaml
+# GitLab CI
+leak_scan:
+  stage: test
+  before_script:
+    - curl -fsSL https://github.com/bziobnic/crosstache/releases/download/v0.28.0/xv-linux-x64.tar.gz | tar xz
+    - install -m755 xv /usr/local/bin/xv
+  script:
+    - xv scan --hook          # exit 50 on findings
+```
+
+Published archives: `xv-linux-x64.tar.gz`, `xv-macos-intel.tar.gz`,
+`xv-macos-apple-silicon.tar.gz`, `xv-windows-x64.zip`, each with `.sha256` and
+`.minisig`.
+
+Exit codes are stable and documented in [`exit-codes.md`](exit-codes.md) — that
+is the contract to script against.
+
+---
+
+## Rotation gates in CI
+
+`xv rotate --check` reports rotation status and exits **51** when any secret is
+due, which makes it a drop-in staleness gate:
+
+```yaml
+  secret-freshness:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: bziobnic/crosstache@v1
+        with:
+          vault: myproj-prod-kv
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      - run: xv rotate --check
+```
+
+And a scheduled workflow can perform the rotation itself:
+
+```yaml
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  rotate:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: bziobnic/crosstache@v1
+        with:
+          vault: myproj-prod-kv
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      - run: xv rotate --due --force
+```
+
+For host-driven rather than CI-driven rotation, `xv schedule install` manages the
+equivalent job in the machine's own scheduler (launchd / systemd user timer / Task
+Scheduler) — see [`rotation.md`](rotation.md#xv-schedule--run-the-sweep-automatically).
+Use CI when the credential belongs to a pipeline and the runner can authenticate
+non-interactively; use `xv schedule` when rotation belongs to a particular host.
+
+Either way, note that a rotating credential an app read at startup still needs a
+restart or redeploy to pick up the new value — rotation alone is not rollout.

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -26,6 +26,8 @@ releases — they are part of the scripting contract.
 | `40`  | Azure API error       | Azure returned an error response                |
 | `43`  | Rename incomplete     | rename created the new secret but failed to delete the original; both copies still exist (`xv-rename-incomplete`) |
 | `50`  | Scan: leak detected   | `xv scan` found a finding (file with a secret value or pattern match) |
+| `51`  | Rotation due          | `xv rotate --check` found at least one secret past its rotation policy (`xv-rotation-due`) |
+| `52`  | Audit chain broken    | `xv audit --verify` found the local audit log's hash chain altered (`xv-audit-chain-broken`) |
 
 ## Error codes
 

--- a/docs/git-versioning.md
+++ b/docs/git-versioning.md
@@ -1,0 +1,277 @@
+# `xv git` — git-native versioning and the local audit trail
+
+Two opt-in features for the local age-encrypted backend:
+
+- **`[local].git`** — the store becomes a real git repository, committed after
+  every mutation. `git log`, `git diff`, `git bisect`, and `git push` all work on
+  the actual history.
+- **`[local].audit`** — an append-only, hash-chained audit log under the store.
+
+They compose: with both on, the audit log is versioned and pushed alongside the
+secrets, which is what gives the chain an off-box copy.
+
+- [Git-native versioning](#git-native-versioning)
+- [Key material is never committed](#key-material-is-never-committed)
+- [Syncing across machines](#syncing-across-machines)
+- [The local audit trail](#the-local-audit-trail)
+- [What the hash chain does and does not prove](#what-the-hash-chain-does-and-does-not-prove)
+- [Why local only](#why-local-only)
+
+---
+
+## Git-native versioning
+
+```toml
+# ~/.config/xv/xv.conf
+backend = "local"
+
+[local]
+store_path = "~/.xv/store"
+key_file   = "~/.xv/key.txt"    # outside the store — see below
+git        = true
+```
+
+```bash
+xv git init      # create the repository (also refreshes the managed .gitignore)
+```
+
+`xv git init` works before `git = true` is set, so you are not stuck needing the
+flag to make the repo and the repo to use the flag. Until the flag is on, no
+commits happen and `init` says so.
+
+From then on, every mutation commits:
+
+```console
+$ xv set DB_PASSWORD --value hunter2
+[ok] Successfully set secret 'DB_PASSWORD'
+
+$ xv rotate DB_PASSWORD --force
+[ok] Successfully rotated secret 'DB_PASSWORD'
+
+$ xv git log
+ Commit   Date                       Subject
+ 4f2a1c9  2026-07-24T22:14:03-04:00  set DB_PASSWORD
+ a91e3f0  2026-07-24T22:13:41-04:00  set DB_PASSWORD
+```
+
+| Command | Description |
+|---------|-------------|
+| `xv git init` | Create the repository and write the managed `.gitignore`. Idempotent. |
+| `xv git log [SECRET]` | History, newest first. A secret name filters to commits touching it. `--limit N` (0 = all). Honors `--format json\|yaml\|csv`. |
+| `xv git status` | Uncommitted changes in the store. |
+| `xv git diff [REV]` | Which files a commit changed. **Names only, never contents.** |
+| `xv git push [REMOTE] [--branch B]` | Push the store. |
+| `xv git pull [REMOTE] [--branch B]` | Pull, fast-forward only. |
+
+Commit subjects mirror the operation: `set NAME`, `update NAME`, `delete NAME`,
+`restore NAME`, `purge NAME`, `rollback NAME to vN`.
+
+`xv git diff` deliberately never prints file contents. For age ciphertext a
+textual diff is noise; for plaintext metadata it could surface note and tag values
+into terminal scrollback and CI logs.
+
+This is **additive**. The backend's own `.versions/` archive still drives
+`xv history` and `xv rollback` exactly as before, on every backend.
+
+### Relationship to `xv purge`
+
+`xv purge` removes a secret from the working tree, but earlier commits still
+contain its ciphertext. `xv git log` therefore remains an honest record that the
+secret existed. Purge is not a history rewrite — and once a store has been
+pushed, it cannot be.
+
+---
+
+## Key material is never committed
+
+The age identity is what decrypts every secret in the store. Git history is
+effectively permanent, so a key committed once is very hard to expunge.
+
+Two independent protections:
+
+1. A **managed `.gitignore`** block listing the identity and recipients files
+   plus lock files. Your own `.gitignore` lines outside that block are preserved.
+2. A **pre-commit check in `xv` itself**: before each commit, the staged path list
+   is inspected and the commit is **refused** if key material appears. This is the
+   actual gate — `.gitignore` is a convenience that `git add -f` can defeat.
+
+```console
+$ xv set A --value v
+error[xv-config-invalid]: refusing to commit the local store: age key material
+('key.txt') is staged. Git history is effectively permanent, so committing a
+private key would expose every secret in the store to anyone who ever sees the
+repo. Move key_file outside the store (the default is ~/.xv/key.txt, with the
+store at ~/.xv/store) or add it to .gitignore, then retry.
+```
+
+The shipped defaults already keep the key outside the store. You only reach this
+error by pointing `key_file` inside `store_path`.
+
+**Even so: a pushed store is ciphertext, but it is ciphertext of all your
+secrets.** Its safety rests entirely on the age key and on age's cryptography. Use
+a private remote.
+
+---
+
+## Syncing across machines
+
+```bash
+git -C ~/.xv/store remote add origin git@github.com:me/my-secret-store.git
+xv git push origin --branch main
+
+# On another machine — clone the store, then copy the key over separately.
+git clone git@github.com:me/my-secret-store.git ~/.xv/store
+# ... transfer ~/.xv/key.txt out of band (never through the repo) ...
+xv ls
+```
+
+`xv git pull` is **fast-forward only**. Two machines that both wrote secrets have
+divergent histories, and a merge conflict inside age ciphertext is not something
+anyone can resolve — better to refuse than to produce a tree with conflict markers
+inside encrypted files. Reconcile manually with git if it happens.
+
+For a lock-free alternative on Azure/local, `xv file sync` and `xv migrate` move
+secrets without involving git at all.
+
+---
+
+## The local audit trail
+
+```toml
+[local]
+audit = true
+```
+
+Records land in `<store>/vaults/<vault>/.audit/log.jsonl`, one JSON object per
+line, and surface through the normal command:
+
+```console
+$ xv audit --vault default
+ Timestamp            Operation        Resource      Caller  Status
+ 2026-07-24 22:14:03  PutSecretValue   DB_PASSWORD   scott   Succeeded
+ 2026-07-24 22:14:07  GetSecretValue   DB_PASSWORD   scott   Succeeded
+```
+
+Recorded operations: `PutSecretValue`, `GetSecretValue`, `UpdateSecret`,
+`DeleteSecret`, `RestoreSecret`, `PurgeSecret`, `RollbackSecret`, and
+`ListSecrets` (as vault-wide `*`).
+
+Only reads that actually **decrypt** a value count as `GetSecretValue`.
+Metadata-only reads — the ones backing `xv ls` and existence checks — are not
+logged, so real value access is not buried in noise.
+
+**Fail-closed:** when auditing is on and an append fails, the operation that
+triggered it fails too. A silently missing record would make the log's own
+completeness unprovable.
+
+### Failed attempts are recorded too
+
+The log answers "what was attempted", not only "what succeeded":
+
+```console
+$ xv get GHOST --raw
+error[xv-secret-not-found]: Secret not found: GHOST
+
+$ xv audit --vault default
+ Timestamp            Operation       Resource     Caller  Status
+ 2026-07-24 22:14:03  PutSecretValue  DB_PASSWORD  scott   Succeeded
+ 2026-07-24 22:15:40  GetSecretValue  GHOST        scott   NotFound
+ 2026-07-24 22:16:02  GetSecretValue  DB_PASSWORD  scott   DecryptionFailed
+```
+
+Status tokens come from a **closed set**, derived from the error's type rather
+than its message, so no future error string can widen what the log records:
+
+| Status | Meaning |
+|--------|---------|
+| `Succeeded` | The operation completed. |
+| `NotFound` / `VaultNotFound` | The named secret or vault does not exist. |
+| `DecryptionFailed` | **The one to watch.** A caller reached a secret's ciphertext and could not open it — the wrong age identity, or altered/truncated material. |
+| `AccessDenied` / `AuthenticationFailed` | Permission or credential failure. |
+| `InvalidArgument` / `Conflict` / `Unsupported` | Rejected request. |
+| `NetworkError` / `RateLimited` | Transport-level failure. |
+| `RenameIncomplete` | A rename created the new secret but left the original. |
+| `InternalError` | Anything else. |
+
+Secret **values** never appear in a record. Secret **names** do, in
+`resource_name` — identically to the successful case, and the reason auditing a
+failed read is worth anything at all.
+
+Metadata-only probes are excluded from failure logging too, matching the success
+path: a `NotFound` from an existence check is normal listing traffic, not an
+access attempt worth recording.
+
+Filter to just the interesting ones:
+
+```bash
+xv audit --operation DecryptionFailed
+xv audit --operation NotFound
+```
+
+### Verifying the chain
+
+Every record carries `mac = HMAC-SHA256(chain_key, prev_mac || record)`, with the
+key HKDF-derived from the age identity.
+
+```console
+$ xv audit --verify
+[ok] Audit chain intact: 12 record(s) verified for vault 'default'.
+
+$ xv audit --verify      # after an edit
+error: Audit chain BROKEN at record 7 for vault 'default': mac mismatch (record
+contents were modified after they were written)
+  6 record(s) before the break verified successfully.
+```
+
+Exits non-zero on a break, so a cron job or CI step can watch for tampering.
+
+---
+
+## What the hash chain does and does not prove
+
+**Does:**
+
+- Editing, reordering, or removing any record breaks the chain and is reported,
+  with the position of the first break.
+- Someone without the age identity cannot forge or repair a record — they cannot
+  compute the MAC.
+
+**Does not:**
+
+- Someone *with* the age identity — anyone who can already decrypt every secret
+  in the store — can rewrite the whole log from any point and re-chain it.
+- Anyone who can write the file can truncate the tail, key or no key.
+
+So it answers "has my history been altered since I last looked?" It does not
+answer "can a compromised operator hide their tracks?" For that you need a sink
+the attacker cannot reach. Pushing the store to a remote gets you most of the way,
+because the remote keeps copies of the log that a local attacker cannot edit:
+
+```bash
+xv git push origin --branch main   # off-box copies of .audit/log.jsonl
+```
+
+This is a genuine difference in kind from Azure Activity Log and AWS CloudTrail,
+which are produced and held by the platform rather than by the caller. That
+asymmetry is also why `xv audit --verify` is local-only: there is no client-side
+chain for `xv` to verify on a cloud backend, and none is needed.
+
+The log grows by one line per audited operation. It is committed with the store
+when git versioning is on, so it is covered by the same history.
+
+---
+
+## Why local only
+
+`xv git` versions the **local** store. On Azure and AWS the secret values live in
+Key Vault / Secrets Manager, so git-native versioning there would mean mirroring
+every secret version into a git repository — a second, effectively permanent copy
+of every secret, in a format designed never to forget anything. For a secrets
+manager that is a poor trade, so it is deliberately not offered.
+
+Cloud backends keep their native version history instead:
+
+```bash
+xv history DB_PASSWORD             # versions on any backend
+xv rollback DB_PASSWORD --version v3
+```

--- a/docs/git-versioning.md
+++ b/docs/git-versioning.md
@@ -87,13 +87,18 @@ pushed, it cannot be.
 The age identity is what decrypts every secret in the store. Git history is
 effectively permanent, so a key committed once is very hard to expunge.
 
-Two independent protections:
+Three independent protections:
 
 1. A **managed `.gitignore`** block listing the identity and recipients files
    plus lock files. Your own `.gitignore` lines outside that block are preserved.
-2. A **pre-commit check in `xv` itself**: before each commit, the staged path list
-   is inspected and the commit is **refused** if key material appears. This is the
-   actual gate — `.gitignore` is a convenience that `git add -f` can defeat.
+2. A **content scan before each commit**: the staged index is searched for
+   `AGE-SECRET-KEY-1` — the prefix every age identity line carries — and the
+   commit is **refused** on a hit. This is the actual gate: it catches a key at
+   any path under any name (`key.txt.bak`, a paste into a notes file), in every
+   layout, and survives both `git add -f` and renames.
+3. A **path check** for the configured `key_file`/`recipients_file` when they
+   resolve inside the store — still wanted for the recipients file, whose
+   contents are public keys and therefore invisible to the content scan.
 
 ```console
 $ xv set A --value v

--- a/docs/git-versioning.md
+++ b/docs/git-versioning.md
@@ -57,7 +57,7 @@ $ xv git log
 | Command | Description |
 |---------|-------------|
 | `xv git init` | Create the repository and write the managed `.gitignore`. Idempotent. |
-| `xv git log [SECRET]` | History, newest first. A secret name filters to commits touching it. `--limit N` (0 = all). Honors `--format json\|yaml\|csv`. |
+| `xv git log [SECRET]` | History, newest first. A secret name filters to the commits recorded for it (matched by commit subject, so `[local].opaque_filenames` does not hide history; renames match on both names). `--limit N` (0 = all). Honors `--format json\|yaml\|csv`. |
 | `xv git status` | Uncommitted changes in the store. |
 | `xv git diff [REV]` | Which files a commit changed. **Names only, never contents.** |
 | `xv git push [REMOTE] [--branch B]` | Push the store. |

--- a/docs/rotation.md
+++ b/docs/rotation.md
@@ -1,0 +1,245 @@
+# `xv rotate` — rotation and rotation policies
+
+Two distinct things share the word "rotation":
+
+1. **Replacing a value** — `xv rotate NAME` generates a new value and writes it
+   as a new version. Works on every backend.
+2. **Knowing *when* to replace it** — a rotation *policy* stored with the secret,
+   a command that acts on everything due, and `xv schedule` to run that command
+   on a cadence via the OS scheduler. All on every backend.
+
+Plus one backend-specific mechanism: `xv rotate --native` hands the whole job to
+AWS Secrets Manager's rotation Lambda.
+
+- [Replacing a value](#replacing-a-value)
+- [Rotation policies](#rotation-policies)
+- [Acting on due secrets](#acting-on-due-secrets)
+- [`xv schedule` — run the sweep automatically](#xv-schedule--run-the-sweep-automatically)
+- [Where the schedule actually lives](#where-the-schedule-actually-lives)
+- [Native rotation (AWS)](#native-rotation-aws)
+- [What rotation does not do](#what-rotation-does-not-do)
+
+---
+
+## Replacing a value
+
+```bash
+xv rotate API_KEY                            # new 32-char alphanumeric value
+xv rotate API_KEY --length 64
+xv rotate API_KEY --charset hex              # hex / base64 / numeric / alphanumeric-symbols / …
+xv rotate API_KEY --generator ./mygen.sh     # custom generator (must be owned by you, mode 0700)
+xv rotate API_KEY --show-value               # echo the new value (otherwise silent)
+xv rotate API_KEY --force                    # skip the confirmation
+```
+
+Metadata is preserved: tags, groups, note, folder, expiry, content type. On a
+typed record, the generated value becomes the new **primary field** rather than
+replacing the envelope.
+
+Every rotation stamps `xv:rotated_at`, so if the secret has a policy its clock
+restarts from the rotation that actually happened.
+
+---
+
+## Rotation policies
+
+A policy is two tags on the secret:
+
+| Tag | Meaning |
+|-----|---------|
+| `xv:rotate_every` | Interval, e.g. `90d`. Its presence is what makes a secret policy-managed. |
+| `xv:rotated_at` | RFC 3339 timestamp of the last rotation. |
+
+Both are ordinary metadata: they travel with the secret through `xv migrate`,
+are visible to anything else reading its tags, and occupy two of the backend's
+tag slots (Azure allows 15 per secret).
+
+### Setting a policy
+
+```bash
+# Policy only — does NOT change the value. The clock starts now.
+xv update DB_PASSWORD --rotate-every 90d
+
+# Rotate now and set (or change) the policy in one step.
+xv rotate DB_PASSWORD --every 90d
+
+# Remove the policy.
+xv update DB_PASSWORD --clear-rotate-every
+```
+
+Interval syntax is `<number><unit>` with unit `m` (minutes), `h` (hours), `d`
+(days), or `w` (weeks). The unit is **required** — a bare `90` is rejected rather
+than guessed, because guessing minutes vs. days is the difference between
+rotating constantly and never rotating. Maximum is 10 years.
+
+`--rotate-every` and `--clear-rotate-every` are standalone operations, like
+`--field`: combine them with other edits by running two commands.
+
+---
+
+## Acting on due secrets
+
+### `--check` — report, change nothing
+
+```bash
+xv rotate --check
+```
+
+```
+ Name          Status  Interval  Due
+ API_KEY       ok                in 74 days (2026-10-07)
+ DB_PASSWORD   due               12 days ago (2026-07-13)
+ LEGACY_TOKEN  invalid  ninety   unparseable xv:rotate_every
+```
+
+Exits **51** (`xv-rotation-due`) when at least one secret is due, so a pipeline
+can gate on staleness. Secrets with no policy are omitted entirely — unmanaged is
+not the same as overdue. `--format json|yaml|csv` works as on any list command.
+
+### `--due` — rotate everything that is due
+
+```bash
+xv rotate --due            # confirms once for the batch
+xv rotate --due --force    # unattended (cron, CI)
+```
+
+Only policy-managed, currently-due secrets are touched. Each goes through the
+same path as a manual `xv rotate`, so record handling, reserved-key guards, and
+the audit/git hooks all apply identically. Generation flags (`--length`,
+`--charset`, `--generator`) apply to the whole batch.
+
+`--due` **fails** rather than proceeding if any secret's `xv:rotate_every` cannot
+be parsed. An unreadable policy means its due-ness is unknown, and a run that
+quietly skipped it would report success while leaving a possibly-overdue secret
+in place. Fix or clear the tag, then re-run.
+
+If some rotations fail, every failure is listed and the command exits non-zero
+with a count — a partial batch never looks like success.
+
+### `xv schedule` — run the sweep automatically
+
+`xv` installs and manages the trigger itself, in the platform's own scheduler:
+
+```bash
+xv schedule install --vault myproj-prod-kv            # daily at 03:00
+xv schedule install --vault v --interval hourly --at 00:15
+xv schedule install --vault v --interval weekly --at 04:00   # Sundays
+xv schedule status
+xv schedule uninstall
+```
+
+| Platform | Mechanism | Unit |
+|----------|-----------|------|
+| macOS | launchd user agent | `~/Library/LaunchAgents/com.crosstache.xv-rotate.plist` |
+| Linux | systemd **user** timer | `~/.config/systemd/user/xv-rotate.{service,timer}` |
+| Windows | Task Scheduler | task `crosstache-xv-rotate` |
+
+All three are per-user, never system-wide: the sweep runs as the user whose
+credentials and config it needs, and uninstalling never requires root. There is
+**no daemon** — a resident process would have to reimplement, worse, what these
+schedulers already do, and would hold decryption credentials for its whole
+lifetime.
+
+Review before committing to it:
+
+```bash
+xv schedule install --vault v --print     # renders the unit, writes nothing
+```
+
+`--print` is also the way to drive a scheduler `xv` does not manage: it prints
+the exact command line to paste into cron, Kubernetes CronJob, or a CI schedule.
+
+#### What the scheduled job runs
+
+```
+xv rotate --due --force --vault <vault>
+```
+
+`--due` bounds the blast radius to secrets that already carry a policy and are
+already past it; `--force` is required because there is no terminal to confirm
+at. The schedule never sets or changes a policy — `--every` is deliberately not
+passed, so a schedule can never redefine what it is sweeping.
+
+The unit contains only an absolute binary path, those arguments, a log path, and
+`HOME`/`XDG_CONFIG_HOME`. **No credentials and no secret values.** The env pair
+matters: a scheduled process does not inherit your shell's environment, and a job
+that resolves a different config than you tested against is the classic way this
+silently sweeps the wrong vault.
+
+#### The limitation to plan around
+
+A scheduled run has **no terminal**, so any credential needing interaction fails
+there even though it works for you now. Azure CLI tokens work while the refresh
+token is valid and the keyring is unlocked; managed identity, service principals,
+and the local backend work unconditionally. Verify before trusting it:
+
+```bash
+xv rotate --due --force --vault v        # in a clean shell
+xv schedule status                       # what the scheduler thinks
+cat ~/.local/state/xv/rotate.log         # what actually happened
+```
+
+Output is captured to that log on every platform (launchd `StandardOutPath`,
+systemd `StandardOutput=append:`, a `>>` redirect for Task Scheduler), because a
+3 a.m. failure with no record is indistinguishable from no failure at all.
+
+For CI-driven rotation instead of host-driven, see
+[`ci-cd.md`](ci-cd.md#rotation-gates-in-ci) — a scheduled workflow plus a
+`--check` gate on pull requests.
+
+---
+
+## Where the schedule actually lives
+
+AWS Secrets Manager rotates server-side: the service invokes a Lambda on its own
+schedule. Azure Key Vault has no equivalent for secret *values* — it can
+auto-rotate keys and emit near-expiry events, but nothing in it will regenerate a
+secret. A local directory has no scheduler at all.
+
+So the cadence has to come from somewhere outside the vault, and `xv schedule`
+puts it in the host's own scheduler rather than in a daemon of its own. That
+keeps reboot survival, catch-up after sleep, and log capture in the hands of
+software that already does them correctly, and it means no long-lived `xv`
+process holding credentials.
+
+The division of labour: `xv` owns the policy, the due-date math, and the unit's
+lifecycle; launchd/systemd/Task Scheduler owns the clock.
+
+---
+
+## Native rotation (AWS)
+
+```bash
+xv rotate DB_PASSWORD --native
+```
+
+Calls `RotateSecret`, which invokes the rotation Lambda configured on the secret;
+rotation completes asynchronously. AWS-only, and errors with a capability hint on
+other backends. `--native` cannot be combined with `--every`, `--due`, or
+`--check`: the schedule and the new value are both AWS's to decide.
+
+A secret can carry an `xv:rotate_every` policy on AWS too, but if AWS is already
+rotating it on a schedule, tracking a second policy in tags is redundant.
+
+---
+
+## What rotation does not do
+
+- **It does not restart anything.** An application that read the secret at
+  startup keeps using the old value until it is restarted or redeployed.
+  Rotation without a rollout plan is how a rotated credential becomes an
+  outage — sequence them.
+- **It does not update external systems.** For a database password, `xv rotate`
+  changes the stored value, not the password on the database. Use
+  `--generator` to hook a script that changes both, or `--native` on AWS where
+  the Lambda owns that logic.
+- **It does not fix a broken credential by itself.** If the scheduled sweep
+  fails — expired login, locked keyring, a vault that moved — rotation silently
+  stops happening until someone reads the log. Watch `rotate.log`, or run
+  `xv rotate --check` from CI so a stale secret fails a pipeline rather than
+  waiting to be noticed.
+- **It does not purge old versions.** Previous values stay in version history
+  (`xv history`) and, with `[local].git`, in commit history. That is deliberate —
+  rollback needs them — but it means rotation is not a way to make an exposed
+  value unrecoverable. Use `xv purge` for that, and remember it cannot rewrite
+  git history that has already been pushed.

--- a/src/backend/azure/auth.rs
+++ b/src/backend/azure/auth.rs
@@ -306,8 +306,32 @@ impl DefaultAzureCredentialProvider {
                     }
                 }
             }
+            AzureCredentialType::Oidc => {
+                // Federate a GitHub Actions OIDC token into Azure AD. No
+                // fallback: the user asked for OIDC explicitly, and silently
+                // dropping to another credential would either fail later with a
+                // confusing error or — worse — succeed as the wrong identity.
+                let config = super::oidc::OidcConfig::from_env(None, None)?;
+                Ok(Arc::new(super::oidc::GithubOidcCredential::new(config)?)
+                    as Arc<dyn TokenCredential>)
+            }
             AzureCredentialType::Default => {
-                // Use the default credential chain
+                // Prefer OIDC when the workflow environment offers it: inside a
+                // GitHub Actions job with `id-token: write`, federation is both
+                // available and strictly better than anything else in the chain
+                // (no stored secret). Outside that environment the check is a
+                // cheap env-var read and the behavior is unchanged.
+                if super::oidc::OidcConfig::available_in_env() {
+                    if let Ok(config) = super::oidc::OidcConfig::from_env(None, None) {
+                        if let Ok(cred) = super::oidc::GithubOidcCredential::new(config) {
+                            return Ok(Arc::new(cred) as Arc<dyn TokenCredential>);
+                        }
+                    }
+                    // Falling through is correct here, unlike the explicit
+                    // `Oidc` arm: the user did not ask for OIDC, so an
+                    // incomplete federation setup should not break a job where
+                    // `azure/login` has already provided env credentials.
+                }
                 Ok(Arc::new(
                     DefaultAzureCredential::create(TokenCredentialOptions::default())
                         .map_err(create_user_friendly_credential_error)?,

--- a/src/backend/azure/mod.rs
+++ b/src/backend/azure/mod.rs
@@ -10,6 +10,7 @@
 pub mod audit;
 pub mod auth;
 pub mod detect;
+pub mod oidc;
 #[allow(clippy::module_inception)]
 pub mod secrets;
 pub mod types;

--- a/src/backend/azure/oidc.rs
+++ b/src/backend/azure/oidc.rs
@@ -1,0 +1,637 @@
+//! GitHub Actions OIDC → Azure AD workload identity federation.
+//!
+//! Lets `xv` authenticate in CI with **no stored secret and no `azure/login`
+//! step**. The exchange is the standard federated-credential flow:
+//!
+//! 1. Ask the Actions runtime for an OIDC ID token, using the
+//!    `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` pair
+//!    that GitHub injects when a job declares `permissions: id-token: write`.
+//!    The audience is `api://AzureADTokenExchange`, which is what a federated
+//!    credential on the app registration expects.
+//! 2. Present that token to Azure AD as a `client_assertion` in a
+//!    `client_credentials` grant. Azure AD validates the issuer, subject
+//!    (`repo:owner/name:ref:...`), and audience against the app registration's
+//!    federated credential, then returns an access token.
+//!
+//! Nothing here is GitHub-specific beyond step 1's env-var protocol; the
+//! assertion exchange in step 2 is generic OIDC federation.
+//!
+//! ## Why this is not just `azure/login`
+//!
+//! `azure/login` sets `AZURE_*` env vars that `EnvironmentCredential` then
+//! picks up, so federation "works" today only as a side effect of another
+//! action having run first. Doing the exchange in-process means the CI recipe
+//! is one step instead of two, `xv` reports federation failures with its own
+//! diagnostics, and nothing depends on env vars set by a third party.
+//!
+//! ## Testability
+//!
+//! Both HTTP calls go through [`TokenHttp`], so the exchange logic — request
+//! shape, error mapping, expiry handling — is unit-tested against a scripted
+//! transport with no network. See the tests at the bottom of this file.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use azure_core::auth::{AccessToken, TokenCredential};
+use serde::Deserialize;
+
+use crate::error::{CrosstacheError, Result};
+
+/// Audience Azure AD requires on a federated ID token.
+const AZURE_AUDIENCE: &str = "api://AzureADTokenExchange";
+
+/// The client-assertion type for a JWT bearer assertion (RFC 7523).
+const ASSERTION_TYPE: &str = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+/// Env var GitHub sets to the ID-token request endpoint.
+pub const ENV_REQUEST_URL: &str = "ACTIONS_ID_TOKEN_REQUEST_URL";
+
+/// Env var GitHub sets to the bearer token for that endpoint.
+pub const ENV_REQUEST_TOKEN: &str = "ACTIONS_ID_TOKEN_REQUEST_TOKEN";
+
+/// Minimal HTTP surface the exchange needs, so tests can script both calls
+/// without a server.
+#[async_trait]
+pub trait TokenHttp: Send + Sync + std::fmt::Debug {
+    /// `GET url` with `Authorization: Bearer <bearer>`; returns the body.
+    async fn get_with_bearer(&self, url: &str, bearer: &str) -> Result<String>;
+
+    /// `POST url` with a form body; returns the (status, body) pair so the
+    /// caller can map Azure AD's error envelope.
+    async fn post_form(&self, url: &str, form: &[(&str, &str)]) -> Result<(u16, String)>;
+}
+
+/// Real transport over the shared `reqwest` client.
+#[derive(Debug)]
+pub struct ReqwestTokenHttp {
+    client: reqwest::Client,
+}
+
+impl ReqwestTokenHttp {
+    /// Build a transport using the project's standard timeouts and user agent.
+    pub fn new() -> Result<Self> {
+        use crate::utils::network::{create_http_client, NetworkConfig};
+        Ok(Self {
+            client: create_http_client(&NetworkConfig::default())?,
+        })
+    }
+}
+
+#[async_trait]
+impl TokenHttp for ReqwestTokenHttp {
+    async fn get_with_bearer(&self, url: &str, bearer: &str) -> Result<String> {
+        let resp = self
+            .client
+            .get(url)
+            .header("Authorization", format!("Bearer {bearer}"))
+            .send()
+            .await
+            .map_err(|e| {
+                CrosstacheError::authentication(format!(
+                    "failed to request a GitHub OIDC token: {e}"
+                ))
+            })?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(CrosstacheError::authentication(format!(
+                "GitHub OIDC token request failed with HTTP {}: {}",
+                status.as_u16(),
+                truncate(&body)
+            )));
+        }
+        Ok(body)
+    }
+
+    async fn post_form(&self, url: &str, form: &[(&str, &str)]) -> Result<(u16, String)> {
+        let resp = self.client.post(url).form(form).send().await.map_err(|e| {
+            CrosstacheError::authentication(format!("federated token exchange failed: {e}"))
+        })?;
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        Ok((status, body))
+    }
+}
+
+/// Where the ID token comes from and which app registration it federates into.
+#[derive(Debug, Clone)]
+pub struct OidcConfig {
+    /// Azure AD tenant ID.
+    pub tenant_id: String,
+    /// Application (client) ID with a federated credential configured.
+    pub client_id: String,
+    /// GitHub's ID-token request endpoint.
+    pub request_url: String,
+    /// Bearer token for that endpoint.
+    pub request_token: String,
+}
+
+impl OidcConfig {
+    /// Read the configuration from the environment.
+    ///
+    /// Returns a diagnostic error naming exactly what is missing, since the two
+    /// common misconfigurations (no `id-token: write` permission, no configured
+    /// client/tenant) look identical from the outside otherwise.
+    pub fn from_env(tenant_id: Option<&str>, client_id: Option<&str>) -> Result<Self> {
+        let request_url = std::env::var(ENV_REQUEST_URL).map_err(|_| {
+            CrosstacheError::authentication(format!(
+                "{ENV_REQUEST_URL} is not set, so no OIDC token can be requested. In GitHub \
+                 Actions this means the job is missing the required permission — add:\n  \
+                 permissions:\n    id-token: write\nto the job (or workflow). Outside GitHub \
+                 Actions, use a different credential type."
+            ))
+        })?;
+        let request_token = std::env::var(ENV_REQUEST_TOKEN).map_err(|_| {
+            CrosstacheError::authentication(format!(
+                "{ENV_REQUEST_TOKEN} is not set, so the OIDC token request cannot be \
+                 authenticated. This normally accompanies {ENV_REQUEST_URL}; if one is present \
+                 without the other, the workflow environment has been altered."
+            ))
+        })?;
+
+        let tenant_id = tenant_id
+            .map(str::to_string)
+            .or_else(|| std::env::var("AZURE_TENANT_ID").ok())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                CrosstacheError::authentication(
+                    "OIDC authentication needs a tenant ID. Set tenant_id in your config or \
+                     AZURE_TENANT_ID in the environment."
+                        .to_string(),
+                )
+            })?;
+
+        let client_id = client_id
+            .map(str::to_string)
+            .or_else(|| std::env::var("AZURE_CLIENT_ID").ok())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                CrosstacheError::authentication(
+                    "OIDC authentication needs the client ID of an app registration with a \
+                     federated credential. Set AZURE_CLIENT_ID."
+                        .to_string(),
+                )
+            })?;
+
+        Ok(Self {
+            tenant_id,
+            client_id,
+            request_url,
+            request_token,
+        })
+    }
+
+    /// Whether the ambient environment can support an OIDC exchange at all.
+    ///
+    /// Used to decide whether OIDC belongs in an automatic credential chain,
+    /// without producing an error when it does not.
+    pub fn available_in_env() -> bool {
+        std::env::var(ENV_REQUEST_URL).is_ok() && std::env::var(ENV_REQUEST_TOKEN).is_ok()
+    }
+}
+
+/// A [`TokenCredential`] that federates a GitHub OIDC token into Azure AD.
+#[derive(Debug)]
+pub struct GithubOidcCredential {
+    config: OidcConfig,
+    http: Arc<dyn TokenHttp>,
+}
+
+impl GithubOidcCredential {
+    /// Build with the real HTTP transport.
+    pub fn new(config: OidcConfig) -> Result<Self> {
+        Ok(Self {
+            config,
+            http: Arc::new(ReqwestTokenHttp::new()?),
+        })
+    }
+
+    /// Build with a caller-supplied transport, so the exchange can be driven
+    /// against a scripted [`TokenHttp`] without a network.
+    #[cfg(test)]
+    pub fn with_http(config: OidcConfig, http: Arc<dyn TokenHttp>) -> Self {
+        Self { config, http }
+    }
+
+    /// Fetch the GitHub ID token for the Azure AD audience.
+    async fn fetch_id_token(&self) -> Result<String> {
+        // GitHub's endpoint already carries query parameters, so the audience
+        // must be appended with `&`, not `?`.
+        let separator = if self.config.request_url.contains('?') {
+            '&'
+        } else {
+            '?'
+        };
+        let url = format!(
+            "{}{separator}audience={}",
+            self.config.request_url,
+            urlencoding::encode(AZURE_AUDIENCE)
+        );
+
+        let body = self
+            .http
+            .get_with_bearer(&url, &self.config.request_token)
+            .await?;
+
+        #[derive(Deserialize)]
+        struct IdTokenResponse {
+            value: Option<String>,
+        }
+
+        let parsed: IdTokenResponse = serde_json::from_str(&body).map_err(|e| {
+            CrosstacheError::authentication(format!(
+                "GitHub OIDC token response was not valid JSON: {e}"
+            ))
+        })?;
+
+        parsed.value.filter(|v| !v.is_empty()).ok_or_else(|| {
+            CrosstacheError::authentication(
+                "GitHub returned an OIDC response with no token value.".to_string(),
+            )
+        })
+    }
+
+    /// Exchange the ID token for an Azure AD access token scoped to `scopes`.
+    async fn exchange(&self, scopes: &[&str], assertion: &str) -> Result<AccessToken> {
+        let scope = scopes.join(" ");
+        let url = format!(
+            "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
+            self.config.tenant_id
+        );
+
+        let form = [
+            ("client_id", self.config.client_id.as_str()),
+            ("scope", scope.as_str()),
+            ("grant_type", "client_credentials"),
+            ("client_assertion_type", ASSERTION_TYPE),
+            ("client_assertion", assertion),
+        ];
+
+        let (status, body) = self.http.post_form(&url, &form).await?;
+
+        if status != 200 {
+            return Err(CrosstacheError::authentication(format!(
+                "Azure AD rejected the federated credential (HTTP {status}): {}\n  \
+                 Check that the app registration '{}' has a federated credential whose subject \
+                 matches this workflow (issuer https://token.actions.githubusercontent.com, \
+                 audience {AZURE_AUDIENCE}) and that tenant '{}' is correct.",
+                describe_aad_error(&body),
+                self.config.client_id,
+                self.config.tenant_id
+            )));
+        }
+
+        #[derive(Deserialize)]
+        struct TokenResponse {
+            access_token: String,
+            /// Seconds until expiry. Azure AD always sends it; treated as
+            /// required so a missing value cannot silently mint a token that
+            /// looks permanently valid.
+            expires_in: Option<i64>,
+        }
+
+        let parsed: TokenResponse = serde_json::from_str(&body).map_err(|e| {
+            CrosstacheError::authentication(format!(
+                "Azure AD token response was not valid JSON: {e}"
+            ))
+        })?;
+
+        let expires_in = parsed.expires_in.ok_or_else(|| {
+            CrosstacheError::authentication(
+                "Azure AD token response omitted expires_in; refusing to treat the token as \
+                 valid for an unknown period."
+                    .to_string(),
+            )
+        })?;
+
+        let expires_on = time::OffsetDateTime::now_utc() + time::Duration::seconds(expires_in);
+        Ok(AccessToken::new(parsed.access_token, expires_on))
+    }
+}
+
+#[async_trait]
+impl TokenCredential for GithubOidcCredential {
+    async fn get_token(&self, scopes: &[&str]) -> azure_core::Result<AccessToken> {
+        let assertion = self.fetch_id_token().await.map_err(to_azure_error)?;
+        self.exchange(scopes, &assertion)
+            .await
+            .map_err(to_azure_error)
+    }
+
+    async fn clear_cache(&self) -> azure_core::Result<()> {
+        // Nothing is cached here: each call re-requests a short-lived ID token.
+        // Azure SDK clients wrap credentials in their own caching layer.
+        Ok(())
+    }
+}
+
+/// Map a crosstache error into the Azure SDK's error type.
+fn to_azure_error(e: CrosstacheError) -> azure_core::Error {
+    azure_core::Error::new(azure_core::error::ErrorKind::Credential, e)
+}
+
+/// Pull `error_description` out of an Azure AD error envelope when present.
+///
+/// Azure AD's descriptions carry the actionable detail (e.g. `AADSTS700213: No
+/// matching federated identity record found`), which a bare status code does
+/// not. Falls back to the truncated raw body.
+fn describe_aad_error(body: &str) -> String {
+    #[derive(Deserialize)]
+    struct AadError {
+        error_description: Option<String>,
+        error: Option<String>,
+    }
+    match serde_json::from_str::<AadError>(body) {
+        Ok(parsed) => parsed
+            .error_description
+            .or(parsed.error)
+            // Descriptions are multi-line with a trailing correlation block;
+            // the first line is the part worth surfacing.
+            .map(|d| d.lines().next().unwrap_or_default().to_string())
+            .unwrap_or_else(|| truncate(body)),
+        Err(_) => truncate(body),
+    }
+}
+
+/// Bound an untrusted body before it reaches an error message.
+fn truncate(body: &str) -> String {
+    const MAX: usize = 300;
+    let trimmed = body.trim();
+    if trimmed.len() <= MAX {
+        return trimmed.to_string();
+    }
+    let cut = trimmed
+        .char_indices()
+        .map(|(i, _)| i)
+        .take_while(|i| *i <= MAX)
+        .last()
+        .unwrap_or(0);
+    format!("{}…", &trimmed[..cut])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Scripted transport recording what it was asked for.
+    #[derive(Debug, Default)]
+    struct FakeHttp {
+        id_token_body: String,
+        exchange_status: u16,
+        exchange_body: String,
+        seen_get_url: Mutex<Option<String>>,
+        seen_get_bearer: Mutex<Option<String>>,
+        seen_post_url: Mutex<Option<String>>,
+        seen_form: Mutex<Vec<(String, String)>>,
+    }
+
+    #[async_trait]
+    impl TokenHttp for FakeHttp {
+        async fn get_with_bearer(&self, url: &str, bearer: &str) -> Result<String> {
+            *self.seen_get_url.lock().unwrap() = Some(url.to_string());
+            *self.seen_get_bearer.lock().unwrap() = Some(bearer.to_string());
+            Ok(self.id_token_body.clone())
+        }
+
+        async fn post_form(&self, url: &str, form: &[(&str, &str)]) -> Result<(u16, String)> {
+            *self.seen_post_url.lock().unwrap() = Some(url.to_string());
+            *self.seen_form.lock().unwrap() = form
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect();
+            Ok((self.exchange_status, self.exchange_body.clone()))
+        }
+    }
+
+    fn config() -> OidcConfig {
+        OidcConfig {
+            tenant_id: "tenant-123".into(),
+            client_id: "client-abc".into(),
+            request_url: "https://pipelines.example.com/token?api-version=2.0".into(),
+            request_token: "runtime-bearer".into(),
+        }
+    }
+
+    fn credential(http: Arc<FakeHttp>) -> GithubOidcCredential {
+        GithubOidcCredential::with_http(config(), http)
+    }
+
+    #[tokio::test]
+    async fn successful_exchange_returns_a_token_with_expiry() {
+        let http = Arc::new(FakeHttp {
+            id_token_body: r#"{"value":"github.jwt.here"}"#.into(),
+            exchange_status: 200,
+            exchange_body: r#"{"access_token":"aad-token","expires_in":3599}"#.into(),
+            ..Default::default()
+        });
+        let cred = credential(Arc::clone(&http));
+
+        let token = cred
+            .get_token(&["https://vault.azure.net/.default"])
+            .await
+            .expect("exchange should succeed");
+
+        assert_eq!(token.token.secret(), "aad-token");
+        let remaining = token.expires_on - time::OffsetDateTime::now_utc();
+        assert!(
+            remaining.whole_seconds() > 3500 && remaining.whole_seconds() <= 3599,
+            "expiry should track expires_in, got {remaining}"
+        );
+    }
+
+    #[tokio::test]
+    async fn id_token_request_uses_the_azure_audience_and_runtime_bearer() {
+        let http = Arc::new(FakeHttp {
+            id_token_body: r#"{"value":"jwt"}"#.into(),
+            exchange_status: 200,
+            exchange_body: r#"{"access_token":"t","expires_in":60}"#.into(),
+            ..Default::default()
+        });
+        let cred = credential(Arc::clone(&http));
+        cred.get_token(&["scope/.default"]).await.unwrap();
+
+        let url = http.seen_get_url.lock().unwrap().clone().unwrap();
+        // Appended with `&` because GitHub's URL already has a query string —
+        // using `?` would produce an invalid URL and a confusing 400.
+        assert!(
+            url.starts_with("https://pipelines.example.com/token?api-version=2.0&audience="),
+            "{url}"
+        );
+        assert!(
+            url.contains("api%3A%2F%2FAzureADTokenExchange"),
+            "audience must be URL-encoded: {url}"
+        );
+        assert_eq!(
+            http.seen_get_bearer.lock().unwrap().clone().unwrap(),
+            "runtime-bearer"
+        );
+    }
+
+    #[tokio::test]
+    async fn exchange_posts_a_correct_client_credentials_assertion() {
+        let http = Arc::new(FakeHttp {
+            id_token_body: r#"{"value":"github.jwt.here"}"#.into(),
+            exchange_status: 200,
+            exchange_body: r#"{"access_token":"t","expires_in":60}"#.into(),
+            ..Default::default()
+        });
+        let cred = credential(Arc::clone(&http));
+        cred.get_token(&["https://vault.azure.net/.default", "extra"])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            http.seen_post_url.lock().unwrap().clone().unwrap(),
+            "https://login.microsoftonline.com/tenant-123/oauth2/v2.0/token"
+        );
+
+        let form = http.seen_form.lock().unwrap().clone();
+        let get = |k: &str| {
+            form.iter()
+                .find(|(key, _)| key == k)
+                .map(|(_, v)| v.clone())
+                .unwrap_or_else(|| panic!("missing form field {k} in {form:?}"))
+        };
+        assert_eq!(get("client_id"), "client-abc");
+        assert_eq!(get("grant_type"), "client_credentials");
+        assert_eq!(get("client_assertion_type"), ASSERTION_TYPE);
+        // The GitHub ID token is the assertion — never a client secret.
+        assert_eq!(get("client_assertion"), "github.jwt.here");
+        // Multiple scopes are space-joined per OAuth 2.0.
+        assert_eq!(get("scope"), "https://vault.azure.net/.default extra");
+        assert!(
+            !form.iter().any(|(k, _)| k == "client_secret"),
+            "a federated exchange must never send a client secret: {form:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn azure_ad_rejection_surfaces_the_actionable_description() {
+        let http = Arc::new(FakeHttp {
+            id_token_body: r#"{"value":"jwt"}"#.into(),
+            exchange_status: 400,
+            exchange_body: r#"{"error":"invalid_request","error_description":"AADSTS700213: No matching federated identity record found for presented assertion subject.\r\nTrace ID: abc\r\nCorrelation ID: def"}"#.into(),
+            ..Default::default()
+        });
+        let cred = credential(Arc::clone(&http));
+        let err = cred.get_token(&["s"]).await.expect_err("should fail");
+        let msg = format!("{err:#}");
+
+        assert!(msg.contains("AADSTS700213"), "{msg}");
+        // The trace/correlation noise is dropped; the first line is the signal.
+        assert!(!msg.contains("Trace ID"), "{msg}");
+        // And the message must say what to fix.
+        assert!(msg.contains("federated credential"), "{msg}");
+        assert!(msg.contains("client-abc"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn missing_id_token_value_is_an_error() {
+        let http = Arc::new(FakeHttp {
+            id_token_body: r#"{"value":""}"#.into(),
+            exchange_status: 200,
+            exchange_body: "{}".into(),
+            ..Default::default()
+        });
+        let err = credential(http)
+            .get_token(&["s"])
+            .await
+            .expect_err("should fail");
+        assert!(format!("{err:#}").contains("no token value"), "{err:#}");
+    }
+
+    #[tokio::test]
+    async fn token_response_without_expires_in_is_rejected() {
+        // A token with unknown lifetime would be cached as if never expiring.
+        let http = Arc::new(FakeHttp {
+            id_token_body: r#"{"value":"jwt"}"#.into(),
+            exchange_status: 200,
+            exchange_body: r#"{"access_token":"t"}"#.into(),
+            ..Default::default()
+        });
+        let err = credential(http)
+            .get_token(&["s"])
+            .await
+            .expect_err("should fail");
+        assert!(format!("{err:#}").contains("expires_in"), "{err:#}");
+    }
+
+    #[tokio::test]
+    async fn malformed_json_is_reported_not_panicked() {
+        let http = Arc::new(FakeHttp {
+            id_token_body: "<html>502</html>".into(),
+            exchange_status: 200,
+            exchange_body: "{}".into(),
+            ..Default::default()
+        });
+        let err = credential(http)
+            .get_token(&["s"])
+            .await
+            .expect_err("should fail");
+        assert!(format!("{err:#}").contains("not valid JSON"), "{err:#}");
+    }
+
+    #[test]
+    fn audience_appends_with_question_mark_when_url_has_no_query() {
+        // Guards the other branch of the separator choice.
+        let mut cfg = config();
+        cfg.request_url = "https://example.com/token".into();
+        let http = Arc::new(FakeHttp {
+            id_token_body: r#"{"value":"jwt"}"#.into(),
+            exchange_status: 200,
+            exchange_body: r#"{"access_token":"t","expires_in":60}"#.into(),
+            ..Default::default()
+        });
+        let cred = GithubOidcCredential::with_http(cfg, Arc::clone(&http) as Arc<dyn TokenHttp>);
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(async { cred.get_token(&["s"]).await.unwrap() });
+        let url = http.seen_get_url.lock().unwrap().clone().unwrap();
+        assert!(
+            url.starts_with("https://example.com/token?audience="),
+            "{url}"
+        );
+    }
+
+    #[test]
+    fn describe_aad_error_handles_non_json_and_bare_error() {
+        assert_eq!(
+            describe_aad_error("plain text failure"),
+            "plain text failure"
+        );
+        assert_eq!(
+            describe_aad_error(r#"{"error":"unauthorized_client"}"#),
+            "unauthorized_client"
+        );
+    }
+
+    #[test]
+    fn truncate_bounds_long_bodies_on_char_boundaries() {
+        let long = "é".repeat(400);
+        let out = truncate(&long);
+        assert!(out.len() <= 310, "len {}", out.len());
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn from_env_names_the_missing_permission() {
+        // Env-var-dependent: assert on the message shape without mutating the
+        // process environment (which would race other tests).
+        let err = OidcConfig::from_env(Some("t"), Some("c"));
+        if std::env::var(ENV_REQUEST_URL).is_err() {
+            let msg = err
+                .expect_err("should fail without the runtime env")
+                .to_string();
+            assert!(msg.contains("id-token: write"), "{msg}");
+        }
+    }
+
+    #[test]
+    fn available_in_env_is_false_outside_actions() {
+        if std::env::var(ENV_REQUEST_URL).is_err() {
+            assert!(!OidcConfig::available_in_env());
+        }
+    }
+}

--- a/src/backend/error.rs
+++ b/src/backend/error.rs
@@ -81,6 +81,17 @@ pub enum BackendError {
         cause: Box<BackendError>,
     },
 
+    /// Decryption failed: the wrong key, or ciphertext that has been altered
+    /// or truncated.
+    ///
+    /// Distinct from [`Internal`](Self::Internal) so an audit trail can record
+    /// "a read was attempted and the material could not be decrypted" as its own
+    /// status. That is the single most security-relevant local failure, and it is
+    /// indistinguishable from an unrelated I/O fault once both collapse into
+    /// `Internal`.
+    #[error("decryption failed: {0}")]
+    Decryption(String),
+
     /// An internal error inside the backend implementation.
     #[error("backend internal error: {0}")]
     Internal(String),
@@ -134,6 +145,10 @@ impl From<BackendError> for CrosstacheError {
                 vault,
                 cause: Box::new((*cause).into()),
             },
+            BackendError::Decryption(msg) => CrosstacheError::Unknown(format!(
+                "decryption failed: {msg}. The age identity may not match this store, or the \
+                 ciphertext may have been altered."
+            )),
             BackendError::Internal(msg) => CrosstacheError::Unknown(msg),
             BackendError::Other(err) => CrosstacheError::Unknown(err.to_string()),
         }

--- a/src/backend/local/audit.rs
+++ b/src/backend/local/audit.rs
@@ -1,0 +1,810 @@
+//! Hash-chained append-only audit log for the local backend.
+//!
+//! Cloud backends get their audit trail from the platform (Azure Activity Log,
+//! AWS CloudTrail) — an independent service the caller cannot rewrite. The
+//! local backend has no such service, so the log lives in the store itself at
+//! `<store>/vaults/<vault>/.audit/log.jsonl`, one JSON record per line.
+//!
+//! ## Threat model — read this before trusting the output
+//!
+//! Every record carries `mac = HMAC-SHA256(chain_key, prev_mac || record)`,
+//! where `chain_key` is HKDF-derived from the age identity. That makes the log
+//! **tamper-evident, not tamper-proof**:
+//!
+//! - Editing or reordering any record, or deleting one from the middle, breaks
+//!   the chain and is reported by [`LocalAuditLog::verify_chain`].
+//! - An attacker who does *not* hold the age identity cannot forge or repair a
+//!   record, because they cannot compute the MAC.
+//! - An attacker who *does* hold the age identity — i.e. anyone who can already
+//!   decrypt every secret in the store — can rewrite the whole log from any
+//!   point and re-chain it. Truncating the tail is also always possible for
+//!   whoever can write the file, key or no key.
+//!
+//! So this log answers "has my history been altered since I last looked?" It
+//! does not answer "can a compromised operator hide their tracks?" — for that
+//! you need an off-box sink. Committing the store to git (`[local].git`, see
+//! [`super::git`]) or replicating `.audit/` somewhere append-only raises the
+//! bar considerably, because the remote keeps copies the local attacker cannot
+//! reach.
+//!
+//! ## Fail-closed
+//!
+//! When `[local].audit` is on, a failed append fails the operation that
+//! triggered it. A silently missing audit record is worse than a refused read:
+//! it makes the log's own completeness unprovable. See
+//! [`LocalAuditLog::record`].
+//!
+//! ## Scope: attempts, not just outcomes
+//!
+//! Both successful and failed operations are recorded, so the log answers "what
+//! was attempted" as well as "what succeeded". A failed read — a missing secret,
+//! a denied path, or ciphertext that would not decrypt — is often the more
+//! interesting entry.
+//!
+//! Failures carry a status token from [`failure_status`], drawn from a closed set
+//! keyed off the error variant rather than its message. `DecryptionFailed` is the
+//! one to watch: it means a caller reached a secret's ciphertext and could not
+//! open it, i.e. the wrong age identity or altered material.
+//!
+//! Secret values never appear in the log. Secret *names* do, in
+//! `resource_name` — identical to the successful case, and the reason auditing a
+//! failed read is worth anything at all.
+
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use age::secrecy::ExposeSecret;
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use fs2::FileExt;
+use hkdf::Hkdf;
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+
+use crate::backend::audit::{AuditBackend, AuditEvent};
+use crate::backend::error::BackendError;
+use crate::utils::helpers::create_private_dir;
+
+use super::paths;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Domain separation for the audit chain key. Distinct from the opaque-filename
+/// HKDF info so the two keys can never coincide even though both derive from
+/// the same age identity.
+const HKDF_INFO: &[u8] = b"crosstache-local-audit-chain-v1";
+
+/// `prev` value of the first record in a chain (32 zero bytes, hex).
+const GENESIS_MAC: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+/// Bytes read per backward chunk when tailing the log for the last record.
+const TAIL_CHUNK: u64 = 8192;
+
+// ---------------------------------------------------------------------------
+// Operation names
+// ---------------------------------------------------------------------------
+
+/// Audited operation names.
+///
+/// Deliberately mirrors the AWS Secrets Manager / CloudTrail vocabulary so
+/// `xv audit` rows read the same regardless of which backend produced them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuditOp {
+    /// A secret's decrypted value was read.
+    GetSecretValue,
+    /// A new secret or a new version was written.
+    PutSecretValue,
+    /// Metadata (tags, groups, note, folder, expiry) was changed.
+    UpdateSecret,
+    /// Secret soft-deleted into the trash.
+    DeleteSecret,
+    /// Secret restored from the trash.
+    RestoreSecret,
+    /// Secret permanently destroyed.
+    PurgeSecret,
+    /// An older version was promoted to current.
+    RollbackSecret,
+    /// Secret renamed; the record's resource is the *source* name, so the
+    /// pre-rename history and the rename itself share one lookup key.
+    RenameSecret,
+    /// The vault's secret names were enumerated.
+    ListSecrets,
+}
+
+impl AuditOp {
+    /// The wire/display name written to the log.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::GetSecretValue => "GetSecretValue",
+            Self::PutSecretValue => "PutSecretValue",
+            Self::UpdateSecret => "UpdateSecret",
+            Self::DeleteSecret => "DeleteSecret",
+            Self::RestoreSecret => "RestoreSecret",
+            Self::PurgeSecret => "PurgeSecret",
+            Self::RollbackSecret => "RollbackSecret",
+            Self::RenameSecret => "RenameSecret",
+            Self::ListSecrets => "ListSecrets",
+        }
+    }
+}
+
+/// Resource name recorded for vault-wide operations that name no single secret.
+pub const RESOURCE_VAULT_WIDE: &str = "*";
+
+/// Status recorded for an operation that completed.
+pub const STATUS_SUCCEEDED: &str = "Succeeded";
+
+/// Map a failure to a fixed status token.
+///
+/// The token comes from the error's **variant**, never from its message. Error
+/// messages are assembled from paths, backend responses, and I/O details; pinning
+/// the vocabulary to a closed set means no future error string can widen what the
+/// log records. Secret *values* are never part of any `BackendError` payload, so
+/// they cannot appear here regardless — the closed set guards against the weaker
+/// but realer risk of leaking incidental context (paths, key fingerprints,
+/// upstream response bodies) into a file that gets shared as evidence.
+///
+/// Secret *names* are recorded separately in `resource_name`, as they already are
+/// for successful operations: the whole point of auditing a failed read is
+/// knowing which secret someone tried to read.
+pub fn failure_status(err: &BackendError) -> &'static str {
+    match err {
+        BackendError::NotFound { .. } => "NotFound",
+        BackendError::VaultNotFound { .. } => "VaultNotFound",
+        BackendError::AuthenticationFailed(_) => "AuthenticationFailed",
+        BackendError::PermissionDenied(_) => "AccessDenied",
+        BackendError::Unsupported(_) => "Unsupported",
+        BackendError::InvalidArgument(_) => "InvalidArgument",
+        BackendError::Conflict(_) => "Conflict",
+        BackendError::RateLimited { .. } => "RateLimited",
+        BackendError::Network(_) => "NetworkError",
+        BackendError::RenameIncomplete { .. } => "RenameIncomplete",
+        // Conditional-write guards: the caller's snapshot went stale, or the
+        // rename destination already exists. Rejections, not faults.
+        BackendError::SourceRevisionConflict { .. } => "Conflict",
+        BackendError::DestinationExists { .. } => "Conflict",
+        // A rename refused because attachments still reference the source name.
+        BackendError::AttachmentsPresent { .. } => "InvalidArgument",
+        // The security-relevant one: a read reached the ciphertext and could not
+        // open it. Wrong identity, or altered/truncated material.
+        BackendError::Decryption(_) => "DecryptionFailed",
+        BackendError::Internal(_) => "InternalError",
+        BackendError::Other(_) => "InternalError",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+/// One line of the audit log.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditRecord {
+    /// 1-based position in the chain.
+    pub seq: u64,
+    /// When the operation completed.
+    pub timestamp: DateTime<Utc>,
+    /// Operation name (see [`AuditOp`]).
+    pub operation: String,
+    /// User-facing secret name, or [`RESOURCE_VAULT_WIDE`].
+    pub resource_name: String,
+    /// Local OS principal that performed the operation.
+    pub caller: String,
+    /// `Succeeded`, or a short failure token.
+    pub status: String,
+    /// MAC of the preceding record ([`GENESIS_MAC`] for the first).
+    pub prev: String,
+    /// `HMAC-SHA256(chain_key, prev || canonical(self))`, hex.
+    pub mac: String,
+}
+
+impl AuditRecord {
+    /// Canonical byte encoding fed to the MAC.
+    ///
+    /// Every field is length-prefixed (`<byte-len>:<bytes>`) rather than
+    /// delimiter-joined, so no combination of field contents can produce the
+    /// same encoding as a different set of fields. Secret *names* can contain
+    /// newlines and colons on the local backend, which a naive `\n`-joined
+    /// encoding would let an attacker exploit to forge an equivalent preimage.
+    fn canonical(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut push = |bytes: &[u8]| {
+            out.extend_from_slice(bytes.len().to_string().as_bytes());
+            out.push(b':');
+            out.extend_from_slice(bytes);
+        };
+        push(self.seq.to_string().as_bytes());
+        push(self.timestamp.to_rfc3339().as_bytes());
+        push(self.operation.as_bytes());
+        push(self.resource_name.as_bytes());
+        push(self.caller.as_bytes());
+        push(self.status.as_bytes());
+        out
+    }
+
+    /// Convert to the backend-agnostic event shape rendered by `xv audit`.
+    fn to_event(&self) -> AuditEvent {
+        AuditEvent {
+            timestamp: self.timestamp,
+            operation: self.operation.clone(),
+            resource_name: self.resource_name.clone(),
+            caller: self.caller.clone(),
+            status: self.status.clone(),
+            // The local backend is not reached over a network; there is no
+            // peer address to record. Kept `None` rather than inventing
+            // "127.0.0.1", which would imply a network hop that never happened.
+            source_ip: None,
+            event_id: self.mac.clone(),
+        }
+    }
+}
+
+/// Outcome of [`LocalAuditLog::verify_chain`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChainStatus {
+    /// No log file exists yet for this vault.
+    Empty,
+    /// Every record's MAC and `prev` link checks out.
+    Intact {
+        /// Number of records verified.
+        records: u64,
+    },
+    /// The chain is broken. `seq` is the first bad record's sequence number.
+    Broken {
+        /// Sequence number of the first record that failed verification.
+        seq: u64,
+        /// Records verified before the break.
+        verified: u64,
+        /// What specifically failed.
+        reason: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// LocalAuditLog
+// ---------------------------------------------------------------------------
+
+/// Append-only, hash-chained audit log for one local store.
+///
+/// Cheap to clone-share behind an `Arc`; all state is on disk. Appends take an
+/// exclusive advisory lock on the log file, so concurrent `xv` processes
+/// serialize instead of interleaving partial lines.
+pub struct LocalAuditLog {
+    store_path: PathBuf,
+    chain_key: [u8; 32],
+}
+
+impl LocalAuditLog {
+    /// Derive the chain key from the store's age identity.
+    pub fn new(store_path: PathBuf, identity: &age::x25519::Identity) -> Self {
+        Self {
+            store_path,
+            chain_key: derive_chain_key(identity),
+        }
+    }
+
+    /// `<store>/vaults/<vault>/.audit/`.
+    fn audit_dir(&self, vault: &str) -> Result<PathBuf, BackendError> {
+        Ok(paths::vault_dir(&self.store_path, vault)?.join(".audit"))
+    }
+
+    /// `<store>/vaults/<vault>/.audit/log.jsonl`.
+    fn log_path(&self, vault: &str) -> Result<PathBuf, BackendError> {
+        Ok(self.audit_dir(vault)?.join("log.jsonl"))
+    }
+
+    /// Append one record for a successful operation.
+    ///
+    /// Fails the caller's operation if the append fails — see the module docs on
+    /// fail-closed behavior.
+    pub fn record(
+        &self,
+        vault: &str,
+        op: AuditOp,
+        resource_name: &str,
+    ) -> Result<(), BackendError> {
+        self.append(vault, op, resource_name, STATUS_SUCCEEDED)
+    }
+
+    /// Append one record for an operation that failed.
+    ///
+    /// The status is derived from the error's variant via [`failure_status`]; the
+    /// error's message is never written.
+    pub fn record_failure(
+        &self,
+        vault: &str,
+        op: AuditOp,
+        resource_name: &str,
+        err: &BackendError,
+    ) -> Result<(), BackendError> {
+        self.append(vault, op, resource_name, failure_status(err))
+    }
+
+    fn append(
+        &self,
+        vault: &str,
+        op: AuditOp,
+        resource_name: &str,
+        status: &str,
+    ) -> Result<(), BackendError> {
+        let dir = self.audit_dir(vault)?;
+        create_private_dir(&dir)
+            .map_err(|e| BackendError::Internal(format!("create audit dir: {e}")))?;
+        let path = self.log_path(vault)?;
+
+        // Open (creating if absent) with 0600 and hold an exclusive lock across
+        // the tail-read + append so two processes cannot both chain onto the
+        // same predecessor.
+        let mut file = open_append_private(&path)?;
+        file.lock_exclusive()
+            .map_err(|e| BackendError::Internal(format!("lock audit log: {e}")))?;
+
+        let previous = last_record(&mut file)?;
+        let (seq, prev) = match previous {
+            Some(rec) => (rec.seq + 1, rec.mac),
+            None => (1, GENESIS_MAC.to_string()),
+        };
+
+        let mut record = AuditRecord {
+            seq,
+            timestamp: Utc::now(),
+            operation: op.as_str().to_string(),
+            resource_name: resource_name.to_string(),
+            caller: current_caller(),
+            status: status.to_string(),
+            prev,
+            mac: String::new(),
+        };
+        record.mac = self.compute_mac(&record);
+
+        let mut line = serde_json::to_vec(&record)
+            .map_err(|e| BackendError::Internal(format!("serialize audit record: {e}")))?;
+        line.push(b'\n');
+
+        file.seek(SeekFrom::End(0))
+            .map_err(|e| BackendError::Internal(format!("seek audit log: {e}")))?;
+        file.write_all(&line)
+            .map_err(|e| BackendError::Internal(format!("append audit log: {e}")))?;
+        // Durability matters more than speed here: an audit record that is lost
+        // to a crash after the secret write landed is exactly the gap this log
+        // exists to rule out.
+        file.sync_all()
+            .map_err(|e| BackendError::Internal(format!("sync audit log: {e}")))?;
+        Ok(())
+    }
+
+    /// MAC over `prev || canonical(record)`.
+    fn compute_mac(&self, record: &AuditRecord) -> String {
+        let mut mac = HmacSha256::new_from_slice(&self.chain_key)
+            .expect("HMAC-SHA256 accepts any key length");
+        mac.update(record.prev.as_bytes());
+        mac.update(&record.canonical());
+        data_encoding::HEXLOWER.encode(&mac.finalize().into_bytes())
+    }
+
+    /// Read every record for a vault, oldest first.
+    ///
+    /// A malformed line is a hard error rather than a skip: silently dropping
+    /// unparseable lines would let an attacker hide a record by corrupting it.
+    pub fn read_all(&self, vault: &str) -> Result<Vec<AuditRecord>, BackendError> {
+        let path = self.log_path(vault)?;
+        if !path.exists() {
+            return Ok(Vec::new());
+        }
+        let file = fs::File::open(&path)
+            .map_err(|e| BackendError::Internal(format!("open audit log: {e}")))?;
+        let mut out = Vec::new();
+        for (idx, line) in BufReader::new(file).lines().enumerate() {
+            let line = line.map_err(|e| BackendError::Internal(format!("read audit log: {e}")))?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let rec: AuditRecord = serde_json::from_str(&line).map_err(|e| {
+                BackendError::Internal(format!(
+                    "audit log line {} is not a valid record: {e}. The log may have been \
+                     tampered with; run 'xv audit --verify' for details.",
+                    idx + 1
+                ))
+            })?;
+            out.push(rec);
+        }
+        Ok(out)
+    }
+
+    /// Recompute the whole chain and report the first break, if any.
+    pub fn verify_chain(&self, vault: &str) -> Result<ChainStatus, BackendError> {
+        let records = self.read_all(vault)?;
+        if records.is_empty() {
+            return Ok(ChainStatus::Empty);
+        }
+
+        let mut expected_prev = GENESIS_MAC.to_string();
+        for (idx, rec) in records.iter().enumerate() {
+            let expected_seq = idx as u64 + 1;
+            if rec.seq != expected_seq {
+                return Ok(ChainStatus::Broken {
+                    seq: rec.seq,
+                    verified: idx as u64,
+                    reason: format!(
+                        "sequence gap: expected seq {expected_seq}, found {}",
+                        rec.seq
+                    ),
+                });
+            }
+            if rec.prev != expected_prev {
+                return Ok(ChainStatus::Broken {
+                    seq: rec.seq,
+                    verified: idx as u64,
+                    reason: "prev link does not match the preceding record's mac (a record was \
+                             inserted, removed, or reordered)"
+                        .to_string(),
+                });
+            }
+            if self.compute_mac(rec) != rec.mac {
+                return Ok(ChainStatus::Broken {
+                    seq: rec.seq,
+                    verified: idx as u64,
+                    reason: "mac mismatch (record contents were modified after they were written)"
+                        .to_string(),
+                });
+            }
+            expected_prev = rec.mac.clone();
+        }
+
+        Ok(ChainStatus::Intact {
+            records: records.len() as u64,
+        })
+    }
+
+    /// Events within the last `days`, newest first.
+    fn events_since(
+        &self,
+        vault: &str,
+        days: u32,
+        filter_name: Option<&str>,
+    ) -> Result<Vec<AuditEvent>, BackendError> {
+        let cutoff = Utc::now() - Duration::days(i64::from(days));
+        let mut events: Vec<AuditEvent> = self
+            .read_all(vault)?
+            .into_iter()
+            .filter(|rec| rec.timestamp >= cutoff)
+            .filter(|rec| match filter_name {
+                // Vault-wide rows (`*`) are kept for a single-secret query: a
+                // `ListSecrets` call did expose that secret's name.
+                Some(name) => rec.resource_name == name || rec.resource_name == RESOURCE_VAULT_WIDE,
+                None => true,
+            })
+            .map(|rec| rec.to_event())
+            .collect();
+        events.reverse();
+        Ok(events)
+    }
+}
+
+#[async_trait]
+impl AuditBackend for LocalAuditLog {
+    async fn get_vault_events(
+        &self,
+        vault: &str,
+        _resource_group: Option<&str>,
+        days: u32,
+    ) -> Result<Vec<AuditEvent>, BackendError> {
+        self.events_since(vault, days, None)
+    }
+
+    async fn get_secret_events(
+        &self,
+        vault: &str,
+        secret_name: &str,
+        _resource_group: Option<&str>,
+        days: u32,
+    ) -> Result<Vec<AuditEvent>, BackendError> {
+        self.events_since(vault, days, Some(secret_name))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// HKDF-SHA256 the age identity into a 32-byte chain key.
+fn derive_chain_key(identity: &age::x25519::Identity) -> [u8; 32] {
+    let secret = identity.to_string();
+    let hk = Hkdf::<Sha256>::new(None, secret.expose_secret().as_bytes());
+    let mut okm = [0u8; 32];
+    hk.expand(HKDF_INFO, &mut okm)
+        .expect("32 bytes is a valid HKDF-SHA256 output length");
+    okm
+}
+
+/// Best-effort local principal. Never contains secret material.
+fn current_caller() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+/// Open the log for append with 0600, creating it if needed.
+fn open_append_private(path: &Path) -> Result<fs::File, BackendError> {
+    let mut opts = fs::OpenOptions::new();
+    opts.create(true).read(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+        opts.custom_flags(libc::O_NOFOLLOW);
+    }
+    opts.open(path)
+        .map_err(|e| BackendError::Internal(format!("open audit log {}: {e}", path.display())))
+}
+
+/// Read the final record by scanning backwards in bounded chunks.
+///
+/// Appends happen on every audited operation, so this must not be O(file); a
+/// full forward scan per append would make store lifetime cost quadratic.
+fn last_record(file: &mut fs::File) -> Result<Option<AuditRecord>, BackendError> {
+    let len = file
+        .metadata()
+        .map_err(|e| BackendError::Internal(format!("stat audit log: {e}")))?
+        .len();
+    if len == 0 {
+        return Ok(None);
+    }
+
+    let mut end = len;
+    // Ignore a trailing newline so the final line is found, not an empty tail.
+    let mut tail: Vec<u8> = Vec::new();
+    loop {
+        let start = end.saturating_sub(TAIL_CHUNK);
+        let mut chunk = vec![0u8; (end - start) as usize];
+        file.seek(SeekFrom::Start(start))
+            .map_err(|e| BackendError::Internal(format!("seek audit log: {e}")))?;
+        file.read_exact(&mut chunk)
+            .map_err(|e| BackendError::Internal(format!("read audit log tail: {e}")))?;
+        chunk.extend_from_slice(&tail);
+        tail = chunk;
+
+        // Strip trailing newlines, then look for the newline that starts the
+        // last complete line.
+        let trimmed_len = tail.iter().rposition(|b| *b != b'\n').map_or(0, |p| p + 1);
+        if trimmed_len == 0 {
+            return Ok(None);
+        }
+        if let Some(nl) = tail[..trimmed_len].iter().rposition(|b| *b == b'\n') {
+            let line = &tail[nl + 1..trimmed_len];
+            return parse_record(line).map(Some);
+        }
+        if start == 0 {
+            // Whole file is one line.
+            return parse_record(&tail[..trimmed_len]).map(Some);
+        }
+        end = start;
+    }
+}
+
+fn parse_record(bytes: &[u8]) -> Result<AuditRecord, BackendError> {
+    serde_json::from_slice(bytes).map_err(|e| {
+        BackendError::Internal(format!(
+            "the last audit log record is unreadable: {e}. Run 'xv audit --verify' to \
+             locate the damage."
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Build a store with an initialized vault directory and an audit log.
+    fn fixture() -> (TempDir, LocalAuditLog, String) {
+        let tmp = TempDir::new().unwrap();
+        let store = tmp.path().to_path_buf();
+        let vault = "default".to_string();
+        create_private_dir(paths::vaults_dir(&store).join(&vault)).unwrap();
+        let identity = age::x25519::Identity::generate();
+        let log = LocalAuditLog::new(store, &identity);
+        (tmp, log, vault)
+    }
+
+    #[test]
+    fn empty_log_verifies_as_empty() {
+        let (_tmp, log, vault) = fixture();
+        assert_eq!(log.verify_chain(&vault).unwrap(), ChainStatus::Empty);
+        assert!(log.read_all(&vault).unwrap().is_empty());
+    }
+
+    #[test]
+    fn appends_chain_and_verify() {
+        let (_tmp, log, vault) = fixture();
+        log.record(&vault, AuditOp::PutSecretValue, "DB_PASSWORD")
+            .unwrap();
+        log.record(&vault, AuditOp::GetSecretValue, "DB_PASSWORD")
+            .unwrap();
+        log.record(&vault, AuditOp::DeleteSecret, "DB_PASSWORD")
+            .unwrap();
+
+        let records = log.read_all(&vault).unwrap();
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].seq, 1);
+        assert_eq!(records[0].prev, GENESIS_MAC);
+        assert_eq!(records[1].prev, records[0].mac);
+        assert_eq!(records[2].prev, records[1].mac);
+        assert_eq!(records[0].operation, "PutSecretValue");
+        assert_eq!(
+            log.verify_chain(&vault).unwrap(),
+            ChainStatus::Intact { records: 3 }
+        );
+    }
+
+    #[test]
+    fn tampering_with_a_record_breaks_the_chain() {
+        let (_tmp, log, vault) = fixture();
+        for name in ["A", "B", "C"] {
+            log.record(&vault, AuditOp::GetSecretValue, name).unwrap();
+        }
+
+        // Rewrite record 2's resource name, leaving its mac untouched — the
+        // edit an attacker would make to hide which secret they read.
+        let path = log.log_path(&vault).unwrap();
+        let body = fs::read_to_string(&path).unwrap();
+        let mut lines: Vec<String> = body.lines().map(str::to_string).collect();
+        lines[1] = lines[1].replace("\"resource_name\":\"B\"", "\"resource_name\":\"Z\"");
+        fs::write(&path, format!("{}\n", lines.join("\n"))).unwrap();
+
+        match log.verify_chain(&vault).unwrap() {
+            ChainStatus::Broken {
+                seq,
+                verified,
+                reason,
+            } => {
+                assert_eq!(seq, 2);
+                assert_eq!(verified, 1);
+                assert!(reason.contains("mac mismatch"), "{reason}");
+            }
+            other => panic!("expected Broken, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deleting_a_middle_record_breaks_the_chain() {
+        let (_tmp, log, vault) = fixture();
+        for name in ["A", "B", "C"] {
+            log.record(&vault, AuditOp::GetSecretValue, name).unwrap();
+        }
+
+        let path = log.log_path(&vault).unwrap();
+        let body = fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = body.lines().collect();
+        fs::write(&path, format!("{}\n{}\n", lines[0], lines[2])).unwrap();
+
+        match log.verify_chain(&vault).unwrap() {
+            ChainStatus::Broken { seq, reason, .. } => {
+                assert_eq!(seq, 3, "the surviving third record is the first anomaly");
+                assert!(reason.contains("sequence gap"), "{reason}");
+            }
+            other => panic!("expected Broken, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_different_identity_cannot_verify_the_chain() {
+        let (tmp, log, vault) = fixture();
+        log.record(&vault, AuditOp::GetSecretValue, "A").unwrap();
+
+        // Same store, different age key — an attacker without the identity.
+        let other =
+            LocalAuditLog::new(tmp.path().to_path_buf(), &age::x25519::Identity::generate());
+        match other.verify_chain(&vault).unwrap() {
+            ChainStatus::Broken { reason, .. } => assert!(reason.contains("mac mismatch")),
+            other => panic!("expected Broken under a foreign key, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn canonical_encoding_is_unambiguous_across_field_boundaries() {
+        // Two records whose fields concatenate to the same bytes under a naive
+        // delimiter-free or newline-joined encoding must still MAC differently.
+        let (_tmp, log, _vault) = fixture();
+        let base = AuditRecord {
+            seq: 1,
+            timestamp: Utc::now(),
+            operation: "GetSecretValue".into(),
+            resource_name: "AB".into(),
+            caller: "C".into(),
+            status: "Succeeded".into(),
+            prev: GENESIS_MAC.into(),
+            mac: String::new(),
+        };
+        let mut shifted = base.clone();
+        shifted.resource_name = "A".into();
+        shifted.caller = "BC".into();
+        assert_ne!(log.compute_mac(&base), log.compute_mac(&shifted));
+    }
+
+    #[test]
+    fn newline_in_secret_name_cannot_forge_a_record() {
+        // Local secret names may contain newlines; a name carrying a crafted
+        // JSON-ish payload must not be able to impersonate extra fields.
+        let (_tmp, log, vault) = fixture();
+        let nasty = "A\n{\"seq\":99,\"operation\":\"GetSecretValue\"}";
+        log.record(&vault, AuditOp::GetSecretValue, nasty).unwrap();
+        let records = log.read_all(&vault).unwrap();
+        assert_eq!(records.len(), 1, "one logical record, one line");
+        assert_eq!(records[0].resource_name, nasty);
+        assert_eq!(
+            log.verify_chain(&vault).unwrap(),
+            ChainStatus::Intact { records: 1 }
+        );
+    }
+
+    #[test]
+    fn tail_read_survives_records_spanning_chunk_boundaries() {
+        // Force the backward tail scan across several TAIL_CHUNK windows.
+        let (_tmp, log, vault) = fixture();
+        let long_name = "N".repeat(4000);
+        for _ in 0..8 {
+            log.record(&vault, AuditOp::GetSecretValue, &long_name)
+                .unwrap();
+        }
+        let records = log.read_all(&vault).unwrap();
+        assert_eq!(records.len(), 8);
+        assert_eq!(records[7].seq, 8);
+        assert_eq!(
+            log.verify_chain(&vault).unwrap(),
+            ChainStatus::Intact { records: 8 }
+        );
+    }
+
+    #[tokio::test]
+    async fn events_filter_by_window_and_secret() {
+        let (_tmp, log, vault) = fixture();
+        log.record(&vault, AuditOp::PutSecretValue, "A").unwrap();
+        log.record(&vault, AuditOp::GetSecretValue, "B").unwrap();
+        log.record(&vault, AuditOp::ListSecrets, RESOURCE_VAULT_WIDE)
+            .unwrap();
+
+        let all = log.get_vault_events(&vault, None, 30).await.unwrap();
+        assert_eq!(all.len(), 3);
+        // Newest first.
+        assert_eq!(all[0].operation, "ListSecrets");
+
+        let for_a = log.get_secret_events(&vault, "A", None, 30).await.unwrap();
+        let names: Vec<&str> = for_a.iter().map(|e| e.resource_name.as_str()).collect();
+        assert_eq!(names, vec![RESOURCE_VAULT_WIDE, "A"]);
+
+        // A zero-day window excludes everything older than now.
+        let none = log.get_vault_events(&vault, None, 0).await.unwrap();
+        assert!(none.len() <= 3);
+    }
+
+    #[test]
+    fn event_ids_are_unique_per_record() {
+        let (_tmp, log, vault) = fixture();
+        for _ in 0..5 {
+            log.record(&vault, AuditOp::GetSecretValue, "same-name")
+                .unwrap();
+        }
+        let records = log.read_all(&vault).unwrap();
+        let mut macs: Vec<&str> = records.iter().map(|r| r.mac.as_str()).collect();
+        macs.sort_unstable();
+        macs.dedup();
+        assert_eq!(
+            macs.len(),
+            5,
+            "each record must have a distinct mac/event_id"
+        );
+    }
+
+    #[test]
+    fn corrupt_line_is_an_error_not_a_silent_skip() {
+        let (_tmp, log, vault) = fixture();
+        log.record(&vault, AuditOp::GetSecretValue, "A").unwrap();
+        let path = log.log_path(&vault).unwrap();
+        fs::write(&path, "{not json}\n").unwrap();
+        assert!(log.read_all(&vault).is_err());
+    }
+}

--- a/src/backend/local/config.rs
+++ b/src/backend/local/config.rs
@@ -28,6 +28,13 @@ pub struct ResolvedLocalConfig {
     /// index). Defaults to `false`, leaving existing stores byte-for-byte
     /// unchanged until migrated.
     pub opaque_filenames: bool,
+    /// Whether to append to the hash-chained audit log on every operation.
+    /// Defaults to `false`; enabling it makes audit-append failures fatal to
+    /// the triggering operation.
+    pub audit: bool,
+    /// Whether the store is tracked as a git repository with an auto-commit
+    /// after every mutation. Defaults to `false`.
+    pub git: bool,
 }
 
 impl ResolvedLocalConfig {
@@ -60,6 +67,8 @@ impl ResolvedLocalConfig {
 
         let encrypt_metadata = raw.and_then(|c| c.encrypt_metadata).unwrap_or(false);
         let opaque_filenames = raw.and_then(|c| c.opaque_filenames).unwrap_or(false);
+        let audit = raw.and_then(|c| c.audit).unwrap_or(false);
+        let git = raw.and_then(|c| c.git).unwrap_or(false);
 
         Self {
             store_path,
@@ -68,6 +77,8 @@ impl ResolvedLocalConfig {
             default_vault,
             encrypt_metadata,
             opaque_filenames,
+            audit,
+            git,
         }
     }
 
@@ -320,6 +331,8 @@ mod tests {
             default_vault: Some("staging".into()),
             encrypt_metadata: None,
             opaque_filenames: None,
+            audit: None,
+            git: None,
         };
         let cfg = ResolvedLocalConfig::from_raw(Some(&raw));
         assert_eq!(cfg.store_path, PathBuf::from("/tmp/my-store"));
@@ -336,6 +349,8 @@ mod tests {
             default_vault: None,
             encrypt_metadata: Some(true),
             opaque_filenames: None,
+            audit: None,
+            git: None,
         };
         let cfg = ResolvedLocalConfig::from_raw(Some(&raw));
         assert!(cfg.encrypt_metadata);
@@ -351,6 +366,8 @@ mod tests {
             default_vault: Some("default".into()),
             encrypt_metadata: None,
             opaque_filenames: None,
+            audit: None,
+            git: None,
         };
         let config = ResolvedLocalConfig::from_raw(Some(&raw));
 
@@ -393,6 +410,8 @@ mod tests {
                 default_vault: Some("default".into()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             };
             let error = ResolvedLocalConfig::from_raw(Some(&raw))
                 .validate()

--- a/src/backend/local/crypto.rs
+++ b/src/backend/local/crypto.rs
@@ -134,7 +134,7 @@ pub fn decrypt_bytes(
     identity: &age::x25519::Identity,
 ) -> Result<Zeroizing<Vec<u8>>, BackendError> {
     let decryptor = match age::Decryptor::new_buffered(data)
-        .map_err(|e| BackendError::Internal(format!("decrypt header: {e}")))?
+        .map_err(|e| BackendError::Decryption(format!("decrypt header: {e}")))?
     {
         age::Decryptor::Recipients(d) => d,
         _other => {
@@ -147,7 +147,7 @@ pub fn decrypt_bytes(
 
     let mut decrypted = decryptor
         .decrypt(std::iter::once(identity as &dyn age::Identity))
-        .map_err(|e| BackendError::Internal(format!("decrypt: {e}")))?;
+        .map_err(|e| BackendError::Decryption(format!("decrypt: {e}")))?;
 
     let mut buf = Zeroizing::new(Vec::new());
     decrypted
@@ -166,7 +166,7 @@ pub fn decrypt_from_reader<R: Read>(
     identity: &age::x25519::Identity,
 ) -> Result<Zeroizing<Vec<u8>>, BackendError> {
     let decryptor = match age::Decryptor::new_buffered(BufReader::new(reader))
-        .map_err(|e| BackendError::Internal(format!("decrypt header: {e}")))?
+        .map_err(|e| BackendError::Decryption(format!("decrypt header: {e}")))?
     {
         age::Decryptor::Recipients(d) => d,
         _other => {
@@ -177,7 +177,7 @@ pub fn decrypt_from_reader<R: Read>(
     };
     let mut decrypted = decryptor
         .decrypt(std::iter::once(identity as &dyn age::Identity))
-        .map_err(|e| BackendError::Internal(format!("decrypt: {e}")))?;
+        .map_err(|e| BackendError::Decryption(format!("decrypt: {e}")))?;
     let mut plaintext = Zeroizing::new(Vec::new());
     decrypted
         .read_to_end(&mut plaintext)
@@ -209,7 +209,7 @@ pub fn decrypt_from_file(
     let reader = BufReader::new(file);
 
     let decryptor = match age::Decryptor::new_buffered(reader)
-        .map_err(|e| BackendError::Internal(format!("decrypt header: {e}")))?
+        .map_err(|e| BackendError::Decryption(format!("decrypt header: {e}")))?
     {
         age::Decryptor::Recipients(d) => d,
         _other => {
@@ -222,7 +222,7 @@ pub fn decrypt_from_file(
 
     let mut decrypted = decryptor
         .decrypt(std::iter::once(identity as &dyn age::Identity))
-        .map_err(|e| BackendError::Internal(format!("decrypt: {e}")))?;
+        .map_err(|e| BackendError::Decryption(format!("decrypt: {e}")))?;
 
     let mut buf = String::new();
     decrypted

--- a/src/backend/local/git.rs
+++ b/src/backend/local/git.rs
@@ -46,6 +46,11 @@ const ALWAYS_IGNORED: &[&str] = &[".lock", "*.lock"];
 
 /// Marker delimiting the block `xv` manages inside `.gitignore`, so a
 /// user-authored `.gitignore` is preserved across upgrades.
+/// Prefix of every age x25519 identity line (bech32 HRP, always upper-case).
+/// Content-scanned in the staged index before any commit — see
+/// [`LocalGitStore::assert_no_key_material_staged`].
+const AGE_IDENTITY_MARKER: &str = "AGE-SECRET-KEY-1";
+
 const MANAGED_HEADER: &str = "# --- managed by crosstache (xv); do not edit this block ---";
 const MANAGED_FOOTER: &str = "# --- end crosstache block ---";
 
@@ -212,8 +217,32 @@ impl LocalGitStore {
         Ok(Some(hash.trim().to_string()))
     }
 
-    /// Error if the index contains the age identity or recipients file.
+    /// Error if the index contains age key material.
+    ///
+    /// Two layers, because each catches what the other cannot:
+    ///
+    /// 1. **Content scan** — `git grep --cached` for `AGE-SECRET-KEY-1`, the
+    ///    bech32 prefix every age identity line carries. This is the real gate:
+    ///    it catches a key at *any* path under *any* name — a stray
+    ///    `key.txt.bak`, a copy pasted into a metadata file — in every layout,
+    ///    including the default one where `key_file` lives outside the store
+    ///    (which left the old path-only check with nothing to guard).
+    /// 2. **Path check** — the configured `key_file`/`recipients_file` when they
+    ///    resolve inside the store. Still wanted for the recipients file, whose
+    ///    contents are public keys and thus invisible to the content scan.
     fn assert_no_key_material_staged(&self) -> Result<(), BackendError> {
+        // Layer 1: content. Exit 1 from grep means "no matches", not failure.
+        if let Some(hit) = self.staged_paths_containing(AGE_IDENTITY_MARKER)?.first() {
+            let _ = self.run(&["reset", "-q", "HEAD", "--", hit]);
+            return Err(BackendError::Internal(format!(
+                "refusing to commit the local store: '{hit}' contains an age private key \
+                 ({AGE_IDENTITY_MARKER}…). Git history is effectively permanent, so committing \
+                 an identity would expose every secret in the store to anyone who ever sees \
+                 the repo. Remove the file (or the embedded key) from the store, then retry."
+            )));
+        }
+
+        // Layer 2: the configured paths, when inside the store.
         let staged = self.run(&["diff", "--cached", "--name-only", "-z"])?;
         let guarded: Vec<PathBuf> = [&self.key_file, &self.recipients_file]
             .iter()
@@ -239,6 +268,30 @@ impl LocalGitStore {
             }
         }
         Ok(())
+    }
+
+    /// Staged paths whose *content* contains `needle` (fixed string, index scan).
+    ///
+    /// `git grep` exits 1 for "no matches", which is success here — only other
+    /// failures propagate.
+    fn staged_paths_containing(&self, needle: &str) -> Result<Vec<String>, BackendError> {
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(&self.store_path)
+            .args(["grep", "--cached", "-l", "-F", "-e", needle, "--", "."])
+            .output()
+            .map_err(|e| BackendError::Internal(format!("failed to run git grep: {e}")))?;
+        match out.status.code() {
+            Some(0) => Ok(String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .map(str::to_string)
+                .collect()),
+            Some(1) => Ok(Vec::new()),
+            _ => Err(BackendError::Internal(format!(
+                "git grep --cached failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            ))),
+        }
     }
 
     /// Whether git resolves a non-empty value for `key` (any config scope).
@@ -623,6 +676,77 @@ mod tests {
         assert!(
             !tracked.contains("key.txt"),
             "key material must never be tracked: {tracked}"
+        );
+    }
+
+    #[test]
+    fn refuses_a_stray_key_copy_in_the_default_layout() {
+        // Bugbot (PR #384, round 4): with key_file OUTSIDE the store — the
+        // shipped default — the old path-only gate had nothing to guard and
+        // returned immediately, so a copied key under any other name committed
+        // cleanly. The content scan must catch it regardless of layout or name.
+        let (_tmp, git) = fixture(); // fixture keys live outside the store
+        write_secret(&git, "A", "ct");
+        // A stray backup under a name .gitignore knows nothing about.
+        std::fs::write(
+            git.store_path.join("backup-notes.txt"),
+            "my key: AGE-SECRET-KEY-1QQPQZRFR7ZW2W7QQPQZRFR7ZW2W7QQPQZRFR7ZW2W7QQPQZRFR\n",
+        )
+        .unwrap();
+
+        let err = git
+            .commit("set A")
+            .expect_err("a staged private key must refuse the commit");
+        let msg = err.to_string();
+        assert!(msg.contains("backup-notes.txt"), "{msg}");
+        assert!(msg.contains("AGE-SECRET-KEY-1"), "{msg}");
+
+        let tracked = git.run(&["ls-files"]).unwrap();
+        assert!(
+            !tracked.contains("backup-notes.txt"),
+            "the key copy must never be tracked: {tracked}"
+        );
+        // And after removing the stray file, committing works again.
+        std::fs::remove_file(git.store_path.join("backup-notes.txt")).unwrap();
+        assert!(git.commit("set A").unwrap().is_some());
+    }
+
+    #[test]
+    fn refuses_a_forced_add_of_a_renamed_key() {
+        // `git add -f` defeats .gitignore, and a rename defeats a filename
+        // check; only the content scan stops this combination.
+        let (_tmp, git) = fixture();
+        git.ensure_repo().unwrap();
+        write_secret(&git, "A", "ct");
+        std::fs::write(
+            git.store_path.join("totally-innocent.dat"),
+            "AGE-SECRET-KEY-1QQPQZRFR7ZW2W7QQPQZRFR7ZW2W7QQPQZRFR7ZW2W7QQPQZRFR",
+        )
+        .unwrap();
+        git.run(&["add", "-f", "totally-innocent.dat"]).unwrap();
+
+        let err = git.commit("set A").expect_err("must refuse");
+        assert!(err.to_string().contains("totally-innocent.dat"), "{err}");
+        let tracked = git.run(&["ls-files"]).unwrap();
+        assert!(!tracked.contains("totally-innocent.dat"), "{tracked}");
+    }
+
+    #[test]
+    fn ciphertext_and_metadata_do_not_trip_the_content_scan() {
+        // The scan must not false-positive on ordinary store contents; the
+        // audit log and metadata mention "age" concepts without the marker.
+        let (_tmp, git) = fixture();
+        write_secret(&git, "A", "binary-ish age ciphertext \x00\x01");
+        let audit_dir = git.store_path.join("vaults/default/.audit");
+        std::fs::create_dir_all(&audit_dir).unwrap();
+        std::fs::write(
+            audit_dir.join("log.jsonl"),
+            "{\"operation\":\"GetSecretValue\",\"note\":\"age-encrypted read\"}\n",
+        )
+        .unwrap();
+        assert!(
+            git.commit("set A").unwrap().is_some(),
+            "ordinary store contents must commit cleanly"
         );
     }
 

--- a/src/backend/local/git.rs
+++ b/src/backend/local/git.rs
@@ -1,0 +1,593 @@
+//! Git-native versioning for the local store.
+//!
+//! With `[local].git = true` the store becomes a real git repository: every
+//! mutation is followed by a commit, so `git log`, `git diff`, `git bisect`, and
+//! `git push` all work on the actual history — the `pass` model. This is
+//! additive to the backend's own `.versions/` archive, which continues to drive
+//! `xv history` / `xv rollback` on every backend.
+//!
+//! ## What is and is not committed
+//!
+//! Only **age ciphertext** and metadata land in commits. The age identity and
+//! recipients files are excluded two ways:
+//!
+//! 1. A managed `.gitignore` (written by [`LocalGitStore::ensure_repo`]) lists
+//!    the identity and recipients filenames plus the advisory `.lock` files.
+//! 2. Before every commit, [`LocalGitStore::commit`] re-inspects the staged
+//!    path list and **aborts** if the identity or recipients file is present.
+//!    The `.gitignore` is a convenience; this check is the actual gate, because
+//!    a user can defeat `.gitignore` with `git add -f` or by relocating
+//!    `key_file` inside the store.
+//!
+//! Git history is append-only for practical purposes, so a private key
+//! committed once is very hard to expunge. That asymmetry is why the guard is a
+//! hard error rather than a warning.
+//!
+//! Committing the store also strengthens [`super::audit`]: a git remote holds
+//! copies of the audit log that a local attacker cannot reach, which is the
+//! off-box sink the hash chain alone cannot provide.
+//!
+//! ## Why the `git` CLI rather than a library
+//!
+//! `src/scan/staged.rs` already shells out to `git` for the pre-commit scanner,
+//! so the dependency is established and users' `includeIf`, hooks, signing
+//! config, and credential helpers all keep working — which matters most for
+//! `push`/`pull` against a real remote.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::backend::error::BackendError;
+
+/// Filenames that must never be committed, relative to the store root.
+/// Extended at runtime with the resolved identity/recipients filenames when
+/// those live inside the store.
+const ALWAYS_IGNORED: &[&str] = &[".lock", "*.lock"];
+
+/// Marker delimiting the block `xv` manages inside `.gitignore`, so a
+/// user-authored `.gitignore` is preserved across upgrades.
+const MANAGED_HEADER: &str = "# --- managed by crosstache (xv); do not edit this block ---";
+const MANAGED_FOOTER: &str = "# --- end crosstache block ---";
+
+/// One commit as reported by [`LocalGitStore::log`].
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct GitCommit {
+    /// Abbreviated commit hash.
+    pub hash: String,
+    /// Author date, ISO-8601.
+    pub date: String,
+    /// Subject line.
+    pub subject: String,
+}
+
+/// Git-backed versioning for one local store directory.
+pub struct LocalGitStore {
+    store_path: PathBuf,
+    /// Absolute path to the age identity file.
+    key_file: PathBuf,
+    /// Absolute path to the age recipients file.
+    recipients_file: PathBuf,
+}
+
+impl LocalGitStore {
+    /// Bind a git store to `store_path`, guarding the given key material.
+    pub fn new(store_path: PathBuf, key_file: PathBuf, recipients_file: PathBuf) -> Self {
+        Self {
+            store_path,
+            key_file,
+            recipients_file,
+        }
+    }
+
+    /// Whether the store already contains a git repository.
+    pub fn is_repo(&self) -> bool {
+        self.store_path.join(".git").exists()
+    }
+
+    /// Initialize the repository if absent and (re)write the managed
+    /// `.gitignore` block. Idempotent.
+    pub fn ensure_repo(&self) -> Result<(), BackendError> {
+        if !self.store_path.exists() {
+            return Err(BackendError::Internal(format!(
+                "local store {} does not exist yet",
+                self.store_path.display()
+            )));
+        }
+        if !self.is_repo() {
+            // `-b main` pins the initial branch so behavior does not depend on
+            // the user's init.defaultBranch or their git version's default.
+            self.run(&["init", "-b", "main"])?;
+        }
+        self.write_gitignore()?;
+        Ok(())
+    }
+
+    /// Paths (relative to the store) that must never be tracked.
+    fn ignored_patterns(&self) -> Vec<String> {
+        let mut patterns: Vec<String> = ALWAYS_IGNORED.iter().map(|s| (*s).to_string()).collect();
+        for key_path in [&self.key_file, &self.recipients_file] {
+            // Ignore by relative path when the file lives inside the store, and
+            // by bare filename otherwise — the latter is belt-and-braces for a
+            // store later moved on top of key material.
+            if let Some(rel) = self.relative_to_store(key_path) {
+                patterns.push(rel.to_string_lossy().replace('\\', "/"));
+            } else if let Some(name) = key_path.file_name() {
+                patterns.push(name.to_string_lossy().to_string());
+            }
+        }
+        patterns.sort();
+        patterns.dedup();
+        patterns
+    }
+
+    /// Write (or refresh) the managed block in `<store>/.gitignore`, preserving
+    /// any user-authored lines outside it.
+    fn write_gitignore(&self) -> Result<(), BackendError> {
+        let path = self.store_path.join(".gitignore");
+        let existing = std::fs::read_to_string(&path).unwrap_or_default();
+
+        let mut preserved: Vec<&str> = Vec::new();
+        let mut inside = false;
+        for line in existing.lines() {
+            if line.trim() == MANAGED_HEADER {
+                inside = true;
+                continue;
+            }
+            if line.trim() == MANAGED_FOOTER {
+                inside = false;
+                continue;
+            }
+            if !inside {
+                preserved.push(line);
+            }
+        }
+
+        let mut out = String::new();
+        out.push_str(MANAGED_HEADER);
+        out.push('\n');
+        out.push_str("# age key material and lock files are never versioned.\n");
+        for pattern in self.ignored_patterns() {
+            out.push_str(&pattern);
+            out.push('\n');
+        }
+        out.push_str(MANAGED_FOOTER);
+        out.push('\n');
+        let trailing = preserved.join("\n");
+        if !trailing.trim().is_empty() {
+            out.push_str(trailing.trim_start_matches('\n'));
+            if !out.ends_with('\n') {
+                out.push('\n');
+            }
+        }
+
+        std::fs::write(&path, out)
+            .map_err(|e| BackendError::Internal(format!("write store .gitignore: {e}")))
+    }
+
+    /// Stage everything and commit with `message`.
+    ///
+    /// Returns the new commit's short hash, or `None` when the working tree was
+    /// already clean (nothing to record).
+    ///
+    /// Aborts with an error — before committing — if key material is staged.
+    pub fn commit(&self, message: &str) -> Result<Option<String>, BackendError> {
+        self.ensure_repo()?;
+        self.run(&["add", "-A"])?;
+
+        // Hard gate. Runs after staging and before the commit, so it sees
+        // exactly what would be recorded, including anything a previous
+        // `git add -f` forced into the index.
+        self.assert_no_key_material_staged()?;
+
+        // Nothing staged → nothing to commit. `git commit` would exit non-zero.
+        if self.run(&["diff", "--cached", "--quiet"]).is_ok() {
+            return Ok(None);
+        }
+
+        let mut args: Vec<String> = Vec::new();
+        // Supply an identity only when the user has none configured, so
+        // existing user.name/user.email and signing settings win.
+        if !self.has_committer_identity() {
+            args.push("-c".into());
+            args.push("user.name=crosstache".into());
+            args.push("-c".into());
+            args.push("user.email=xv@localhost".into());
+        }
+        args.push("commit".into());
+        args.push("-m".into());
+        args.push(message.to_string());
+        // A store commit must not be blocked or rewritten by repo hooks the
+        // user installed for source code (e.g. an `xv scan` pre-commit hook,
+        // which would flag the store's own ciphertext).
+        args.push("--no-verify".into());
+
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        self.run(&arg_refs)?;
+        let hash = self.run(&["rev-parse", "--short", "HEAD"])?;
+        Ok(Some(hash.trim().to_string()))
+    }
+
+    /// Error if the index contains the age identity or recipients file.
+    fn assert_no_key_material_staged(&self) -> Result<(), BackendError> {
+        let staged = self.run(&["diff", "--cached", "--name-only", "-z"])?;
+        let guarded: Vec<PathBuf> = [&self.key_file, &self.recipients_file]
+            .iter()
+            .filter_map(|p| self.relative_to_store(p))
+            .collect();
+        if guarded.is_empty() {
+            return Ok(());
+        }
+
+        for entry in staged.split('\0').filter(|s| !s.is_empty()) {
+            let entry_path = PathBuf::from(entry);
+            if guarded.contains(&entry_path) {
+                // Unstage so a retry after the user moves the key does not trip
+                // over a still-staged secret key.
+                let _ = self.run(&["reset", "-q", "HEAD", "--", entry]);
+                return Err(BackendError::Internal(format!(
+                    "refusing to commit the local store: age key material ('{entry}') is staged. \
+                     Git history is effectively permanent, so committing a private key would \
+                     expose every secret in the store to anyone who ever sees the repo. Move \
+                     key_file outside the store (the default is ~/.xv/key.txt, with the store at \
+                     ~/.xv/store) or add it to .gitignore, then retry."
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether git can already determine a committer identity.
+    fn has_committer_identity(&self) -> bool {
+        self.run(&["config", "user.email"])
+            .map(|v| !v.trim().is_empty())
+            .unwrap_or(false)
+    }
+
+    /// Commit history, newest first. `limit` of 0 means unlimited.
+    ///
+    /// `path_filter` restricts history to commits touching a path — used by
+    /// `xv git log <secret>` to show one secret's timeline.
+    pub fn log(
+        &self,
+        path_filter: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<GitCommit>, BackendError> {
+        if !self.is_repo() {
+            return Err(self.not_a_repo());
+        }
+        let mut args: Vec<String> = vec![
+            "log".into(),
+            // Unit separator between fields, record separator between commits:
+            // neither can appear in a commit subject, unlike the tab/pipe a
+            // naive format would use.
+            "--pretty=format:%h\u{1f}%aI\u{1f}%s".into(),
+        ];
+        if limit > 0 {
+            args.push(format!("-n{limit}"));
+        }
+        if let Some(filter) = path_filter {
+            args.push("--".into());
+            // Match the secret anywhere in the tree: callers pass a bare secret
+            // name, not a store-relative path.
+            args.push(format!("*{filter}*"));
+        }
+
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let out = self.run(&arg_refs)?;
+        Ok(out
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .filter_map(|line| {
+                let mut parts = line.split('\u{1f}');
+                Some(GitCommit {
+                    hash: parts.next()?.to_string(),
+                    date: parts.next()?.to_string(),
+                    subject: parts.next().unwrap_or_default().to_string(),
+                })
+            })
+            .collect())
+    }
+
+    /// `git status --short` output for the store.
+    pub fn status(&self) -> Result<String, BackendError> {
+        if !self.is_repo() {
+            return Err(self.not_a_repo());
+        }
+        // `--untracked-files=all` lists individual files; the default collapses
+        // an untracked directory to `?? vaults/`, which hides which secrets are
+        // uncommitted — the one thing this command exists to answer.
+        self.run(&["status", "--short", "--branch", "--untracked-files=all"])
+    }
+
+    /// Name-and-status diff for `rev` (default: last commit).
+    ///
+    /// Deliberately never emits file *contents*: a textual diff of the store
+    /// would be a diff of age ciphertext (useless) or, for plaintext metadata,
+    /// could surface note/tag values in terminal scrollback and CI logs.
+    pub fn diff(&self, rev: Option<&str>) -> Result<String, BackendError> {
+        if !self.is_repo() {
+            return Err(self.not_a_repo());
+        }
+        let rev = rev.unwrap_or("HEAD");
+        // `--name-status` gives paths plus change type and no file contents.
+        // Note `--no-patch` would suppress the name list too, defeating the
+        // purpose, so it is deliberately absent.
+        self.run(&["show", "--name-status", "--oneline", rev])
+    }
+
+    /// Push the store to a remote.
+    pub fn push(&self, remote: &str, branch: Option<&str>) -> Result<String, BackendError> {
+        if !self.is_repo() {
+            return Err(self.not_a_repo());
+        }
+        match branch {
+            Some(b) => self.run(&["push", remote, b]),
+            None => self.run(&["push", remote]),
+        }
+    }
+
+    /// Pull from a remote. Uses `--ff-only`: a merge of two divergent secret
+    /// stores would need conflict resolution on ciphertext, which cannot be
+    /// done meaningfully, so we refuse rather than produce a broken tree.
+    pub fn pull(&self, remote: &str, branch: Option<&str>) -> Result<String, BackendError> {
+        if !self.is_repo() {
+            return Err(self.not_a_repo());
+        }
+        let mut args = vec!["pull", "--ff-only", remote];
+        if let Some(b) = branch {
+            args.push(b);
+        }
+        self.run(&args)
+    }
+
+    /// Make `path` relative to the store root, or `None` if it is outside.
+    ///
+    /// Canonicalizes both sides where possible so a symlinked or
+    /// `..`-containing `key_file` cannot slip past the containment check.
+    fn relative_to_store(&self, path: &Path) -> Option<PathBuf> {
+        let store = self
+            .store_path
+            .canonicalize()
+            .unwrap_or_else(|_| self.store_path.clone());
+        let candidate = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        candidate.strip_prefix(&store).ok().map(Path::to_path_buf)
+    }
+
+    fn not_a_repo(&self) -> BackendError {
+        BackendError::Internal(format!(
+            "the local store at {} is not a git repository. Run 'xv git init' to start \
+             versioning it, or set git = true under [local] in your config.",
+            self.store_path.display()
+        ))
+    }
+
+    /// Run `git` inside the store, returning stdout on success.
+    fn run(&self, args: &[&str]) -> Result<String, BackendError> {
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(&self.store_path)
+            .args(args)
+            .output()
+            .map_err(|e| {
+                BackendError::Internal(format!(
+                    "failed to run git: {e}. Git-native versioning requires git on PATH."
+                ))
+            })?;
+        if !out.status.success() {
+            return Err(BackendError::Internal(format!(
+                "git {} failed: {}",
+                args.first().copied().unwrap_or("?"),
+                String::from_utf8_lossy(&out.stderr).trim()
+            )));
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Store with key material *outside* it — the default, safe layout.
+    fn fixture() -> (TempDir, LocalGitStore) {
+        let tmp = TempDir::new().unwrap();
+        let store = tmp.path().join("store");
+        std::fs::create_dir_all(store.join("vaults/default/secrets")).unwrap();
+        let git = LocalGitStore::new(
+            store,
+            tmp.path().join("key.txt"),
+            tmp.path().join("recipients.txt"),
+        );
+        (tmp, git)
+    }
+
+    fn write_secret(git: &LocalGitStore, name: &str, body: &str) {
+        let dir = git.store_path.join("vaults/default/secrets");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(format!("{name}.age")), body).unwrap();
+    }
+
+    #[test]
+    fn ensure_repo_is_idempotent_and_writes_managed_gitignore() {
+        let (_tmp, git) = fixture();
+        assert!(!git.is_repo());
+        git.ensure_repo().unwrap();
+        assert!(git.is_repo());
+        git.ensure_repo().unwrap();
+
+        let ignore = std::fs::read_to_string(git.store_path.join(".gitignore")).unwrap();
+        assert!(ignore.contains(MANAGED_HEADER));
+        assert!(ignore.contains("key.txt"));
+        assert!(ignore.contains("recipients.txt"));
+        // Exactly one managed block after two runs.
+        assert_eq!(ignore.matches(MANAGED_HEADER).count(), 1);
+    }
+
+    #[test]
+    fn gitignore_preserves_user_lines() {
+        let (_tmp, git) = fixture();
+        std::fs::write(git.store_path.join(".gitignore"), "# mine\nscratch/\n").unwrap();
+        git.ensure_repo().unwrap();
+        let ignore = std::fs::read_to_string(git.store_path.join(".gitignore")).unwrap();
+        assert!(ignore.contains("# mine"), "{ignore}");
+        assert!(ignore.contains("scratch/"), "{ignore}");
+        assert!(ignore.contains("key.txt"), "{ignore}");
+    }
+
+    #[test]
+    fn commit_records_ciphertext_and_returns_hash() {
+        let (_tmp, git) = fixture();
+        write_secret(&git, "DB_PASSWORD", "age-ciphertext-1");
+        let hash = git.commit("set DB_PASSWORD").unwrap();
+        assert!(hash.is_some(), "first write should produce a commit");
+
+        let log = git.log(None, 10).unwrap();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].subject, "set DB_PASSWORD");
+        assert!(!log[0].hash.is_empty());
+        assert!(!log[0].date.is_empty());
+    }
+
+    #[test]
+    fn clean_tree_commits_nothing() {
+        let (_tmp, git) = fixture();
+        write_secret(&git, "A", "ct");
+        assert!(git.commit("set A").unwrap().is_some());
+        assert!(
+            git.commit("set A again").unwrap().is_none(),
+            "an unchanged tree must not create an empty commit"
+        );
+        assert_eq!(git.log(None, 10).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn log_filters_by_secret_name() {
+        let (_tmp, git) = fixture();
+        write_secret(&git, "ALPHA", "ct1");
+        git.commit("set ALPHA").unwrap();
+        write_secret(&git, "BETA", "ct2");
+        git.commit("set BETA").unwrap();
+        write_secret(&git, "ALPHA", "ct3");
+        git.commit("rotate ALPHA").unwrap();
+
+        let alpha = git.log(Some("ALPHA"), 0).unwrap();
+        let subjects: Vec<&str> = alpha.iter().map(|c| c.subject.as_str()).collect();
+        assert_eq!(subjects, vec!["rotate ALPHA", "set ALPHA"]);
+
+        assert_eq!(git.log(None, 0).unwrap().len(), 3);
+        assert_eq!(git.log(None, 2).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn commit_subject_with_delimiters_survives_log_parsing() {
+        let (_tmp, git) = fixture();
+        write_secret(&git, "WEIRD", "ct");
+        // Tabs and pipes would break a naive --pretty format.
+        git.commit("set A\tB|C secret").unwrap();
+        let log = git.log(None, 1).unwrap();
+        assert_eq!(log[0].subject, "set A\tB|C secret");
+    }
+
+    #[test]
+    fn refuses_to_commit_identity_inside_the_store() {
+        let tmp = TempDir::new().unwrap();
+        let store = tmp.path().join("store");
+        std::fs::create_dir_all(&store).unwrap();
+        // Pathological config: key_file lives *inside* the versioned store.
+        let key = store.join("key.txt");
+        std::fs::write(&key, "AGE-SECRET-KEY-1EXAMPLE").unwrap();
+        let git = LocalGitStore::new(store.clone(), key.clone(), store.join("recipients.txt"));
+
+        write_secret(&git, "A", "ct");
+        git.ensure_repo().unwrap();
+        // Force it past .gitignore, exactly as `git add -f` would.
+        git.run(&["add", "-f", "key.txt"]).unwrap();
+
+        let err = git.commit("set A").expect_err("must refuse");
+        let msg = err.to_string();
+        assert!(msg.contains("refusing to commit"), "{msg}");
+        assert!(msg.contains("key.txt"), "{msg}");
+
+        // And the key must not have been recorded.
+        let tracked = git.run(&["ls-files"]).unwrap();
+        assert!(
+            !tracked.contains("key.txt"),
+            "key material must never be tracked: {tracked}"
+        );
+    }
+
+    #[test]
+    fn gitignore_keeps_inside_store_key_untracked_by_default() {
+        let tmp = TempDir::new().unwrap();
+        let store = tmp.path().join("store");
+        std::fs::create_dir_all(&store).unwrap();
+        let key = store.join("key.txt");
+        std::fs::write(&key, "AGE-SECRET-KEY-1EXAMPLE").unwrap();
+        let git = LocalGitStore::new(store.clone(), key, store.join("recipients.txt"));
+
+        write_secret(&git, "A", "ct");
+        // No `add -f` this time: the managed .gitignore should keep it out and
+        // the commit should succeed.
+        let hash = git.commit("set A").unwrap();
+        assert!(hash.is_some());
+        let tracked = git.run(&["ls-files"]).unwrap();
+        assert!(!tracked.contains("key.txt"), "{tracked}");
+        assert!(tracked.contains("A.age"), "{tracked}");
+    }
+
+    #[test]
+    fn audit_log_is_versioned() {
+        // The audit log must be committed — a git remote is the off-box copy
+        // the hash chain alone cannot provide.
+        let (_tmp, git) = fixture();
+        let audit_dir = git.store_path.join("vaults/default/.audit");
+        std::fs::create_dir_all(&audit_dir).unwrap();
+        std::fs::write(audit_dir.join("log.jsonl"), "{\"seq\":1}\n").unwrap();
+        git.commit("set A").unwrap();
+        let tracked = git.run(&["ls-files"]).unwrap();
+        assert!(tracked.contains(".audit/log.jsonl"), "{tracked}");
+    }
+
+    #[test]
+    fn lock_files_are_not_versioned() {
+        let (_tmp, git) = fixture();
+        write_secret(&git, "A", "ct");
+        std::fs::write(git.store_path.join("vaults/default/.lock"), "").unwrap();
+        git.commit("set A").unwrap();
+        let tracked = git.run(&["ls-files"]).unwrap();
+        assert!(!tracked.contains(".lock"), "{tracked}");
+    }
+
+    #[test]
+    fn operations_error_before_init() {
+        let (_tmp, git) = fixture();
+        assert!(git.log(None, 5).is_err());
+        assert!(git.status().is_err());
+        assert!(git.diff(None).is_err());
+        let msg = git.log(None, 5).unwrap_err().to_string();
+        assert!(msg.contains("xv git init"), "{msg}");
+    }
+
+    #[test]
+    fn diff_reports_names_without_contents() {
+        let (_tmp, git) = fixture();
+        write_secret(&git, "A", "plaintext-metadata-value");
+        git.commit("set A").unwrap();
+        let diff = git.diff(None).unwrap();
+        assert!(diff.contains("A.age"), "{diff}");
+        assert!(
+            !diff.contains("plaintext-metadata-value"),
+            "diff must not print file contents: {diff}"
+        );
+    }
+
+    #[test]
+    fn status_reports_untracked_changes() {
+        let (_tmp, git) = fixture();
+        git.ensure_repo().unwrap();
+        write_secret(&git, "A", "ct");
+        let status = git.status().unwrap();
+        assert!(status.contains("A.age"), "{status}");
+    }
+}

--- a/src/backend/local/git.rs
+++ b/src/backend/local/git.rs
@@ -245,11 +245,16 @@ impl LocalGitStore {
 
     /// Commit history, newest first. `limit` of 0 means unlimited.
     ///
-    /// `path_filter` restricts history to commits touching a path — used by
-    /// `xv git log <secret>` to show one secret's timeline.
+    /// `secret_filter` restricts history to commits *recorded for* that secret,
+    /// by matching the commit subjects this module writes (`set NAME`,
+    /// `rename OLD to NEW`, …) — never by pathspec. Paths would miss every
+    /// commit under `[local].opaque_filenames`, where on-disk stems are keyed
+    /// hashes that contain no trace of the name; subjects always carry the
+    /// plain name on both layouts, and keep matching across a legacy→opaque
+    /// migration that renames every file.
     pub fn log(
         &self,
-        path_filter: Option<&str>,
+        secret_filter: Option<&str>,
         limit: usize,
     ) -> Result<Vec<GitCommit>, BackendError> {
         if !self.is_repo() {
@@ -262,19 +267,15 @@ impl LocalGitStore {
             // naive format would use.
             "--pretty=format:%h\u{1f}%aI\u{1f}%s".into(),
         ];
-        if limit > 0 {
+        // With a filter, fetch everything and bound *after* filtering —
+        // otherwise `-nN` would count non-matching commits against the limit.
+        if limit > 0 && secret_filter.is_none() {
             args.push(format!("-n{limit}"));
-        }
-        if let Some(filter) = path_filter {
-            args.push("--".into());
-            // Match the secret anywhere in the tree: callers pass a bare secret
-            // name, not a store-relative path.
-            args.push(format!("*{filter}*"));
         }
 
         let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
         let out = self.run(&arg_refs)?;
-        Ok(out
+        let mut commits: Vec<GitCommit> = out
             .lines()
             .filter(|l| !l.trim().is_empty())
             .filter_map(|line| {
@@ -285,7 +286,15 @@ impl LocalGitStore {
                     subject: parts.next().unwrap_or_default().to_string(),
                 })
             })
-            .collect())
+            .collect();
+
+        if let Some(name) = secret_filter {
+            commits.retain(|c| subject_mentions(&c.subject, name));
+            if limit > 0 {
+                commits.truncate(limit);
+            }
+        }
+        Ok(commits)
     }
 
     /// `git status --short` output for the store.
@@ -384,6 +393,29 @@ impl LocalGitStore {
     }
 }
 
+/// Whether a commit subject written by this module refers to `name`.
+///
+/// The subject vocabulary is closed — every auto-commit message is produced by
+/// [`LocalSecretBackend`](super::secrets::LocalSecretBackend)'s hooks — so exact
+/// verb matching is possible and preferred over a substring search, which would
+/// let a secret named `A` match every other secret's history.
+///
+/// A rename matches on either side, so `xv git log NEW_NAME` picks up the
+/// commit that created the name and `xv git log OLD_NAME` shows where the old
+/// history ends. A name that itself contains `" to "` can over-match the rename
+/// patterns; that ambiguity is inherent to a flat subject line and acceptable
+/// for a history *view* (nothing security-relevant keys off this filter).
+fn subject_mentions(subject: &str, name: &str) -> bool {
+    for verb in ["set", "update", "delete", "restore", "purge"] {
+        if subject == format!("{verb} {name}") {
+            return true;
+        }
+    }
+    subject.starts_with(&format!("rollback {name} to "))
+        || subject.starts_with(&format!("rename {name} to "))
+        || (subject.starts_with("rename ") && subject.ends_with(&format!(" to {name}")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -469,14 +501,86 @@ mod tests {
         write_secret(&git, "BETA", "ct2");
         git.commit("set BETA").unwrap();
         write_secret(&git, "ALPHA", "ct3");
-        git.commit("rotate ALPHA").unwrap();
+        git.commit("update ALPHA").unwrap();
 
         let alpha = git.log(Some("ALPHA"), 0).unwrap();
         let subjects: Vec<&str> = alpha.iter().map(|c| c.subject.as_str()).collect();
-        assert_eq!(subjects, vec!["rotate ALPHA", "set ALPHA"]);
+        assert_eq!(subjects, vec!["update ALPHA", "set ALPHA"]);
 
         assert_eq!(git.log(None, 0).unwrap().len(), 3);
         assert_eq!(git.log(None, 2).unwrap().len(), 2);
+        // With a filter, the limit bounds MATCHING commits, not raw history —
+        // "set BETA" between the two ALPHA commits must not eat the budget.
+        assert_eq!(git.log(Some("ALPHA"), 1).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn log_filter_works_when_paths_are_opaque_stems() {
+        // The regression Bugbot caught: with [local].opaque_filenames the
+        // committed paths are keyed-hash stems that contain no trace of the
+        // secret name, so a pathspec filter (`*NAME*`) matches nothing. The
+        // filter must key on commit subjects, which always carry plain names.
+        let (_tmp, git) = fixture();
+        write_secret(&git, "T5KQZJ2MBQXW3ZL6", "opaque-ct-1");
+        git.commit("set DB_PASSWORD").unwrap();
+        write_secret(&git, "9YHFA4WNPRC8E2VD", "opaque-ct-2");
+        git.commit("set OTHER").unwrap();
+        write_secret(&git, "T5KQZJ2MBQXW3ZL6", "opaque-ct-3");
+        git.commit("update DB_PASSWORD").unwrap();
+
+        let subjects: Vec<String> = git
+            .log(Some("DB_PASSWORD"), 0)
+            .unwrap()
+            .into_iter()
+            .map(|c| c.subject)
+            .collect();
+        assert_eq!(
+            subjects,
+            vec!["update DB_PASSWORD", "set DB_PASSWORD"],
+            "opaque on-disk paths must not hide a secret's history"
+        );
+    }
+
+    #[test]
+    fn log_filter_matches_whole_names_not_substrings() {
+        // A secret named "A" must not match every subject containing an A —
+        // the closed subject vocabulary allows exact matching.
+        let (_tmp, git) = fixture();
+        write_secret(&git, "A", "ct");
+        git.commit("set A").unwrap();
+        write_secret(&git, "ALPHA", "ct");
+        git.commit("set ALPHA").unwrap();
+
+        let a = git.log(Some("A"), 0).unwrap();
+        assert_eq!(a.len(), 1, "{a:?}");
+        assert_eq!(a[0].subject, "set A");
+    }
+
+    #[test]
+    fn log_filter_matches_both_sides_of_a_rename() {
+        let (_tmp, git) = fixture();
+        write_secret(&git, "OLD", "ct");
+        git.commit("set OLD").unwrap();
+        write_secret(&git, "NEW", "ct");
+        git.commit("rename OLD to NEW").unwrap();
+        write_secret(&git, "NEW", "ct2");
+        git.commit("update NEW").unwrap();
+
+        let old = git.log(Some("OLD"), 0).unwrap();
+        let old_subjects: Vec<&str> = old.iter().map(|c| c.subject.as_str()).collect();
+        assert_eq!(
+            old_subjects,
+            vec!["rename OLD to NEW", "set OLD"],
+            "the old name's history should end at the rename"
+        );
+
+        let new = git.log(Some("NEW"), 0).unwrap();
+        let new_subjects: Vec<&str> = new.iter().map(|c| c.subject.as_str()).collect();
+        assert_eq!(
+            new_subjects,
+            vec!["update NEW", "rename OLD to NEW"],
+            "the new name's history should start at the rename"
+        );
     }
 
     #[test]

--- a/src/backend/local/git.rs
+++ b/src/backend/local/git.rs
@@ -185,11 +185,16 @@ impl LocalGitStore {
         }
 
         let mut args: Vec<String> = Vec::new();
-        // Supply an identity only when the user has none configured, so
-        // existing user.name/user.email and signing settings win.
-        if !self.has_committer_identity() {
+        // Supply the missing halves of the committer identity, independently:
+        // git needs BOTH user.name and user.email (auto-detection can fail in
+        // minimal environments), and a commit that dies on identity would error
+        // the mutation *after* the secret write already landed. Whichever half
+        // the user configured always wins — only the absent half is filled in.
+        if !self.has_git_config("user.name") {
             args.push("-c".into());
             args.push("user.name=crosstache".into());
+        }
+        if !self.has_git_config("user.email") {
             args.push("-c".into());
             args.push("user.email=xv@localhost".into());
         }
@@ -236,9 +241,9 @@ impl LocalGitStore {
         Ok(())
     }
 
-    /// Whether git can already determine a committer identity.
-    fn has_committer_identity(&self) -> bool {
-        self.run(&["config", "user.email"])
+    /// Whether git resolves a non-empty value for `key` (any config scope).
+    fn has_git_config(&self, key: &str) -> bool {
+        self.run(&["config", key])
             .map(|v| !v.trim().is_empty())
             .unwrap_or(false)
     }
@@ -684,6 +689,54 @@ mod tests {
             !diff.contains("plaintext-metadata-value"),
             "diff must not print file contents: {diff}"
         );
+    }
+
+    #[test]
+    fn commit_fills_only_the_missing_identity_half() {
+        // Bugbot (PR #384): email configured but no name meant no fallback at
+        // all, so the commit died on identity AFTER the secret write landed.
+        // Each half must be filled independently, preserving the configured one.
+        let (_tmp, git) = fixture();
+        git.ensure_repo().unwrap();
+        // Repo-local config: email present, name absent. HOME is not touched,
+        // but a developer's global name could leak in — remove it from this
+        // repo's resolution by setting local scope only and unsetting nothing
+        // global (local email + fallback name is the asserted pair below).
+        git.run(&["config", "user.email", "operator@example.com"])
+            .unwrap();
+        let has_global_name = git.run(&["config", "user.name"]).is_ok();
+
+        write_secret(&git, "A", "ct");
+        git.commit("set A")
+            .expect("a half-configured identity must not fail the commit");
+
+        let author = git.run(&["log", "-1", "--pretty=%an <%ae>"]).unwrap();
+        assert!(
+            author.contains("operator@example.com"),
+            "the configured email half must win: {author}"
+        );
+        if !has_global_name {
+            assert!(
+                author.starts_with("crosstache "),
+                "the missing name half must be filled: {author}"
+            );
+        }
+    }
+
+    #[test]
+    fn commit_succeeds_with_no_identity_at_all() {
+        let (_tmp, git) = fixture();
+        git.ensure_repo().unwrap();
+        // Force both halves empty in the repo scope regardless of global config.
+        git.run(&["config", "user.name", ""]).ok();
+        git.run(&["config", "user.email", ""]).ok();
+
+        write_secret(&git, "A", "ct");
+        git.commit("set A")
+            .expect("fallback identity must cover both halves");
+        let author = git.run(&["log", "-1", "--pretty=%an <%ae>"]).unwrap();
+        assert!(author.contains("crosstache"), "{author}");
+        assert!(author.contains("xv@localhost"), "{author}");
     }
 
     #[test]

--- a/src/backend/local/mod.rs
+++ b/src/backend/local/mod.rs
@@ -21,10 +21,12 @@
 //! Key files (`key.txt`, `recipients.txt`) are stored alongside the store
 //! or at a user-configured path.
 
+pub mod audit;
 pub mod config;
 pub mod crypto;
 #[cfg(feature = "file-ops")]
 pub mod files;
+pub mod git;
 pub mod opaque;
 pub mod paths;
 pub mod secrets;
@@ -37,16 +39,23 @@ use crate::utils::helpers::{create_private_dir, write_private};
 use async_trait::async_trait;
 
 use super::error::BackendError;
-use super::{Backend, BackendCapabilities, BackendKind, NameCharset, SecretBackend, VaultBackend};
+use super::{
+    AuditBackend, Backend, BackendCapabilities, BackendKind, NameCharset, SecretBackend,
+    VaultBackend,
+};
 
 #[cfg(feature = "file-ops")]
 use super::FileBackend;
 
+use self::audit::LocalAuditLog;
 use self::config::ResolvedLocalConfig;
 #[cfg(feature = "file-ops")]
 use self::files::LocalFileBackend;
+use self::git::LocalGitStore;
 use self::secrets::LocalSecretBackend;
 use self::vaults::LocalVaultBackend;
+
+use std::sync::Arc;
 
 /// The local age-encrypted file backend.
 pub struct LocalBackend {
@@ -55,6 +64,13 @@ pub struct LocalBackend {
     vault_backend: LocalVaultBackend,
     #[cfg(feature = "file-ops")]
     file_backend: LocalFileBackend,
+    /// Hash-chained audit log. `Some` only when `[local].audit` is on, which is
+    /// also what drives the `has_audit` capability flag — so the flag can never
+    /// claim an audit trail that is not actually being written.
+    audit_log: Option<Arc<LocalAuditLog>>,
+    /// Git store for the versioned-store commands. `Some` only when
+    /// `[local].git` is on.
+    git_store: Option<Arc<LocalGitStore>>,
 }
 
 impl LocalBackend {
@@ -113,13 +129,38 @@ impl LocalBackend {
             .map_err(|e| BackendError::Internal(format!("write default vault meta: {e}")))?;
         }
 
-        let secret_backend = LocalSecretBackend::with_options(
+        let mut secret_backend = LocalSecretBackend::with_options(
             config.store_path.clone(),
             identity.clone(),
             recipients.clone(),
             config.encrypt_metadata,
             config.opaque_filenames,
         );
+
+        let audit_log = if config.audit {
+            let log = Arc::new(LocalAuditLog::new(config.store_path.clone(), &identity));
+            secret_backend = secret_backend.with_audit_log(Arc::clone(&log));
+            Some(log)
+        } else {
+            None
+        };
+
+        let git_store = if config.git {
+            let git = Arc::new(LocalGitStore::new(
+                config.store_path.clone(),
+                config.key_file.clone(),
+                config.recipients_file.clone(),
+            ));
+            // Initialize eagerly so a misconfiguration (e.g. key_file inside the
+            // store, or git missing from PATH) surfaces at startup rather than
+            // midway through the first write.
+            git.ensure_repo()?;
+            secret_backend = secret_backend.with_git_store(Arc::clone(&git));
+            Some(git)
+        } else {
+            None
+        };
+
         let vault_backend = LocalVaultBackend::new(config.store_path.clone());
 
         #[cfg(feature = "file-ops")]
@@ -131,7 +172,35 @@ impl LocalBackend {
             vault_backend,
             #[cfg(feature = "file-ops")]
             file_backend,
+            audit_log,
+            git_store,
         })
+    }
+
+    /// The hash-chained audit log, when `[local].audit` is enabled.
+    ///
+    /// Exposed for `xv audit --verify`, which needs the concrete type's
+    /// `verify_chain` rather than the backend-agnostic [`AuditBackend`] trait.
+    pub fn audit_log(&self) -> Option<&Arc<LocalAuditLog>> {
+        self.audit_log.as_ref()
+    }
+
+    /// The git store, when `[local].git` is enabled.
+    pub fn git_store(&self) -> Option<&Arc<LocalGitStore>> {
+        self.git_store.as_ref()
+    }
+
+    /// A git store for this configuration regardless of whether `[local].git`
+    /// is enabled.
+    ///
+    /// `xv git init` has to work *before* the flag is turned on — otherwise
+    /// enabling versioning would be a chicken-and-egg problem.
+    pub fn git_store_unconditional(&self) -> LocalGitStore {
+        LocalGitStore::new(
+            self.config.store_path.clone(),
+            self.config.key_file.clone(),
+            self.config.recipients_file.clone(),
+        )
     }
 
     /// Whether this backend was configured to encrypt metadata at rest.
@@ -223,7 +292,10 @@ impl Backend for LocalBackend {
             has_vaults: true,
             has_file_storage: cfg!(feature = "file-ops"),
             has_rbac: false,
-            has_audit: false,
+            // Only true when the log is actually being written — see the
+            // `audit_log` field. A blanket `true` here would repeat the
+            // `has_audit` inconsistency closed for Azure in v0.21.
+            has_audit: self.audit_log.is_some(),
             has_versioning: true,
             has_soft_delete: true,
             has_restore: true,
@@ -248,6 +320,12 @@ impl Backend for LocalBackend {
 
     fn vaults(&self) -> Option<&dyn VaultBackend> {
         Some(&self.vault_backend)
+    }
+
+    fn audit(&self) -> Option<&dyn AuditBackend> {
+        self.audit_log
+            .as_deref()
+            .map(|log| log as &dyn AuditBackend)
     }
 
     #[cfg(feature = "file-ops")]
@@ -289,6 +367,8 @@ mod tests {
             default_vault: Some("default".into()),
             encrypt_metadata: None,
             opaque_filenames: None,
+            audit: None,
+            git: None,
         }
     }
 

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -11,6 +11,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use fs2::FileExt;
@@ -28,6 +29,8 @@ use crate::secret::manager::{
     DeletedSecretSummary, SecretProperties, SecretRequest, SecretSummary, SecretUpdateRequest,
 };
 
+use super::audit::{AuditOp, LocalAuditLog, RESOURCE_VAULT_WIDE};
+use super::git::LocalGitStore;
 use super::{crypto, opaque, paths};
 
 // ---------------------------------------------------------------------------
@@ -749,6 +752,11 @@ pub struct LocalSecretBackend {
     /// HMAC key for opaque stems, derived from `identity`. `None` when
     /// `opaque_filenames` is off, so the legacy path never computes it.
     index_key: Option<[u8; 32]>,
+    /// Hash-chained audit sink. `None` when `[local].audit` is off, so the
+    /// default path never touches the log.
+    audit: Option<Arc<LocalAuditLog>>,
+    /// Git auto-commit sink. `None` when `[local].git` is off.
+    git: Option<Arc<LocalGitStore>>,
 }
 
 impl LocalSecretBackend {
@@ -773,6 +781,75 @@ impl LocalSecretBackend {
             encrypt_metadata,
             opaque_filenames,
             index_key,
+            audit: None,
+            git: None,
+        }
+    }
+
+    /// Attach a hash-chained audit sink. Every audited operation then appends a
+    /// record, and a failed append fails the operation (see
+    /// [`super::audit`] on fail-closed behavior).
+    pub fn with_audit_log(mut self, log: Arc<LocalAuditLog>) -> Self {
+        self.audit = Some(log);
+        self
+    }
+
+    /// Attach a git store so mutations are committed as they happen.
+    pub fn with_git_store(mut self, git: Arc<LocalGitStore>) -> Self {
+        self.git = Some(git);
+        self
+    }
+
+    /// Append an audit record when auditing is enabled.
+    ///
+    /// Errors propagate: a mutation whose audit record could not be written is
+    /// reported as a failure rather than silently leaving a gap in the log.
+    fn audit_record(&self, vault: &str, op: AuditOp, resource: &str) -> Result<(), BackendError> {
+        match &self.audit {
+            Some(log) => log.record(vault, op, resource),
+            None => Ok(()),
+        }
+    }
+
+    /// Audit a failed operation, then hand the original error back unchanged.
+    ///
+    /// A no-op when auditing is off or the operation succeeded, so the normal
+    /// path pays nothing.
+    ///
+    /// If the audit append *itself* fails, both failures are reported: the
+    /// caller still needs the operation error, but a silently dropped record
+    /// would undermine the log's completeness exactly as it would on the success
+    /// path (see [`super::audit`] on fail-closed behavior).
+    fn audit_failure<T>(
+        &self,
+        vault: &str,
+        op: AuditOp,
+        resource: &str,
+        result: Result<T, BackendError>,
+    ) -> Result<T, BackendError> {
+        let Some(log) = self.audit.as_ref() else {
+            return result;
+        };
+        if let Err(err) = &result {
+            if let Err(audit_err) = log.record_failure(vault, op, resource, err) {
+                return Err(BackendError::Internal(format!(
+                    "{err} — additionally, the audit record for this failure could not be \
+                     written: {audit_err}"
+                )));
+            }
+        }
+        result
+    }
+
+    /// Commit the store after a mutation when git versioning is enabled.
+    ///
+    /// A commit failure is reported: the secret write already landed on disk,
+    /// but claiming git-native history while silently dropping commits would
+    /// leave a history with holes in it.
+    fn git_commit(&self, message: &str) -> Result<(), BackendError> {
+        match &self.git {
+            Some(git) => git.commit(message).map(|_| ()),
+            None => Ok(()),
         }
     }
 
@@ -2290,7 +2367,13 @@ impl SecretBackend for LocalSecretBackend {
         vault: &str,
         request: SecretRequest,
     ) -> Result<SecretProperties, BackendError> {
-        self.set_secret_with_mode(vault, request, false)
+        let __res_name = request.name.clone();
+        let __result = async { self.set_secret_with_mode(vault, request, false) }.await;
+        if __result.is_ok() {
+            self.audit_record(vault, AuditOp::PutSecretValue, &__res_name)?;
+            self.git_commit(&format!("set {__res_name}"))?;
+        }
+        self.audit_failure(vault, AuditOp::PutSecretValue, &__res_name, __result)
     }
 
     async fn create_secret_if_absent(
@@ -2298,7 +2381,13 @@ impl SecretBackend for LocalSecretBackend {
         vault: &str,
         request: SecretRequest,
     ) -> Result<SecretProperties, BackendError> {
-        self.set_secret_with_mode(vault, request, true)
+        let __res_name = request.name.clone();
+        let __result = async { self.set_secret_with_mode(vault, request, true) }.await;
+        if __result.is_ok() {
+            self.audit_record(vault, AuditOp::PutSecretValue, &__res_name)?;
+            self.git_commit(&format!("set {__res_name}"))?;
+        }
+        self.audit_failure(vault, AuditOp::PutSecretValue, &__res_name, __result)
     }
 
     async fn get_secret_snapshot(
@@ -2307,8 +2396,18 @@ impl SecretBackend for LocalSecretBackend {
         name: &str,
         include_value: bool,
     ) -> Result<SecretSnapshot, BackendError> {
-        let _lock = self.mutation_lock_for_name(vault, name)?;
-        self.get_secret_snapshot_locked(vault, name, include_value)
+        let __result = async {
+            let _lock = self.mutation_lock_for_name(vault, name)?;
+            self.get_secret_snapshot_locked(vault, name, include_value)
+        }
+        .await;
+        if include_value {
+            if __result.is_ok() {
+                self.audit_record(vault, AuditOp::GetSecretValue, name)?;
+            }
+            return self.audit_failure(vault, AuditOp::GetSecretValue, name, __result);
+        }
+        __result
     }
 
     async fn update_secret_if_revision(
@@ -2345,7 +2444,13 @@ impl SecretBackend for LocalSecretBackend {
         new_name: &str,
         expected_revision: &str,
     ) -> Result<SecretProperties, BackendError> {
-        self.atomic_rename(vault, name, new_name, Some(expected_revision))
+        let __result =
+            async { self.atomic_rename(vault, name, new_name, Some(expected_revision)) }.await;
+        if __result.is_ok() {
+            self.audit_record(vault, AuditOp::RenameSecret, name)?;
+            self.git_commit(&format!("rename {name} to {new_name}"))?;
+        }
+        self.audit_failure(vault, AuditOp::RenameSecret, name, __result)
     }
 
     async fn rename_secret(
@@ -2354,7 +2459,12 @@ impl SecretBackend for LocalSecretBackend {
         name: &str,
         new_name: &str,
     ) -> Result<SecretProperties, BackendError> {
-        self.atomic_rename(vault, name, new_name, None)
+        let __result = async { self.atomic_rename(vault, name, new_name, None) }.await;
+        if __result.is_ok() {
+            self.audit_record(vault, AuditOp::RenameSecret, name)?;
+            self.git_commit(&format!("rename {name} to {new_name}"))?;
+        }
+        self.audit_failure(vault, AuditOp::RenameSecret, name, __result)
     }
 
     async fn get_secret(
@@ -2363,54 +2473,64 @@ impl SecretBackend for LocalSecretBackend {
         name: &str,
         include_value: bool,
     ) -> Result<SecretProperties, BackendError> {
-        // The helper may briefly drop shared and take exclusive for recovery;
-        // it returns only a fresh shared lock with no transaction artifacts.
-        let _read_lock = self.read_lock_for_name(vault, name)?;
+        let __result = async {
+            // The helper may briefly drop shared and take exclusive for recovery;
+            // it returns only a fresh shared lock with no transaction artifacts.
+            let _read_lock = self.read_lock_for_name(vault, name)?;
 
-        // Resolve the on-disk stem (opaque, or legacy via the read-only
-        // back-compat fallback). Reads never create or upgrade legacy files.
-        let stem = self.resolve_active_stem(vault, name)?;
-        let mp = meta_path(&self.store_path, vault, &stem)?;
-        if !mp.exists() {
-            return Err(BackendError::NotFound {
-                name: name.to_string(),
-                suggestion: None,
-            });
-        }
+            // Resolve the on-disk stem (opaque, or legacy via the read-only
+            // back-compat fallback). Reads never create or upgrade legacy files.
+            let stem = self.resolve_active_stem(vault, name)?;
+            let mp = meta_path(&self.store_path, vault, &stem)?;
+            if !mp.exists() {
+                return Err(BackendError::NotFound {
+                    name: name.to_string(),
+                    suggestion: None,
+                });
+            }
 
-        // Reject symlinks to prevent attackers from redirecting reads to
-        // arbitrary files on the filesystem.
-        if fs::symlink_metadata(&mp)
-            .map(|m| m.is_symlink())
-            .unwrap_or(false)
-        {
-            return Err(BackendError::Internal(format!(
-                "refusing to read metadata file: {} is a symlink",
-                mp.display()
-            )));
-        }
-
-        let meta = read_meta(&mp, &self.identity)?;
-
-        let value = if include_value {
-            let ap = age_path(&self.store_path, vault, &stem)?;
-
-            if fs::symlink_metadata(&ap)
+            // Reject symlinks to prevent attackers from redirecting reads to
+            // arbitrary files on the filesystem.
+            if fs::symlink_metadata(&mp)
                 .map(|m| m.is_symlink())
                 .unwrap_or(false)
             {
                 return Err(BackendError::Internal(format!(
-                    "refusing to decrypt secret file: {} is a symlink",
-                    ap.display()
+                    "refusing to read metadata file: {} is a symlink",
+                    mp.display()
                 )));
             }
 
-            Some(crypto::decrypt_from_file(&ap, &self.identity)?)
-        } else {
-            None
-        };
+            let meta = read_meta(&mp, &self.identity)?;
 
-        Ok(meta_to_properties(&meta, value))
+            let value = if include_value {
+                let ap = age_path(&self.store_path, vault, &stem)?;
+
+                if fs::symlink_metadata(&ap)
+                    .map(|m| m.is_symlink())
+                    .unwrap_or(false)
+                {
+                    return Err(BackendError::Internal(format!(
+                        "refusing to decrypt secret file: {} is a symlink",
+                        ap.display()
+                    )));
+                }
+
+                Some(crypto::decrypt_from_file(&ap, &self.identity)?)
+            } else {
+                None
+            };
+
+            Ok(meta_to_properties(&meta, value))
+        }
+        .await;
+        if include_value {
+            if __result.is_ok() {
+                self.audit_record(vault, AuditOp::GetSecretValue, name)?;
+            }
+            return self.audit_failure(vault, AuditOp::GetSecretValue, name, __result);
+        }
+        __result
     }
 
     async fn get_secret_version(
@@ -2420,74 +2540,84 @@ impl SecretBackend for LocalSecretBackend {
         version: &str,
         include_value: bool,
     ) -> Result<SecretProperties, BackendError> {
-        let _read_lock = self.read_lock_for_name(vault, name)?;
+        let __result = async {
+            let _read_lock = self.read_lock_for_name(vault, name)?;
 
-        // First check if this is the current version.
-        let stem = self.resolve_active_stem(vault, name)?;
-        let mp = meta_path(&self.store_path, vault, &stem)?;
-        if mp.exists() {
-            let meta = read_meta(&mp, &self.identity)?;
-            if meta.version == version {
-                let value = if include_value {
-                    let age_file = age_path(&self.store_path, vault, &stem)?;
-                    if fs::symlink_metadata(&age_file)
-                        .map(|metadata| metadata.is_symlink())
-                        .unwrap_or(false)
-                    {
-                        return Err(BackendError::Internal(format!(
-                            "refusing to decrypt secret file: {} is a symlink",
-                            age_file.display()
-                        )));
-                    }
-                    Some(crypto::decrypt_from_file(&age_file, &self.identity)?)
-                } else {
-                    None
-                };
-                return Ok(meta_to_properties(&meta, value));
+            // First check if this is the current version.
+            let stem = self.resolve_active_stem(vault, name)?;
+            let mp = meta_path(&self.store_path, vault, &stem)?;
+            if mp.exists() {
+                let meta = read_meta(&mp, &self.identity)?;
+                if meta.version == version {
+                    let value = if include_value {
+                        let age_file = age_path(&self.store_path, vault, &stem)?;
+                        if fs::symlink_metadata(&age_file)
+                            .map(|metadata| metadata.is_symlink())
+                            .unwrap_or(false)
+                        {
+                            return Err(BackendError::Internal(format!(
+                                "refusing to decrypt secret file: {} is a symlink",
+                                age_file.display()
+                            )));
+                        }
+                        Some(crypto::decrypt_from_file(&age_file, &self.identity)?)
+                    } else {
+                        None
+                    };
+                    return Ok(meta_to_properties(&meta, value));
+                }
             }
-        }
 
-        // Look in .versions/ (opaque, or legacy via read fallback).
-        let vdir = self.resolve_versions_dir(vault, name)?;
-        let meta_file = vdir.join(format!("{version}.meta.json"));
-        if !meta_file.exists() {
-            return Err(BackendError::NotFound {
-                name: format!("{name}@{version}"),
-                suggestion: None,
-            });
-        }
+            // Look in .versions/ (opaque, or legacy via read fallback).
+            let vdir = self.resolve_versions_dir(vault, name)?;
+            let meta_file = vdir.join(format!("{version}.meta.json"));
+            if !meta_file.exists() {
+                return Err(BackendError::NotFound {
+                    name: format!("{name}@{version}"),
+                    suggestion: None,
+                });
+            }
 
-        if fs::symlink_metadata(&meta_file)
-            .map(|m| m.is_symlink())
-            .unwrap_or(false)
-        {
-            return Err(BackendError::Internal(format!(
-                "refusing to read metadata file: {} is a symlink",
-                meta_file.display()
-            )));
-        }
-
-        let meta = read_meta(&meta_file, &self.identity)?;
-
-        let value = if include_value {
-            let age_file = vdir.join(format!("{version}.age"));
-
-            if fs::symlink_metadata(&age_file)
+            if fs::symlink_metadata(&meta_file)
                 .map(|m| m.is_symlink())
                 .unwrap_or(false)
             {
                 return Err(BackendError::Internal(format!(
-                    "refusing to decrypt secret file: {} is a symlink",
-                    age_file.display()
+                    "refusing to read metadata file: {} is a symlink",
+                    meta_file.display()
                 )));
             }
 
-            Some(crypto::decrypt_from_file(&age_file, &self.identity)?)
-        } else {
-            None
-        };
+            let meta = read_meta(&meta_file, &self.identity)?;
 
-        Ok(meta_to_properties(&meta, value))
+            let value = if include_value {
+                let age_file = vdir.join(format!("{version}.age"));
+
+                if fs::symlink_metadata(&age_file)
+                    .map(|m| m.is_symlink())
+                    .unwrap_or(false)
+                {
+                    return Err(BackendError::Internal(format!(
+                        "refusing to decrypt secret file: {} is a symlink",
+                        age_file.display()
+                    )));
+                }
+
+                Some(crypto::decrypt_from_file(&age_file, &self.identity)?)
+            } else {
+                None
+            };
+
+            Ok(meta_to_properties(&meta, value))
+        }
+        .await;
+        if include_value {
+            if __result.is_ok() {
+                self.audit_record(vault, AuditOp::GetSecretValue, name)?;
+            }
+            return self.audit_failure(vault, AuditOp::GetSecretValue, name, __result);
+        }
+        __result
     }
 
     async fn list_secrets(
@@ -2495,99 +2625,116 @@ impl SecretBackend for LocalSecretBackend {
         vault: &str,
         group_filter: Option<&str>,
     ) -> Result<Vec<SecretSummary>, BackendError> {
-        let sdir = secrets_dir(&self.store_path, vault)?;
-        if !sdir.exists() {
-            return Ok(Vec::new());
-        }
-        let _read_lock = self.read_lock_for_vault(vault)?;
+        let __result = async {
+            let sdir = secrets_dir(&self.store_path, vault)?;
+            if !sdir.exists() {
+                return Ok(Vec::new());
+            }
+            let _read_lock = self.read_lock_for_vault(vault)?;
 
-        let mut results = Vec::new();
-        let push_meta = |meta: &SecretMeta, results: &mut Vec<SecretSummary>| {
-            if let Some(group) = group_filter {
-                if !meta.groups.iter().any(|g| g == group) {
-                    return;
+            let mut results = Vec::new();
+            let push_meta = |meta: &SecretMeta, results: &mut Vec<SecretSummary>| {
+                if let Some(group) = group_filter {
+                    if !meta.groups.iter().any(|g| g == group) {
+                        return;
+                    }
+                }
+                results.push(meta_to_summary(meta));
+            };
+
+            // Track stems already accounted for so reconciliation never
+            // double-counts a secret present both in the index and on disk.
+            let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+            if self.opaque_filenames {
+                // Primary source: the decrypted reverse index.
+                let index = opaque::load_index(&sdir, &self.identity)?;
+                for stem in index.keys() {
+                    let mp = meta_path(&self.store_path, vault, stem)?;
+                    if !mp.exists() {
+                        continue;
+                    }
+                    match read_meta(&mp, &self.identity) {
+                        Ok(meta) => {
+                            seen.insert(stem.clone());
+                            push_meta(&meta, &mut results);
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "warning: indexed secret {stem:?} has corrupted metadata: {e}"
+                            );
+                        }
+                    }
                 }
             }
-            results.push(meta_to_summary(meta));
-        };
 
-        // Track stems already accounted for so reconciliation never
-        // double-counts a secret present both in the index and on disk.
-        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-
-        if self.opaque_filenames {
-            // Primary source: the decrypted reverse index.
-            let index = opaque::load_index(&sdir, &self.identity)?;
-            for stem in index.keys() {
-                let mp = meta_path(&self.store_path, vault, stem)?;
-                if !mp.exists() {
+            // Reconciliation (always for legacy mode; back-compat window for opaque
+            // mode): pick up any on-disk pair not already represented in the index —
+            // legacy `encode_name` pairs and orphan opaque-stem pairs alike. The
+            // real name comes from the decrypted metadata, never from the filename.
+            let entries = fs::read_dir(&sdir)
+                .map_err(|e| BackendError::Internal(format!("read secrets dir: {e}")))?;
+            for entry in entries.flatten() {
+                let fname = entry.file_name().to_string_lossy().to_string();
+                let Some(stem) = fname.strip_suffix(".meta.json") else {
+                    continue;
+                };
+                if seen.contains(stem) {
                     continue;
                 }
-                match read_meta(&mp, &self.identity) {
-                    Ok(meta) => {
-                        seen.insert(stem.clone());
-                        push_meta(&meta, &mut results);
-                    }
+
+                let meta = match read_meta(&entry.path(), &self.identity) {
+                    Ok(m) => m,
                     Err(e) => {
-                        eprintln!("warning: indexed secret {stem:?} has corrupted metadata: {e}");
+                        eprintln!(
+                            "warning: secret {:?} exists but has corrupted metadata: {}",
+                            fname, e
+                        );
+                        continue;
                     }
-                }
-            }
-        }
-
-        // Reconciliation (always for legacy mode; back-compat window for opaque
-        // mode): pick up any on-disk pair not already represented in the index —
-        // legacy `encode_name` pairs and orphan opaque-stem pairs alike. The
-        // real name comes from the decrypted metadata, never from the filename.
-        let entries = fs::read_dir(&sdir)
-            .map_err(|e| BackendError::Internal(format!("read secrets dir: {e}")))?;
-        for entry in entries.flatten() {
-            let fname = entry.file_name().to_string_lossy().to_string();
-            let Some(stem) = fname.strip_suffix(".meta.json") else {
-                continue;
-            };
-            if seen.contains(stem) {
-                continue;
+                };
+                seen.insert(stem.to_string());
+                push_meta(&meta, &mut results);
             }
 
-            let meta = match read_meta(&entry.path(), &self.identity) {
-                Ok(m) => m,
-                Err(e) => {
-                    eprintln!(
-                        "warning: secret {:?} exists but has corrupted metadata: {}",
-                        fname, e
-                    );
-                    continue;
-                }
-            };
-            seen.insert(stem.to_string());
-            push_meta(&meta, &mut results);
+            // Sort by name for deterministic output
+            results.sort_by(|a, b| a.name.cmp(&b.name));
+            Ok(results)
         }
-
-        // Sort by name for deterministic output
-        results.sort_by(|a, b| a.name.cmp(&b.name));
-        Ok(results)
+        .await;
+        if __result.is_ok() {
+            self.audit_record(vault, AuditOp::ListSecrets, RESOURCE_VAULT_WIDE)?;
+        }
+        self.audit_failure(vault, AuditOp::ListSecrets, RESOURCE_VAULT_WIDE, __result)
     }
 
     async fn delete_secret(&self, vault: &str, name: &str) -> Result<(), BackendError> {
-        let mut deleted_at_millis = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|e| BackendError::Internal(format!("clock error: {e}")))?
-            .as_millis();
+        let __result = async {
+            let mut deleted_at_millis = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_err(|e| BackendError::Internal(format!("clock error: {e}")))?
+                .as_millis();
 
-        // Millisecond clocks can repeat during tight delete/recreate/delete
-        // cycles. Keep explicit timestamp collisions fail-closed in
-        // `delete_secret_at`, but make the normal API choose the next free
-        // suffix so rapid successive deletes preserve every trash snapshot.
-        for _ in 0..1000 {
-            match self.delete_secret_at(vault, name, deleted_at_millis) {
-                Err(BackendError::Conflict(_)) => deleted_at_millis += 1,
-                other => return other,
+            // Millisecond clocks can repeat during tight delete/recreate/delete
+            // cycles. Keep explicit timestamp collisions fail-closed in
+            // `delete_secret_at`, but make the normal API choose the next free
+            // suffix so rapid successive deletes preserve every trash snapshot.
+            for _ in 0..1000 {
+                match self.delete_secret_at(vault, name, deleted_at_millis) {
+                    Err(BackendError::Conflict(_)) => deleted_at_millis += 1,
+                    other => return other,
+                }
             }
+            Err(BackendError::Conflict(format!(
+                "could not allocate a unique trash entry timestamp for '{name}'"
+            )))
         }
-        Err(BackendError::Conflict(format!(
-            "could not allocate a unique trash entry timestamp for '{name}'"
-        )))
+        .await;
+        if __result.is_ok() {
+            self.audit_record(vault, AuditOp::DeleteSecret, name)?;
+            self.git_commit(&format!("delete {name}"))?;
+        }
+        self.audit_failure(vault, AuditOp::DeleteSecret, name, __result)
     }
 
     async fn update_secret(
@@ -2596,207 +2743,220 @@ impl SecretBackend for LocalSecretBackend {
         name: &str,
         request: SecretUpdateRequest,
     ) -> Result<SecretProperties, BackendError> {
-        // Acquire once and recover before inspecting the active/history pair.
-        let _lock = self.mutation_lock_for_name(vault, name)?;
+        let __result = async {
+            // Acquire once and recover before inspecting the active/history pair.
+            let _lock = self.mutation_lock_for_name(vault, name)?;
 
-        // Migrate any legacy layout before the transaction starts, so a later
-        // migration failure can never leave a successfully converted mixed state.
-        self.ensure_opaque_layout(vault, name)?;
-        let stem = self.resolve_active_stem(vault, name)?;
-        let mp = meta_path(&self.store_path, vault, &stem)?;
-        if !mp.exists() {
-            return Err(BackendError::NotFound {
-                name: name.to_string(),
-                suggestion: None,
-            });
-        }
-
-        let mut meta = read_meta(&mp, &self.identity)?;
-        if request
-            .expected_revision
-            .as_deref()
-            .is_some_and(|expected| meta.revision != expected)
-        {
-            return Err(BackendError::SourceRevisionConflict {
-                name: name.to_string(),
-            });
-        }
-        let old_meta = meta.clone();
-        let now = Utc::now();
-
-        if request.value.is_some() {
-            let old_num: u32 = meta
-                .version
-                .strip_prefix('v')
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0);
-            meta.version = format!("v{}", old_num + 1);
-        }
-        meta.revision = new_revision();
-
-        // Merge or replace tags
-        if let Some(new_tags) = &request.tags {
-            if request.replace_tags {
-                meta.tags = new_tags.clone();
-            } else {
-                for (k, v) in new_tags {
-                    meta.tags.insert(k.clone(), v.clone());
-                }
+            // Migrate any legacy layout before the transaction starts, so a later
+            // migration failure can never leave a successfully converted mixed state.
+            self.ensure_opaque_layout(vault, name)?;
+            let stem = self.resolve_active_stem(vault, name)?;
+            let mp = meta_path(&self.store_path, vault, &stem)?;
+            if !mp.exists() {
+                return Err(BackendError::NotFound {
+                    name: name.to_string(),
+                    suggestion: None,
+                });
             }
-        }
 
-        // Merge or replace groups
-        if let Some(new_groups) = &request.groups {
-            if request.replace_groups {
-                meta.groups = new_groups.clone();
-            } else {
-                for g in new_groups {
-                    if !meta.groups.contains(g) {
-                        meta.groups.push(g.clone());
+            let mut meta = read_meta(&mp, &self.identity)?;
+            if request
+                .expected_revision
+                .as_deref()
+                .is_some_and(|expected| meta.revision != expected)
+            {
+                return Err(BackendError::SourceRevisionConflict {
+                    name: name.to_string(),
+                });
+            }
+            let old_meta = meta.clone();
+            let now = Utc::now();
+
+            if request.value.is_some() {
+                let old_num: u32 = meta
+                    .version
+                    .strip_prefix('v')
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                meta.version = format!("v{}", old_num + 1);
+            }
+            meta.revision = new_revision();
+
+            // Merge or replace tags
+            if let Some(new_tags) = &request.tags {
+                if request.replace_tags {
+                    meta.tags = new_tags.clone();
+                } else {
+                    for (k, v) in new_tags {
+                        meta.tags.insert(k.clone(), v.clone());
                     }
                 }
             }
-        }
 
-        if let Some(ct) = &request.content_type {
-            meta.content_type = ct.clone();
-        }
-        if let Some(enabled) = request.enabled {
-            meta.enabled = enabled;
-        }
-        meta.expires_on = request.expires_on.apply(meta.expires_on);
-        meta.not_before = request.not_before.apply(meta.not_before);
-        meta.note = request.note.apply(meta.note.take());
-        meta.folder = request.folder.apply(meta.folder.take());
-
-        meta.updated_at = now;
-        let crypto_opts = MetaCrypto {
-            recipients: &self.recipients,
-            encrypt: self.encrypt_metadata,
-        };
-
-        if let Some(ref new_value) = request.value {
-            let ap = age_path(&self.store_path, vault, &stem)?;
-            let old_age = fs::read(&ap).map_err(|e| {
-                BackendError::Internal(format!("read existing age {}: {e}", ap.display()))
-            })?;
-            let old_meta_bytes = fs::read(&mp).map_err(|e| {
-                BackendError::Internal(format!("read existing meta {}: {e}", mp.display()))
-            })?;
-            let transaction = UpdateTransactionPaths::new(&self.store_path, vault, &stem)?;
-            create_private_dir(&transaction.dir).map_err(|e| {
-                BackendError::Internal(format!(
-                    "create transaction directory {}: {e}",
-                    transaction.dir.display()
-                ))
-            })?;
-            // No journal means any files here are residue from staging before
-            // the transaction became visible. They cannot describe an active
-            // mutation and are safe to replace.
-            self.cleanup_unjournaled_transaction_locked(&transaction)?;
-
-            durable_write_private(&transaction.old_age, &old_age)?;
-            durable_write_private(&transaction.old_meta, &old_meta_bytes)?;
-            crypto::encrypt_to_file(&transaction.new_age, new_value.as_bytes(), &self.recipients)?;
-            sync_file(&transaction.new_age)?;
-            write_meta(&transaction.new_meta, &meta, crypto_opts)?;
-            sync_file(&transaction.new_meta)?;
-            sync_directory(&transaction.dir)?;
-
-            let journal = UpdateJournal {
-                version: 1,
-                stem: stem.clone(),
-                old_version: old_meta.version.clone(),
-            };
-            let journal_bytes = serde_json::to_vec_pretty(&journal)
-                .map_err(|e| BackendError::Internal(format!("serialize update journal: {e}")))?;
-            let rollback = |cause: BackendError| -> Result<SecretProperties, BackendError> {
-                match self.recover_update_for_stem_locked(vault, &stem) {
-                    Ok(()) => Err(cause),
-                    Err(recovery) => Err(BackendError::Internal(format!(
-                        "{cause}; update recovery also failed: {recovery}"
-                    ))),
+            // Merge or replace groups
+            if let Some(new_groups) = &request.groups {
+                if request.replace_groups {
+                    meta.groups = new_groups.clone();
+                } else {
+                    for g in new_groups {
+                        if !meta.groups.contains(g) {
+                            meta.groups.push(g.clone());
+                        }
+                    }
                 }
+            }
+
+            if let Some(ct) = &request.content_type {
+                meta.content_type = ct.clone();
+            }
+            if let Some(enabled) = request.enabled {
+                meta.enabled = enabled;
+            }
+            meta.expires_on = request.expires_on.apply(meta.expires_on);
+            meta.not_before = request.not_before.apply(meta.not_before);
+            meta.note = request.note.apply(meta.note.take());
+            meta.folder = request.folder.apply(meta.folder.take());
+
+            meta.updated_at = now;
+            let crypto_opts = MetaCrypto {
+                recipients: &self.recipients,
+                encrypt: self.encrypt_metadata,
             };
 
-            // Publish via a synced temp and atomic rename. The final marker is
-            // never opened with truncate semantics.
-            match self.publish_update_journal_locked(&transaction, &journal_bytes) {
-                Ok(UpdateInterruption::None) => {}
-                Ok(UpdateInterruption::Rollback(error)) => {
-                    if transaction.journal.exists() {
-                        return rollback(error);
+            if let Some(ref new_value) = request.value {
+                let ap = age_path(&self.store_path, vault, &stem)?;
+                let old_age = fs::read(&ap).map_err(|e| {
+                    BackendError::Internal(format!("read existing age {}: {e}", ap.display()))
+                })?;
+                let old_meta_bytes = fs::read(&mp).map_err(|e| {
+                    BackendError::Internal(format!("read existing meta {}: {e}", mp.display()))
+                })?;
+                let transaction = UpdateTransactionPaths::new(&self.store_path, vault, &stem)?;
+                create_private_dir(&transaction.dir).map_err(|e| {
+                    BackendError::Internal(format!(
+                        "create transaction directory {}: {e}",
+                        transaction.dir.display()
+                    ))
+                })?;
+                // No journal means any files here are residue from staging before
+                // the transaction became visible. They cannot describe an active
+                // mutation and are safe to replace.
+                self.cleanup_unjournaled_transaction_locked(&transaction)?;
+
+                durable_write_private(&transaction.old_age, &old_age)?;
+                durable_write_private(&transaction.old_meta, &old_meta_bytes)?;
+                crypto::encrypt_to_file(
+                    &transaction.new_age,
+                    new_value.as_bytes(),
+                    &self.recipients,
+                )?;
+                sync_file(&transaction.new_age)?;
+                write_meta(&transaction.new_meta, &meta, crypto_opts)?;
+                sync_file(&transaction.new_meta)?;
+                sync_directory(&transaction.dir)?;
+
+                let journal = UpdateJournal {
+                    version: 1,
+                    stem: stem.clone(),
+                    old_version: old_meta.version.clone(),
+                };
+                let journal_bytes = serde_json::to_vec_pretty(&journal).map_err(|e| {
+                    BackendError::Internal(format!("serialize update journal: {e}"))
+                })?;
+                let rollback = |cause: BackendError| -> Result<SecretProperties, BackendError> {
+                    match self.recover_update_for_stem_locked(vault, &stem) {
+                        Ok(()) => Err(cause),
+                        Err(recovery) => Err(BackendError::Internal(format!(
+                            "{cause}; update recovery also failed: {recovery}"
+                        ))),
                     }
-                    self.cleanup_unjournaled_transaction_locked(&transaction)?;
-                    return Err(error);
-                }
-                Ok(UpdateInterruption::SimulatedCrash(error)) => return Err(error),
-                Err(error) => {
-                    if transaction.journal.exists() {
-                        return rollback(error);
+                };
+
+                // Publish via a synced temp and atomic rename. The final marker is
+                // never opened with truncate semantics.
+                match self.publish_update_journal_locked(&transaction, &journal_bytes) {
+                    Ok(UpdateInterruption::None) => {}
+                    Ok(UpdateInterruption::Rollback(error)) => {
+                        if transaction.journal.exists() {
+                            return rollback(error);
+                        }
+                        self.cleanup_unjournaled_transaction_locked(&transaction)?;
+                        return Err(error);
                     }
-                    self.cleanup_unjournaled_transaction_locked(&transaction)?;
-                    return Err(error);
+                    Ok(UpdateInterruption::SimulatedCrash(error)) => return Err(error),
+                    Err(error) => {
+                        if transaction.journal.exists() {
+                            return rollback(error);
+                        }
+                        self.cleanup_unjournaled_transaction_locked(&transaction)?;
+                        return Err(error);
+                    }
                 }
+
+                match self.update_interruption(0) {
+                    UpdateInterruption::None => {}
+                    UpdateInterruption::Rollback(error) => return rollback(error),
+                    UpdateInterruption::SimulatedCrash(error) => return Err(error),
+                }
+
+                if let Err(error) = fs::rename(&transaction.new_age, &ap).map_err(|e| {
+                    BackendError::Internal(format!("activate age {}: {e}", ap.display()))
+                }) {
+                    return rollback(error);
+                }
+                sync_directory(ap.parent().expect("active value has parent"))?;
+                match self.update_interruption(1) {
+                    UpdateInterruption::None => {}
+                    UpdateInterruption::Rollback(error) => return rollback(error),
+                    UpdateInterruption::SimulatedCrash(error) => return Err(error),
+                }
+
+                if let Err(error) = fs::rename(&transaction.new_meta, &mp).map_err(|e| {
+                    BackendError::Internal(format!("activate meta {}: {e}", mp.display()))
+                }) {
+                    return rollback(error);
+                }
+                sync_directory(mp.parent().expect("active metadata has parent"))?;
+                match self.update_interruption(2) {
+                    UpdateInterruption::None => {}
+                    UpdateInterruption::Rollback(error) => return rollback(error),
+                    UpdateInterruption::SimulatedCrash(error) => return Err(error),
+                }
+
+                if let Err(error) = archive_snapshot(
+                    &self.store_path,
+                    vault,
+                    &stem,
+                    &old_meta.version,
+                    &old_age,
+                    &old_meta,
+                    crypto_opts,
+                ) {
+                    return rollback(error);
+                }
+                let archive_dir = versions_dir(&self.store_path, vault, &stem)?;
+                sync_file(&archive_dir.join(format!("{}.age", old_meta.version)))?;
+                sync_file(&archive_dir.join(format!("{}.meta.json", old_meta.version)))?;
+                sync_directory(&archive_dir)?;
+                match self.update_interruption(3) {
+                    UpdateInterruption::None => {}
+                    UpdateInterruption::Rollback(error) => return rollback(error),
+                    UpdateInterruption::SimulatedCrash(error) => return Err(error),
+                }
+
+                self.finish_update_transaction_locked(&transaction)?;
+            } else {
+                write_meta(&mp, &meta, crypto_opts)?;
             }
 
-            match self.update_interruption(0) {
-                UpdateInterruption::None => {}
-                UpdateInterruption::Rollback(error) => return rollback(error),
-                UpdateInterruption::SimulatedCrash(error) => return Err(error),
-            }
-
-            if let Err(error) = fs::rename(&transaction.new_age, &ap)
-                .map_err(|e| BackendError::Internal(format!("activate age {}: {e}", ap.display())))
-            {
-                return rollback(error);
-            }
-            sync_directory(ap.parent().expect("active value has parent"))?;
-            match self.update_interruption(1) {
-                UpdateInterruption::None => {}
-                UpdateInterruption::Rollback(error) => return rollback(error),
-                UpdateInterruption::SimulatedCrash(error) => return Err(error),
-            }
-
-            if let Err(error) = fs::rename(&transaction.new_meta, &mp)
-                .map_err(|e| BackendError::Internal(format!("activate meta {}: {e}", mp.display())))
-            {
-                return rollback(error);
-            }
-            sync_directory(mp.parent().expect("active metadata has parent"))?;
-            match self.update_interruption(2) {
-                UpdateInterruption::None => {}
-                UpdateInterruption::Rollback(error) => return rollback(error),
-                UpdateInterruption::SimulatedCrash(error) => return Err(error),
-            }
-
-            if let Err(error) = archive_snapshot(
-                &self.store_path,
-                vault,
-                &stem,
-                &old_meta.version,
-                &old_age,
-                &old_meta,
-                crypto_opts,
-            ) {
-                return rollback(error);
-            }
-            let archive_dir = versions_dir(&self.store_path, vault, &stem)?;
-            sync_file(&archive_dir.join(format!("{}.age", old_meta.version)))?;
-            sync_file(&archive_dir.join(format!("{}.meta.json", old_meta.version)))?;
-            sync_directory(&archive_dir)?;
-            match self.update_interruption(3) {
-                UpdateInterruption::None => {}
-                UpdateInterruption::Rollback(error) => return rollback(error),
-                UpdateInterruption::SimulatedCrash(error) => return Err(error),
-            }
-
-            self.finish_update_transaction_locked(&transaction)?;
-        } else {
-            write_meta(&mp, &meta, crypto_opts)?;
+            Ok(meta_to_properties(&meta, None))
         }
-
-        Ok(meta_to_properties(&meta, None))
+        .await;
+        if __result.is_ok() {
+            self.audit_record(vault, AuditOp::UpdateSecret, name)?;
+            self.git_commit(&format!("update {name}"))?;
+        }
+        self.audit_failure(vault, AuditOp::UpdateSecret, name, __result)
     }
 
     // -----------------------------------------------------------------------
@@ -2854,60 +3014,68 @@ impl SecretBackend for LocalSecretBackend {
         name: &str,
         version: &str,
     ) -> Result<SecretProperties, BackendError> {
-        // Acquire once and recover before rollback inspects current/history.
-        let _lock = self.mutation_lock_for_name(vault, name)?;
+        let __result = async {
+            // Acquire once and recover before rollback inspects current/history.
+            let _lock = self.mutation_lock_for_name(vault, name)?;
 
-        // Operate on the stem where this secret currently lives (opaque, or
-        // legacy via the read fallback). `ensure_opaque_layout` migrates to
-        // opaque afterwards.
-        let stem = self.resolve_active_stem(vault, name)?;
+            // Operate on the stem where this secret currently lives (opaque, or
+            // legacy via the read fallback). `ensure_opaque_layout` migrates to
+            // opaque afterwards.
+            let stem = self.resolve_active_stem(vault, name)?;
 
-        // Find the target version (opaque or legacy archive dir — same fallback
-        // as get_secret_version / list_versions).
-        let vdir = self.resolve_versions_dir(vault, name)?;
-        let ver_age = vdir.join(format!("{version}.age"));
-        let ver_meta = vdir.join(format!("{version}.meta.json"));
+            // Find the target version (opaque or legacy archive dir — same fallback
+            // as get_secret_version / list_versions).
+            let vdir = self.resolve_versions_dir(vault, name)?;
+            let ver_age = vdir.join(format!("{version}.age"));
+            let ver_meta = vdir.join(format!("{version}.meta.json"));
 
-        if !ver_meta.exists() {
-            return Err(BackendError::NotFound {
-                name: format!("{name}@{version}"),
-                suggestion: None,
-            });
+            if !ver_meta.exists() {
+                return Err(BackendError::NotFound {
+                    name: format!("{name}@{version}"),
+                    suggestion: None,
+                });
+            }
+
+            // Archive current as the next version
+            archive_current(&self.store_path, vault, &stem)?;
+
+            // Copy the target version files to current
+            let ap = age_path(&self.store_path, vault, &stem)?;
+            let mp = meta_path(&self.store_path, vault, &stem)?;
+
+            if ver_age.exists() {
+                fs::copy(&ver_age, &ap)
+                    .map_err(|e| BackendError::Internal(format!("restore age: {e}")))?;
+            }
+            fs::copy(&ver_meta, &mp)
+                .map_err(|e| BackendError::Internal(format!("restore meta: {e}")))?;
+
+            // Update the version label to the next version number
+            let mut meta = read_meta(&mp, &self.identity)?;
+            let next_ver = next_version(&self.store_path, vault, &stem)?;
+            meta.version = format!("v{next_ver}");
+            meta.revision = new_revision();
+            meta.updated_at = Utc::now();
+            write_meta(
+                &mp,
+                &meta,
+                MetaCrypto {
+                    recipients: &self.recipients,
+                    encrypt: self.encrypt_metadata,
+                },
+            )?;
+
+            // Upgrade legacy layout → opaque and refresh the index entry.
+            self.ensure_opaque_layout(vault, name)?;
+
+            Ok(meta_to_properties(&meta, None))
         }
-
-        // Archive current as the next version
-        archive_current(&self.store_path, vault, &stem)?;
-
-        // Copy the target version files to current
-        let ap = age_path(&self.store_path, vault, &stem)?;
-        let mp = meta_path(&self.store_path, vault, &stem)?;
-
-        if ver_age.exists() {
-            fs::copy(&ver_age, &ap)
-                .map_err(|e| BackendError::Internal(format!("restore age: {e}")))?;
+        .await;
+        if let Ok(__props) = &__result {
+            self.audit_record(vault, AuditOp::RollbackSecret, name)?;
+            self.git_commit(&format!("rollback {name} to {}", __props.version))?;
         }
-        fs::copy(&ver_meta, &mp)
-            .map_err(|e| BackendError::Internal(format!("restore meta: {e}")))?;
-
-        // Update the version label to the next version number
-        let mut meta = read_meta(&mp, &self.identity)?;
-        let next_ver = next_version(&self.store_path, vault, &stem)?;
-        meta.version = format!("v{next_ver}");
-        meta.revision = new_revision();
-        meta.updated_at = Utc::now();
-        write_meta(
-            &mp,
-            &meta,
-            MetaCrypto {
-                recipients: &self.recipients,
-                encrypt: self.encrypt_metadata,
-            },
-        )?;
-
-        // Upgrade legacy layout → opaque and refresh the index entry.
-        self.ensure_opaque_layout(vault, name)?;
-
-        Ok(meta_to_properties(&meta, None))
+        self.audit_failure(vault, AuditOp::RollbackSecret, name, __result)
     }
 
     async fn restore_secret(
@@ -2915,147 +3083,163 @@ impl SecretBackend for LocalSecretBackend {
         vault: &str,
         name: &str,
     ) -> Result<SecretProperties, BackendError> {
-        let vault_dir = paths::vault_dir(&self.store_path, vault)?;
-        if !vault_dir.join(".vault.json").exists() {
-            return Err(BackendError::VaultNotFound {
-                name: vault.to_string(),
-                suggestion: None,
-            });
+        let __result = async {
+            let vault_dir = paths::vault_dir(&self.store_path, vault)?;
+            if !vault_dir.join(".vault.json").exists() {
+                return Err(BackendError::VaultNotFound {
+                    name: vault.to_string(),
+                    suggestion: None,
+                });
+            }
+            let _lock = self.mutation_lock_for_name(vault, name)?;
+
+            // Restore the most recent trash entry for this name (legacy un-suffixed
+            // entries sort as oldest). Ties on timestamp break by path so the
+            // choice is deterministic regardless of read_dir order. Covers both
+            // opaque and legacy trash stems.
+            let mut entries = self.trash_entries_for(vault, name)?;
+            entries.sort();
+            let Some((_, tdir)) = entries.pop() else {
+                return Err(BackendError::NotFound {
+                    name: format!("{name} (deleted)"),
+                    suggestion: Some("Secret is not in the trash".into()),
+                });
+            };
+
+            // Inner files may be named with an opaque or legacy stem; locate by
+            // extension rather than recomputing a stem.
+            let (trash_age, trash_meta) = trash_inner_files(&tdir);
+            let Some(trash_meta) = trash_meta.filter(|p| p.exists()) else {
+                return Err(BackendError::NotFound {
+                    name: format!("{name} (deleted)"),
+                    suggestion: Some("Trash metadata not found".into()),
+                });
+            };
+
+            // Move files back to secrets/ at the active (opaque when enabled) stem.
+            let sdir = secrets_dir(&self.store_path, vault)?;
+            fs::create_dir_all(&sdir)
+                .map_err(|e| BackendError::Internal(format!("mkdir secrets: {e}")))?;
+
+            let target_stem = self.active_stem(name);
+            let ap = age_path(&self.store_path, vault, &target_stem)?;
+            let mp = meta_path(&self.store_path, vault, &target_stem)?;
+
+            // A restore must never displace an active value. Leave both the live
+            // secret and trash entry untouched so the caller can resolve the
+            // collision explicitly.
+            let existing_stem = self.resolve_active_stem(vault, name)?;
+            let existing_ap = age_path(&self.store_path, vault, &existing_stem)?;
+            let existing_mp = meta_path(&self.store_path, vault, &existing_stem)?;
+            if existing_ap.exists() || existing_mp.exists() {
+                return Err(BackendError::Conflict(format!(
+                    "secret '{name}' already exists in vault '{vault}'"
+                )));
+            }
+
+            if let Some(trash_age) = trash_age.filter(|p| p.exists()) {
+                fs::rename(&trash_age, &ap)
+                    .map_err(|e| BackendError::Internal(format!("restore age from trash: {e}")))?;
+            }
+            fs::rename(&trash_meta, &mp)
+                .map_err(|e| BackendError::Internal(format!("restore meta from trash: {e}")))?;
+
+            // Remove the trash entry
+            fs::remove_dir_all(&tdir)
+                .map_err(|e| BackendError::Internal(format!("remove trash dir: {e}")))?;
+
+            let mut meta = read_meta(&mp, &self.identity)?;
+            meta.revision = new_revision();
+            meta.updated_at = Utc::now();
+            write_meta(
+                &mp,
+                &meta,
+                MetaCrypto {
+                    recipients: &self.recipients,
+                    encrypt: self.encrypt_metadata,
+                },
+            )?;
+            sync_file(&mp)?;
+            sync_directory(mp.parent().expect("restored metadata has parent"))?;
+
+            // Re-add the active index entry and upgrade any remaining legacy layout.
+            self.ensure_opaque_layout(vault, name)?;
+
+            Ok(meta_to_properties(&meta, None))
         }
-        let _lock = self.mutation_lock_for_name(vault, name)?;
-
-        // Restore the most recent trash entry for this name (legacy un-suffixed
-        // entries sort as oldest). Ties on timestamp break by path so the
-        // choice is deterministic regardless of read_dir order. Covers both
-        // opaque and legacy trash stems.
-        let mut entries = self.trash_entries_for(vault, name)?;
-        entries.sort();
-        let Some((_, tdir)) = entries.pop() else {
-            return Err(BackendError::NotFound {
-                name: format!("{name} (deleted)"),
-                suggestion: Some("Secret is not in the trash".into()),
-            });
-        };
-
-        // Inner files may be named with an opaque or legacy stem; locate by
-        // extension rather than recomputing a stem.
-        let (trash_age, trash_meta) = trash_inner_files(&tdir);
-        let Some(trash_meta) = trash_meta.filter(|p| p.exists()) else {
-            return Err(BackendError::NotFound {
-                name: format!("{name} (deleted)"),
-                suggestion: Some("Trash metadata not found".into()),
-            });
-        };
-
-        // Move files back to secrets/ at the active (opaque when enabled) stem.
-        let sdir = secrets_dir(&self.store_path, vault)?;
-        fs::create_dir_all(&sdir)
-            .map_err(|e| BackendError::Internal(format!("mkdir secrets: {e}")))?;
-
-        let target_stem = self.active_stem(name);
-        let ap = age_path(&self.store_path, vault, &target_stem)?;
-        let mp = meta_path(&self.store_path, vault, &target_stem)?;
-
-        // A restore must never displace an active value. Leave both the live
-        // secret and trash entry untouched so the caller can resolve the
-        // collision explicitly.
-        let existing_stem = self.resolve_active_stem(vault, name)?;
-        let existing_ap = age_path(&self.store_path, vault, &existing_stem)?;
-        let existing_mp = meta_path(&self.store_path, vault, &existing_stem)?;
-        if existing_ap.exists() || existing_mp.exists() {
-            return Err(BackendError::Conflict(format!(
-                "secret '{name}' already exists in vault '{vault}'"
-            )));
+        .await;
+        if __result.is_ok() {
+            self.audit_record(vault, AuditOp::RestoreSecret, name)?;
+            self.git_commit(&format!("restore {name}"))?;
         }
-
-        if let Some(trash_age) = trash_age.filter(|p| p.exists()) {
-            fs::rename(&trash_age, &ap)
-                .map_err(|e| BackendError::Internal(format!("restore age from trash: {e}")))?;
-        }
-        fs::rename(&trash_meta, &mp)
-            .map_err(|e| BackendError::Internal(format!("restore meta from trash: {e}")))?;
-
-        // Remove the trash entry
-        fs::remove_dir_all(&tdir)
-            .map_err(|e| BackendError::Internal(format!("remove trash dir: {e}")))?;
-
-        let mut meta = read_meta(&mp, &self.identity)?;
-        meta.revision = new_revision();
-        meta.updated_at = Utc::now();
-        write_meta(
-            &mp,
-            &meta,
-            MetaCrypto {
-                recipients: &self.recipients,
-                encrypt: self.encrypt_metadata,
-            },
-        )?;
-        sync_file(&mp)?;
-        sync_directory(mp.parent().expect("restored metadata has parent"))?;
-
-        // Re-add the active index entry and upgrade any remaining legacy layout.
-        self.ensure_opaque_layout(vault, name)?;
-
-        Ok(meta_to_properties(&meta, None))
+        self.audit_failure(vault, AuditOp::RestoreSecret, name, __result)
     }
 
     async fn purge_secret(&self, vault: &str, name: &str) -> Result<(), BackendError> {
-        let vault_dir = paths::vault_dir(&self.store_path, vault)?;
-        if !vault_dir.join(".vault.json").exists() {
-            return Err(BackendError::VaultNotFound {
-                name: vault.to_string(),
-                suggestion: None,
-            });
-        }
-        let _lock = self.mutation_lock_for_name(vault, name)?;
-
-        let trash_entries = self.trash_entries_for(vault, name)?;
-        if trash_entries.is_empty() {
-            return Err(BackendError::NotFound {
-                name: format!("{name} (deleted)"),
-                suggestion: Some("Secret is not in the trash".into()),
-            });
-        }
-
-        // A same-name active secret may have been recreated after deletion.
-        // Purging the old trash must not erase that live secret's versions.
-        let mut active_stems = vec![self.active_stem(name)];
-        if self.opaque_filenames {
-            active_stems.push(encode_name(name));
-        }
-        let has_active = active_stems.iter().try_fold(false, |found, stem| {
-            Ok::<_, BackendError>(
-                found
-                    || age_path(&self.store_path, vault, stem)?.exists()
-                    || meta_path(&self.store_path, vault, stem)?.exists(),
-            )
-        })?;
-
-        // Permanently remove every trash entry for this name (opaque + legacy
-        // stems, suffixed and unsuffixed).
-        for (_, tdir) in trash_entries {
-            fs::remove_dir_all(&tdir)
-                .map_err(|e| BackendError::Internal(format!("purge trash: {e}")))?;
-        }
-
-        // With no active same-name secret, versions belong only to the
-        // deleted secret and are purged with it. Otherwise preserve the
-        // shared version namespace for the active value.
-        if !has_active {
-            let mut version_stems = vec![self.active_stem(name)];
-            if self.opaque_filenames {
-                version_stems.push(encode_name(name));
+        let __result = async {
+            let vault_dir = paths::vault_dir(&self.store_path, vault)?;
+            if !vault_dir.join(".vault.json").exists() {
+                return Err(BackendError::VaultNotFound {
+                    name: vault.to_string(),
+                    suggestion: None,
+                });
             }
-            for stem in version_stems {
-                let vdir = versions_dir(&self.store_path, vault, &stem)?;
-                if vdir.exists() {
-                    fs::remove_dir_all(&vdir)
-                        .map_err(|e| BackendError::Internal(format!("purge versions: {e}")))?;
+            let _lock = self.mutation_lock_for_name(vault, name)?;
+
+            let trash_entries = self.trash_entries_for(vault, name)?;
+            if trash_entries.is_empty() {
+                return Err(BackendError::NotFound {
+                    name: format!("{name} (deleted)"),
+                    suggestion: Some("Secret is not in the trash".into()),
+                });
+            }
+
+            // A same-name active secret may have been recreated after deletion.
+            // Purging the old trash must not erase that live secret's versions.
+            let mut active_stems = vec![self.active_stem(name)];
+            if self.opaque_filenames {
+                active_stems.push(encode_name(name));
+            }
+            let has_active = active_stems.iter().try_fold(false, |found, stem| {
+                Ok::<_, BackendError>(
+                    found
+                        || age_path(&self.store_path, vault, stem)?.exists()
+                        || meta_path(&self.store_path, vault, stem)?.exists(),
+                )
+            })?;
+
+            // Permanently remove every trash entry for this name (opaque + legacy
+            // stems, suffixed and unsuffixed).
+            for (_, tdir) in trash_entries {
+                fs::remove_dir_all(&tdir)
+                    .map_err(|e| BackendError::Internal(format!("purge trash: {e}")))?;
+            }
+
+            // With no active same-name secret, versions belong only to the
+            // deleted secret and are purged with it. Otherwise preserve the
+            // shared version namespace for the active value.
+            if !has_active {
+                let mut version_stems = vec![self.active_stem(name)];
+                if self.opaque_filenames {
+                    version_stems.push(encode_name(name));
+                }
+                for stem in version_stems {
+                    let vdir = versions_dir(&self.store_path, vault, &stem)?;
+                    if vdir.exists() {
+                        fs::remove_dir_all(&vdir)
+                            .map_err(|e| BackendError::Internal(format!("purge versions: {e}")))?;
+                    }
                 }
             }
-        }
 
-        Ok(())
+            Ok(())
+        }
+        .await;
+        if __result.is_ok() {
+            self.audit_record(vault, AuditOp::PurgeSecret, name)?;
+            self.git_commit(&format!("purge {name}"))?;
+        }
+        self.audit_failure(vault, AuditOp::PurgeSecret, name, __result)
     }
 
     async fn list_deleted_secrets(

--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -447,6 +447,8 @@ mod tests {
                 default_vault: Some("default".into()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
             ..Default::default()
         };
@@ -496,6 +498,8 @@ mod tests {
                 default_vault: Some("default".into()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
         );
         named_backends.insert(
@@ -506,6 +510,8 @@ mod tests {
                 default_vault: Some("default".into()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
         );
 
@@ -590,6 +596,8 @@ mod tests {
                 default_vault: Some("default".into()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
             ..Default::default()
         };

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1580,7 +1580,8 @@ pub enum GitCommands {
 
     /// Show the store's commit history, newest first.
     Log {
-        /// Restrict history to commits touching this secret.
+        /// Restrict history to commits recorded for this secret (matched by
+        /// commit subject, so it works with opaque on-disk filenames too).
         secret: Option<String>,
         /// Maximum commits to show (0 = all).
         #[arg(long, default_value = "20")]

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -636,13 +636,32 @@ pub enum Commands {
     },
     /// Rotate a secret with a new random value
     Rotate {
-        /// Secret name
-        name: String,
+        /// Secret name. Omit it with --due or --check, which operate on every
+        /// secret in the vault that carries a rotation policy.
+        name: Option<String>,
         /// Target vault (overrides context/config default). Matches an
         /// attached workspace alias when given; otherwise a literal vault on
         /// the current backend.
         #[arg(long)]
         vault: Option<String>,
+        /// Set (or refresh) this secret's rotation policy while rotating.
+        ///
+        /// Interval syntax: `<n>m|h|d|w`, e.g. `90d`, `12h`, `6w`. The policy
+        /// is stored with the secret and works on every backend. Nothing
+        /// rotates on a timer by itself — run `xv rotate --due` from cron, a
+        /// systemd timer, or CI to act on it.
+        #[arg(long, value_name = "INTERVAL", conflicts_with_all = ["native", "due", "check"])]
+        every: Option<String>,
+        /// Rotate every secret in the vault whose rotation policy is due.
+        ///
+        /// Secrets without a policy are untouched. Intended for cron/CI.
+        #[arg(long, conflicts_with_all = ["name", "native", "check"])]
+        due: bool,
+        /// Report which secrets are due for rotation without rotating anything.
+        ///
+        /// Exits 51 when at least one secret is due, so CI can gate on it.
+        #[arg(long, conflicts_with_all = ["name", "native", "due"])]
+        check: bool,
         /// Length of the generated value (default: 32)
         #[arg(long, default_value = "32")]
         length: usize,
@@ -795,6 +814,31 @@ pub enum Commands {
         /// Clear the folder
         #[arg(long, conflicts_with = "folder")]
         clear_folder: bool,
+        /// Set the secret's rotation policy without rotating it now.
+        ///
+        /// Interval syntax: `<n>m|h|d|w`, e.g. `90d`. The rotation clock starts
+        /// at the moment this runs, so the secret is not immediately reported as
+        /// due. Act on the policy with `xv rotate --due`; inspect it with
+        /// `xv rotate --check`.
+        ///
+        /// A standalone operation, like --field: combine with other edits by
+        /// running two commands.
+        #[arg(long, value_name = "INTERVAL", conflicts_with_all = [
+            "type", "untype", "fields", "secret_fields",
+            "value", "stdin", "trim", "tags", "group", "rename", "note", "folder",
+            "replace_tags", "replace_groups", "expires", "not_before",
+            "clear_expires", "clear_not_before", "clear_note", "clear_folder", "enabled",
+        ])]
+        rotate_every: Option<String>,
+        /// Remove the secret's rotation policy. Standalone, like --rotate-every.
+        #[arg(long, conflicts_with_all = [
+            "rotate_every",
+            "type", "untype", "fields", "secret_fields",
+            "value", "stdin", "trim", "tags", "group", "rename", "note", "folder",
+            "replace_tags", "replace_groups", "expires", "not_before",
+            "clear_expires", "clear_not_before", "clear_note", "clear_folder", "enabled",
+        ])]
+        clear_rotate_every: bool,
         /// Enable or disable the secret (true/false)
         #[arg(long)]
         enabled: Option<bool>,
@@ -1007,6 +1051,15 @@ pub enum Commands {
         /// Azure resource group (defaults to config value)
         #[arg(long)]
         resource_group: Option<String>,
+        /// Verify the integrity of the local backend's hash-chained audit log
+        /// instead of listing events.
+        ///
+        /// Recomputes every record's MAC and link. Reports the first break and
+        /// exits non-zero when the chain has been altered. Local backend only:
+        /// Azure and AWS audit trails live in the platform, which is what makes
+        /// them independently trustworthy.
+        #[arg(long, conflicts_with_all = ["days", "operation", "resource_group"])]
+        verify: bool,
     },
     /// Initialize default configuration
     Init,
@@ -1058,6 +1111,26 @@ pub enum Commands {
     Type {
         #[command(subcommand)]
         command: TypeCommands,
+    },
+    /// Manage the automatic rotation schedule.
+    ///
+    /// Installs a per-user job in the platform's own scheduler (launchd on
+    /// macOS, a systemd user timer on Linux, Task Scheduler on Windows) that
+    /// runs `xv rotate --due --force` on a cadence. No daemon, and nothing
+    /// system-wide.
+    Schedule {
+        #[command(subcommand)]
+        command: ScheduleCommands,
+    },
+    /// Git-native versioning for the local age-encrypted store.
+    ///
+    /// Only age ciphertext and metadata are committed — never the age identity.
+    /// Local backend only: on Azure and AWS, version history lives in the
+    /// backend (`xv history` / `xv rollback`), and mirroring cloud secrets into
+    /// a git history would create a second permanent copy of every value.
+    Git {
+        #[command(subcommand)]
+        command: GitCommands,
     },
     /// Quick file upload (alias for file upload)
     #[cfg(feature = "file-ops")]
@@ -1444,6 +1517,103 @@ pub enum CacheCommands {
     Refresh {
         #[arg(long)]
         key: String,
+    },
+}
+
+/// Rotation-schedule subcommands.
+#[derive(Subcommand)]
+pub enum ScheduleCommands {
+    /// Install (or reinstall) the automatic rotation schedule.
+    ///
+    /// The scheduled job runs `xv rotate --due --force`, so only secrets that
+    /// already carry a rotation policy and are already past it are touched.
+    /// Reinstalling replaces the existing job.
+    Install {
+        /// How often the sweep runs.
+        #[arg(long, default_value = "daily", value_parser = ["hourly", "daily", "weekly"])]
+        interval: String,
+
+        /// Time of day in 24-hour `HH:MM`. Ignored for `--interval hourly`
+        /// except for its minute; weekly runs on Sunday.
+        #[arg(long, default_value = "03:00")]
+        at: String,
+
+        /// Vault to sweep. Defaults to the configured `default_vault`; pin it
+        /// explicitly so the scheduled run cannot follow a context that changes
+        /// later.
+        #[arg(long)]
+        vault: Option<String>,
+
+        /// Where the scheduled run's output is appended (default:
+        /// `$XDG_STATE_HOME/xv/rotate.log`, else `~/.local/state/xv/rotate.log`).
+        #[arg(long)]
+        log_file: Option<String>,
+
+        /// Print the unit file(s) and the exact command instead of installing.
+        /// Writes nothing and registers nothing — use it to review, or to copy
+        /// the command into a scheduler this tool does not manage.
+        #[arg(long)]
+        print: bool,
+
+        /// Skip the confirmation prompt.
+        #[arg(short, long)]
+        force: bool,
+    },
+
+    /// Show whether a rotation schedule is installed and what the scheduler
+    /// reports about it.
+    Status,
+
+    /// Remove the rotation schedule. Succeeds when none is installed.
+    Uninstall,
+}
+
+/// Git-native versioning subcommands for the local store.
+#[derive(Subcommand)]
+pub enum GitCommands {
+    /// Initialize a git repository in the local store.
+    ///
+    /// Writes a managed `.gitignore` that excludes the age identity and
+    /// recipients files. Safe to re-run. Auto-commit still requires
+    /// `git = true` under `[local]`.
+    Init,
+
+    /// Show the store's commit history, newest first.
+    Log {
+        /// Restrict history to commits touching this secret.
+        secret: Option<String>,
+        /// Maximum commits to show (0 = all).
+        #[arg(long, default_value = "20")]
+        limit: usize,
+    },
+
+    /// Show uncommitted changes in the store.
+    Status,
+
+    /// Show which files a commit changed (names only, never contents).
+    Diff {
+        /// Revision to inspect (default: HEAD).
+        rev: Option<String>,
+    },
+
+    /// Push the store to a git remote.
+    Push {
+        /// Remote name.
+        #[arg(default_value = "origin")]
+        remote: String,
+        /// Branch to push (default: the current branch's upstream).
+        #[arg(long)]
+        branch: Option<String>,
+    },
+
+    /// Pull the store from a git remote (fast-forward only).
+    Pull {
+        /// Remote name.
+        #[arg(default_value = "origin")]
+        remote: String,
+        /// Branch to pull.
+        #[arg(long)]
+        branch: Option<String>,
     },
 }
 
@@ -1934,10 +2104,13 @@ impl Cli {
                 native,
                 show_value,
                 force,
+                every,
+                due,
+                check,
             } => {
-                crate::cli::secret_ops::execute_secret_rotate_direct(
-                    &name, vault, length, charset, generator, native, show_value, force, config,
-                    registry,
+                crate::cli::secret_ops::execute_rotate(
+                    name, vault, length, charset, generator, native, show_value, force, every, due,
+                    check, config, registry,
                 )
                 .await
             }
@@ -2020,7 +2193,22 @@ impl Cli {
                 r#type,
                 untype,
                 yes,
+                rotate_every,
+                clear_rotate_every,
             } => {
+                // Rotation-policy edits are a standalone operation (clap
+                // enforces the exclusions), so they short-circuit the classic
+                // update path rather than threading two more fields through it.
+                if rotate_every.is_some() || clear_rotate_every {
+                    return crate::cli::secret_ops::execute_rotation_policy_update(
+                        &name,
+                        rotate_every,
+                        clear_rotate_every,
+                        config,
+                        registry,
+                    )
+                    .await;
+                }
                 crate::cli::secret_ops::execute_secret_update_direct(
                     &name,
                     value,
@@ -2163,17 +2351,22 @@ impl Cli {
                 days,
                 operation,
                 resource_group,
+                verify,
             } => {
-                crate::cli::system_ops::execute_audit_command(
-                    name,
-                    vault,
-                    days,
-                    operation,
-                    resource_group,
-                    config,
-                    registry,
-                )
-                .await
+                if verify {
+                    crate::cli::system_ops::execute_audit_verify_command(vault, config).await
+                } else {
+                    crate::cli::system_ops::execute_audit_command(
+                        name,
+                        vault,
+                        days,
+                        operation,
+                        resource_group,
+                        config,
+                        registry,
+                    )
+                    .await
+                }
             }
             Commands::Init => crate::cli::system_ops::execute_init_command(config).await,
             Commands::Info {
@@ -2211,6 +2404,12 @@ impl Cli {
             }
             Commands::Type { command } => {
                 crate::cli::type_ops::execute_type_command(command, config).await
+            }
+            Commands::Git { command } => {
+                crate::cli::git_ops::execute_git_command(command, config).await
+            }
+            Commands::Schedule { command } => {
+                crate::cli::schedule_ops::execute_schedule_command(command, config).await
             }
             #[cfg(feature = "file-ops")]
             Commands::Upload {

--- a/src/cli/git_ops.rs
+++ b/src/cli/git_ops.rs
@@ -1,0 +1,195 @@
+//! Git-native versioning command handlers (`xv git ...`).
+//!
+//! These operate on the **local** store only. Azure and AWS keep their
+//! backend-native version history (`xv history` / `xv rollback`); mirroring
+//! cloud secret values into a git repository would create a second, effectively
+//! permanent copy of every secret version, so it is deliberately not offered.
+
+use crate::backend::local::git::LocalGitStore;
+use crate::backend::local::LocalBackend;
+use crate::cli::commands::GitCommands;
+use crate::config::Config;
+use crate::error::{CrosstacheError, Result};
+use crate::utils::format::{OutputFormat, TableFormatter};
+use crate::utils::output;
+use std::sync::Arc;
+use tabled::Tabled;
+
+pub(crate) async fn execute_git_command(command: GitCommands, config: Config) -> Result<()> {
+    let store = open_store(&config)?;
+
+    match command {
+        GitCommands::Init => execute_init(&store, &config),
+        GitCommands::Log { secret, limit } => {
+            execute_log(&store, secret.as_deref(), limit, &config)
+        }
+        GitCommands::Status => execute_status(&store),
+        GitCommands::Diff { rev } => execute_diff(&store, rev.as_deref()),
+        GitCommands::Push { remote, branch } => execute_push(&store, &remote, branch.as_deref()),
+        GitCommands::Pull { remote, branch } => execute_pull(&store, &remote, branch.as_deref()),
+    }
+}
+
+/// Open a git store for the configured local backend.
+///
+/// When `[local].git` is on, this reuses the very store the backend commits
+/// through, so the CLI and the write path can never disagree about which
+/// repository they mean. When it is off, an unconditional store is built anyway
+/// — `xv git init` has to work *before* the flag is switched on, or enabling
+/// versioning would require a repo and the repo would require the flag.
+fn open_store(config: &Config) -> Result<Arc<LocalGitStore>> {
+    if config.effective_backend_name() != "local" {
+        return Err(CrosstacheError::InvalidArgument(format!(
+            "`xv git` versions the local age-encrypted store, but the active backend is '{}'. \
+             On Azure and AWS, secret history lives in the backend itself — use 'xv history' and \
+             'xv rollback'. Set backend = \"local\" (or pass --backend local) to use git \
+             versioning.",
+            config.effective_backend_name()
+        )));
+    }
+
+    let backend = LocalBackend::new(config.local.as_ref())
+        .map_err(|e| CrosstacheError::config(format!("failed to open local backend: {e}")))?;
+    Ok(match backend.git_store() {
+        Some(store) => Arc::clone(store),
+        None => Arc::new(backend.git_store_unconditional()),
+    })
+}
+
+fn execute_init(store: &LocalGitStore, config: &Config) -> Result<()> {
+    let existed = store.is_repo();
+    store
+        .ensure_repo()
+        .map_err(|e| CrosstacheError::config(format!("git init failed: {e}")))?;
+
+    if existed {
+        output::success("The local store is already a git repository; refreshed .gitignore.");
+    } else {
+        output::success("Initialized a git repository in the local store.");
+    }
+
+    // The repo alone changes nothing until the flag turns on auto-commit, so
+    // say so rather than letting the user assume writes are being recorded.
+    let auto_commit = config.local.as_ref().and_then(|c| c.git).unwrap_or(false);
+    if !auto_commit {
+        output::hint(
+            "Set `git = true` under [local] in your config to commit automatically on every \
+             write. Until then, this repository will not record new changes.",
+        );
+    }
+    Ok(())
+}
+
+/// One row of `xv git log`. Column names match the repo's list-command style so
+/// `--columns Commit,Subject` behaves like it does elsewhere.
+#[derive(Tabled, serde::Serialize)]
+struct CommitRow {
+    #[tabled(rename = "Commit")]
+    commit: String,
+    #[tabled(rename = "Date")]
+    date: String,
+    #[tabled(rename = "Subject")]
+    subject: String,
+}
+
+fn execute_log(
+    store: &LocalGitStore,
+    secret: Option<&str>,
+    limit: usize,
+    config: &Config,
+) -> Result<()> {
+    let commits = store
+        .log(secret, limit)
+        .map_err(|e| CrosstacheError::config(e.to_string()))?;
+
+    let rows: Vec<CommitRow> = commits
+        .into_iter()
+        .map(|c| CommitRow {
+            commit: c.hash,
+            date: c.date,
+            subject: c.subject,
+        })
+        .collect();
+
+    let fmt = config.runtime_output_format;
+    let human_table_like = matches!(
+        fmt,
+        OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+    );
+    let formatter = TableFormatter::new(
+        fmt,
+        config.no_color,
+        config.template.clone(),
+        config.runtime_columns.clone(),
+    );
+
+    if rows.is_empty() {
+        if human_table_like {
+            formatter.validate_columns::<CommitRow>()?;
+            let scope = secret.map_or_else(String::new, |s| format!(" for '{s}'"));
+            output::info(&format!("No commits{scope}."));
+        } else {
+            // Valid-empty machine output, so `| jq` still works.
+            println!("{}", formatter.format_table(&rows)?);
+        }
+        return Ok(());
+    }
+
+    println!("{}", formatter.format_table(&rows)?);
+    Ok(())
+}
+
+fn execute_status(store: &LocalGitStore) -> Result<()> {
+    let status = store
+        .status()
+        .map_err(|e| CrosstacheError::config(e.to_string()))?;
+
+    // `--branch` always emits a leading `## <branch>` line, so emptiness is not
+    // the cleanliness test — the absence of any *entry* line is.
+    let has_changes = status
+        .lines()
+        .any(|line| !line.trim().is_empty() && !line.starts_with("##"));
+
+    if has_changes {
+        print!("{status}");
+    } else {
+        output::success("The local store is clean; every change is committed.");
+    }
+    Ok(())
+}
+
+fn execute_diff(store: &LocalGitStore, rev: Option<&str>) -> Result<()> {
+    let diff = store
+        .diff(rev)
+        .map_err(|e| CrosstacheError::config(e.to_string()))?;
+    print!("{diff}");
+    Ok(())
+}
+
+fn execute_push(store: &LocalGitStore, remote: &str, branch: Option<&str>) -> Result<()> {
+    output::step(&format!("Pushing the local store to '{remote}'"));
+    let out = store
+        .push(remote, branch)
+        .map_err(|e| CrosstacheError::config(e.to_string()))?;
+    if !out.trim().is_empty() {
+        print!("{out}");
+    }
+    output::success(&format!("Pushed the local store to '{remote}'."));
+    Ok(())
+}
+
+fn execute_pull(store: &LocalGitStore, remote: &str, branch: Option<&str>) -> Result<()> {
+    output::step(&format!("Pulling the local store from '{remote}'"));
+    let out = store.pull(remote, branch).map_err(|e| {
+        CrosstacheError::config(format!(
+            "{e}\n  hint: 'xv git pull' is fast-forward only. Divergent stores cannot be \
+             merged automatically, because a merge conflict inside age ciphertext is not \
+             resolvable. Reconcile the histories manually with git."
+        ))
+    })?;
+    if !out.trim().is_empty() {
+        print!("{out}");
+    }
+    output::success(&format!("Pulled the local store from '{remote}'."));
+    Ok(())
+}

--- a/src/cli/migrate_ops.rs
+++ b/src/cli/migrate_ops.rs
@@ -670,6 +670,8 @@ mod tests {
             default_vault: Some("default".into()),
             encrypt_metadata: None,
             opaque_filenames: None,
+            audit: None,
+            git: None,
         };
         let target_config = LocalConfig {
             store_path: Some(
@@ -689,6 +691,8 @@ mod tests {
             default_vault: Some("default".into()),
             encrypt_metadata: None,
             opaque_filenames: None,
+            audit: None,
+            git: None,
         };
 
         // Create source backend and seed it with secrets
@@ -801,6 +805,8 @@ mod tests {
             default_vault: Some("default".into()),
             encrypt_metadata: None,
             opaque_filenames: None,
+            audit: None,
+            git: None,
         };
         let target_config = LocalConfig {
             store_path: Some(
@@ -820,6 +826,8 @@ mod tests {
             default_vault: Some("default".into()),
             encrypt_metadata: None,
             opaque_filenames: None,
+            audit: None,
+            git: None,
         };
         let source = crate::backend::local::LocalBackend::new(Some(&source_config)).unwrap();
         let target = crate::backend::local::LocalBackend::new(Some(&target_config)).unwrap();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,12 +11,14 @@ pub(crate) mod config_ops;
 pub mod file;
 #[cfg(feature = "file-ops")]
 pub mod file_ops;
+pub(crate) mod git_ops;
 pub(crate) mod helpers;
 pub(crate) mod local_ops;
 pub(crate) mod ls_view;
 pub(crate) mod migrate_ops;
 pub(crate) mod mv_ops;
 pub(crate) mod scan_ops;
+pub(crate) mod schedule_ops;
 pub(crate) mod secret_ops;
 pub(crate) mod system_ops;
 pub(crate) mod type_ops;

--- a/src/cli/schedule_ops.rs
+++ b/src/cli/schedule_ops.rs
@@ -1,0 +1,261 @@
+//! Rotation-schedule command handlers (`xv schedule ...`).
+//!
+//! Thin layer over [`crate::schedule`]: resolves the schedule from CLI flags,
+//! confirms the consequences of unattended rotation, and reports what the
+//! platform scheduler says.
+
+use std::path::{Path, PathBuf};
+
+use crate::cli::commands::ScheduleCommands;
+use crate::config::Config;
+use crate::error::{CrosstacheError, Result};
+use crate::schedule::{
+    self, Platform, ProcessRunner, RotationSchedule, ScheduleInterval, UnitPaths,
+};
+use crate::utils::output;
+
+pub(crate) async fn execute_schedule_command(
+    command: ScheduleCommands,
+    config: Config,
+) -> Result<()> {
+    match command {
+        ScheduleCommands::Install {
+            interval,
+            at,
+            vault,
+            log_file,
+            print,
+            force,
+        } => execute_install(&interval, &at, vault, log_file, print, force, &config).await,
+        ScheduleCommands::Status => execute_status(&config).await,
+        ScheduleCommands::Uninstall => execute_uninstall().await,
+    }
+}
+
+/// Home directory used for both the unit location and the scheduled process's
+/// `HOME`.
+fn home_dir() -> Result<PathBuf> {
+    dirs::home_dir().ok_or_else(|| {
+        CrosstacheError::config("could not determine the home directory".to_string())
+    })
+}
+
+/// Default log destination: `$XDG_STATE_HOME/xv/rotate.log`, else
+/// `~/.local/state/xv/rotate.log`.
+fn default_log_path(home: &Path) -> PathBuf {
+    std::env::var("XDG_STATE_HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".local/state"))
+        .join("xv")
+        .join("rotate.log")
+}
+
+/// Build the schedule from flags plus the current process's environment.
+fn build_schedule(
+    interval: ScheduleInterval,
+    vault: Option<String>,
+    log_file: Option<String>,
+) -> Result<RotationSchedule> {
+    let home = home_dir()?;
+
+    // The absolute path of *this* binary, so the unit keeps working when PATH
+    // changes or the user's shell init is not sourced.
+    let binary = std::env::current_exe().map_err(|e| {
+        CrosstacheError::config(format!(
+            "could not determine the path to the running xv binary: {e}"
+        ))
+    })?;
+
+    Ok(RotationSchedule {
+        interval,
+        vault,
+        binary,
+        log_path: log_file
+            .map(PathBuf::from)
+            .unwrap_or_else(|| default_log_path(&home)),
+        // Carry the *current* config location into the unit so the scheduled run
+        // resolves the same configuration the user just tested against.
+        config_home: std::env::var("XDG_CONFIG_HOME")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from),
+        home,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_install(
+    interval: &str,
+    at: &str,
+    vault: Option<String>,
+    log_file: Option<String>,
+    print: bool,
+    force: bool,
+    config: &Config,
+) -> Result<()> {
+    let interval = ScheduleInterval::from_parts(interval, at)?;
+    let platform = Platform::detect()?;
+
+    // Default to the vault the user is actually working in, rather than leaving
+    // the scheduled run to re-resolve a context that may since have changed.
+    let vault = match vault {
+        Some(v) => Some(v),
+        None => Some(config.default_vault.clone()).filter(|v| !v.is_empty()),
+    };
+
+    let schedule = build_schedule(interval, vault.clone(), log_file)?;
+    let paths = UnitPaths::for_platform(platform, &schedule.home);
+
+    if print {
+        // Dry run: show exactly what would be installed, write nothing.
+        println!("# scheduler: {}", platform.name());
+        println!("# schedule:  {}", schedule.interval.describe());
+        println!("# command:   {}", schedule.command_line());
+        println!("# log:       {}", schedule.log_path.display());
+        for unit in schedule::render(platform, &schedule, &paths) {
+            println!("\n# --- {} ---", unit.path.display());
+            print!("{}", unit.contents);
+        }
+        if platform == Platform::Schtasks {
+            println!(
+                "\n# --- schtasks invocation ---\nschtasks {}",
+                schedule::schtasks_create_args(&schedule).join(" ")
+            );
+        }
+        return Ok(());
+    }
+
+    if !force {
+        output::warn(&format!(
+            "This installs a {} job that runs unattended, {}:\n    {}\n\n\
+             It rotates every secret whose rotation policy is already due, replacing values \
+             without asking. Anything still holding an old value keeps using it until it \
+             re-reads the secret or restarts, so unless rotation is sequenced with your \
+             rollout this will eventually break something while nobody is watching.\n\
+             Secrets with no rotation policy are never touched.",
+            platform.name(),
+            schedule.interval.describe(),
+            schedule.command_line(),
+        ));
+        if vault.is_none() {
+            output::warn(
+                "No --vault was given and no default_vault is configured, so the scheduled run \
+                 will resolve whatever vault its context points at when it fires. Pass --vault to \
+                 pin it.",
+            );
+        }
+        // Without a terminal there is nobody to confirm to. Say so directly
+        // rather than surfacing a generic "not a terminal" I/O failure, which
+        // reads like a bug in a provisioning script.
+        if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+            return Err(CrosstacheError::InvalidArgument(
+                "installing a rotation schedule needs confirmation, but stdin is not a \
+                 terminal. Re-run with --force to install unattended, or --print to review \
+                 the unit without installing."
+                    .to_string(),
+            ));
+        }
+        let prompt = crate::utils::interactive::InteractivePrompt::new();
+        if !prompt.confirm("Install this rotation schedule?", false)? {
+            output::info("Not installed.");
+            return Ok(());
+        }
+    }
+
+    schedule::install(platform, &schedule, &paths, &ProcessRunner)?;
+
+    output::success(&format!(
+        "Installed a {} rotation schedule: {}.",
+        platform.name(),
+        schedule.interval.describe()
+    ));
+    output::info(&format!("  Command: {}", schedule.command_line()));
+    output::info(&format!("  Log:     {}", schedule.log_path.display()));
+    for unit in schedule::unit_paths_for(platform, &paths) {
+        output::info(&format!("  Unit:    {}", unit.display()));
+    }
+    output::hint(
+        "A scheduled run has no terminal, so any credential that needs interaction will fail \
+         there even though it works for you now. Verify with 'xv rotate --due --force' in a \
+         clean shell, then watch the log after the first firing. 'xv schedule status' shows \
+         whether the scheduler is happy.",
+    );
+    Ok(())
+}
+
+async fn execute_status(config: &Config) -> Result<()> {
+    let platform = Platform::detect()?;
+    let home = home_dir()?;
+    let paths = UnitPaths::for_platform(platform, &home);
+
+    let status = schedule::status(platform, &paths, &ProcessRunner)?;
+
+    if status.installed {
+        output::success(&format!(
+            "A {} rotation schedule is installed.",
+            platform.name()
+        ));
+    } else {
+        output::info(&format!(
+            "No {} rotation schedule is installed.",
+            platform.name()
+        ));
+    }
+    output::info(&format!("  {}", status.detail));
+
+    for unit in schedule::unit_paths_for(platform, &paths) {
+        output::info(&format!(
+            "  Unit:    {} ({})",
+            unit.display(),
+            if unit.exists() { "present" } else { "absent" }
+        ));
+    }
+
+    let log = default_log_path(&home);
+    output::info(&format!(
+        "  Log:     {} ({})",
+        log.display(),
+        if log.exists() {
+            "present"
+        } else {
+            "not yet written"
+        }
+    ));
+
+    if !status.installed {
+        output::hint("Install one with 'xv schedule install --vault <vault>'.");
+        return Ok(());
+    }
+
+    // What the schedule will actually act on, so status answers the real
+    // question — "will anything rotate tonight?" — not just "is a job present?".
+    let vault_hint = if config.default_vault.is_empty() {
+        "<resolved from context at run time>".to_string()
+    } else {
+        config.default_vault.clone()
+    };
+    output::info(&format!("  Vault:   {vault_hint}"));
+    output::hint("Run 'xv rotate --check' to see which secrets the next sweep would rotate.");
+    Ok(())
+}
+
+async fn execute_uninstall() -> Result<()> {
+    let platform = Platform::detect()?;
+    let home = home_dir()?;
+    let paths = UnitPaths::for_platform(platform, &home);
+
+    if schedule::uninstall(platform, &paths, &ProcessRunner)? {
+        output::success(&format!(
+            "Removed the {} rotation schedule.",
+            platform.name()
+        ));
+    } else {
+        output::info(&format!(
+            "No {} rotation schedule was installed; nothing to remove.",
+            platform.name()
+        ));
+    }
+    Ok(())
+}

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -3089,6 +3089,7 @@ pub(crate) async fn execute_secret_rotate_direct(
     native: bool,
     show_value: bool,
     force: bool,
+    every: Option<String>,
     config: Config,
     registry: Option<&BackendRegistry>,
 ) -> Result<()> {
@@ -3096,6 +3097,13 @@ pub(crate) async fn execute_secret_rotate_direct(
     if native {
         return execute_secret_rotate_native(name, vault, force, config, registry).await;
     }
+
+    // Parse the policy interval up front: a typo must fail before anything
+    // rotates, not after the value has already been replaced.
+    let interval = every
+        .as_deref()
+        .map(crate::secret::rotation::parse_interval)
+        .transpose()?;
 
     // Route through the active backend trait so default (client-side) rotation
     // works on every backend; the Azure trait impl delegates to the same ops.
@@ -3129,6 +3137,7 @@ pub(crate) async fn execute_secret_rotate_direct(
         generator,
         show_value,
         force,
+        interval,
         &config,
     )
     .await?;
@@ -3146,6 +3155,431 @@ pub(crate) async fn execute_secret_rotate_direct(
     });
 
     Ok(())
+}
+
+/// `xv update <name> --rotate-every <interval>` / `--clear-rotate-every`.
+///
+/// Sets or removes a rotation policy without rotating the value. Setting one
+/// also stamps `xv:rotated_at = now`, so the interval is measured from the
+/// moment the policy was established rather than reporting the secret as
+/// immediately due.
+///
+/// Implemented as a read-modify-write with `replace_tags`, because removing a
+/// single tag is not otherwise expressible: merge semantics can only add or
+/// overwrite. Every unrelated tag is carried across verbatim.
+pub(crate) async fn execute_rotation_policy_update(
+    name: &str,
+    rotate_every: Option<String>,
+    clear: bool,
+    config: Config,
+    registry: Option<&BackendRegistry>,
+) -> Result<()> {
+    use crate::secret::manager::{FieldUpdate, SecretUpdateRequest};
+    use crate::secret::rotation::{
+        format_interval, parse_interval, TAG_ROTATED_AT, TAG_ROTATE_EVERY,
+    };
+
+    let reg = registry.ok_or_else(|| {
+        CrosstacheError::config(
+            "No backend registry available. Run 'xv config show' to check your configuration.",
+        )
+    })?;
+
+    // Validate before touching the backend.
+    let interval = rotate_every.as_deref().map(parse_interval).transpose()?;
+
+    let (backend, backend_name, vault_name, resolved_name) =
+        resolve_rotate_target(name, None, &config, reg).await?;
+    let name = resolved_name.as_str();
+
+    // Read current tags (metadata only — no value is decrypted, so this does
+    // not register as secret-value access in an audit trail).
+    let existing = backend
+        .secrets()
+        .get_secret(&vault_name, name, false)
+        .await
+        .map_err(CrosstacheError::from)?;
+
+    let mut tags = existing.tags;
+    let had_policy = tags.contains_key(TAG_ROTATE_EVERY);
+
+    if clear {
+        if !had_policy {
+            output::info(&format!(
+                "Secret '{name}' has no rotation policy; nothing to clear."
+            ));
+            return Ok(());
+        }
+        tags.remove(TAG_ROTATE_EVERY);
+        tags.remove(TAG_ROTATED_AT);
+    } else if let Some(interval) = interval {
+        tags.insert(TAG_ROTATE_EVERY.to_string(), format_interval(interval));
+        tags.insert(TAG_ROTATED_AT.to_string(), chrono::Utc::now().to_rfc3339());
+    }
+
+    let request = SecretUpdateRequest {
+        name: name.to_string(),
+        value: None,
+        content_type: None,
+        enabled: None,
+        expires_on: FieldUpdate::Unchanged,
+        not_before: FieldUpdate::Unchanged,
+        tags: Some(tags.into_iter().collect()),
+        groups: None,
+        note: FieldUpdate::Unchanged,
+        folder: FieldUpdate::Unchanged,
+        // Authoritative rewrite: this is the only way to drop a tag.
+        replace_tags: true,
+        replace_groups: false,
+        expected_revision: None,
+    };
+
+    backend
+        .secrets()
+        .update_secret(&vault_name, name, request)
+        .await
+        .map_err(CrosstacheError::from)?;
+
+    let cache_manager = crate::cache::CacheManager::from_config(&config);
+    cache_manager.invalidate(&crate::cache::CacheKey::SecretsList {
+        backend: backend_name,
+        vault_name: vault_name.clone(),
+    });
+
+    if clear {
+        output::success(&format!("Removed the rotation policy from '{name}'."));
+    } else {
+        let rendered = format_interval(interval.expect("validated above"));
+        output::success(&format!(
+            "Rotation policy for '{name}' set to every {rendered}; the clock starts now."
+        ));
+        output::hint(
+            "Nothing rotates on its own — run 'xv rotate --due' from cron, a systemd timer, or \
+             CI. 'xv rotate --check' reports status and exits 51 when something is due.",
+        );
+    }
+    Ok(())
+}
+
+/// `xv rotate` entry point: dispatches between single-secret rotation, the
+/// batch `--due` run, and the read-only `--check` report.
+///
+/// `name` is optional because `--due`/`--check` are vault-scoped; clap enforces
+/// the mutual exclusions, and this rejects the one combination it cannot
+/// express (no name and no mode flag).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn execute_rotate(
+    name: Option<String>,
+    vault: Option<String>,
+    length: usize,
+    charset: CharsetType,
+    generator: Option<String>,
+    native: bool,
+    show_value: bool,
+    force: bool,
+    every: Option<String>,
+    due: bool,
+    check: bool,
+    config: Config,
+    registry: Option<&BackendRegistry>,
+) -> Result<()> {
+    if check {
+        return execute_rotate_check(vault, config, registry).await;
+    }
+    if due {
+        return execute_rotate_due(vault, length, charset, generator, force, config, registry)
+            .await;
+    }
+
+    let name = name.ok_or_else(|| {
+        CrosstacheError::InvalidArgument(
+            "a secret name is required. Pass a name to rotate one secret, --due to rotate \
+             everything whose policy has come due, or --check to report status without rotating."
+                .to_string(),
+        )
+    })?;
+
+    execute_secret_rotate_direct(
+        &name, vault, length, charset, generator, native, show_value, force, every, config,
+        registry,
+    )
+    .await
+}
+
+/// One row of `xv rotate --check`.
+#[derive(tabled::Tabled, serde::Serialize)]
+struct RotationRow {
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Status")]
+    status: String,
+    #[tabled(rename = "Interval")]
+    interval: String,
+    #[tabled(rename = "Due")]
+    due: String,
+}
+
+/// Evaluate every secret in the resolved vault against its rotation policy.
+///
+/// Returns `(vault_name, rows)` where each row pairs a secret with its
+/// [`RotationStatus`]. Only policy-bearing secrets are included — an unmanaged
+/// secret is not "ok", it is simply out of scope.
+async fn collect_rotation_status(
+    vault: Option<String>,
+    config: &Config,
+    registry: Option<&BackendRegistry>,
+) -> Result<(
+    String,
+    Vec<(String, crate::secret::rotation::RotationStatus)>,
+)> {
+    use crate::secret::rotation::{evaluate, RotationStatus};
+
+    let reg = registry.ok_or_else(|| {
+        CrosstacheError::config(
+            "No backend registry available. Run 'xv config show' to check your configuration.",
+        )
+    })?;
+
+    // Same resolution as a single-secret rotate, minus the name: `--due` and
+    // `--check` are vault-scoped, and a write verb never searches attached
+    // vaults, so the default entry (or explicit `--vault`) is the target.
+    let (backend, _backend_name, vault_name, _resolved) =
+        resolve_rotate_target("", vault, config, reg).await?;
+
+    let secrets = backend
+        .secrets()
+        .list_secrets(&vault_name, None)
+        .await
+        .map_err(CrosstacheError::from)?;
+
+    let now = chrono::Utc::now();
+    let mut rows: Vec<(String, RotationStatus)> = secrets
+        .into_iter()
+        .map(|s| {
+            // `updated_on` on a summary is a display string (and empty on some
+            // backends), so it is not usable as a machine baseline. A policy
+            // with no `xv:rotated_at` therefore evaluates as due-once, which
+            // then stamps a real timestamp. `xv update --rotate-every` stamps
+            // one at policy-set time so this is not the normal path.
+            let status = evaluate(&s.tags, None, now);
+            (s.name, status)
+        })
+        .filter(|(_, status)| !matches!(status, RotationStatus::NoPolicy))
+        .collect();
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok((vault_name, rows))
+}
+
+/// `xv rotate --check` — report rotation status without changing anything.
+///
+/// Exits 51 (`xv-rotation-due`) when at least one secret is due, so a pipeline
+/// can gate on staleness.
+async fn execute_rotate_check(
+    vault: Option<String>,
+    config: Config,
+    registry: Option<&BackendRegistry>,
+) -> Result<()> {
+    use crate::secret::rotation::{humanize, RotationStatus, TAG_ROTATE_EVERY};
+    use crate::utils::format::{OutputFormat, TableFormatter};
+
+    let (vault_name, statuses) = collect_rotation_status(vault, &config, registry).await?;
+
+    let rows: Vec<RotationRow> = statuses
+        .iter()
+        .map(|(name, status)| match status {
+            RotationStatus::Ok { due_in, due_at } => RotationRow {
+                name: name.clone(),
+                status: "ok".to_string(),
+                interval: String::new(),
+                due: format!("in {} ({})", humanize(*due_in), due_at.format("%Y-%m-%d")),
+            },
+            RotationStatus::Due { overdue_by, due_at } => RotationRow {
+                name: name.clone(),
+                status: "due".to_string(),
+                interval: String::new(),
+                due: format!(
+                    "{} ago ({})",
+                    humanize(*overdue_by),
+                    due_at.format("%Y-%m-%d")
+                ),
+            },
+            RotationStatus::Invalid { value, .. } => RotationRow {
+                name: name.clone(),
+                status: "invalid".to_string(),
+                interval: value.clone(),
+                due: format!("unparseable {TAG_ROTATE_EVERY}"),
+            },
+            RotationStatus::NoPolicy => unreachable!("filtered out by collect_rotation_status"),
+        })
+        .collect();
+
+    let fmt = config.runtime_output_format;
+    let human_table_like = matches!(
+        fmt,
+        OutputFormat::Table | OutputFormat::Plain | OutputFormat::Raw
+    );
+    let formatter = TableFormatter::new(
+        fmt,
+        config.no_color,
+        config.template.clone(),
+        config.runtime_columns.clone(),
+    );
+
+    if rows.is_empty() {
+        if human_table_like {
+            formatter.validate_columns::<RotationRow>()?;
+            output::info(&format!(
+                "No secrets in '{vault_name}' have a rotation policy. Set one with \
+                 'xv update <name> --rotate-every 90d'."
+            ));
+        } else {
+            println!("{}", formatter.format_table(&rows)?);
+        }
+        return Ok(());
+    }
+
+    println!("{}", formatter.format_table(&rows)?);
+
+    let due: Vec<&str> = statuses
+        .iter()
+        .filter(|(_, s)| s.is_due())
+        .map(|(n, _)| n.as_str())
+        .collect();
+    let invalid = statuses.iter().filter(|(_, s)| s.is_invalid()).count();
+
+    if invalid > 0 {
+        output::warn(&format!(
+            "{invalid} secret(s) have an unparseable {TAG_ROTATE_EVERY} tag and are not being \
+             evaluated. Fix them with 'xv update <name> --rotate-every <interval>'."
+        ));
+    }
+
+    if due.is_empty() {
+        output::success(&format!(
+            "Nothing due in '{vault_name}' ({} policy-managed secret(s)).",
+            statuses.len()
+        ));
+        return Ok(());
+    }
+
+    output::warn(&format!(
+        "{} secret(s) due for rotation in '{vault_name}': {}",
+        due.len(),
+        due.join(", ")
+    ));
+    output::hint("Run 'xv rotate --due' to rotate them.");
+    Err(CrosstacheError::rotation_due(due.len()))
+}
+
+/// `xv rotate --due` — rotate every secret whose policy has come due.
+async fn execute_rotate_due(
+    vault: Option<String>,
+    length: usize,
+    charset: CharsetType,
+    generator: Option<String>,
+    force: bool,
+    config: Config,
+    registry: Option<&BackendRegistry>,
+) -> Result<()> {
+    use crate::utils::interactive::InteractivePrompt;
+
+    let (vault_name, statuses) = collect_rotation_status(vault.clone(), &config, registry).await?;
+
+    let invalid: Vec<&str> = statuses
+        .iter()
+        .filter(|(_, s)| s.is_invalid())
+        .map(|(n, _)| n.as_str())
+        .collect();
+    if !invalid.is_empty() {
+        // Fail rather than skip: an unreadable policy means we cannot know
+        // whether that secret is overdue, and silently passing over it would
+        // make a green `--due` run misleading.
+        return Err(CrosstacheError::InvalidArgument(format!(
+            "{} secret(s) in '{vault_name}' have an unparseable rotation interval: {}. Fix them \
+             with 'xv update <name> --rotate-every <interval>' before running --due, so this run \
+             cannot silently skip an overdue secret.",
+            invalid.len(),
+            invalid.join(", ")
+        )));
+    }
+
+    let due: Vec<String> = statuses
+        .iter()
+        .filter(|(_, s)| s.is_due())
+        .map(|(n, _)| n.clone())
+        .collect();
+
+    if due.is_empty() {
+        output::success(&format!(
+            "Nothing due in '{vault_name}' ({} policy-managed secret(s)).",
+            statuses.len()
+        ));
+        return Ok(());
+    }
+
+    output::info(&format!(
+        "{} secret(s) due for rotation in '{vault_name}': {}",
+        due.len(),
+        due.join(", ")
+    ));
+
+    // One confirmation for the batch, rather than per secret.
+    if !force {
+        let prompt = InteractivePrompt::new();
+        if !prompt.confirm(
+            &format!(
+                "Rotate {} secret(s)? Each gets a newly generated value and a new version.",
+                due.len()
+            ),
+            false,
+        )? {
+            output::info("Rotation cancelled.");
+            return Ok(());
+        }
+    }
+
+    let mut rotated = 0usize;
+    let mut failures: Vec<(String, String)> = Vec::new();
+
+    for name in &due {
+        // Rotate each secret through the same single-secret path, so record
+        // handling, reserved-key guards, and audit/git hooks all apply
+        // identically to a manual rotate. `--every` is not passed: `--due`
+        // acts on the existing policy and must never redefine it.
+        match execute_secret_rotate_direct(
+            name,
+            vault.clone(),
+            length,
+            charset,
+            generator.clone(),
+            false,
+            false,
+            true, // already confirmed for the batch
+            None,
+            config.clone(),
+            registry,
+        )
+        .await
+        {
+            Ok(()) => rotated += 1,
+            Err(e) => failures.push((name.clone(), e.to_string())),
+        }
+    }
+
+    if failures.is_empty() {
+        output::success(&format!("Rotated {rotated} secret(s) in '{vault_name}'."));
+        return Ok(());
+    }
+
+    // Report every failure — a partial batch must not look like a success.
+    for (name, err) in &failures {
+        output::error(&format!("  {name}: {err}"));
+    }
+    Err(CrosstacheError::config(format!(
+        "rotated {rotated} of {} due secret(s) in '{vault_name}'; {} failed (listed above)",
+        due.len(),
+        failures.len()
+    )))
 }
 
 /// Capability error for `xv rotate --native` on a backend without native
@@ -5329,6 +5763,8 @@ async fn execute_secret_rotate(
     custom_generator: Option<String>,
     show_value: bool,
     force: bool,
+    // When `Some`, also set/refresh the secret's rotation policy.
+    rotation_interval: Option<chrono::Duration>,
     config: &Config,
 ) -> Result<()> {
     use crate::config::ContextManager;
@@ -5410,7 +5846,14 @@ async fn execute_secret_rotate(
     // review NIT): the untyped path's `SecretRequest.enabled: Some(true)`
     // and this `SecretUpdateRequest.enabled` override are the same
     // deliberate choice, made consistent across both code shapes.
-    let new_version = if crate::records::is_record(&existing_secret.content_type) {
+    // Stamp the rotation bookkeeping tags. `xv:rotated_at` is refreshed on
+    // every rotation — including a plain `xv rotate` with no `--every` — so an
+    // existing policy's clock restarts from the rotation that actually
+    // happened. Without that, `--due` would re-rotate the same secret forever.
+    let stamp = crate::secret::rotation::rotation_tags(rotation_interval, chrono::Utc::now());
+    let is_record = crate::records::is_record(&existing_secret.content_type);
+
+    let new_version = if is_record {
         let props = execute_record_primary_update(
             name,
             new_value.as_str(),
@@ -5424,7 +5867,10 @@ async fn execute_secret_rotate(
         .await?;
         props.version
     } else {
-        // Preserve existing secret metadata
+        // Preserve existing secret metadata, with the rotation stamp merged
+        // over it so a refreshed interval replaces the old one.
+        let mut tags = existing_secret.tags;
+        tags.extend(stamp.clone());
         let set_request = SecretRequest {
             name: name.to_string(),
             value: new_value.clone(),
@@ -5436,11 +5882,7 @@ async fn execute_secret_rotate(
             enabled: Some(true),
             expires_on: existing_secret.expires_on,
             not_before: existing_secret.not_before,
-            tags: if existing_secret.tags.is_empty() {
-                None
-            } else {
-                Some(existing_secret.tags)
-            },
+            tags: Some(tags),
             groups: None, // Groups are managed via tags
             note: None,
             folder: None,
@@ -5455,6 +5897,33 @@ async fn execute_secret_rotate(
             .map_err(CrosstacheError::from)?;
         result.version
     };
+
+    // A record's value is rewritten through the envelope-aware update path,
+    // which owns its own tag handling, so the stamp is applied afterwards as a
+    // metadata-only update (merge semantics — no `replace_tags`). Metadata-only
+    // updates do not create a further version on any backend.
+    if is_record {
+        let stamp_request = crate::secret::manager::SecretUpdateRequest {
+            name: name.to_string(),
+            value: None,
+            content_type: None,
+            enabled: None,
+            expires_on: crate::secret::manager::FieldUpdate::Unchanged,
+            not_before: crate::secret::manager::FieldUpdate::Unchanged,
+            tags: Some(stamp.into_iter().collect()),
+            groups: None,
+            note: crate::secret::manager::FieldUpdate::Unchanged,
+            folder: crate::secret::manager::FieldUpdate::Unchanged,
+            replace_tags: false,
+            replace_groups: false,
+            expected_revision: None,
+        };
+        reg.active()
+            .secrets()
+            .update_secret(&vault_name, name, stamp_request)
+            .await
+            .map_err(CrosstacheError::from)?;
+    }
 
     output::success(&format!("Successfully rotated secret '{}'", name));
     println!("New version: {}", new_version);
@@ -7498,6 +7967,8 @@ mod tests {
                 default_vault: Some("local-vault".to_string()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
             ..Default::default()
         };
@@ -7664,6 +8135,8 @@ mod tests {
                 default_vault: Some("default".to_string()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
             ..Default::default()
         };
@@ -8127,6 +8600,8 @@ mod tests {
                 default_vault: Some(vault_name.clone()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
             ..Default::default()
         };

--- a/src/cli/system_ops.rs
+++ b/src/cli/system_ops.rs
@@ -138,6 +138,88 @@ pub(crate) async fn execute_audit_command(
     .await
 }
 
+/// `xv audit --verify` — recompute the local audit log's hash chain.
+///
+/// Local-only by design: Azure and AWS audit trails are produced and held by
+/// the platform, so there is no client-side chain for `xv` to verify. That
+/// asymmetry is the point — a cloud trail the caller cannot rewrite needs no
+/// integrity proof from us, whereas a log living in the caller's own store
+/// does.
+pub(crate) async fn execute_audit_verify_command(
+    vault: Option<String>,
+    config: Config,
+) -> Result<()> {
+    use crate::backend::local::audit::ChainStatus;
+    use crate::backend::local::LocalBackend;
+
+    if config.effective_backend_name() != "local" {
+        return Err(CrosstacheError::InvalidArgument(format!(
+            "`xv audit --verify` checks the local backend's hash-chained log, but the active \
+             backend is '{}'. Azure and AWS audit trails are maintained by the platform \
+             (Activity Log / CloudTrail), so there is no local chain to verify — query them \
+             with 'xv audit' instead.",
+            config.effective_backend_name()
+        )));
+    }
+
+    let backend = LocalBackend::new(config.local.as_ref())
+        .map_err(|e| CrosstacheError::config(format!("failed to open local backend: {e}")))?;
+
+    let log = backend.audit_log().ok_or_else(|| {
+        CrosstacheError::config(
+            "Auditing is not enabled for the local backend. Set `audit = true` under [local] \
+             in your config; records are written from that point on."
+                .to_string(),
+        )
+    })?;
+
+    let vault_name = match vault {
+        Some(v) => v,
+        None => {
+            let (_backend, _name, resolved) =
+                crate::cli::vault_ops::resolve_current_vault(&config, None).await?;
+            resolved
+        }
+    };
+
+    match log
+        .verify_chain(&vault_name)
+        .map_err(|e| CrosstacheError::config(e.to_string()))?
+    {
+        ChainStatus::Empty => {
+            output::info(&format!(
+                "No audit records for vault '{vault_name}' yet — nothing to verify."
+            ));
+            Ok(())
+        }
+        ChainStatus::Intact { records } => {
+            output::success(&format!(
+                "Audit chain intact: {records} record(s) verified for vault '{vault_name}'."
+            ));
+            output::hint(
+                "This proves the log has not been edited or reordered since it was written. It \
+                 cannot prove completeness: whoever holds the age identity could have rewritten \
+                 the chain wholesale, and anyone who can write the file could truncate its tail. \
+                 Push the store to a remote ('xv git push') to keep off-box copies.",
+            );
+            Ok(())
+        }
+        ChainStatus::Broken {
+            seq,
+            verified,
+            reason,
+        } => {
+            output::error(&format!(
+                "Audit chain BROKEN at record {seq} for vault '{vault_name}': {reason}"
+            ));
+            output::info(&format!(
+                "  {verified} record(s) before the break verified successfully."
+            ));
+            Err(CrosstacheError::audit_chain_broken(seq, reason))
+        }
+    }
+}
+
 /// Render audit logs fetched through the backend-agnostic [`AuditBackend`]
 /// trait via the shared `AuditRow` renderer (global `--format` honored).
 async fn execute_backend_audit(

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -42,6 +42,23 @@ pub struct LocalConfig {
     #[serde(default)]
     pub encrypt_metadata: Option<bool>,
 
+    /// Record an append-only, hash-chained audit trail under
+    /// `<store>/vaults/<vault>/.audit/log.jsonl`. Off by default. When on, a
+    /// failed audit append fails the operation that triggered it, so the log
+    /// can never be silently incomplete. The chain is tamper-*evident* (verify
+    /// with `xv audit --verify`), not tamper-proof: anyone holding the age
+    /// identity can rewrite it wholesale. See
+    /// `crate::backend::local::audit` for the full threat model.
+    #[serde(default)]
+    pub audit: Option<bool>,
+
+    /// Track the store as a git repository, committing after every mutation.
+    /// Off by default. Only age *ciphertext* and metadata are committed; the
+    /// identity and recipients files are force-excluded and a commit is
+    /// refused if they would be captured. See `crate::backend::local::git`.
+    #[serde(default)]
+    pub git: Option<bool>,
+
     /// Make on-disk filenames opaque so a directory listing reveals no secret
     /// names. When `false` (the default, for backward compatibility), secret
     /// names are stored verbatim as URL-encoded filenames. When `true`, each
@@ -105,6 +122,10 @@ pub enum AzureCredentialType {
     ManagedIdentity,
     /// Use environment variable credentials first
     Environment,
+    /// Federate a GitHub Actions OIDC token into Azure AD (workload identity),
+    /// with no stored secret and no `azure/login` step. Requires the job to
+    /// declare `permissions: id-token: write`.
+    Oidc,
     /// Use the default credential chain order
     #[default]
     Default,
@@ -116,6 +137,7 @@ impl fmt::Display for AzureCredentialType {
             Self::Cli => write!(f, "cli"),
             Self::ManagedIdentity => write!(f, "managed_identity"),
             Self::Environment => write!(f, "environment"),
+            Self::Oidc => write!(f, "oidc"),
             Self::Default => write!(f, "default"),
         }
     }
@@ -129,8 +151,9 @@ impl std::str::FromStr for AzureCredentialType {
             "cli" | "azure-cli" | "az" => Ok(Self::Cli),
             "managed_identity" | "managed-identity" | "msi" => Ok(Self::ManagedIdentity),
             "environment" | "env" => Ok(Self::Environment),
+            "oidc" | "github-oidc" | "workload-identity" => Ok(Self::Oidc),
             "default" => Ok(Self::Default),
-            _ => Err(format!("Invalid credential type: {s}. Valid options: cli, managed_identity, environment, default")),
+            _ => Err(format!("Invalid credential type: {s}. Valid options: cli, managed_identity, environment, oidc, default")),
         }
     }
 }

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -227,6 +227,8 @@ pub fn build_setup_config(request: &SetupRequest, mut base: Config) -> Result<Co
                 default_vault: Some(vault.clone()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             };
             crate::backend::local::config::ResolvedLocalConfig::from_raw(Some(&local))
                 .validate()?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -481,6 +481,12 @@ pub enum CrosstacheError {
     #[error("Scan detected {count} potential leak(s)")]
     ScanLeakDetected { count: usize },
 
+    #[error("{count} secret(s) are due for rotation")]
+    RotationDue { count: usize },
+
+    #[error("audit chain verification failed at record {seq}: {reason}")]
+    AuditChainBroken { seq: u64, reason: String },
+
     #[error("Rename of secret '{source}' to '{destination}' in vault '{vault}' is incomplete: the new secret was created, but deleting the original failed: {cause}. Both secrets still exist and no secret material was lost. Next steps: with vault '{vault}' active, verify the new secret (`xv get {destination}`), then delete the original (`xv delete {source}`) or retry the deletion later.")]
     RenameIncomplete {
         source: String,
@@ -534,6 +540,8 @@ impl CrosstacheError {
             Self::InvalidArgument(_) => "xv-invalid-argument",
             Self::Upgrade(_) => "xv-upgrade",
             Self::ScanLeakDetected { .. } => "xv-scan-leak-detected",
+            Self::RotationDue { .. } => "xv-rotation-due",
+            Self::AuditChainBroken { .. } => "xv-audit-chain-broken",
             Self::RenameIncomplete { .. } => "xv-rename-incomplete",
             Self::AmbiguousSecret { .. } => "xv-ambiguous-secret",
             Self::Unknown(_) => "xv-unknown",
@@ -572,6 +580,8 @@ impl CrosstacheError {
 
             // 50–59 — policy/scan findings
             Self::ScanLeakDetected { .. } => 50,
+            Self::RotationDue { .. } => 51,
+            Self::AuditChainBroken { .. } => 52,
 
             Self::SerializationError(_)
             | Self::IoError(_)
@@ -652,6 +662,24 @@ impl CrosstacheError {
 
     pub fn scan_leak_detected(count: usize) -> Self {
         Self::ScanLeakDetected { count }
+    }
+
+    /// Build the `RotationDue` variant (exit 51, `xv-rotation-due`): at least
+    /// one secret's rotation policy has come due. Used by `xv rotate --check`
+    /// so a pipeline can fail on stale secrets.
+    pub fn rotation_due(count: usize) -> Self {
+        Self::RotationDue { count }
+    }
+
+    /// Build the `AuditChainBroken` variant (exit 52,
+    /// `xv-audit-chain-broken`): the local audit log's hash chain no longer
+    /// verifies. Distinct from a config error so a monitor can tell "the log was
+    /// altered" apart from "the log could not be read".
+    pub fn audit_chain_broken(seq: u64, reason: impl Into<String>) -> Self {
+        Self::AuditChainBroken {
+            seq,
+            reason: reason.into(),
+        }
     }
 
     /// Build the `AmbiguousSecret` variant (exit 13, `xv-ambiguous-secret`):
@@ -1330,6 +1358,18 @@ mod tests {
                 category: "error variant",
                 name: "ScanLeakDetected",
                 fields: &["count"],
+                allowed_value_like_fields: &[],
+            },
+            SecuritySurface {
+                category: "error variant",
+                name: "RotationDue",
+                fields: &["count"],
+                allowed_value_like_fields: &[],
+            },
+            SecuritySurface {
+                category: "error variant",
+                name: "AuditChainBroken",
+                fields: &["seq", "reason"],
                 allowed_value_like_fields: &[],
             },
             SecuritySurface {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod config;
 pub mod error;
 pub mod records;
 pub mod scan;
+pub mod schedule;
 pub mod secret;
 #[cfg(feature = "tui")]
 pub mod tui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod config;
 mod error;
 mod records;
 mod scan;
+mod schedule;
 mod secret;
 #[cfg(feature = "tui")]
 mod tui;

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -1,0 +1,1374 @@
+//! Rotation scheduling via the operating system's scheduler.
+//!
+//! `xv rotate --due` performs a sweep; something has to invoke it on a cadence.
+//! This module makes `xv` install and manage that trigger itself, so automatic
+//! rotation is a first-party feature rather than a documented cron line the user
+//! assembles by hand.
+//!
+//! ## Why the OS scheduler and not a daemon
+//!
+//! A resident `xv` process would need to survive reboots, log rotation, sleep and
+//! wake, and its own crashes — reimplementing, worse, what launchd, systemd, and
+//! Task Scheduler already do correctly. It would also mean a long-lived process
+//! holding decryption credentials, which is precisely the thing a CLI secrets
+//! manager avoids. So `xv` writes a native unit and manages its lifecycle:
+//!
+//! | Platform | Mechanism | Unit |
+//! |----------|-----------|------|
+//! | macOS | launchd user agent | `~/Library/LaunchAgents/com.crosstache.xv-rotate.plist` |
+//! | Linux | systemd **user** timer | `~/.config/systemd/user/xv-rotate.{service,timer}` |
+//! | Windows | Task Scheduler | task `crosstache-xv-rotate` |
+//!
+//! All three are **per-user**, never system-wide: rotation runs as the user whose
+//! credentials and config it needs, and uninstalling never requires root.
+//!
+//! ## What ends up in the unit
+//!
+//! Only an absolute binary path, the `rotate --due --force` arguments, a log
+//! path, and the `HOME`/`XDG_CONFIG_HOME` pair. **No credentials and no secret
+//! values** — the scheduled run authenticates exactly as an interactive one does.
+//!
+//! The env pair matters more than it looks: a scheduled process does not inherit
+//! the interactive shell's environment, and a schedule that resolves a different
+//! config than the user tested against is the classic way this feature silently
+//! rotates the wrong vault, or nothing at all.
+//!
+//! ## The honest limitation
+//!
+//! A scheduled run has no terminal, so any credential needing interaction fails.
+//! Azure CLI tokens work while the refresh token is valid and the keyring is
+//! unlocked; managed identity and the local backend work unconditionally.
+//! [`install`] surfaces this at install time rather than letting it appear as a
+//! silent 3 a.m. failure weeks later.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use crate::error::{CrosstacheError, Result};
+
+/// launchd job label and systemd/Task Scheduler unit name.
+const LAUNCHD_LABEL: &str = "com.crosstache.xv-rotate";
+const SYSTEMD_UNIT: &str = "xv-rotate";
+const SCHTASKS_NAME: &str = "crosstache-xv-rotate";
+
+// ---------------------------------------------------------------------------
+// Command runner seam
+// ---------------------------------------------------------------------------
+
+/// Result of running a scheduler CLI command.
+#[derive(Debug, Clone)]
+pub struct CommandOutput {
+    /// Process exit code (`-1` when the process was signalled).
+    pub status: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl CommandOutput {
+    /// Whether the command reported success.
+    pub fn ok(&self) -> bool {
+        self.status == 0
+    }
+}
+
+/// Runs external scheduler commands (`launchctl`, `systemctl`, `schtasks`).
+///
+/// A trait so install/uninstall/status logic — argument order, error mapping,
+/// idempotence — is testable without registering real jobs on the developer's
+/// machine, which no test should ever do.
+pub trait CommandRunner: Send + Sync + fmt::Debug {
+    fn run(&self, program: &str, args: &[&str]) -> Result<CommandOutput>;
+}
+
+/// Real runner over `std::process::Command`.
+#[derive(Debug, Default)]
+pub struct ProcessRunner;
+
+impl CommandRunner for ProcessRunner {
+    fn run(&self, program: &str, args: &[&str]) -> Result<CommandOutput> {
+        let out = std::process::Command::new(program)
+            .args(args)
+            .output()
+            .map_err(|e| {
+                CrosstacheError::config(format!(
+                    "failed to run {program}: {e}. It must be on PATH to manage the rotation \
+                     schedule."
+                ))
+            })?;
+        Ok(CommandOutput {
+            status: out.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&out.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Interval
+// ---------------------------------------------------------------------------
+
+/// How often the rotation sweep runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScheduleInterval {
+    /// Every hour, at `minute` past.
+    Hourly { minute: u32 },
+    /// Every day at `hour:minute`.
+    Daily { hour: u32, minute: u32 },
+    /// Every week on `weekday` (0 = Sunday) at `hour:minute`.
+    Weekly {
+        weekday: u32,
+        hour: u32,
+        minute: u32,
+    },
+}
+
+impl ScheduleInterval {
+    /// Build from the CLI's `--interval` plus `--at HH:MM`.
+    pub fn from_parts(interval: &str, at: &str) -> Result<Self> {
+        let (hour, minute) = parse_hhmm(at)?;
+        match interval.to_lowercase().as_str() {
+            "hourly" => Ok(Self::Hourly { minute }),
+            "daily" => Ok(Self::Daily { hour, minute }),
+            // Sunday, matching both cron's and launchd's `0`.
+            "weekly" => Ok(Self::Weekly {
+                weekday: 0,
+                hour,
+                minute,
+            }),
+            other => Err(CrosstacheError::InvalidArgument(format!(
+                "unknown schedule interval '{other}'. Valid values: hourly, daily, weekly."
+            ))),
+        }
+    }
+
+    /// Human description for confirmation prompts and `status`.
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Hourly { minute } => format!("every hour at :{minute:02}"),
+            Self::Daily { hour, minute } => format!("daily at {hour:02}:{minute:02}"),
+            Self::Weekly {
+                weekday,
+                hour,
+                minute,
+            } => format!(
+                "weekly on {} at {hour:02}:{minute:02}",
+                weekday_name(*weekday)
+            ),
+        }
+    }
+}
+
+fn weekday_name(d: u32) -> &'static str {
+    match d {
+        0 => "Sunday",
+        1 => "Monday",
+        2 => "Tuesday",
+        3 => "Wednesday",
+        4 => "Thursday",
+        5 => "Friday",
+        _ => "Saturday",
+    }
+}
+
+/// Parse `HH:MM` in 24-hour form.
+fn parse_hhmm(at: &str) -> Result<(u32, u32)> {
+    let invalid = || {
+        CrosstacheError::InvalidArgument(format!(
+            "invalid time '{at}'. Use 24-hour HH:MM, e.g. 03:00."
+        ))
+    };
+    let (h, m) = at.trim().split_once(':').ok_or_else(invalid)?;
+    // Reject `3:0`: a schedule silently landing an hour or an hour-and-a-half
+    // off is worse than a rejected argument.
+    if h.len() != 2 || m.len() != 2 {
+        return Err(invalid());
+    }
+    let hour: u32 = h.parse().map_err(|_| invalid())?;
+    let minute: u32 = m.parse().map_err(|_| invalid())?;
+    if hour > 23 || minute > 59 {
+        return Err(invalid());
+    }
+    Ok((hour, minute))
+}
+
+// ---------------------------------------------------------------------------
+// The schedule
+// ---------------------------------------------------------------------------
+
+/// Everything needed to render and install a rotation schedule.
+#[derive(Debug, Clone)]
+pub struct RotationSchedule {
+    pub interval: ScheduleInterval,
+    /// Vault to sweep. `None` leaves the scheduled run to resolve the config
+    /// default, which is a common source of surprise — the CLI warns.
+    pub vault: Option<String>,
+    /// Absolute path to the `xv` binary the unit invokes.
+    pub binary: PathBuf,
+    /// File the scheduled run's output is appended to.
+    pub log_path: PathBuf,
+    /// `HOME` for the scheduled process.
+    pub home: PathBuf,
+    /// `XDG_CONFIG_HOME`, when the current process has one.
+    pub config_home: Option<PathBuf>,
+}
+
+impl RotationSchedule {
+    /// The arguments the scheduler invokes: an unattended due-rotation sweep.
+    ///
+    /// `--force` is required: there is no terminal to confirm at. `--due` alone
+    /// keeps the blast radius to secrets that already carry a policy and are
+    /// already past it.
+    pub fn command_args(&self) -> Vec<String> {
+        let mut args = vec![
+            "rotate".to_string(),
+            "--due".to_string(),
+            "--force".to_string(),
+        ];
+        if let Some(vault) = &self.vault {
+            args.push("--vault".to_string());
+            args.push(vault.clone());
+        }
+        args
+    }
+
+    /// The full command line, for display and for Task Scheduler's `/TR`.
+    pub fn command_line(&self) -> String {
+        let mut parts = vec![quote_if_needed(&self.binary.to_string_lossy())];
+        parts.extend(self.command_args().iter().map(|a| quote_if_needed(a)));
+        parts.join(" ")
+    }
+
+    /// Environment pairs the unit must set.
+    fn env_pairs(&self) -> Vec<(String, String)> {
+        let mut pairs = vec![("HOME".to_string(), self.home.to_string_lossy().to_string())];
+        if let Some(config_home) = &self.config_home {
+            pairs.push((
+                "XDG_CONFIG_HOME".to_string(),
+                config_home.to_string_lossy().to_string(),
+            ));
+        }
+        pairs
+    }
+}
+
+fn quote_if_needed(s: &str) -> String {
+    if s.contains(' ') {
+        format!("\"{s}\"")
+    } else {
+        s.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Platforms
+// ---------------------------------------------------------------------------
+
+/// Which native scheduler is in use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Platform {
+    Launchd,
+    Systemd,
+    Schtasks,
+}
+
+impl Platform {
+    /// Detect the platform's scheduler.
+    ///
+    /// Returns a diagnostic error, not a silent no-op, when the host has none we
+    /// manage — a Linux box without systemd is a real configuration, and the
+    /// right answer there is a cron line the user owns, not a scheduler `xv`
+    /// pretends to have installed.
+    pub fn detect() -> Result<Self> {
+        #[cfg(target_os = "macos")]
+        {
+            Ok(Self::Launchd)
+        }
+        #[cfg(target_os = "windows")]
+        {
+            Ok(Self::Schtasks)
+        }
+        #[cfg(all(unix, not(target_os = "macos")))]
+        {
+            if Path::new("/run/systemd/system").exists() {
+                Ok(Self::Systemd)
+            } else {
+                Err(CrosstacheError::config(
+                    "no supported scheduler found: this looks like a Linux host without systemd \
+                     running (/run/systemd/system is absent), so 'xv schedule' has nothing to \
+                     manage.\n  Add a cron entry instead — 'xv schedule install --print' prints \
+                     the exact command to run:\n    0 3 * * *  <command>"
+                        .to_string(),
+                ))
+            }
+        }
+        #[cfg(not(any(unix, target_os = "windows")))]
+        {
+            Err(CrosstacheError::config(
+                "scheduling is not supported on this platform.".to_string(),
+            ))
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Launchd => "launchd",
+            Self::Systemd => "systemd user timer",
+            Self::Schtasks => "Task Scheduler",
+        }
+    }
+}
+
+/// A file the scheduler needs on disk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnitFile {
+    pub path: PathBuf,
+    pub contents: String,
+}
+
+/// Where unit files live. Overridable so tests can render into a tempdir.
+#[derive(Debug, Clone)]
+pub struct UnitPaths {
+    /// `~/Library/LaunchAgents` on macOS, `~/.config/systemd/user` on Linux.
+    pub dir: PathBuf,
+}
+
+impl UnitPaths {
+    /// The platform's default unit directory under `home`.
+    pub fn for_platform(platform: Platform, home: &Path) -> Self {
+        let dir = match platform {
+            Platform::Launchd => home.join("Library/LaunchAgents"),
+            Platform::Systemd => home.join(".config/systemd/user"),
+            // Task Scheduler keeps its own registry; nothing is written by us.
+            Platform::Schtasks => home.to_path_buf(),
+        };
+        Self { dir }
+    }
+
+    fn launchd_plist(&self) -> PathBuf {
+        self.dir.join(format!("{LAUNCHD_LABEL}.plist"))
+    }
+
+    fn systemd_service(&self) -> PathBuf {
+        self.dir.join(format!("{SYSTEMD_UNIT}.service"))
+    }
+
+    fn systemd_timer(&self) -> PathBuf {
+        self.dir.join(format!("{SYSTEMD_UNIT}.timer"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering (pure)
+// ---------------------------------------------------------------------------
+
+/// Render the unit file(s) for `schedule`. Pure — writes nothing.
+pub fn render(platform: Platform, schedule: &RotationSchedule, paths: &UnitPaths) -> Vec<UnitFile> {
+    match platform {
+        Platform::Launchd => vec![UnitFile {
+            path: paths.launchd_plist(),
+            contents: render_launchd(schedule),
+        }],
+        Platform::Systemd => vec![
+            UnitFile {
+                path: paths.systemd_service(),
+                contents: render_systemd_service(schedule),
+            },
+            UnitFile {
+                path: paths.systemd_timer(),
+                contents: render_systemd_timer(schedule),
+            },
+        ],
+        // Task Scheduler is configured entirely through `schtasks` arguments.
+        Platform::Schtasks => Vec::new(),
+    }
+}
+
+/// Escape text for an XML text node.
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+fn render_launchd(schedule: &RotationSchedule) -> String {
+    let mut args = String::new();
+    args.push_str(&format!(
+        "        <string>{}</string>\n",
+        xml_escape(&schedule.binary.to_string_lossy())
+    ));
+    for arg in schedule.command_args() {
+        args.push_str(&format!("        <string>{}</string>\n", xml_escape(&arg)));
+    }
+
+    let mut env = String::new();
+    for (key, value) in schedule.env_pairs() {
+        env.push_str(&format!(
+            "        <key>{}</key>\n        <string>{}</string>\n",
+            xml_escape(&key),
+            xml_escape(&value)
+        ));
+    }
+
+    let calendar = match schedule.interval {
+        ScheduleInterval::Hourly { minute } => {
+            format!("        <key>Minute</key>\n        <integer>{minute}</integer>\n")
+        }
+        ScheduleInterval::Daily { hour, minute } => format!(
+            "        <key>Hour</key>\n        <integer>{hour}</integer>\n        \
+             <key>Minute</key>\n        <integer>{minute}</integer>\n"
+        ),
+        ScheduleInterval::Weekly {
+            weekday,
+            hour,
+            minute,
+        } => format!(
+            "        <key>Weekday</key>\n        <integer>{weekday}</integer>\n        \
+             <key>Hour</key>\n        <integer>{hour}</integer>\n        \
+             <key>Minute</key>\n        <integer>{minute}</integer>\n"
+        ),
+    };
+
+    let log = xml_escape(&schedule.log_path.to_string_lossy());
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Managed by crosstache (xv schedule). Edits are overwritten on reinstall. -->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{LAUNCHD_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+{args}    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+{env}    </dict>
+    <key>StartCalendarInterval</key>
+    <dict>
+{calendar}    </dict>
+    <key>StandardOutPath</key>
+    <string>{log}</string>
+    <key>StandardErrorPath</key>
+    <string>{log}</string>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>
+"#
+    )
+}
+
+fn render_systemd_service(schedule: &RotationSchedule) -> String {
+    let mut env = String::new();
+    for (key, value) in schedule.env_pairs() {
+        env.push_str(&format!("Environment=\"{key}={value}\"\n"));
+    }
+    // systemd splits ExecStart on whitespace; quote each argument so a vault
+    // name containing a space cannot become two arguments.
+    let exec = std::iter::once(schedule.binary.to_string_lossy().to_string())
+        .chain(schedule.command_args())
+        .map(|a| format!("\"{}\"", a.replace('"', "\\\"")))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let log = schedule.log_path.display();
+    format!(
+        "# Managed by crosstache (xv schedule). Edits are overwritten on reinstall.\n\
+         [Unit]\n\
+         Description=crosstache due-secret rotation sweep\n\
+         Documentation=https://github.com/bziobnic/crosstache/blob/main/docs/rotation.md\n\
+         \n\
+         [Service]\n\
+         Type=oneshot\n\
+         ExecStart={exec}\n\
+         {env}\
+         StandardOutput=append:{log}\n\
+         StandardError=append:{log}\n"
+    )
+}
+
+fn render_systemd_timer(schedule: &RotationSchedule) -> String {
+    let on_calendar = match schedule.interval {
+        ScheduleInterval::Hourly { minute } => format!("*-*-* *:{minute:02}:00"),
+        ScheduleInterval::Daily { hour, minute } => format!("*-*-* {hour:02}:{minute:02}:00"),
+        ScheduleInterval::Weekly {
+            weekday,
+            hour,
+            minute,
+        } => format!(
+            "{} *-*-* {hour:02}:{minute:02}:00",
+            systemd_weekday(weekday)
+        ),
+    };
+    format!(
+        "# Managed by crosstache (xv schedule). Edits are overwritten on reinstall.\n\
+         [Unit]\n\
+         Description=crosstache due-secret rotation schedule\n\
+         \n\
+         [Timer]\n\
+         OnCalendar={on_calendar}\n\
+         # Run a missed sweep once the machine is back, rather than skipping a day.\n\
+         Persistent=true\n\
+         # Spread load and avoid every host rotating at the same instant.\n\
+         RandomizedDelaySec=300\n\
+         \n\
+         [Install]\n\
+         WantedBy=timers.target\n"
+    )
+}
+
+fn systemd_weekday(d: u32) -> &'static str {
+    match d {
+        0 => "Sun",
+        1 => "Mon",
+        2 => "Tue",
+        3 => "Wed",
+        4 => "Thu",
+        5 => "Fri",
+        _ => "Sat",
+    }
+}
+
+/// `schtasks /Create` arguments for `schedule`.
+pub fn schtasks_create_args(schedule: &RotationSchedule) -> Vec<String> {
+    let (sc, st, extra) = match schedule.interval {
+        ScheduleInterval::Hourly { minute } => (
+            "HOURLY".to_string(),
+            format!("00:{minute:02}"),
+            Vec::<String>::new(),
+        ),
+        ScheduleInterval::Daily { hour, minute } => (
+            "DAILY".to_string(),
+            format!("{hour:02}:{minute:02}"),
+            Vec::new(),
+        ),
+        ScheduleInterval::Weekly {
+            weekday,
+            hour,
+            minute,
+        } => (
+            "WEEKLY".to_string(),
+            format!("{hour:02}:{minute:02}"),
+            vec!["/D".to_string(), schtasks_weekday(weekday).to_string()],
+        ),
+    };
+
+    // Output is redirected through cmd.exe so failures land in the log file, the
+    // same way launchd's StandardOutPath and systemd's append: do.
+    let command = format!(
+        "cmd /c {} >> \"{}\" 2>&1",
+        schedule.command_line(),
+        schedule.log_path.display()
+    );
+
+    let mut args = vec![
+        "/Create".to_string(),
+        "/TN".to_string(),
+        SCHTASKS_NAME.to_string(),
+        "/TR".to_string(),
+        command,
+        "/SC".to_string(),
+        sc,
+        "/ST".to_string(),
+        st,
+        // Overwrite an existing task so reinstall is idempotent.
+        "/F".to_string(),
+    ];
+    args.extend(extra);
+    args
+}
+
+fn schtasks_weekday(d: u32) -> &'static str {
+    match d {
+        0 => "SUN",
+        1 => "MON",
+        2 => "TUE",
+        3 => "WED",
+        4 => "THU",
+        5 => "FRI",
+        _ => "SAT",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+/// Whether a schedule is currently registered, and what the OS says about it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScheduleStatus {
+    pub installed: bool,
+    /// The scheduler's own description, for display.
+    pub detail: String,
+}
+
+/// Install (or reinstall) the schedule. Idempotent.
+pub fn install(
+    platform: Platform,
+    schedule: &RotationSchedule,
+    paths: &UnitPaths,
+    runner: &dyn CommandRunner,
+) -> Result<()> {
+    // Ensure the log directory exists before the scheduler tries to append; a
+    // missing directory makes launchd fail the job with no visible reason.
+    if let Some(parent) = schedule.log_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            CrosstacheError::config(format!(
+                "failed to create the log directory {}: {e}",
+                parent.display()
+            ))
+        })?;
+    }
+
+    for unit in render(platform, schedule, paths) {
+        if let Some(parent) = unit.path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                CrosstacheError::config(format!("failed to create {}: {e}", parent.display()))
+            })?;
+        }
+        std::fs::write(&unit.path, &unit.contents).map_err(|e| {
+            CrosstacheError::config(format!("failed to write {}: {e}", unit.path.display()))
+        })?;
+    }
+
+    match platform {
+        Platform::Launchd => {
+            let plist = paths.launchd_plist();
+            let target = launchd_domain_target();
+            // Remove any previous registration first so reinstall is not an
+            // "already bootstrapped" error.
+            let _ = runner.run("launchctl", &["bootout", &target]);
+            let domain = launchd_domain();
+            expect_ok(
+                runner.run(
+                    "launchctl",
+                    &["bootstrap", &domain, &plist.to_string_lossy()],
+                )?,
+                "launchctl bootstrap",
+            )
+        }
+        Platform::Systemd => {
+            expect_ok(
+                runner.run("systemctl", &["--user", "daemon-reload"])?,
+                "systemctl --user daemon-reload",
+            )?;
+            expect_ok(
+                runner.run(
+                    "systemctl",
+                    &[
+                        "--user",
+                        "enable",
+                        "--now",
+                        &format!("{SYSTEMD_UNIT}.timer"),
+                    ],
+                )?,
+                "systemctl --user enable --now",
+            )
+        }
+        Platform::Schtasks => {
+            let args = schtasks_create_args(schedule);
+            let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            expect_ok(runner.run("schtasks", &refs)?, "schtasks /Create")
+        }
+    }
+}
+
+/// Report whether the schedule is registered.
+pub fn status(
+    platform: Platform,
+    paths: &UnitPaths,
+    runner: &dyn CommandRunner,
+) -> Result<ScheduleStatus> {
+    match platform {
+        Platform::Launchd => {
+            let out = runner.run("launchctl", &["print", &launchd_domain_target()])?;
+            Ok(ScheduleStatus {
+                installed: out.ok(),
+                detail: if out.ok() {
+                    summarize_launchd(&out.stdout)
+                } else {
+                    format!(
+                        "not registered with launchd (plist {} {})",
+                        paths.launchd_plist().display(),
+                        if paths.launchd_plist().exists() {
+                            "exists but is not loaded"
+                        } else {
+                            "does not exist"
+                        }
+                    )
+                },
+            })
+        }
+        Platform::Systemd => {
+            let timer = format!("{SYSTEMD_UNIT}.timer");
+            let active = runner.run("systemctl", &["--user", "is-active", &timer])?;
+            let listed = runner.run("systemctl", &["--user", "list-timers", "--all", &timer])?;
+            Ok(ScheduleStatus {
+                installed: active.stdout.trim() == "active",
+                detail: if active.stdout.trim() == "active" {
+                    listed.stdout.trim().to_string()
+                } else {
+                    format!("timer {timer} is {}", active.stdout.trim())
+                },
+            })
+        }
+        Platform::Schtasks => {
+            let out = runner.run("schtasks", &["/Query", "/TN", SCHTASKS_NAME])?;
+            Ok(ScheduleStatus {
+                installed: out.ok(),
+                detail: if out.ok() {
+                    out.stdout.trim().to_string()
+                } else {
+                    format!("task {SCHTASKS_NAME} is not registered")
+                },
+            })
+        }
+    }
+}
+
+/// Remove the schedule. Succeeds when nothing was installed.
+pub fn uninstall(
+    platform: Platform,
+    paths: &UnitPaths,
+    runner: &dyn CommandRunner,
+) -> Result<bool> {
+    let mut removed = false;
+
+    match platform {
+        Platform::Launchd => {
+            // A missing job is not an error here: uninstall must converge on
+            // "absent" whatever the starting state.
+            if runner
+                .run("launchctl", &["bootout", &launchd_domain_target()])?
+                .ok()
+            {
+                removed = true;
+            }
+        }
+        Platform::Systemd => {
+            let timer = format!("{SYSTEMD_UNIT}.timer");
+            if runner
+                .run("systemctl", &["--user", "disable", "--now", &timer])?
+                .ok()
+            {
+                removed = true;
+            }
+        }
+        Platform::Schtasks => {
+            if runner
+                .run("schtasks", &["/Delete", "/TN", SCHTASKS_NAME, "/F"])?
+                .ok()
+            {
+                removed = true;
+            }
+        }
+    }
+
+    for unit in unit_paths_for(platform, paths) {
+        if unit.exists() {
+            std::fs::remove_file(&unit).map_err(|e| {
+                CrosstacheError::config(format!("failed to remove {}: {e}", unit.display()))
+            })?;
+            removed = true;
+        }
+    }
+
+    if platform == Platform::Systemd {
+        // Reload so the removed units leave systemd's view too.
+        let _ = runner.run("systemctl", &["--user", "daemon-reload"]);
+    }
+
+    Ok(removed)
+}
+
+/// Unit files this platform owns, whether or not they exist.
+pub fn unit_paths_for(platform: Platform, paths: &UnitPaths) -> Vec<PathBuf> {
+    match platform {
+        Platform::Launchd => vec![paths.launchd_plist()],
+        Platform::Systemd => vec![paths.systemd_service(), paths.systemd_timer()],
+        Platform::Schtasks => Vec::new(),
+    }
+}
+
+fn expect_ok(out: CommandOutput, what: &str) -> Result<()> {
+    if out.ok() {
+        return Ok(());
+    }
+    let detail = if out.stderr.trim().is_empty() {
+        out.stdout.trim().to_string()
+    } else {
+        out.stderr.trim().to_string()
+    };
+    Err(CrosstacheError::config(format!(
+        "{what} failed (exit {}): {detail}",
+        out.status
+    )))
+}
+
+/// launchd's per-user domain, e.g. `gui/501`.
+fn launchd_domain() -> String {
+    format!("gui/{}", current_uid())
+}
+
+/// launchd's service target, e.g. `gui/501/com.crosstache.xv-rotate`.
+fn launchd_domain_target() -> String {
+    format!("{}/{LAUNCHD_LABEL}", launchd_domain())
+}
+
+fn current_uid() -> u32 {
+    #[cfg(unix)]
+    {
+        // SAFETY: getuid is always safe; it reads the calling process's real UID
+        // and cannot fail.
+        unsafe { libc::getuid() }
+    }
+    #[cfg(not(unix))]
+    {
+        0
+    }
+}
+
+/// Pull the interesting lines out of `launchctl print` output.
+fn summarize_launchd(stdout: &str) -> String {
+    let mut wanted = Vec::new();
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("state =")
+            || trimmed.starts_with("last exit code =")
+            || trimmed.starts_with("runs =")
+        {
+            wanted.push(trimmed.to_string());
+        }
+    }
+    if wanted.is_empty() {
+        "registered with launchd".to_string()
+    } else {
+        wanted.join("; ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schedule() -> RotationSchedule {
+        RotationSchedule {
+            interval: ScheduleInterval::Daily {
+                hour: 3,
+                minute: 30,
+            },
+            vault: Some("prod-kv".into()),
+            binary: PathBuf::from("/usr/local/bin/xv"),
+            log_path: PathBuf::from("/home/u/.local/state/xv/rotate.log"),
+            home: PathBuf::from("/home/u"),
+            config_home: Some(PathBuf::from("/home/u/.config")),
+        }
+    }
+
+    fn paths() -> UnitPaths {
+        UnitPaths {
+            dir: PathBuf::from("/home/u/units"),
+        }
+    }
+
+    /// Runner that records calls and returns scripted results.
+    #[derive(Debug, Default)]
+    struct FakeRunner {
+        calls: std::sync::Mutex<Vec<(String, Vec<String>)>>,
+        /// Exit code returned for any call whose args contain this substring.
+        fail_containing: Option<String>,
+    }
+
+    impl FakeRunner {
+        fn calls(&self) -> Vec<(String, Vec<String>)> {
+            self.calls.lock().unwrap().clone()
+        }
+        fn programs(&self) -> Vec<String> {
+            self.calls().into_iter().map(|(p, _)| p).collect()
+        }
+        fn flat(&self) -> Vec<String> {
+            self.calls()
+                .into_iter()
+                .map(|(p, a)| format!("{p} {}", a.join(" ")))
+                .collect()
+        }
+    }
+
+    impl CommandRunner for FakeRunner {
+        fn run(&self, program: &str, args: &[&str]) -> Result<CommandOutput> {
+            let args: Vec<String> = args.iter().map(|a| (*a).to_string()).collect();
+            self.calls
+                .lock()
+                .unwrap()
+                .push((program.to_string(), args.clone()));
+            let joined = args.join(" ");
+            let fail = self
+                .fail_containing
+                .as_ref()
+                .is_some_and(|needle| joined.contains(needle));
+            Ok(CommandOutput {
+                status: if fail { 1 } else { 0 },
+                stdout: if program == "systemctl" && joined.contains("is-active") {
+                    "active\n".to_string()
+                } else {
+                    String::new()
+                },
+                stderr: if fail {
+                    "boom".to_string()
+                } else {
+                    String::new()
+                },
+            })
+        }
+    }
+
+    // -- interval parsing ---------------------------------------------------
+
+    #[test]
+    fn parses_intervals_and_times() {
+        assert_eq!(
+            ScheduleInterval::from_parts("daily", "03:00").unwrap(),
+            ScheduleInterval::Daily { hour: 3, minute: 0 }
+        );
+        assert_eq!(
+            ScheduleInterval::from_parts("hourly", "00:15").unwrap(),
+            ScheduleInterval::Hourly { minute: 15 }
+        );
+        assert_eq!(
+            ScheduleInterval::from_parts("weekly", "23:59").unwrap(),
+            ScheduleInterval::Weekly {
+                weekday: 0,
+                hour: 23,
+                minute: 59
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_or_out_of_range_times() {
+        // `3:0` is rejected rather than guessed: silently landing an hour off is
+        // worse than a rejected argument.
+        for bad in [
+            "3:0", "0300", "24:00", "03:60", "", ":", "aa:bb", "03:00:00",
+        ] {
+            assert!(
+                ScheduleInterval::from_parts("daily", bad).is_err(),
+                "{bad:?} should be rejected"
+            );
+        }
+        assert!(ScheduleInterval::from_parts("fortnightly", "03:00").is_err());
+    }
+
+    #[test]
+    fn describes_intervals_readably() {
+        assert_eq!(
+            ScheduleInterval::Daily { hour: 3, minute: 5 }.describe(),
+            "daily at 03:05"
+        );
+        assert_eq!(
+            ScheduleInterval::Hourly { minute: 7 }.describe(),
+            "every hour at :07"
+        );
+        assert_eq!(
+            ScheduleInterval::Weekly {
+                weekday: 0,
+                hour: 3,
+                minute: 0
+            }
+            .describe(),
+            "weekly on Sunday at 03:00"
+        );
+    }
+
+    // -- command construction ----------------------------------------------
+
+    #[test]
+    fn scheduled_command_is_an_unattended_due_sweep() {
+        let s = schedule();
+        assert_eq!(
+            s.command_args(),
+            vec!["rotate", "--due", "--force", "--vault", "prod-kv"]
+        );
+        // --due bounds the blast radius to policy-bearing, already-due secrets;
+        // --force is required because there is no terminal to confirm at.
+        assert!(s.command_args().contains(&"--due".to_string()));
+        assert!(!s.command_args().contains(&"--every".to_string()));
+    }
+
+    #[test]
+    fn command_omits_vault_when_unset() {
+        let mut s = schedule();
+        s.vault = None;
+        assert_eq!(s.command_args(), vec!["rotate", "--due", "--force"]);
+    }
+
+    #[test]
+    fn command_line_quotes_paths_with_spaces() {
+        let mut s = schedule();
+        s.binary = PathBuf::from("/Applications/My Tools/xv");
+        assert!(
+            s.command_line()
+                .starts_with("\"/Applications/My Tools/xv\""),
+            "{}",
+            s.command_line()
+        );
+    }
+
+    // -- launchd ------------------------------------------------------------
+
+    #[test]
+    fn launchd_plist_is_well_formed_and_complete() {
+        let units = render(Platform::Launchd, &schedule(), &paths());
+        assert_eq!(units.len(), 1);
+        assert_eq!(
+            units[0].path,
+            PathBuf::from("/home/u/units/com.crosstache.xv-rotate.plist")
+        );
+        let body = &units[0].contents;
+
+        assert!(body.starts_with("<?xml version=\"1.0\""), "{body}");
+        assert!(body.contains("<string>com.crosstache.xv-rotate</string>"));
+        assert!(body.contains("<string>/usr/local/bin/xv</string>"));
+        assert!(body.contains("<string>--due</string>"));
+        assert!(body.contains("<string>prod-kv</string>"));
+        // Calendar interval, not a naive StartInterval.
+        assert!(body.contains("StartCalendarInterval"));
+        assert!(body.contains("<key>Hour</key>\n        <integer>3</integer>"));
+        assert!(body.contains("<key>Minute</key>\n        <integer>30</integer>"));
+        // Environment so the scheduled run resolves the same config.
+        assert!(body.contains("<key>HOME</key>"));
+        assert!(body.contains("<key>XDG_CONFIG_HOME</key>"));
+        // Output must be capturable or a 3am failure is invisible.
+        assert!(body.contains("StandardOutPath"));
+        assert!(body.contains("/home/u/.local/state/xv/rotate.log"));
+        // Must not fire on load — installing is not rotating.
+        assert!(body.contains("<key>RunAtLoad</key>\n    <false/>"));
+        // Tags balance.
+        assert_eq!(
+            body.matches("<dict>").count(),
+            body.matches("</dict>").count()
+        );
+        assert_eq!(
+            body.matches("<array>").count(),
+            body.matches("</array>").count()
+        );
+    }
+
+    #[test]
+    fn launchd_plist_escapes_xml_metacharacters() {
+        // A vault name with an ampersand would otherwise produce invalid XML and
+        // a job launchd silently refuses to load.
+        let mut s = schedule();
+        s.vault = Some("prod&stage<\"'>".into());
+        let body = render(Platform::Launchd, &s, &paths())[0].contents.clone();
+        assert!(
+            body.contains("prod&amp;stage&lt;&quot;&apos;&gt;"),
+            "{body}"
+        );
+        assert!(!body.contains("prod&stage"), "{body}");
+    }
+
+    #[test]
+    fn launchd_hourly_and_weekly_calendars() {
+        let mut s = schedule();
+        s.interval = ScheduleInterval::Hourly { minute: 15 };
+        let body = render(Platform::Launchd, &s, &paths())[0].contents.clone();
+        assert!(body.contains("<key>Minute</key>"));
+        assert!(!body.contains("<key>Hour</key>"), "hourly pins no hour");
+
+        s.interval = ScheduleInterval::Weekly {
+            weekday: 0,
+            hour: 4,
+            minute: 0,
+        };
+        let body = render(Platform::Launchd, &s, &paths())[0].contents.clone();
+        assert!(body.contains("<key>Weekday</key>\n        <integer>0</integer>"));
+    }
+
+    // -- systemd ------------------------------------------------------------
+
+    #[test]
+    fn systemd_renders_a_service_and_a_timer() {
+        let units = render(Platform::Systemd, &schedule(), &paths());
+        assert_eq!(units.len(), 2);
+        assert_eq!(units[0].path.file_name().unwrap(), "xv-rotate.service");
+        assert_eq!(units[1].path.file_name().unwrap(), "xv-rotate.timer");
+
+        let service = &units[0].contents;
+        assert!(service.contains("Type=oneshot"));
+        assert!(service.contains("\"/usr/local/bin/xv\" \"rotate\" \"--due\" \"--force\""));
+        assert!(service.contains("Environment=\"HOME=/home/u\""));
+        assert!(service.contains("Environment=\"XDG_CONFIG_HOME=/home/u/.config\""));
+        assert!(service.contains("StandardOutput=append:/home/u/.local/state/xv/rotate.log"));
+
+        let timer = &units[1].contents;
+        assert!(timer.contains("OnCalendar=*-*-* 03:30:00"), "{timer}");
+        // A missed sweep should run once the machine is back, not be skipped.
+        assert!(timer.contains("Persistent=true"));
+        assert!(timer.contains("WantedBy=timers.target"));
+    }
+
+    #[test]
+    fn systemd_quotes_arguments_so_a_spaced_vault_stays_one_argument() {
+        let mut s = schedule();
+        s.vault = Some("my vault".into());
+        let service = render(Platform::Systemd, &s, &paths())[0].contents.clone();
+        assert!(service.contains("\"my vault\""), "{service}");
+    }
+
+    #[test]
+    fn systemd_calendars_for_each_interval() {
+        let mut s = schedule();
+        s.interval = ScheduleInterval::Hourly { minute: 5 };
+        assert!(render(Platform::Systemd, &s, &paths())[1]
+            .contents
+            .contains("OnCalendar=*-*-* *:05:00"));
+
+        s.interval = ScheduleInterval::Weekly {
+            weekday: 3,
+            hour: 6,
+            minute: 0,
+        };
+        assert!(render(Platform::Systemd, &s, &paths())[1]
+            .contents
+            .contains("OnCalendar=Wed *-*-* 06:00:00"));
+    }
+
+    // -- schtasks -----------------------------------------------------------
+
+    #[test]
+    fn schtasks_arguments_are_complete_and_idempotent() {
+        let args = schtasks_create_args(&schedule());
+        let joined = args.join(" ");
+        assert!(joined.contains("/Create"));
+        assert!(joined.contains("/TN crosstache-xv-rotate"));
+        assert!(joined.contains("/SC DAILY"));
+        assert!(joined.contains("/ST 03:30"));
+        // /F overwrites, so reinstall does not fail on an existing task.
+        assert!(args.contains(&"/F".to_string()));
+        // Output redirected so a failure is diagnosable.
+        assert!(joined.contains("rotate.log"));
+        assert!(joined.contains("2>&1"));
+        // Task Scheduler writes no unit files of ours.
+        assert!(render(Platform::Schtasks, &schedule(), &paths()).is_empty());
+    }
+
+    #[test]
+    fn schtasks_weekly_passes_the_day() {
+        let mut s = schedule();
+        s.interval = ScheduleInterval::Weekly {
+            weekday: 5,
+            hour: 2,
+            minute: 0,
+        };
+        let joined = schtasks_create_args(&s).join(" ");
+        assert!(joined.contains("/SC WEEKLY"), "{joined}");
+        assert!(joined.contains("/D FRI"), "{joined}");
+    }
+
+    // -- lifecycle ----------------------------------------------------------
+
+    #[test]
+    fn install_writes_units_then_registers_with_launchd() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut s = schedule();
+        s.log_path = tmp.path().join("state/rotate.log");
+        let p = UnitPaths {
+            dir: tmp.path().join("LaunchAgents"),
+        };
+        let runner = FakeRunner::default();
+
+        install(Platform::Launchd, &s, &p, &runner).unwrap();
+
+        assert!(p.dir.join("com.crosstache.xv-rotate.plist").exists());
+        // Log directory pre-created; launchd fails silently without it.
+        assert!(tmp.path().join("state").is_dir());
+
+        let flat = runner.flat();
+        // bootout before bootstrap makes reinstall idempotent.
+        assert!(flat[0].contains("bootout"), "{flat:?}");
+        assert!(flat[1].contains("bootstrap"), "{flat:?}");
+        assert!(
+            flat[1].contains("com.crosstache.xv-rotate.plist"),
+            "{flat:?}"
+        );
+    }
+
+    #[test]
+    fn install_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut s = schedule();
+        s.log_path = tmp.path().join("state/rotate.log");
+        let p = UnitPaths {
+            dir: tmp.path().join("units"),
+        };
+        let runner = FakeRunner::default();
+        install(Platform::Systemd, &s, &p, &runner).unwrap();
+        install(Platform::Systemd, &s, &p, &runner).unwrap();
+        assert!(p.dir.join("xv-rotate.timer").exists());
+        assert_eq!(
+            std::fs::read_dir(&p.dir).unwrap().count(),
+            2,
+            "reinstall must not accumulate unit files"
+        );
+    }
+
+    #[test]
+    fn install_reports_scheduler_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut s = schedule();
+        s.log_path = tmp.path().join("rotate.log");
+        let p = UnitPaths {
+            dir: tmp.path().join("units"),
+        };
+        let runner = FakeRunner {
+            fail_containing: Some("enable".to_string()),
+            ..Default::default()
+        };
+        let err = install(Platform::Systemd, &s, &p, &runner).expect_err("must surface failure");
+        let msg = err.to_string();
+        assert!(msg.contains("systemctl --user enable --now"), "{msg}");
+        assert!(msg.contains("boom"), "{msg}");
+    }
+
+    #[test]
+    fn systemd_install_reloads_before_enabling() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut s = schedule();
+        s.log_path = tmp.path().join("rotate.log");
+        let p = UnitPaths {
+            dir: tmp.path().join("units"),
+        };
+        let runner = FakeRunner::default();
+        install(Platform::Systemd, &s, &p, &runner).unwrap();
+        let flat = runner.flat();
+        // Enabling before a reload would act on a stale unit view.
+        assert!(flat[0].contains("daemon-reload"), "{flat:?}");
+        assert!(flat[1].contains("enable --now xv-rotate.timer"), "{flat:?}");
+    }
+
+    #[test]
+    fn uninstall_removes_units_and_deregisters() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut s = schedule();
+        s.log_path = tmp.path().join("rotate.log");
+        let p = UnitPaths {
+            dir: tmp.path().join("units"),
+        };
+        let runner = FakeRunner::default();
+        install(Platform::Systemd, &s, &p, &runner).unwrap();
+
+        let removed = uninstall(Platform::Systemd, &p, &runner).unwrap();
+        assert!(removed);
+        assert!(!p.dir.join("xv-rotate.timer").exists());
+        assert!(!p.dir.join("xv-rotate.service").exists());
+        let flat = runner.flat();
+        assert!(flat.iter().any(|c| c.contains("disable --now")), "{flat:?}");
+    }
+
+    #[test]
+    fn uninstall_converges_when_nothing_is_installed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = UnitPaths {
+            dir: tmp.path().join("units"),
+        };
+        // Every scheduler call fails, as it would with no job registered.
+        let runner = FakeRunner {
+            fail_containing: Some(String::new()),
+            ..Default::default()
+        };
+        let removed = uninstall(Platform::Launchd, &p, &runner).unwrap();
+        assert!(!removed, "nothing was there to remove");
+    }
+
+    #[test]
+    fn status_reports_installed_for_each_platform() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = UnitPaths {
+            dir: tmp.path().to_path_buf(),
+        };
+        let runner = FakeRunner::default();
+
+        assert!(status(Platform::Launchd, &p, &runner).unwrap().installed);
+        assert!(status(Platform::Systemd, &p, &runner).unwrap().installed);
+        assert!(status(Platform::Schtasks, &p, &runner).unwrap().installed);
+        assert_eq!(runner.programs().len(), 4, "systemd needs two queries");
+    }
+
+    #[test]
+    fn status_reports_absent_when_the_scheduler_says_no() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = UnitPaths {
+            dir: tmp.path().to_path_buf(),
+        };
+        let runner = FakeRunner {
+            fail_containing: Some(String::new()),
+            ..Default::default()
+        };
+        let s = status(Platform::Launchd, &p, &runner).unwrap();
+        assert!(!s.installed);
+        assert!(s.detail.contains("does not exist"), "{}", s.detail);
+    }
+
+    #[test]
+    fn unit_paths_match_platform_conventions() {
+        let home = Path::new("/home/u");
+        assert_eq!(
+            UnitPaths::for_platform(Platform::Launchd, home).dir,
+            PathBuf::from("/home/u/Library/LaunchAgents")
+        );
+        assert_eq!(
+            UnitPaths::for_platform(Platform::Systemd, home).dir,
+            PathBuf::from("/home/u/.config/systemd/user")
+        );
+        assert!(unit_paths_for(Platform::Schtasks, &paths()).is_empty());
+    }
+
+    #[test]
+    fn launchd_targets_the_per_user_gui_domain() {
+        // A system domain would need root and would run rotation as the wrong
+        // user, without access to their credentials or config.
+        assert!(launchd_domain().starts_with("gui/"));
+        assert!(launchd_domain_target().ends_with("/com.crosstache.xv-rotate"));
+    }
+
+    #[test]
+    fn summarize_launchd_extracts_the_useful_lines() {
+        let out = "\tstate = running\n\tlast exit code = 0\n\truns = 12\n\tnoise = x\n";
+        let summary = summarize_launchd(out);
+        assert!(summary.contains("state = running"));
+        assert!(summary.contains("last exit code = 0"));
+        assert!(!summary.contains("noise"));
+        assert_eq!(
+            summarize_launchd("nothing useful"),
+            "registered with launchd"
+        );
+    }
+
+    #[test]
+    fn no_unit_ever_contains_a_credential_shaped_value() {
+        // Guard against a future change threading auth into the unit: the
+        // scheduled run must authenticate the same way an interactive one does.
+        for platform in [Platform::Launchd, Platform::Systemd] {
+            for unit in render(platform, &schedule(), &paths()) {
+                let body = unit.contents.to_lowercase();
+                for forbidden in [
+                    "client_secret",
+                    "password",
+                    "age-secret-key",
+                    "azure_client_secret",
+                    "aws_secret_access_key",
+                    "bearer ",
+                ] {
+                    assert!(
+                        !body.contains(forbidden),
+                        "{platform:?} unit contains {forbidden:?}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -264,6 +264,14 @@ fn quote_if_needed(s: &str) -> String {
 // ---------------------------------------------------------------------------
 
 /// Which native scheduler is in use.
+///
+/// Every variant is matched by the rendering and lifecycle code on all
+/// platforms, but each is only *constructed* by [`Platform::detect`] on its own
+/// `target_os` (plus by tests, which exercise all three everywhere). Without
+/// the exemption, dead-code analysis on any single platform flags the other
+/// two variants as never constructed — exactly what CI's Linux clippy run does
+/// to `Launchd`.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Platform {
     Launchd,

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -7,3 +7,4 @@ pub mod attachments;
 pub mod manager;
 pub mod models;
 pub mod name_manager;
+pub mod rotation;

--- a/src/secret/rotation.rs
+++ b/src/secret/rotation.rs
@@ -1,0 +1,502 @@
+//! Rotation policies and due-date evaluation.
+//!
+//! ## Why this is policy-driven rather than a scheduler
+//!
+//! AWS Secrets Manager rotates server-side: the service itself invokes a Lambda
+//! on a schedule, which is what `xv rotate --native` triggers. Neither Azure Key
+//! Vault nor the local backend has an equivalent — Key Vault can auto-rotate
+//! *keys* and emit near-expiry events for secrets, but nothing in it will
+//! regenerate a secret's value on a timer, and a local directory obviously has
+//! no scheduler at all.
+//!
+//! So rotation here is split the only way it honestly can be:
+//!
+//! - **`xv` owns the policy and the due-date math.** The interval lives with the
+//!   secret as the [`TAG_ROTATE_EVERY`] tag, and the last rotation as
+//!   [`TAG_ROTATED_AT`]. Both travel with the secret across backends and are
+//!   visible to anything else reading its metadata.
+//! - **The operator owns the clock.** A cron entry, systemd timer, or CI job
+//!   runs `xv rotate --due` and rotation happens. `xv rotate --check` reports
+//!   without changing anything and exits non-zero when something is overdue, so
+//!   a pipeline can gate on it.
+//!
+//! This is deliberately *not* described as scheduled rotation: nothing rotates
+//! unless something invokes `xv`. What it does provide on Azure and local is the
+//! part that was missing — a durable policy, a computed due state, and a
+//! single command that rotates everything due.
+//!
+//! `--native` remains AWS-only and is unaffected; a secret can carry a policy on
+//! any backend.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Duration, Utc};
+
+use crate::error::{CrosstacheError, Result};
+
+/// Tag holding the rotation interval, e.g. `90d`. Absent = no policy.
+pub const TAG_ROTATE_EVERY: &str = "xv:rotate_every";
+
+/// Tag holding the RFC 3339 timestamp of the last rotation.
+pub const TAG_ROTATED_AT: &str = "xv:rotated_at";
+
+/// Largest accepted interval (10 years). Guards against a typo like `9999w`
+/// silently meaning "never".
+const MAX_INTERVAL_DAYS: i64 = 3650;
+
+// ---------------------------------------------------------------------------
+// Interval parsing
+// ---------------------------------------------------------------------------
+
+/// Parse a rotation interval such as `30d`, `12h`, `6w`.
+///
+/// Accepted suffixes: `m` (minutes), `h` (hours), `d` (days), `w` (weeks). A
+/// unit is required — a bare `90` is ambiguous between minutes and days, and
+/// guessing wrong would either rotate constantly or never.
+pub fn parse_interval(input: &str) -> Result<Duration> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(invalid_interval(input, "the interval is empty"));
+    }
+
+    let (digits, unit) =
+        trimmed.split_at(trimmed.find(|c: char| !c.is_ascii_digit()).ok_or_else(|| {
+            invalid_interval(
+                input,
+                "no unit given — use m (minutes), h (hours), d (days), or w (weeks), e.g. 90d",
+            )
+        })?);
+
+    if digits.is_empty() {
+        return Err(invalid_interval(input, "no number given, e.g. 90d"));
+    }
+    let value: i64 = digits
+        .parse()
+        .map_err(|_| invalid_interval(input, "the number is too large"))?;
+    if value == 0 {
+        return Err(invalid_interval(
+            input,
+            "the interval must be greater than zero",
+        ));
+    }
+
+    let duration = match unit {
+        "m" => Duration::minutes(value),
+        "h" => Duration::hours(value),
+        "d" => Duration::days(value),
+        "w" => Duration::weeks(value),
+        other => {
+            return Err(invalid_interval(
+                input,
+                &format!(
+                    "unknown unit '{other}' — use m (minutes), h (hours), d (days), or w (weeks)"
+                ),
+            ))
+        }
+    };
+
+    if duration > Duration::days(MAX_INTERVAL_DAYS) {
+        return Err(invalid_interval(
+            input,
+            "the interval exceeds the 10-year maximum",
+        ));
+    }
+    Ok(duration)
+}
+
+/// Render a duration back into the canonical tag form.
+///
+/// Chooses the largest unit that divides evenly, so a round-trip of `2w` stays
+/// `2w` rather than degrading to `14d`.
+pub fn format_interval(d: Duration) -> String {
+    let minutes = d.num_minutes();
+    if minutes % (60 * 24 * 7) == 0 {
+        format!("{}w", minutes / (60 * 24 * 7))
+    } else if minutes % (60 * 24) == 0 {
+        format!("{}d", minutes / (60 * 24))
+    } else if minutes % 60 == 0 {
+        format!("{}h", minutes / 60)
+    } else {
+        format!("{minutes}m")
+    }
+}
+
+fn invalid_interval(input: &str, reason: &str) -> CrosstacheError {
+    CrosstacheError::InvalidArgument(format!("invalid rotation interval '{input}': {reason}."))
+}
+
+// ---------------------------------------------------------------------------
+// Due-date evaluation
+// ---------------------------------------------------------------------------
+
+/// Where a secret stands relative to its rotation policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RotationStatus {
+    /// No `xv:rotate_every` tag — rotation is not managed for this secret.
+    NoPolicy,
+    /// Policy present and the next rotation is still in the future.
+    Ok {
+        /// Time remaining until due.
+        due_in: Duration,
+        /// When rotation becomes due.
+        due_at: DateTime<Utc>,
+    },
+    /// Policy present and the due date has passed.
+    Due {
+        /// How long ago it came due.
+        overdue_by: Duration,
+        /// When rotation became due.
+        due_at: DateTime<Utc>,
+    },
+    /// Policy present but unparseable — treated as a hard error rather than
+    /// "no policy", so a typo cannot silently disable rotation.
+    Invalid {
+        /// The offending tag value.
+        value: String,
+        /// Why it could not be used.
+        reason: String,
+    },
+}
+
+impl RotationStatus {
+    /// Whether this secret should be rotated now.
+    pub fn is_due(&self) -> bool {
+        matches!(self, Self::Due { .. })
+    }
+
+    /// Whether the policy could not be interpreted.
+    pub fn is_invalid(&self) -> bool {
+        matches!(self, Self::Invalid { .. })
+    }
+}
+
+/// Evaluate a secret's rotation status from its tags.
+///
+/// `fallback` is used as the rotation baseline when a policy exists but
+/// [`TAG_ROTATED_AT`] does not — normally the secret's `updated_on` or
+/// `created_on`. Without it, a policy added to an existing secret would have no
+/// reference point and could never come due.
+pub fn evaluate(
+    tags: &HashMap<String, String>,
+    fallback: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> RotationStatus {
+    let Some(raw) = tags.get(TAG_ROTATE_EVERY) else {
+        return RotationStatus::NoPolicy;
+    };
+
+    let interval = match parse_interval(raw) {
+        Ok(d) => d,
+        Err(e) => {
+            return RotationStatus::Invalid {
+                value: raw.clone(),
+                reason: e.to_string(),
+            }
+        }
+    };
+
+    let last = tags
+        .get(TAG_ROTATED_AT)
+        .and_then(|v| DateTime::parse_from_rfc3339(v).ok())
+        .map(|dt| dt.with_timezone(&Utc))
+        .or(fallback);
+
+    let Some(last) = last else {
+        // A policy with no baseline at all: treat as due, so it gets rotated
+        // once and acquires a timestamp, rather than being skipped forever.
+        return RotationStatus::Due {
+            overdue_by: Duration::zero(),
+            due_at: now,
+        };
+    };
+
+    let due_at = last + interval;
+    if now >= due_at {
+        RotationStatus::Due {
+            overdue_by: now - due_at,
+            due_at,
+        }
+    } else {
+        RotationStatus::Ok {
+            due_in: due_at - now,
+            due_at,
+        }
+    }
+}
+
+/// Human-friendly, coarse duration for status output ("3 days", "5 hours").
+pub fn humanize(d: Duration) -> String {
+    let d = if d < Duration::zero() { -d } else { d };
+    let days = d.num_days();
+    if days >= 1 {
+        return format!("{days} day{}", plural(days));
+    }
+    let hours = d.num_hours();
+    if hours >= 1 {
+        return format!("{hours} hour{}", plural(hours));
+    }
+    let minutes = d.num_minutes();
+    if minutes >= 1 {
+        return format!("{minutes} minute{}", plural(minutes));
+    }
+    "less than a minute".to_string()
+}
+
+fn plural(n: i64) -> &'static str {
+    if n == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
+/// Tags to write when a rotation completes: refresh the timestamp, and set the
+/// interval when the caller supplied a new one.
+pub fn rotation_tags(interval: Option<Duration>, now: DateTime<Utc>) -> HashMap<String, String> {
+    let mut tags = HashMap::new();
+    tags.insert(TAG_ROTATED_AT.to_string(), now.to_rfc3339());
+    if let Some(interval) = interval {
+        tags.insert(TAG_ROTATE_EVERY.to_string(), format_interval(interval));
+    }
+    tags
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tags(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    // -- parsing ------------------------------------------------------------
+
+    #[test]
+    fn parses_every_unit() {
+        assert_eq!(parse_interval("30m").unwrap(), Duration::minutes(30));
+        assert_eq!(parse_interval("12h").unwrap(), Duration::hours(12));
+        assert_eq!(parse_interval("90d").unwrap(), Duration::days(90));
+        assert_eq!(parse_interval("6w").unwrap(), Duration::weeks(6));
+        assert_eq!(parse_interval("  90d  ").unwrap(), Duration::days(90));
+    }
+
+    #[test]
+    fn rejects_ambiguous_or_malformed_intervals() {
+        // A bare number is the important rejection: guessing the unit wrong
+        // means either constant rotation or none.
+        for bad in ["", "90", "d", "-5d", "90x", "9999w", "0d", "1.5d", "d90"] {
+            assert!(parse_interval(bad).is_err(), "{bad:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn interval_error_names_the_valid_units() {
+        let err = parse_interval("90").unwrap_err().to_string();
+        assert!(err.contains("90d"), "{err}");
+        assert!(err.contains("weeks"), "{err}");
+    }
+
+    #[test]
+    fn format_interval_round_trips_and_prefers_large_units() {
+        for input in ["30m", "12h", "90d", "2w"] {
+            let parsed = parse_interval(input).unwrap();
+            assert_eq!(format_interval(parsed), input, "round trip of {input}");
+        }
+        // 14 days is exactly 2 weeks and should render as such.
+        assert_eq!(format_interval(Duration::days(14)), "2w");
+        assert_eq!(format_interval(Duration::hours(36)), "36h");
+    }
+
+    // -- evaluation ---------------------------------------------------------
+
+    #[test]
+    fn no_policy_tag_means_unmanaged() {
+        let now = Utc::now();
+        assert_eq!(
+            evaluate(&tags(&[]), Some(now), now),
+            RotationStatus::NoPolicy
+        );
+        // A stray timestamp without an interval is still unmanaged.
+        assert_eq!(
+            evaluate(
+                &tags(&[(TAG_ROTATED_AT, &now.to_rfc3339())]),
+                Some(now),
+                now
+            ),
+            RotationStatus::NoPolicy
+        );
+    }
+
+    #[test]
+    fn not_yet_due_reports_remaining_time() {
+        let now = Utc::now();
+        let last = now - Duration::days(10);
+        let status = evaluate(
+            &tags(&[
+                (TAG_ROTATE_EVERY, "30d"),
+                (TAG_ROTATED_AT, &last.to_rfc3339()),
+            ]),
+            None,
+            now,
+        );
+        match status {
+            RotationStatus::Ok { due_in, due_at } => {
+                assert_eq!(due_in.num_days(), 20);
+                assert_eq!(due_at, last + Duration::days(30));
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+        assert!(!status.is_due());
+    }
+
+    #[test]
+    fn past_due_reports_overdue_amount() {
+        let now = Utc::now();
+        let last = now - Duration::days(40);
+        let status = evaluate(
+            &tags(&[
+                (TAG_ROTATE_EVERY, "30d"),
+                (TAG_ROTATED_AT, &last.to_rfc3339()),
+            ]),
+            None,
+            now,
+        );
+        match status {
+            RotationStatus::Due { overdue_by, .. } => {
+                assert_eq!(overdue_by.num_days(), 10);
+            }
+            other => panic!("expected Due, got {other:?}"),
+        }
+        assert!(status.is_due());
+    }
+
+    #[test]
+    fn exactly_at_the_boundary_is_due() {
+        let now = Utc::now();
+        let last = now - Duration::days(30);
+        let status = evaluate(
+            &tags(&[
+                (TAG_ROTATE_EVERY, "30d"),
+                (TAG_ROTATED_AT, &last.to_rfc3339()),
+            ]),
+            None,
+            now,
+        );
+        assert!(status.is_due(), "the boundary should rotate, not wait");
+    }
+
+    #[test]
+    fn falls_back_to_the_secrets_own_timestamp() {
+        // Policy added to a pre-existing secret that has never been rotated.
+        let now = Utc::now();
+        let created = now - Duration::days(100);
+        let status = evaluate(&tags(&[(TAG_ROTATE_EVERY, "30d")]), Some(created), now);
+        assert!(
+            status.is_due(),
+            "a policy on an old secret must come due, not be skipped: {status:?}"
+        );
+
+        let recent = now - Duration::days(1);
+        let status = evaluate(&tags(&[(TAG_ROTATE_EVERY, "30d")]), Some(recent), now);
+        assert!(!status.is_due());
+    }
+
+    #[test]
+    fn policy_without_any_baseline_is_due_once() {
+        let now = Utc::now();
+        let status = evaluate(&tags(&[(TAG_ROTATE_EVERY, "30d")]), None, now);
+        assert!(
+            status.is_due(),
+            "with no baseline it must rotate once to acquire a timestamp"
+        );
+    }
+
+    #[test]
+    fn unparseable_policy_is_invalid_not_unmanaged() {
+        // The safety-critical case: a typo must be loud, never a silent
+        // "rotation is off".
+        let now = Utc::now();
+        let status = evaluate(&tags(&[(TAG_ROTATE_EVERY, "ninety days")]), Some(now), now);
+        match &status {
+            RotationStatus::Invalid { value, .. } => assert_eq!(value, "ninety days"),
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+        assert!(
+            !status.is_due(),
+            "an invalid policy must not trigger a write"
+        );
+        assert!(status.is_invalid());
+    }
+
+    #[test]
+    fn unparseable_timestamp_falls_back_rather_than_failing() {
+        // A corrupt timestamp with a valid interval should still evaluate,
+        // using the fallback, so rotation is not blocked by bad bookkeeping.
+        let now = Utc::now();
+        let created = now - Duration::days(100);
+        let status = evaluate(
+            &tags(&[
+                (TAG_ROTATE_EVERY, "30d"),
+                (TAG_ROTATED_AT, "not-a-timestamp"),
+            ]),
+            Some(created),
+            now,
+        );
+        assert!(status.is_due(), "{status:?}");
+    }
+
+    #[test]
+    fn non_utc_timestamps_are_normalized() {
+        let now = Utc::now();
+        // Same instant expressed with a +05:00 offset.
+        let last = (now - Duration::days(40))
+            .with_timezone(&chrono::FixedOffset::east_opt(5 * 3600).unwrap())
+            .to_rfc3339();
+        let status = evaluate(
+            &tags(&[(TAG_ROTATE_EVERY, "30d"), (TAG_ROTATED_AT, &last)]),
+            None,
+            now,
+        );
+        match status {
+            RotationStatus::Due { overdue_by, .. } => assert_eq!(overdue_by.num_days(), 10),
+            other => panic!("offset timestamps must normalize to UTC, got {other:?}"),
+        }
+    }
+
+    // -- tag emission -------------------------------------------------------
+
+    #[test]
+    fn rotation_tags_always_stamp_time_and_optionally_the_interval() {
+        let now = Utc::now();
+        let only_time = rotation_tags(None, now);
+        assert_eq!(only_time.len(), 1);
+        assert_eq!(only_time[TAG_ROTATED_AT], now.to_rfc3339());
+
+        let with_policy = rotation_tags(Some(Duration::days(90)), now);
+        assert_eq!(with_policy[TAG_ROTATE_EVERY], "90d");
+        assert_eq!(with_policy[TAG_ROTATED_AT], now.to_rfc3339());
+    }
+
+    #[test]
+    fn stamped_tags_evaluate_as_not_due() {
+        // A rotation that just happened must not immediately look due again.
+        let now = Utc::now();
+        let written = rotation_tags(Some(Duration::days(1)), now);
+        let status = evaluate(&written, None, now);
+        assert!(!status.is_due(), "{status:?}");
+    }
+
+    #[test]
+    fn humanize_reads_naturally() {
+        assert_eq!(humanize(Duration::days(1)), "1 day");
+        assert_eq!(humanize(Duration::days(3)), "3 days");
+        assert_eq!(humanize(Duration::hours(5)), "5 hours");
+        assert_eq!(humanize(Duration::minutes(1)), "1 minute");
+        assert_eq!(humanize(Duration::seconds(30)), "less than a minute");
+        // Overdue durations arrive negated; the label should still read forward.
+        assert_eq!(humanize(-Duration::days(2)), "2 days");
+    }
+}

--- a/src/web/context.rs
+++ b/src/web/context.rs
@@ -573,6 +573,8 @@ vaults = [
                     default_vault: Some("config-local-vault".into()),
                     encrypt_metadata: None,
                     opaque_filenames: None,
+                    audit: None,
+                    git: None,
                 }),
             );
             let config = Config {
@@ -593,6 +595,8 @@ vaults = [
                     default_vault: Some("config-local-vault".into()),
                     encrypt_metadata: None,
                     opaque_filenames: None,
+                    audit: None,
+                    git: None,
                 }),
                 named_backends,
                 clipboard_timeout: 17,
@@ -1082,6 +1086,8 @@ vaults = [
             default_vault: None,
             encrypt_metadata: None,
             opaque_filenames: None,
+            audit: None,
+            git: None,
         });
         let config = Config {
             backend: Some("full".into()),
@@ -1325,6 +1331,8 @@ vaults = [
                 default_vault: Some("desktop-vault".into()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
             ..Default::default()
         };
@@ -1424,6 +1432,8 @@ vault = "single-vault"
                 default_vault: Some("single-vault".into()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
             ..Default::default()
         };

--- a/src/web/errors.rs
+++ b/src/web/errors.rs
@@ -207,6 +207,14 @@ pub(crate) fn crosstache_error(error: CrosstacheError) -> (StatusCode, ApiErrorB
             "The operation was blocked by a security finding.".into(),
             "Review the finding and remove the sensitive value before retrying.",
         ),
+        RotationDue { count } => (
+            format!("{count} secret(s) are due for rotation."),
+            "Run 'xv rotate --due' to rotate them.",
+        ),
+        AuditChainBroken { seq, .. } => (
+            format!("The audit log failed integrity verification at record {seq}."),
+            "The log may have been altered. Investigate before trusting its history.",
+        ),
         RenameIncomplete { .. } => (
             "The secret was renamed, but the original could not be removed.".into(),
             "Refresh the vault and verify both secrets before retrying deletion.",
@@ -318,6 +326,12 @@ pub(crate) fn backend_error(error: BackendError) -> (StatusCode, ApiErrorBody) {
             "xv-rename-incomplete",
             "The secret was renamed, but the original could not be removed.",
             "Refresh the vault and verify both secrets before retrying deletion.",
+        ),
+        Decryption(_) => generic(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "xv-decryption-failed",
+            "The secret could not be decrypted.",
+            "The configured age identity may not match this store, or the data may be damaged.",
         ),
         Internal(_) | Other(_) => generic(
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/web/secrets.rs
+++ b/src/web/secrets.rs
@@ -589,6 +589,8 @@ mod tests {
             default_vault: Some("default".to_string()),
             encrypt_metadata: None,
             opaque_filenames: None,
+            audit: None,
+            git: None,
         }))
         .unwrap();
         let backend: Arc<dyn crate::backend::Backend> = Arc::new(backend);

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -705,6 +705,8 @@ mod tests {
                 default_vault: Some("mystore".to_string()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
             ..Default::default()
         };

--- a/src/workspace/resolve.rs
+++ b/src/workspace/resolve.rs
@@ -229,6 +229,8 @@ mod tests {
                 default_vault: Some("default".into()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
         );
         named_backends.insert(
@@ -239,6 +241,8 @@ mod tests {
                 default_vault: Some("default".into()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
         );
         let config = Config {
@@ -559,6 +563,8 @@ mod tests {
                 default_vault: Some("default".into()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
         );
         // No top-level `backend`/`local`/`azure` config at all — this
@@ -633,6 +639,8 @@ mod tests {
                 default_vault: Some("default".into()),
                 encrypt_metadata: None,
                 opaque_filenames: None,
+                audit: None,
+                git: None,
             }),
         );
         // No top-level `backend`/`local`/`azure` config at all — same

--- a/tests/action_yml_tests.rs
+++ b/tests/action_yml_tests.rs
@@ -1,0 +1,460 @@
+//! Tests for the first-party GitHub Action (`action.yml`).
+//!
+//! A composite action cannot be run end-to-end without a runner, so this
+//! covers the two things that can go wrong silently:
+//!
+//! 1. **The action contract** — inputs, outputs, and step wiring. A typo here
+//!    surfaces as a confusing runtime failure in someone else's workflow.
+//! 2. **The secret-fetch shell logic** — extracted from the YAML and executed
+//!    against a stub `xv`, with a temporary `GITHUB_ENV`. This is the part that
+//!    handles secret material, so masking, multi-line values, and delimiter
+//!    injection are all exercised for real rather than reviewed by eye.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+fn action_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("action.yml")
+}
+
+fn action_yaml() -> serde_yaml::Value {
+    let body = std::fs::read_to_string(action_path()).expect("read action.yml");
+    serde_yaml::from_str(&body).expect("action.yml must be valid YAML")
+}
+
+/// Pull one composite step's `run:` script out of the action by step name.
+fn step_script(name: &str) -> String {
+    let doc = action_yaml();
+    let steps = doc["runs"]["steps"]
+        .as_sequence()
+        .expect("runs.steps must be a sequence");
+    for step in steps {
+        if step["name"].as_str() == Some(name) {
+            return step["run"]
+                .as_str()
+                .unwrap_or_else(|| panic!("step {name} has no run script"))
+                .to_string();
+        }
+    }
+    panic!("no step named {name} in action.yml");
+}
+
+// ---------------------------------------------------------------------------
+// Action contract
+// ---------------------------------------------------------------------------
+
+#[test]
+fn action_declares_a_composite_run_with_the_expected_steps() {
+    let doc = action_yaml();
+    assert_eq!(doc["runs"]["using"].as_str(), Some("composite"));
+
+    let names: Vec<&str> = doc["runs"]["steps"]
+        .as_sequence()
+        .unwrap()
+        .iter()
+        .filter_map(|s| s["name"].as_str())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["Install xv", "Configure authentication", "Fetch secrets"],
+        "step order matters: install, then auth, then read"
+    );
+
+    // Every step must pin a shell; composite actions error without it.
+    for step in doc["runs"]["steps"].as_sequence().unwrap() {
+        assert_eq!(
+            step["shell"].as_str(),
+            Some("bash"),
+            "step {:?} must declare shell: bash",
+            step["name"].as_str()
+        );
+    }
+}
+
+#[test]
+fn action_inputs_cover_the_documented_surface() {
+    let doc = action_yaml();
+    let inputs = doc["inputs"].as_mapping().expect("inputs mapping");
+    for key in [
+        "version",
+        "backend",
+        "vault",
+        "secrets",
+        "auth",
+        "client-id",
+        "tenant-id",
+        "subscription-id",
+        "verify-signature",
+    ] {
+        assert!(
+            inputs.contains_key(serde_yaml::Value::from(key)),
+            "missing input: {key}"
+        );
+    }
+
+    // Defaults that define the action's behavior out of the box.
+    assert_eq!(doc["inputs"]["version"]["default"].as_str(), Some("latest"));
+    assert_eq!(doc["inputs"]["auth"]["default"].as_str(), Some("oidc"));
+    assert_eq!(doc["inputs"]["backend"]["default"].as_str(), Some("azure"));
+
+    // Every input needs a description — it is the only docs a consumer sees in
+    // the marketplace UI.
+    for (name, spec) in inputs {
+        assert!(
+            spec["description"].as_str().is_some_and(|d| d.len() > 20),
+            "input {name:?} needs a substantive description"
+        );
+    }
+}
+
+#[test]
+fn action_exposes_version_and_path_outputs() {
+    let doc = action_yaml();
+    assert!(
+        doc["outputs"]["version"]["value"]
+            .as_str()
+            .unwrap()
+            .contains("steps.install.outputs.version"),
+        "version output must come from the install step"
+    );
+    assert!(doc["outputs"]["path"]["value"].as_str().is_some());
+}
+
+#[test]
+fn install_step_verifies_checksums_and_fails_closed() {
+    let script = step_script("Install xv");
+    assert!(script.contains("set -euo pipefail"), "must fail fast");
+    assert!(
+        script.contains(".sha256"),
+        "must fetch the published digest"
+    );
+    assert!(
+        script.contains("Checksum mismatch"),
+        "must reject a mismatched archive"
+    );
+    // A digest that is not a digest must not be treated as a pass.
+    assert!(
+        script.contains("[0-9a-f]{64}"),
+        "must validate the digest's shape before comparing"
+    );
+    // Cache key must include the platform, or a restored cache could hand over
+    // a binary for the wrong OS.
+    assert!(
+        script.contains("${RUNNER_OS}-${RUNNER_ARCH}"),
+        "tool-cache path must be platform-scoped"
+    );
+}
+
+#[test]
+fn install_step_covers_every_published_platform() {
+    let script = step_script("Install xv");
+    for archive in [
+        "xv-linux-x64.tar.gz",
+        "xv-macos-intel.tar.gz",
+        "xv-macos-apple-silicon.tar.gz",
+        "xv-windows-x64.zip",
+    ] {
+        assert!(
+            script.contains(archive),
+            "install step must map a runner to {archive}"
+        );
+    }
+}
+
+#[test]
+fn signature_verification_uses_the_release_signing_key() {
+    // Must match the key embedded in `xv upgrade`; a mismatch would mean the
+    // action trusts a different signer than the CLI does.
+    let embedded = std::fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli/upgrade_ops.rs"),
+    )
+    .unwrap();
+    let key = embedded
+        .lines()
+        .find(|l| l.contains("RELEASE_SIGNING_KEY"))
+        .and_then(|l| l.split('"').nth(1))
+        .expect("upgrade_ops.rs must define RELEASE_SIGNING_KEY");
+
+    let script = step_script("Install xv");
+    assert!(
+        script.contains(key),
+        "action.yml must verify against the same minisign key as xv upgrade ({key})"
+    );
+}
+
+#[test]
+fn oidc_auth_requires_the_id_token_permission_and_ids() {
+    let script = step_script("Configure authentication");
+    assert!(script.contains("ACTIONS_ID_TOKEN_REQUEST_URL"));
+    assert!(
+        script.contains("id-token: write"),
+        "the error must tell the user exactly what to add"
+    );
+    assert!(
+        script.contains("AZURE_CREDENTIAL_PRIORITY=oidc"),
+        "must select the OIDC credential in the CLI"
+    );
+    assert!(
+        script.contains("client-id and tenant-id"),
+        "must reject a half-configured federation"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Secret-fetch logic, executed for real
+// ---------------------------------------------------------------------------
+
+/// Run the extracted "Fetch secrets" script with a stub `xv` on PATH.
+///
+/// `responses` maps a secret name to the value the stub prints. A name absent
+/// from the map makes the stub exit non-zero, standing in for a fetch failure.
+struct FetchRun {
+    status: std::process::ExitStatus,
+    stdout: String,
+    github_env: String,
+}
+
+fn run_fetch(secrets_input: &str, responses: &[(&str, &str)]) -> FetchRun {
+    let tmp = tempfile::tempdir().unwrap();
+    let bin_dir = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+
+    // Stub `xv`: `xv get <name> --raw [--vault v]`.
+    let mut cases = String::new();
+    for (name, value) in responses {
+        cases.push_str(&format!(
+            "  {})\n    printf '%s' \"$(cat <<'XVVALUE'\n{}\nXVVALUE\n)\"\n    exit 0 ;;\n",
+            shell_case_pattern(name),
+            value
+        ));
+    }
+    let stub = format!(
+        "#!/usr/bin/env bash\n\
+         # stub xv: only `get <name> --raw` is used by the action\n\
+         if [[ \"$1\" != \"get\" ]]; then exit 0; fi\n\
+         case \"$2\" in\n{cases}  *) echo \"secret not found: $2\" >&2; exit 10 ;;\n\
+         esac\n"
+    );
+    let stub_path = bin_dir.join("xv");
+    std::fs::write(&stub_path, stub).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&stub_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let github_env = tmp.path().join("github_env");
+    std::fs::File::create(&github_env).unwrap();
+
+    let script_path = tmp.path().join("fetch.sh");
+    let mut f = std::fs::File::create(&script_path).unwrap();
+    f.write_all(step_script("Fetch secrets").as_bytes())
+        .unwrap();
+    drop(f);
+
+    let path = format!(
+        "{}:{}",
+        bin_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let out = std::process::Command::new("bash")
+        .arg(&script_path)
+        .env("PATH", path)
+        .env("INPUT_SECRETS", secrets_input)
+        .env("INPUT_VAULT", "")
+        .env("GITHUB_ENV", &github_env)
+        .output()
+        .expect("run fetch script");
+
+    FetchRun {
+        status: out.status,
+        stdout: String::from_utf8_lossy(&out.stdout).to_string()
+            + &String::from_utf8_lossy(&out.stderr),
+        github_env: std::fs::read_to_string(&github_env).unwrap(),
+    }
+}
+
+fn shell_case_pattern(name: &str) -> String {
+    // Test names are plain, but quote anyway so a pattern char cannot alter the
+    // stub's control flow.
+    format!("\"{name}\"")
+}
+
+/// Extract `NAME=value` pairs from a GITHUB_ENV file written in heredoc form.
+fn parse_github_env(body: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut lines = body.lines().peekable();
+    while let Some(line) = lines.next() {
+        if let Some((name, delim)) = line.split_once("<<") {
+            let mut value = Vec::new();
+            for inner in lines.by_ref() {
+                if inner == delim {
+                    break;
+                }
+                value.push(inner.to_string());
+            }
+            out.push((name.to_string(), value.join("\n")));
+        }
+    }
+    out
+}
+
+#[test]
+fn fetch_exports_and_masks_each_secret() {
+    let run = run_fetch(
+        "DB_PASSWORD=db-secret\nAPI_KEY=api-secret\n",
+        &[("db-secret", "hunter2"), ("api-secret", "abc123")],
+    );
+    assert!(run.status.success(), "{}", run.stdout);
+
+    let vars = parse_github_env(&run.github_env);
+    assert_eq!(
+        vars,
+        vec![
+            ("DB_PASSWORD".to_string(), "hunter2".to_string()),
+            ("API_KEY".to_string(), "abc123".to_string()),
+        ]
+    );
+
+    // Masking must be requested for every value, before anything else logs.
+    assert!(run.stdout.contains("::add-mask::hunter2"), "{}", run.stdout);
+    assert!(run.stdout.contains("::add-mask::abc123"), "{}", run.stdout);
+    assert!(run.stdout.contains("Fetched 2 secret(s)"), "{}", run.stdout);
+}
+
+#[test]
+fn fetch_handles_multiline_values_and_masks_every_line() {
+    // A PEM key is the canonical multi-line secret. The runner matches masks
+    // per line, so each line must be registered separately.
+    let pem =
+        "-----BEGIN PRIVATE KEY-----\nline-one-secret\nline-two-secret\n-----END PRIVATE KEY-----";
+    let run = run_fetch("TLS_KEY=pem-secret\n", &[("pem-secret", pem)]);
+    assert!(run.status.success(), "{}", run.stdout);
+
+    let vars = parse_github_env(&run.github_env);
+    assert_eq!(vars.len(), 1);
+    assert_eq!(vars[0].0, "TLS_KEY");
+    assert_eq!(vars[0].1, pem, "the full multi-line value must round-trip");
+
+    assert!(
+        run.stdout.contains("::add-mask::line-one-secret"),
+        "each line needs its own mask: {}",
+        run.stdout
+    );
+    assert!(
+        run.stdout.contains("::add-mask::line-two-secret"),
+        "{}",
+        run.stdout
+    );
+}
+
+#[test]
+fn fetch_uses_a_random_delimiter_per_value() {
+    let run = run_fetch("A=sa\nB=sb\n", &[("sa", "value-a"), ("sb", "value-b")]);
+    assert!(run.status.success(), "{}", run.stdout);
+
+    let delims: Vec<&str> = run
+        .github_env
+        .lines()
+        .filter_map(|l| l.split_once("<<").map(|(_, d)| d))
+        .collect();
+    assert_eq!(delims.len(), 2);
+    assert_ne!(
+        delims[0], delims[1],
+        "a fixed delimiter would let one secret's content terminate another's block"
+    );
+    assert!(delims.iter().all(|d| d.starts_with("XV_EOF_")));
+}
+
+#[test]
+fn fetch_rejects_a_value_containing_its_delimiter() {
+    // Defence against env injection: a value that could close the heredoc early
+    // must abort rather than be written.
+    let run = run_fetch("A=sa\n", &[("sa", "prefix\nXV_EOF_deadbeef\nA=INJECTED")]);
+    // The generated delimiter is random, so this specific value will not match
+    // it; the guard is asserted structurally instead.
+    assert!(run.status.success(), "{}", run.stdout);
+    let script = step_script("Fetch secrets");
+    assert!(
+        script.contains("contains the generated delimiter"),
+        "the delimiter-collision guard must exist"
+    );
+    // And the injected-looking line must have landed inside the value, not as
+    // its own env var.
+    let vars = parse_github_env(&run.github_env);
+    assert_eq!(vars.len(), 1, "exactly one variable: {vars:?}");
+    assert_eq!(vars[0].0, "A");
+    assert!(vars[0].1.contains("A=INJECTED"));
+}
+
+#[test]
+fn fetch_rejects_invalid_environment_variable_names() {
+    for bad in ["1BAD=x", "has-dash=x", "has space=x", "=x"] {
+        let run = run_fetch(&format!("{bad}\n"), &[("x", "v")]);
+        assert!(
+            !run.status.success(),
+            "{bad:?} should be rejected: {}",
+            run.stdout
+        );
+        assert!(
+            run.stdout.contains("not a valid environment variable name")
+                || run.stdout.contains("Malformed"),
+            "{}",
+            run.stdout
+        );
+    }
+}
+
+#[test]
+fn fetch_rejects_malformed_entries() {
+    let run = run_fetch("NO_EQUALS_SIGN\n", &[]);
+    assert!(!run.status.success());
+    assert!(
+        run.stdout.contains("Malformed secrets entry"),
+        "{}",
+        run.stdout
+    );
+
+    let run = run_fetch("EMPTY_NAME=\n", &[]);
+    assert!(!run.status.success());
+    assert!(run.stdout.contains("No secret name"), "{}", run.stdout);
+}
+
+#[test]
+fn fetch_fails_the_step_when_a_secret_is_missing() {
+    // A missing secret must fail loudly; exporting an empty value would let a
+    // deploy proceed with a blank credential.
+    let run = run_fetch("A=present\nB=absent\n", &[("present", "v")]);
+    assert!(!run.status.success(), "{}", run.stdout);
+    assert!(
+        run.stdout.contains("Failed to read secret 'absent'"),
+        "{}",
+        run.stdout
+    );
+}
+
+#[test]
+fn fetch_skips_blanks_and_comments_and_tolerates_crlf() {
+    let run = run_fetch(
+        "\n# a comment\r\nDB=db-secret\r\n\n   \n",
+        &[("db-secret", "hunter2")],
+    );
+    assert!(run.status.success(), "{}", run.stdout);
+    let vars = parse_github_env(&run.github_env);
+    assert_eq!(vars, vec![("DB".to_string(), "hunter2".to_string())]);
+}
+
+#[test]
+fn fetch_preserves_values_with_shell_metacharacters() {
+    // Values are data, never code: a value that looks like a command
+    // substitution must survive byte-for-byte.
+    let nasty = "$(touch /tmp/xv-pwned); `id`; ${HOME}; \"quoted\" 'single' \\backslash";
+    let run = run_fetch("V=nasty\n", &[("nasty", nasty)]);
+    assert!(run.status.success(), "{}", run.stdout);
+    let vars = parse_github_env(&run.github_env);
+    assert_eq!(vars[0].1, nasty, "value must not be expanded or mangled");
+    assert!(
+        !std::path::Path::new("/tmp/xv-pwned").exists(),
+        "the value must never be evaluated as shell"
+    );
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,7 +7,7 @@
 
 #![allow(dead_code)] // each test file imports a subset of helpers
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
 
@@ -104,6 +104,58 @@ default_vault = "default"
         .env("NO_COLOR", "1")
         .current_dir(temp.path());
     (cmd, temp)
+}
+
+/// Isolated local-backend `xv` command with the audit and/or git-versioning
+/// options enabled under `[local]`.
+///
+/// Same hermetic setup as [`xv_isolated_local`]; returns the store path too,
+/// since these tests assert on the on-disk store (audit log, `.git/`).
+pub fn xv_isolated_local_with_opts(audit: bool, git: bool) -> (Command, TempDir, PathBuf) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config_dir = temp.path().join(".config");
+    let store_dir = temp.path().join("store");
+    let key_file = temp.path().join("key.txt");
+    let xv_dir = config_dir.join("xv");
+    std::fs::create_dir_all(&xv_dir).expect("create config dir");
+    std::fs::create_dir_all(&store_dir).expect("create store dir");
+
+    let config_content = format!(
+        r#"backend = "local"
+debug = false
+subscription_id = ""
+default_vault = "default"
+default_resource_group = ""
+default_location = ""
+tenant_id = ""
+output_json = false
+no_color = true
+cache_enabled = false
+cache_ttl_secs = 0
+clipboard_timeout = 0
+
+[local]
+store_path = "{store}"
+key_file = "{key}"
+default_vault = "default"
+audit = {audit}
+git = {git}
+"#,
+        store = store_dir.display(),
+        key = key_file.display(),
+    );
+    std::fs::write(xv_dir.join("xv.conf"), config_content).expect("write config");
+
+    let mut cmd = xv();
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", temp.path())
+        .env("XDG_CONFIG_HOME", &config_dir)
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "local")
+        .env("NO_COLOR", "1")
+        .current_dir(temp.path());
+    (cmd, temp, store_dir)
 }
 
 /// Build an isolated `xv` command backed by the **local** backend (same

--- a/tests/e2e_record_types.rs
+++ b/tests/e2e_record_types.rs
@@ -798,6 +798,8 @@ fn get_corrupt_envelope_fails_loud() {
         default_vault: Some("default".to_string()),
         encrypt_metadata: None,
         opaque_filenames: None,
+        audit: None,
+        git: None,
     };
 
     let rt = tokio::runtime::Runtime::new().unwrap();
@@ -881,6 +883,8 @@ fn get_unknown_type_degrades() {
         default_vault: Some("default".to_string()),
         encrypt_metadata: None,
         opaque_filenames: None,
+        audit: None,
+        git: None,
     };
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
@@ -2796,6 +2800,8 @@ fn update_positional_value_on_corrupt_envelope_fails_loud_without_writing() {
         default_vault: Some("default".to_string()),
         encrypt_metadata: None,
         opaque_filenames: None,
+        audit: None,
+        git: None,
     };
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
@@ -2883,6 +2889,8 @@ fn update_positional_value_on_unknown_type_record_errors_without_writing() {
         default_vault: Some("default".to_string()),
         encrypt_metadata: None,
         opaque_filenames: None,
+        audit: None,
+        git: None,
     };
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {

--- a/tests/git_audit_cli_tests.rs
+++ b/tests/git_audit_cli_tests.rs
@@ -1,0 +1,317 @@
+//! CLI-level coverage for `xv git` and `xv audit --verify`.
+//!
+//! Complements `local_audit_git_tests.rs` (which drives the backend directly)
+//! by exercising the actual argument parsing, capability gates, output, and exit
+//! codes a user hits.
+
+mod common;
+
+use common::xv_isolated_local_with_opts;
+
+/// Run a git command inside the store and return stdout.
+fn git_in(store: &std::path::Path, args: &[&str]) -> String {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(store)
+        .args(args)
+        .output()
+        .expect("run git");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+// ---------------------------------------------------------------------------
+// xv git
+// ---------------------------------------------------------------------------
+
+#[test]
+fn git_log_lists_a_commit_per_write() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, true);
+    assert!(cmd
+        .args(["set", "A", "--value", "1"])
+        .status()
+        .unwrap()
+        .success());
+    assert!(xv_cmd_for(&store)
+        .args(["set", "B", "--value", "2"])
+        .status()
+        .unwrap()
+        .success());
+
+    let out = xv_cmd_for(&store).args(["git", "log"]).output().unwrap();
+    assert!(
+        out.status.success(),
+        "{:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("set A"), "{stdout}");
+    assert!(stdout.contains("set B"), "{stdout}");
+
+    // Cross-check against git itself, not just our own rendering.
+    let subjects = git_in(&store, &["log", "--pretty=%s"]);
+    assert_eq!(
+        subjects.lines().collect::<Vec<_>>(),
+        vec!["set B", "set A"],
+        "real git history should show one commit per write, newest first"
+    );
+}
+
+/// Rebuild a command against an existing isolated store dir.
+///
+/// `xv_isolated_local_with_opts` mints a fresh tempdir per call, so multi-step
+/// CLI flows need to re-point at the same store; this reuses the tempdir that
+/// owns `store`.
+fn xv_cmd_for(store: &std::path::Path) -> std::process::Command {
+    let root = store.parent().expect("store has a parent");
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_xv"));
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", root)
+        .env("XDG_CONFIG_HOME", root.join(".config"))
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "local")
+        .env("NO_COLOR", "1")
+        .current_dir(root);
+    cmd
+}
+
+#[test]
+fn git_log_filters_by_secret_and_honors_json_format() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, true);
+    cmd.args(["set", "ALPHA", "--value", "1"]).status().unwrap();
+    xv_cmd_for(&store)
+        .args(["set", "BETA", "--value", "2"])
+        .status()
+        .unwrap();
+
+    let out = xv_cmd_for(&store)
+        .args(["git", "log", "ALPHA"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("set ALPHA"), "{stdout}");
+    assert!(
+        !stdout.contains("set BETA"),
+        "filtered log leaked BETA: {stdout}"
+    );
+
+    let out = xv_cmd_for(&store)
+        .args(["git", "log", "--format", "json"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("git log --format json must emit JSON ({e}): {stdout}"));
+    assert!(parsed.is_array(), "{parsed}");
+    assert_eq!(parsed.as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn git_status_and_diff_report_the_store() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, true);
+    cmd.args(["set", "A", "--value", "1"]).status().unwrap();
+
+    let out = xv_cmd_for(&store).args(["git", "status"]).output().unwrap();
+    assert!(out.status.success());
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("clean"),
+        "auto-commit leaves a clean tree: {combined}"
+    );
+
+    let out = xv_cmd_for(&store).args(["git", "diff"]).output().unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains(".age"),
+        "diff should name the ciphertext file: {stdout}"
+    );
+    assert!(
+        !stdout.contains("value") || !stdout.contains("+1"),
+        "diff must not include file contents: {stdout}"
+    );
+}
+
+#[test]
+fn git_init_works_before_the_flag_is_enabled() {
+    // Chicken-and-egg guard: `xv git init` must not require [local].git, since
+    // enabling versioning is the reason you'd run it.
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    let out = cmd.args(["git", "init"]).output().unwrap();
+    assert!(
+        out.status.success(),
+        "{:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(store.join(".git").exists(), "repository should exist");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("git = true"),
+        "must tell the user auto-commit is still off: {combined}"
+    );
+
+    // The managed .gitignore protects key material from the very first commit.
+    let ignore = std::fs::read_to_string(store.join(".gitignore")).unwrap();
+    assert!(ignore.contains("key.txt"), "{ignore}");
+}
+
+#[test]
+fn git_commands_are_rejected_on_non_local_backends() {
+    // Needs a config that passes Azure's own validation (subscription_id), so
+    // the request reaches the `xv git` capability gate rather than tripping
+    // config validation first.
+    let tmp = tempfile::tempdir().unwrap();
+    let config_dir = tmp.path().join(".config");
+    let xv_dir = config_dir.join("xv");
+    std::fs::create_dir_all(&xv_dir).unwrap();
+    std::fs::write(
+        xv_dir.join("xv.conf"),
+        r#"backend = "azure"
+debug = false
+subscription_id = "00000000-0000-0000-0000-000000000000"
+default_vault = "example-kv"
+default_resource_group = "example-rg"
+default_location = "eastus"
+tenant_id = "00000000-0000-0000-0000-000000000000"
+output_json = false
+no_color = true
+cache_enabled = false
+cache_ttl_secs = 0
+clipboard_timeout = 0
+"#,
+    )
+    .unwrap();
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_xv"))
+        .env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", &config_dir)
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "azure")
+        .env("NO_COLOR", "1")
+        .current_dir(tmp.path())
+        .args(["git", "log"])
+        .output()
+        .unwrap();
+
+    assert!(!out.status.success(), "must refuse on a cloud backend");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("xv history"),
+        "error should point at the backend-native alternative: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// xv audit (local)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_lists_local_events() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(true, false);
+    cmd.args(["set", "DB_PASSWORD", "--value", "hunter2"])
+        .status()
+        .unwrap();
+    xv_cmd_for(&store)
+        .args(["get", "DB_PASSWORD", "--raw"])
+        .output()
+        .unwrap();
+
+    let out = xv_cmd_for(&store)
+        .args(["audit", "--vault", "default", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(String::from_utf8_lossy(&out.stdout).trim()).expect("json rows");
+    let ops: Vec<&str> = parsed
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["operation"].as_str().unwrap())
+        .collect();
+    assert!(ops.contains(&"PutSecretValue"), "{ops:?}");
+    assert!(ops.contains(&"GetSecretValue"), "{ops:?}");
+}
+
+#[test]
+fn audit_verify_reports_an_intact_chain() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(true, false);
+    cmd.args(["set", "A", "--value", "1"]).status().unwrap();
+
+    let out = xv_cmd_for(&store)
+        .args(["audit", "--verify"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(combined.contains("intact"), "{combined}");
+    // The honesty caveat must travel with the success message.
+    assert!(
+        combined.contains("cannot prove completeness"),
+        "verify output must not overstate the guarantee: {combined}"
+    );
+}
+
+#[test]
+fn audit_verify_fails_nonzero_on_a_tampered_chain() {
+    let (cmd, _tmp, store) = xv_isolated_local_with_opts(true, false);
+    for name in ["A", "B", "C"] {
+        xv_cmd_for(&store)
+            .args(["set", name, "--value", "1"])
+            .status()
+            .unwrap();
+    }
+    drop(cmd);
+
+    let log = store.join("vaults/default/.audit/log.jsonl");
+    let body = std::fs::read_to_string(&log).unwrap();
+    let lines: Vec<&str> = body.lines().collect();
+    assert!(lines.len() >= 3, "expected records, got {}", lines.len());
+    // Excise the middle record.
+    std::fs::write(&log, format!("{}\n{}\n", lines[0], lines[lines.len() - 1])).unwrap();
+
+    let out = xv_cmd_for(&store)
+        .args(["audit", "--verify"])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "a broken chain must exit non-zero so CI can gate on it"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.to_lowercase().contains("broken"), "{stderr}");
+}
+
+#[test]
+fn audit_verify_requires_the_audit_flag() {
+    let (mut cmd, _tmp, _store) = xv_isolated_local_with_opts(false, false);
+    let out = cmd.args(["audit", "--verify"]).output().unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("audit = true"),
+        "should name the config key to enable: {stderr}"
+    );
+}

--- a/tests/local_audit_git_tests.rs
+++ b/tests/local_audit_git_tests.rs
@@ -97,7 +97,10 @@ async fn audit_records_the_full_secret_lifecycle() {
     assert!(be.capabilities().has_audit);
     let audit = be.audit().expect("AuditBackend when [local].audit is on");
 
-    // set → get(value) → update → delete → restore → get → purge
+    // set → get(value) → update → delete → restore → delete → purge.
+    // Purge follows a *delete*: since the transactional-store rework, purge
+    // applies only to soft-deleted (trashed) secrets and errors on an active
+    // one, so the lifecycle re-deletes before purging.
     be.secrets()
         .set_secret("default", request("DB_PASSWORD", "hunter2"))
         .await
@@ -123,6 +126,10 @@ async fn audit_records_the_full_secret_lifecycle() {
         .await
         .unwrap();
     be.secrets()
+        .delete_secret("default", "DB_PASSWORD")
+        .await
+        .unwrap();
+    be.secrets()
         .purge_secret("default", "DB_PASSWORD")
         .await
         .unwrap();
@@ -138,6 +145,7 @@ async fn audit_records_the_full_secret_lifecycle() {
             "UpdateSecret",
             "DeleteSecret",
             "RestoreSecret",
+            "DeleteSecret",
             "PurgeSecret",
         ],
         "every mutation and value read must be recorded, in order"
@@ -154,11 +162,11 @@ async fn audit_records_the_full_secret_lifecycle() {
         .get_secret_events("default", "DB_PASSWORD", None, 30)
         .await
         .unwrap();
-    assert_eq!(scoped.len(), 6);
+    assert_eq!(scoped.len(), 7);
 
     assert_eq!(
         be.audit_log().unwrap().verify_chain("default").unwrap(),
-        ChainStatus::Intact { records: 6 }
+        ChainStatus::Intact { records: 7 }
     );
 }
 
@@ -634,4 +642,123 @@ async fn failures_are_not_audited_when_auditing_is_off() {
     let be = backend(&tmp, false, false);
     let _ = be.secrets().get_secret("default", "NOPE", true).await;
     assert!(!tmp.path().join("store/vaults/default/.audit").exists());
+}
+
+#[tokio::test]
+async fn renames_are_audited_and_committed() {
+    // `rename_secret` arrived with the transactional-store rework; it must flow
+    // through the same audit/git hooks as every other mutation.
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, true, true);
+    be.secrets()
+        .set_secret("default", request("OLD_NAME", "v"))
+        .await
+        .unwrap();
+
+    be.secrets()
+        .rename_secret("default", "OLD_NAME", "NEW_NAME")
+        .await
+        .unwrap();
+
+    let records = audit_records(&tmp);
+    let rename = records
+        .iter()
+        .find(|r| r["operation"] == "RenameSecret")
+        .expect("the rename must be recorded");
+    assert_eq!(
+        rename["resource_name"], "OLD_NAME",
+        "the record keys on the source name, joining the pre-rename history"
+    );
+    assert_eq!(rename["status"], "Succeeded");
+
+    // And a failed rename (missing source) is recorded too.
+    let err = be
+        .secrets()
+        .rename_secret("default", "GHOST", "ANYTHING")
+        .await
+        .expect_err("renaming a missing secret fails");
+    let _ = err;
+    let records = audit_records(&tmp);
+    let failed = records
+        .iter()
+        .rev()
+        .find(|r| r["operation"] == "RenameSecret" && r["resource_name"] == "GHOST")
+        .expect("the failed attempt must be recorded");
+    assert_ne!(failed["status"], "Succeeded");
+
+    let subjects = std::process::Command::new("git")
+        .arg("-C")
+        .arg(tmp.path().join("store"))
+        .args(["log", "--pretty=%s"])
+        .output()
+        .unwrap();
+    let subjects = String::from_utf8_lossy(&subjects.stdout);
+    assert!(
+        subjects.contains("rename OLD_NAME to NEW_NAME"),
+        "the rename should be its own commit: {subjects}"
+    );
+
+    assert_eq!(
+        be.audit_log().unwrap().verify_chain("default").unwrap(),
+        ChainStatus::Intact { records: 3 },
+        "set + rename + failed rename: the chain must verify across all three"
+    );
+}
+
+#[tokio::test]
+async fn git_log_filter_survives_opaque_filenames() {
+    // End-to-end for the Bugbot finding: with opaque filenames the committed
+    // paths are keyed-hash stems, so only subject-based filtering can find a
+    // secret's history.
+    let tmp = TempDir::new().unwrap();
+    let cfg = LocalConfig {
+        store_path: Some(tmp.path().join("store").to_string_lossy().to_string()),
+        key_file: Some(tmp.path().join("key.txt").to_string_lossy().to_string()),
+        default_vault: Some("default".into()),
+        encrypt_metadata: None,
+        opaque_filenames: Some(true),
+        audit: None,
+        git: Some(true),
+    };
+    let be = LocalBackend::new(Some(&cfg)).expect("create local backend");
+
+    be.secrets()
+        .set_secret("default", request("DB_PASSWORD", "v1"))
+        .await
+        .unwrap();
+    be.secrets()
+        .set_secret("default", request("OTHER", "v"))
+        .await
+        .unwrap();
+    be.secrets()
+        .set_secret("default", request("DB_PASSWORD", "v2"))
+        .await
+        .unwrap();
+
+    // Confirm the layout really is opaque — no committed path contains the name.
+    let tracked = std::process::Command::new("git")
+        .arg("-C")
+        .arg(tmp.path().join("store"))
+        .args(["ls-files"])
+        .output()
+        .unwrap();
+    let tracked = String::from_utf8_lossy(&tracked.stdout);
+    assert!(
+        !tracked.contains("DB_PASSWORD"),
+        "precondition: paths must be opaque, got {tracked}"
+    );
+
+    let subjects: Vec<String> = be
+        .git_store()
+        .unwrap()
+        .log(Some("DB_PASSWORD"), 0)
+        .unwrap()
+        .into_iter()
+        .map(|c| c.subject)
+        .collect();
+    assert_eq!(
+        subjects,
+        vec!["set DB_PASSWORD", "set DB_PASSWORD"],
+        "opaque paths must not hide the secret's history"
+    );
 }

--- a/tests/local_audit_git_tests.rs
+++ b/tests/local_audit_git_tests.rs
@@ -1,0 +1,637 @@
+//! End-to-end coverage for the local backend's audit trail and git-native
+//! versioning, driven through `LocalBackend` rather than the inner types — so
+//! the config plumbing, capability flags, and per-operation hooks are all
+//! exercised the way the CLI reaches them.
+
+use crosstache::backend::local::audit::ChainStatus;
+use crosstache::backend::local::LocalBackend;
+use crosstache::backend::Backend;
+use crosstache::config::settings::LocalConfig;
+use crosstache::secret::manager::{FieldUpdate, SecretRequest, SecretUpdateRequest};
+use tempfile::TempDir;
+
+/// Build a local backend rooted in a temp dir.
+///
+/// Key material deliberately sits *outside* `store/`, matching the shipped
+/// default (`~/.xv/key.txt` alongside `~/.xv/store`).
+fn backend(tmp: &TempDir, audit: bool, git: bool) -> LocalBackend {
+    let cfg = LocalConfig {
+        store_path: Some(tmp.path().join("store").to_string_lossy().to_string()),
+        key_file: Some(tmp.path().join("key.txt").to_string_lossy().to_string()),
+        default_vault: Some("default".into()),
+        encrypt_metadata: None,
+        opaque_filenames: None,
+        audit: Some(audit),
+        git: Some(git),
+    };
+    LocalBackend::new(Some(&cfg)).expect("create local backend")
+}
+
+fn request(name: &str, value: &str) -> SecretRequest {
+    SecretRequest {
+        name: name.to_string(),
+        value: value.to_string().into(),
+        content_type: None,
+        enabled: None,
+        expires_on: None,
+        not_before: None,
+        tags: None,
+        groups: None,
+        note: None,
+        folder: None,
+    }
+}
+
+/// A metadata-only update that sets `note`.
+fn note_update(name: &str, note: &str) -> SecretUpdateRequest {
+    SecretUpdateRequest {
+        name: name.to_string(),
+        value: None,
+        content_type: None,
+        enabled: None,
+        expires_on: FieldUpdate::Unchanged,
+        not_before: FieldUpdate::Unchanged,
+        tags: None,
+        groups: None,
+        note: FieldUpdate::Set(note.to_string()),
+        folder: FieldUpdate::Unchanged,
+        replace_tags: false,
+        replace_groups: false,
+        expected_revision: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Audit trail
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn audit_disabled_by_default_and_writes_nothing() {
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, false, false);
+
+    assert!(
+        !be.capabilities().has_audit,
+        "has_audit must stay false when [local].audit is off"
+    );
+    assert!(be.audit().is_none(), "no AuditBackend without the flag");
+    assert!(be.audit_log().is_none());
+
+    be.secrets()
+        .set_secret("default", request("DB_PASSWORD", "hunter2"))
+        .await
+        .unwrap();
+
+    let audit_dir = tmp.path().join("store/vaults/default/.audit");
+    assert!(
+        !audit_dir.exists(),
+        "the default path must not create an audit log"
+    );
+}
+
+#[tokio::test]
+async fn audit_records_the_full_secret_lifecycle() {
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, true, false);
+
+    assert!(be.capabilities().has_audit);
+    let audit = be.audit().expect("AuditBackend when [local].audit is on");
+
+    // set → get(value) → update → delete → restore → get → purge
+    be.secrets()
+        .set_secret("default", request("DB_PASSWORD", "hunter2"))
+        .await
+        .unwrap();
+    be.secrets()
+        .get_secret("default", "DB_PASSWORD", true)
+        .await
+        .unwrap();
+    be.secrets()
+        .update_secret(
+            "default",
+            "DB_PASSWORD",
+            note_update("DB_PASSWORD", "prod db"),
+        )
+        .await
+        .unwrap();
+    be.secrets()
+        .delete_secret("default", "DB_PASSWORD")
+        .await
+        .unwrap();
+    be.secrets()
+        .restore_secret("default", "DB_PASSWORD")
+        .await
+        .unwrap();
+    be.secrets()
+        .purge_secret("default", "DB_PASSWORD")
+        .await
+        .unwrap();
+
+    let events = audit.get_vault_events("default", None, 30).await.unwrap();
+    // Newest first, so reverse for a chronological read.
+    let ops: Vec<&str> = events.iter().rev().map(|e| e.operation.as_str()).collect();
+    assert_eq!(
+        ops,
+        vec![
+            "PutSecretValue",
+            "GetSecretValue",
+            "UpdateSecret",
+            "DeleteSecret",
+            "RestoreSecret",
+            "PurgeSecret",
+        ],
+        "every mutation and value read must be recorded, in order"
+    );
+    assert!(events.iter().all(|e| e.status == "Succeeded"));
+    assert!(events.iter().all(|e| e.resource_name == "DB_PASSWORD"));
+    assert!(
+        events.iter().all(|e| e.source_ip.is_none()),
+        "local access has no network peer to report"
+    );
+
+    // Per-secret query narrows to that secret.
+    let scoped = audit
+        .get_secret_events("default", "DB_PASSWORD", None, 30)
+        .await
+        .unwrap();
+    assert_eq!(scoped.len(), 6);
+
+    assert_eq!(
+        be.audit_log().unwrap().verify_chain("default").unwrap(),
+        ChainStatus::Intact { records: 6 }
+    );
+}
+
+#[tokio::test]
+async fn metadata_only_reads_are_not_logged_as_value_access() {
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, true, false);
+    be.secrets()
+        .set_secret("default", request("A", "v"))
+        .await
+        .unwrap();
+
+    // include_value = false — backs listings and existence checks.
+    be.secrets()
+        .get_secret("default", "A", false)
+        .await
+        .unwrap();
+    be.secrets().secret_exists("default", "A").await.unwrap();
+
+    let events = be
+        .audit()
+        .unwrap()
+        .get_vault_events("default", None, 30)
+        .await
+        .unwrap();
+    let gets = events
+        .iter()
+        .filter(|e| e.operation == "GetSecretValue")
+        .count();
+    assert_eq!(
+        gets, 0,
+        "metadata-only reads must not look like value access"
+    );
+}
+
+#[tokio::test]
+async fn listing_is_recorded_as_a_vault_wide_event() {
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, true, false);
+    be.secrets()
+        .set_secret("default", request("A", "v"))
+        .await
+        .unwrap();
+    be.secrets().list_secrets("default", None).await.unwrap();
+
+    let events = be
+        .audit()
+        .unwrap()
+        .get_vault_events("default", None, 30)
+        .await
+        .unwrap();
+    let list = events
+        .iter()
+        .find(|e| e.operation == "ListSecrets")
+        .expect("enumeration is audit-relevant");
+    assert_eq!(list.resource_name, "*");
+}
+
+#[tokio::test]
+async fn tampering_with_the_audit_log_is_detected() {
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, true, false);
+    for name in ["A", "B", "C"] {
+        be.secrets()
+            .set_secret("default", request(name, "v"))
+            .await
+            .unwrap();
+    }
+
+    let log_path = tmp.path().join("store/vaults/default/.audit/log.jsonl");
+    let body = std::fs::read_to_string(&log_path).unwrap();
+    let lines: Vec<&str> = body.lines().collect();
+    assert_eq!(lines.len(), 3);
+
+    // Drop the middle record — the classic "hide one access" edit.
+    std::fs::write(&log_path, format!("{}\n{}\n", lines[0], lines[2])).unwrap();
+
+    match be.audit_log().unwrap().verify_chain("default").unwrap() {
+        ChainStatus::Broken { verified, .. } => {
+            assert_eq!(verified, 1, "the first record still verifies");
+        }
+        other => panic!("expected a broken chain, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Git-native versioning
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn git_disabled_by_default() {
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, false, false);
+    be.secrets()
+        .set_secret("default", request("A", "v"))
+        .await
+        .unwrap();
+
+    assert!(be.git_store().is_none());
+    assert!(
+        !tmp.path().join("store/.git").exists(),
+        "the default path must not create a repository"
+    );
+}
+
+#[tokio::test]
+async fn every_mutation_produces_a_commit() {
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, false, true);
+
+    // The repo is created eagerly at backend construction.
+    assert!(tmp.path().join("store/.git").exists());
+    let git = be.git_store().expect("git store when [local].git is on");
+
+    be.secrets()
+        .set_secret("default", request("DB_PASSWORD", "hunter2"))
+        .await
+        .unwrap();
+    be.secrets()
+        .set_secret("default", request("DB_PASSWORD", "hunter3"))
+        .await
+        .unwrap();
+    be.secrets()
+        .update_secret("default", "DB_PASSWORD", note_update("DB_PASSWORD", "prod"))
+        .await
+        .unwrap();
+    be.secrets()
+        .delete_secret("default", "DB_PASSWORD")
+        .await
+        .unwrap();
+
+    let subjects: Vec<String> = git
+        .log(None, 0)
+        .unwrap()
+        .into_iter()
+        .map(|c| c.subject)
+        .collect();
+    assert_eq!(
+        subjects,
+        vec![
+            "delete DB_PASSWORD",
+            "update DB_PASSWORD",
+            "set DB_PASSWORD",
+            "set DB_PASSWORD",
+        ],
+        "history should read as the operation log, newest first"
+    );
+}
+
+#[tokio::test]
+async fn only_ciphertext_is_committed_never_the_identity() {
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, false, true);
+    be.secrets()
+        .set_secret("default", request("DB_PASSWORD", "hunter2"))
+        .await
+        .unwrap();
+
+    let tracked = std::process::Command::new("git")
+        .arg("-C")
+        .arg(tmp.path().join("store"))
+        .args(["ls-files"])
+        .output()
+        .unwrap();
+    let tracked = String::from_utf8_lossy(&tracked.stdout);
+
+    assert!(
+        tracked.contains(".age"),
+        "age ciphertext should be versioned: {tracked}"
+    );
+    assert!(
+        !tracked.contains("key.txt"),
+        "the age identity must never be tracked: {tracked}"
+    );
+
+    // And the committed blob must not contain the plaintext value.
+    let blobs = std::process::Command::new("git")
+        .arg("-C")
+        .arg(tmp.path().join("store"))
+        .args(["grep", "-I", "--cached", "hunter2"])
+        .output()
+        .unwrap();
+    assert!(
+        !String::from_utf8_lossy(&blobs.stdout).contains("hunter2"),
+        "plaintext must never reach a commit"
+    );
+}
+
+#[tokio::test]
+async fn git_versioning_and_audit_compose() {
+    // The combination is the interesting one: git gives the audit log an
+    // off-box copy, which is what the hash chain alone cannot provide.
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, true, true);
+    be.secrets()
+        .set_secret("default", request("A", "v"))
+        .await
+        .unwrap();
+
+    let tracked = std::process::Command::new("git")
+        .arg("-C")
+        .arg(tmp.path().join("store"))
+        .args(["ls-files"])
+        .output()
+        .unwrap();
+    let tracked = String::from_utf8_lossy(&tracked.stdout);
+    assert!(
+        tracked.contains(".audit/log.jsonl"),
+        "the audit log must be versioned so a remote holds copies: {tracked}"
+    );
+    assert_eq!(
+        be.audit_log().unwrap().verify_chain("default").unwrap(),
+        ChainStatus::Intact { records: 1 }
+    );
+}
+
+#[tokio::test]
+async fn history_and_rollback_still_work_alongside_git() {
+    // Git versioning is additive: the backend's own version archive continues
+    // to drive `xv history` / `xv rollback` unchanged.
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, true, true);
+    be.secrets()
+        .set_secret("default", request("A", "v1"))
+        .await
+        .unwrap();
+    be.secrets()
+        .set_secret("default", request("A", "v2"))
+        .await
+        .unwrap();
+
+    let versions = be.secrets().list_versions("default", "A").await.unwrap();
+    assert!(versions.len() >= 2, "version archive still populated");
+
+    be.secrets().rollback("default", "A", "v1").await.unwrap();
+    let current = be.secrets().get_secret("default", "A", true).await.unwrap();
+    assert_eq!(current.value.as_deref().map(|v| v.as_str()), Some("v1"));
+
+    let subjects: Vec<String> = be
+        .git_store()
+        .unwrap()
+        .log(None, 1)
+        .unwrap()
+        .into_iter()
+        .map(|c| c.subject)
+        .collect();
+    assert!(
+        subjects[0].starts_with("rollback A"),
+        "rollback should be its own commit: {subjects:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Failed attempts
+// ---------------------------------------------------------------------------
+
+/// Read the raw audit records for a vault.
+fn audit_records(tmp: &TempDir) -> Vec<serde_json::Value> {
+    let path = tmp.path().join("store/vaults/default/.audit/log.jsonl");
+    let body = std::fs::read_to_string(&path).unwrap_or_default();
+    body.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("audit line is JSON"))
+        .collect()
+}
+
+#[tokio::test]
+async fn a_read_of_a_missing_secret_is_audited_as_notfound() {
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, true, false);
+
+    let err = be
+        .secrets()
+        .get_secret("default", "NOPE", true)
+        .await
+        .expect_err("missing secret");
+    assert!(matches!(
+        err,
+        crosstache::backend::BackendError::NotFound { .. }
+    ));
+
+    let records = audit_records(&tmp);
+    assert_eq!(
+        records.len(),
+        1,
+        "the attempt must be recorded: {records:?}"
+    );
+    assert_eq!(records[0]["operation"], "GetSecretValue");
+    assert_eq!(records[0]["resource_name"], "NOPE");
+    assert_eq!(records[0]["status"], "NotFound");
+
+    // The failure record must not break the chain.
+    assert_eq!(
+        be.audit_log().unwrap().verify_chain("default").unwrap(),
+        ChainStatus::Intact { records: 1 }
+    );
+}
+
+#[tokio::test]
+async fn a_metadata_only_read_of_a_missing_secret_is_not_audited() {
+    // Existence probes back listings; auditing them would bury real access in
+    // noise, and the success path already declines to log them.
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, true, false);
+    let _ = be.secrets().get_secret("default", "NOPE", false).await;
+    let _ = be.secrets().secret_exists("default", "NOPE").await;
+    assert!(audit_records(&tmp).is_empty());
+}
+
+#[tokio::test]
+async fn undecryptable_ciphertext_is_audited_as_decryption_failed() {
+    // The security-relevant failure: the caller reached the material and could
+    // not open it — wrong identity, or altered/truncated ciphertext.
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, true, false);
+    be.secrets()
+        .set_secret("default", request("DB_PASSWORD", "hunter2"))
+        .await
+        .unwrap();
+
+    // Corrupt the ciphertext, leaving metadata intact so the read gets that far.
+    let age_path = tmp
+        .path()
+        .join("store/vaults/default/secrets/DB_PASSWORD.age");
+    std::fs::write(&age_path, b"not-age-ciphertext-at-all").unwrap();
+
+    let err = be
+        .secrets()
+        .get_secret("default", "DB_PASSWORD", true)
+        .await
+        .expect_err("corrupt ciphertext must not decrypt");
+    assert!(
+        matches!(err, crosstache::backend::BackendError::Decryption(_)),
+        "expected a Decryption error, got {err:?}"
+    );
+
+    let records = audit_records(&tmp);
+    let last = records.last().expect("a record");
+    assert_eq!(last["operation"], "GetSecretValue");
+    assert_eq!(last["resource_name"], "DB_PASSWORD");
+    assert_eq!(
+        last["status"], "DecryptionFailed",
+        "a failed decryption must be distinguishable from a generic internal error: {records:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_write_to_a_missing_vault_is_audited_as_vaultnotfound() {
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, true, false);
+    // The vault dir must exist for the audit log to be written into it, so use
+    // a real vault for the log and a missing one for the operation.
+    let err = be
+        .secrets()
+        .set_secret("default", request("A", "v"))
+        .await
+        .map(|_| ())
+        .and(
+            be.secrets()
+                .delete_secret("default", "GHOST")
+                .await
+                .map(|_| ()),
+        )
+        .expect_err("deleting a nonexistent secret fails");
+    let _ = err;
+
+    let records = audit_records(&tmp);
+    let failure = records
+        .iter()
+        .find(|r| r["operation"] == "DeleteSecret")
+        .expect("the delete attempt must be recorded");
+    assert_eq!(failure["resource_name"], "GHOST");
+    assert_ne!(
+        failure["status"], "Succeeded",
+        "a failed delete must not be recorded as a success: {records:?}"
+    );
+}
+
+#[tokio::test]
+async fn failure_records_never_contain_secret_values() {
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, true, false);
+    let secret_value = "super-secret-canary-value";
+    be.secrets()
+        .set_secret("default", request("CANARY", secret_value))
+        .await
+        .unwrap();
+
+    // Force a decryption failure, whose error message is the richest of any
+    // failure path.
+    let age_path = tmp.path().join("store/vaults/default/secrets/CANARY.age");
+    std::fs::write(&age_path, b"corrupt").unwrap();
+    let _ = be.secrets().get_secret("default", "CANARY", true).await;
+    // And an invalid-argument failure via a traversal vault name.
+    let _ = be.secrets().get_secret("../escape", "CANARY", true).await;
+
+    let raw =
+        std::fs::read_to_string(tmp.path().join("store/vaults/default/.audit/log.jsonl")).unwrap();
+    assert!(
+        !raw.contains(secret_value),
+        "no audit record may contain a secret value: {raw}"
+    );
+    // Statuses come from a closed set, so no error text leaks in either.
+    for record in audit_records(&tmp) {
+        let status = record["status"].as_str().unwrap();
+        assert!(
+            [
+                "Succeeded",
+                "NotFound",
+                "VaultNotFound",
+                "AuthenticationFailed",
+                "AccessDenied",
+                "Unsupported",
+                "InvalidArgument",
+                "Conflict",
+                "RateLimited",
+                "NetworkError",
+                "RenameIncomplete",
+                "DecryptionFailed",
+                "InternalError",
+            ]
+            .contains(&status),
+            "status {status:?} is outside the closed vocabulary"
+        );
+    }
+}
+
+#[tokio::test]
+async fn successes_and_failures_interleave_in_one_verifiable_chain() {
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, true, false);
+
+    be.secrets()
+        .set_secret("default", request("A", "v"))
+        .await
+        .unwrap();
+    let _ = be.secrets().get_secret("default", "MISSING", true).await;
+    be.secrets().get_secret("default", "A", true).await.unwrap();
+    let _ = be
+        .secrets()
+        .get_secret("default", "ALSO_MISSING", true)
+        .await;
+
+    let records = audit_records(&tmp);
+    let pairs: Vec<(&str, &str)> = records
+        .iter()
+        .map(|r| {
+            (
+                r["resource_name"].as_str().unwrap(),
+                r["status"].as_str().unwrap(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        pairs,
+        vec![
+            ("A", "Succeeded"),
+            ("MISSING", "NotFound"),
+            ("A", "Succeeded"),
+            ("ALSO_MISSING", "NotFound"),
+        ]
+    );
+
+    assert_eq!(
+        be.audit_log().unwrap().verify_chain("default").unwrap(),
+        ChainStatus::Intact { records: 4 }
+    );
+}
+
+#[tokio::test]
+async fn failures_are_not_audited_when_auditing_is_off() {
+    let tmp = TempDir::new().unwrap();
+    let be = backend(&tmp, false, false);
+    let _ = be.secrets().get_secret("default", "NOPE", true).await;
+    assert!(!tmp.path().join("store/vaults/default/.audit").exists());
+}

--- a/tests/local_backend_integration.rs
+++ b/tests/local_backend_integration.rs
@@ -26,6 +26,8 @@ fn make_backend(tmp: &TempDir) -> crosstache::backend::local::LocalBackend {
         default_vault: Some("default".into()),
         encrypt_metadata: None,
         opaque_filenames: None,
+        audit: None,
+        git: None,
     };
     crosstache::backend::local::LocalBackend::new(Some(&cfg)).expect("create backend")
 }

--- a/tests/migration_round_trip_tests.rs
+++ b/tests/migration_round_trip_tests.rs
@@ -49,6 +49,8 @@ async fn local_to_aws_round_trip() {
         default_vault: Some("test-vault".into()),
         encrypt_metadata: None,
         opaque_filenames: None,
+        audit: None,
+        git: None,
     };
     let local = LocalBackend::new(Some(&local_cfg)).unwrap();
 

--- a/tests/rotation_policy_tests.rs
+++ b/tests/rotation_policy_tests.rs
@@ -1,0 +1,520 @@
+//! End-to-end coverage for rotation policies (`xv update --rotate-every`,
+//! `xv rotate --every/--due/--check`) on the local backend.
+//!
+//! The policy is backend-agnostic metadata, so exercising it on the local
+//! backend covers the same code path Azure and AWS take; only `--native`
+//! remains AWS-specific and is untouched here.
+
+mod common;
+
+use common::xv_isolated_local_with_opts;
+
+/// Rebuild a command against an existing isolated store.
+fn xv_cmd_for(store: &std::path::Path) -> std::process::Command {
+    let root = store.parent().expect("store has a parent");
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_xv"));
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", root)
+        .env("XDG_CONFIG_HOME", root.join(".config"))
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "local")
+        .env("NO_COLOR", "1")
+        .current_dir(root);
+    cmd
+}
+
+/// Parse the first JSON document on stdout.
+///
+/// With an explicit `--format json`, `xv` also writes a machine-readable error
+/// envelope to stdout when the command exits non-zero (see
+/// `print_user_friendly_error`). So a `--check` run that finds due secrets emits
+/// the rows *and* the envelope — the same shape `xv scan --format json` has
+/// produced since it shipped. Read only the leading document.
+fn first_json_doc(stdout: &str) -> serde_json::Value {
+    let mut stream = serde_json::Deserializer::from_str(stdout).into_iter::<serde_json::Value>();
+    stream
+        .next()
+        .unwrap_or_else(|| panic!("expected a JSON document on stdout: {stdout}"))
+        .unwrap_or_else(|e| panic!("invalid JSON on stdout ({e}): {stdout}"))
+}
+
+/// `xv rotate --check --format json` rows plus whether the command succeeded.
+fn check_rows(store: &std::path::Path) -> (bool, Vec<serde_json::Value>) {
+    let out = xv_cmd_for(store)
+        .args(["rotate", "--check", "--format", "json"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let rows = first_json_doc(&stdout);
+    let rows = rows
+        .as_array()
+        .unwrap_or_else(|| panic!("--check must emit an array: {stdout}"))
+        .clone();
+    (out.status.success(), rows)
+}
+
+/// A secret's tag map, read straight from the local store's metadata file.
+///
+/// `xv ls --format json` emits a curated row shape without the raw tag map, so
+/// on-disk metadata is the direct way to assert on rotation bookkeeping. Test
+/// names here are plain ASCII, which the local backend stores verbatim.
+fn tags_of(store: &std::path::Path, name: &str) -> serde_json::Value {
+    let path = store
+        .join("vaults/default/secrets")
+        .join(format!("{name}.meta.json"));
+    let body =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let meta: serde_json::Value = serde_json::from_str(&body).unwrap();
+    meta["tags"].clone()
+}
+
+// ---------------------------------------------------------------------------
+// Setting and clearing a policy
+// ---------------------------------------------------------------------------
+
+#[test]
+fn setting_a_policy_does_not_rotate_and_starts_the_clock() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    cmd.args(["set", "DB_PASSWORD", "--value", "original"])
+        .status()
+        .unwrap();
+
+    let out = xv_cmd_for(&store)
+        .args(["update", "DB_PASSWORD", "--rotate-every", "90d"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The value must be untouched — setting a policy is not a rotation.
+    let value = xv_cmd_for(&store)
+        .args(["get", "DB_PASSWORD", "--raw"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        String::from_utf8_lossy(&value.stdout).trim(),
+        "original",
+        "setting a policy must not change the value"
+    );
+
+    // Both tags are written, so the secret is not immediately due.
+    let tags = tags_of(&store, "DB_PASSWORD");
+    assert_eq!(tags["xv:rotate_every"], "90d");
+    assert!(
+        tags["xv:rotated_at"].is_string(),
+        "the clock must start at policy-set time: {tags}"
+    );
+
+    let (ok, rows) = check_rows(&store);
+    assert!(ok, "a fresh policy must not be reported as due");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["status"], "ok");
+    assert_eq!(rows[0]["name"], "DB_PASSWORD");
+}
+
+#[test]
+fn clearing_a_policy_removes_both_tags_and_keeps_others() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    cmd.args([
+        "set",
+        "A",
+        "--value",
+        "v",
+        "--tag",
+        "owner=platform",
+        "--note",
+        "keep me",
+    ])
+    .status()
+    .unwrap();
+    xv_cmd_for(&store)
+        .args(["update", "A", "--rotate-every", "30d"])
+        .status()
+        .unwrap();
+
+    let out = xv_cmd_for(&store)
+        .args(["update", "A", "--clear-rotate-every"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let tags = tags_of(&store, "A");
+    assert!(tags.get("xv:rotate_every").is_none(), "{tags}");
+    assert!(tags.get("xv:rotated_at").is_none(), "{tags}");
+    assert_eq!(
+        tags["owner"], "platform",
+        "unrelated tags must survive the authoritative rewrite: {tags}"
+    );
+
+    // Note lives outside the tag map on some backends; confirm it survived too.
+    let listed = xv_cmd_for(&store)
+        .args(["ls", "--format", "json"])
+        .output()
+        .unwrap();
+    let rows = first_json_doc(&String::from_utf8_lossy(&listed.stdout));
+    let row = rows
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["name"] == "A")
+        .unwrap();
+    assert_eq!(row["note"], "keep me", "{row}");
+
+    let (ok, rows) = check_rows(&store);
+    assert!(ok);
+    assert!(rows.is_empty(), "no policies remain: {rows:?}");
+}
+
+#[test]
+fn clearing_a_missing_policy_is_a_no_op() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    cmd.args(["set", "A", "--value", "v"]).status().unwrap();
+
+    let out = xv_cmd_for(&store)
+        .args(["update", "A", "--clear-rotate-every"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(combined.contains("no rotation policy"), "{combined}");
+}
+
+#[test]
+fn invalid_intervals_are_rejected_before_any_write() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    cmd.args(["set", "A", "--value", "v"]).status().unwrap();
+
+    for bad in ["90", "abc", "0d", "9999w"] {
+        let out = xv_cmd_for(&store)
+            .args(["update", "A", "--rotate-every", bad])
+            .output()
+            .unwrap();
+        assert!(!out.status.success(), "interval {bad:?} should be rejected");
+    }
+
+    // No partial policy should have been written by the failed attempts.
+    let tags = tags_of(&store, "A");
+    assert!(tags.get("xv:rotate_every").is_none(), "{tags}");
+}
+
+// ---------------------------------------------------------------------------
+// --check / --due
+// ---------------------------------------------------------------------------
+
+/// Force a due state by back-dating the rotation timestamp.
+fn make_due(store: &std::path::Path, name: &str) {
+    let status = xv_cmd_for(store)
+        .args([
+            "update",
+            name,
+            "--tag",
+            "xv:rotate_every=30d",
+            "--tag",
+            "xv:rotated_at=2020-01-01T00:00:00Z",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success(), "failed to back-date {name}");
+}
+
+#[test]
+fn check_exits_51_when_a_secret_is_due() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    cmd.args(["set", "STALE", "--value", "v"]).status().unwrap();
+    make_due(&store, "STALE");
+
+    let out = xv_cmd_for(&store)
+        .args(["rotate", "--check", "--format", "json"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(51),
+        "a due secret must exit 51 so CI can gate: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let rows = first_json_doc(&String::from_utf8_lossy(&out.stdout));
+    assert_eq!(rows[0]["status"], "due");
+}
+
+#[test]
+fn check_ignores_secrets_without_a_policy() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    cmd.args(["set", "UNMANAGED", "--value", "v"])
+        .status()
+        .unwrap();
+
+    let (ok, rows) = check_rows(&store);
+    assert!(ok, "an unmanaged secret is out of scope, not overdue");
+    assert!(rows.is_empty(), "{rows:?}");
+}
+
+#[test]
+fn due_rotates_only_due_secrets_and_restamps_them() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    cmd.args(["set", "STALE", "--value", "old-value"])
+        .status()
+        .unwrap();
+    xv_cmd_for(&store)
+        .args(["set", "FRESH", "--value", "fresh-value"])
+        .status()
+        .unwrap();
+    xv_cmd_for(&store)
+        .args(["set", "UNMANAGED", "--value", "untouched"])
+        .status()
+        .unwrap();
+
+    make_due(&store, "STALE");
+    xv_cmd_for(&store)
+        .args(["update", "FRESH", "--rotate-every", "90d"])
+        .status()
+        .unwrap();
+
+    let out = xv_cmd_for(&store)
+        .args(["rotate", "--due", "--force"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Only STALE rotated.
+    let stale = xv_cmd_for(&store)
+        .args(["get", "STALE", "--raw"])
+        .output()
+        .unwrap();
+    assert_ne!(
+        String::from_utf8_lossy(&stale.stdout).trim(),
+        "old-value",
+        "the due secret should have a new value"
+    );
+
+    for (name, expected) in [("FRESH", "fresh-value"), ("UNMANAGED", "untouched")] {
+        let got = xv_cmd_for(&store)
+            .args(["get", name, "--raw"])
+            .output()
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&got.stdout).trim(),
+            expected,
+            "{name} must not have been rotated"
+        );
+    }
+
+    // The rotation restamped the clock, so nothing is due any more — this is
+    // what stops --due from re-rotating the same secret on every run.
+    let (ok, rows) = check_rows(&store);
+    assert!(ok, "after rotating, --check should be clean: {rows:?}");
+    assert_eq!(rows.len(), 2, "both policies still tracked: {rows:?}");
+    assert!(rows.iter().all(|r| r["status"] == "ok"), "{rows:?}");
+
+    // And the policy interval survived the rotation.
+    let tags = tags_of(&store, "STALE");
+    assert_eq!(tags["xv:rotate_every"], "30d", "{tags}");
+}
+
+#[test]
+fn due_is_a_no_op_when_nothing_is_due() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    cmd.args(["set", "A", "--value", "v"]).status().unwrap();
+    xv_cmd_for(&store)
+        .args(["update", "A", "--rotate-every", "90d"])
+        .status()
+        .unwrap();
+
+    let out = xv_cmd_for(&store)
+        .args(["rotate", "--due", "--force"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(combined.contains("Nothing due"), "{combined}");
+
+    let value = xv_cmd_for(&store)
+        .args(["get", "A", "--raw"])
+        .output()
+        .unwrap();
+    assert_eq!(String::from_utf8_lossy(&value.stdout).trim(), "v");
+}
+
+#[test]
+fn an_unparseable_policy_fails_due_rather_than_being_skipped() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    cmd.args(["set", "BROKEN", "--value", "v"])
+        .status()
+        .unwrap();
+    // A hand-edited or externally-written tag that xv cannot interpret.
+    xv_cmd_for(&store)
+        .args(["update", "BROKEN", "--tag", "xv:rotate_every=ninety days"])
+        .status()
+        .unwrap();
+
+    let out = xv_cmd_for(&store)
+        .args(["rotate", "--due", "--force"])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "an uninterpretable policy must fail the run, not be silently skipped"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("BROKEN"), "{stderr}");
+
+    // --check surfaces it as invalid rather than pretending it is fine.
+    let out = xv_cmd_for(&store)
+        .args(["rotate", "--check", "--format", "json"])
+        .output()
+        .unwrap();
+    let rows = first_json_doc(&String::from_utf8_lossy(&out.stdout));
+    assert_eq!(rows[0]["status"], "invalid", "{rows:?}");
+}
+
+#[test]
+fn rotate_every_sets_the_policy_while_rotating() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    cmd.args(["set", "A", "--value", "original"])
+        .status()
+        .unwrap();
+
+    let out = xv_cmd_for(&store)
+        .args(["rotate", "A", "--every", "2w", "--force"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let value = xv_cmd_for(&store)
+        .args(["get", "A", "--raw"])
+        .output()
+        .unwrap();
+    assert_ne!(
+        String::from_utf8_lossy(&value.stdout).trim(),
+        "original",
+        "--every should still rotate the value"
+    );
+
+    let tags = tags_of(&store, "A");
+    assert_eq!(tags["xv:rotate_every"], "2w", "{tags}");
+    assert!(tags["xv:rotated_at"].is_string(), "{tags}");
+}
+
+#[test]
+fn plain_rotate_restamps_an_existing_policy_without_redefining_it() {
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    cmd.args(["set", "A", "--value", "v"]).status().unwrap();
+    make_due(&store, "A");
+
+    // No --every: the existing 30d policy must survive, and the timestamp must
+    // move forward so the secret stops being due.
+    let out = xv_cmd_for(&store)
+        .args(["rotate", "A", "--force"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let tags = tags_of(&store, "A");
+    assert_eq!(
+        tags["xv:rotate_every"], "30d",
+        "policy must persist: {tags}"
+    );
+    assert_ne!(
+        tags["xv:rotated_at"], "2020-01-01T00:00:00Z",
+        "timestamp must be refreshed: {tags}"
+    );
+
+    let (ok, _rows) = check_rows(&store);
+    assert!(ok, "the secret should no longer be due");
+}
+
+#[test]
+fn rotate_requires_a_name_or_a_mode_flag() {
+    let (mut cmd, _tmp, _store) = xv_isolated_local_with_opts(false, false);
+    let out = cmd.args(["rotate"]).output().unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--due") && stderr.contains("--check"),
+        "the error should name the alternatives: {stderr}"
+    );
+}
+
+#[test]
+fn every_and_due_are_mutually_exclusive() {
+    let (mut cmd, _tmp, _store) = xv_isolated_local_with_opts(false, false);
+    let out = cmd
+        .args(["rotate", "--due", "--every", "30d"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "clap should reject the combination");
+}
+
+// ---------------------------------------------------------------------------
+// Composition with the other new features
+// ---------------------------------------------------------------------------
+
+#[test]
+fn due_rotation_is_audited_and_committed() {
+    // Rotation must flow through the same hooks a manual write does.
+    let (mut cmd, _tmp, store) = xv_isolated_local_with_opts(true, true);
+    cmd.args(["set", "STALE", "--value", "v"]).status().unwrap();
+    make_due(&store, "STALE");
+
+    xv_cmd_for(&store)
+        .args(["rotate", "--due", "--force"])
+        .status()
+        .unwrap();
+
+    let out = xv_cmd_for(&store)
+        .args(["audit", "--vault", "default", "--format", "json"])
+        .output()
+        .unwrap();
+    let rows = first_json_doc(&String::from_utf8_lossy(&out.stdout));
+    let rows = rows.as_array().unwrap();
+    let puts = rows
+        .iter()
+        .filter(|r| r["operation"] == "PutSecretValue" && r["resource"] == "STALE")
+        .count();
+    assert!(puts >= 2, "the rotation write should be audited: {rows:?}");
+
+    let log = xv_cmd_for(&store).args(["git", "log"]).output().unwrap();
+    let stdout = String::from_utf8_lossy(&log.stdout);
+    assert!(
+        stdout.contains("set STALE"),
+        "rotation should commit: {stdout}"
+    );
+
+    let verify = xv_cmd_for(&store)
+        .args(["audit", "--verify"])
+        .output()
+        .unwrap();
+    assert!(
+        verify.status.success(),
+        "chain must stay intact across rotation"
+    );
+}

--- a/tests/schedule_cli_tests.rs
+++ b/tests/schedule_cli_tests.rs
@@ -1,0 +1,287 @@
+//! CLI coverage for `xv schedule`.
+//!
+//! **These tests never register a real job.** `launchctl`, `systemctl --user`,
+//! and `schtasks` act on the invoking user's live session regardless of `HOME`,
+//! so a test that actually installed would leave a rotation job running on the
+//! developer's machine. Everything here goes through `--print`, which renders and
+//! writes nothing, or through argument validation that fails before any
+//! scheduler is touched.
+//!
+//! The install/uninstall/status *logic* — command order, idempotence, error
+//! mapping — is covered against a fake command runner in
+//! `src/schedule/mod.rs`'s unit tests.
+
+mod common;
+
+use common::xv_isolated_local_with_opts;
+
+fn xv_cmd_for(store: &std::path::Path) -> std::process::Command {
+    let root = store.parent().expect("store has a parent");
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_xv"));
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", root)
+        .env("XDG_CONFIG_HOME", root.join(".config"))
+        .env("XV_NO_PARENT_CONFIG", "1")
+        .env("XV_BACKEND", "local")
+        .env("NO_COLOR", "1")
+        .current_dir(root);
+    cmd
+}
+
+/// Run `xv schedule install --print ...` and return stdout.
+fn print_schedule(store: &std::path::Path, extra: &[&str]) -> (bool, String) {
+    let mut args = vec!["schedule", "install", "--print"];
+    args.extend_from_slice(extra);
+    let out = xv_cmd_for(store).args(&args).output().unwrap();
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string() + &String::from_utf8_lossy(&out.stderr),
+    )
+}
+
+#[test]
+fn print_renders_a_unit_without_installing_anything() {
+    let (_cmd, tmp, store) = xv_isolated_local_with_opts(false, false);
+    let (ok, out) = print_schedule(&store, &["--vault", "prod-kv"]);
+    assert!(ok, "{out}");
+
+    // The command the scheduler will run.
+    assert!(
+        out.contains("rotate --due --force --vault prod-kv"),
+        "{out}"
+    );
+    // A log destination, so a failed 3am run is diagnosable.
+    assert!(out.contains("rotate.log"), "{out}");
+    // The default cadence.
+    assert!(out.contains("daily at 03:00"), "{out}");
+
+    // Nothing may have been written to the unit directory.
+    for candidate in [
+        tmp.path().join("Library/LaunchAgents"),
+        tmp.path().join(".config/systemd/user"),
+    ] {
+        assert!(
+            !candidate.exists(),
+            "--print must not create {}",
+            candidate.display()
+        );
+    }
+}
+
+#[test]
+fn print_respects_interval_and_time() {
+    let (_cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+
+    let (ok, out) = print_schedule(&store, &["--interval", "hourly", "--at", "00:15"]);
+    assert!(ok, "{out}");
+    assert!(out.contains("every hour at :15"), "{out}");
+
+    let (ok, out) = print_schedule(&store, &["--interval", "weekly", "--at", "04:30"]);
+    assert!(ok, "{out}");
+    assert!(out.contains("weekly on Sunday at 04:30"), "{out}");
+}
+
+#[test]
+fn print_output_contains_a_loadable_unit_for_this_platform() {
+    let (_cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    let (ok, out) = print_schedule(&store, &["--vault", "v"]);
+    assert!(ok, "{out}");
+
+    if cfg!(target_os = "macos") {
+        assert!(out.contains("<?xml version=\"1.0\""), "{out}");
+        assert!(out.contains("com.crosstache.xv-rotate"), "{out}");
+        assert!(out.contains("StartCalendarInterval"), "{out}");
+        // Installing must not itself trigger a rotation.
+        assert!(out.contains("<key>RunAtLoad</key>"), "{out}");
+        assert!(out.contains("<false/>"), "{out}");
+    } else if cfg!(target_os = "windows") {
+        assert!(out.contains("schtasks"), "{out}");
+        assert!(out.contains("/TN crosstache-xv-rotate"), "{out}");
+    } else {
+        // Linux: either systemd units, or a clear "no systemd" error handled by
+        // the dedicated test below.
+        assert!(
+            out.contains("OnCalendar=") || out.contains("without systemd"),
+            "{out}"
+        );
+    }
+}
+
+#[test]
+fn invalid_times_are_rejected_before_touching_the_scheduler() {
+    let (_cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    for bad in ["3:0", "24:00", "03:60", "0300", "morning"] {
+        let out = xv_cmd_for(&store)
+            .args(["schedule", "install", "--at", bad, "--force"])
+            .output()
+            .unwrap();
+        assert!(
+            !out.status.success(),
+            "time {bad:?} should be rejected: {}",
+            String::from_utf8_lossy(&out.stdout)
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("HH:MM"),
+            "the error should show the expected form: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn invalid_interval_is_rejected_by_clap() {
+    let (_cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    let out = xv_cmd_for(&store)
+        .args([
+            "schedule",
+            "install",
+            "--interval",
+            "fortnightly",
+            "--force",
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("hourly") && stderr.contains("weekly"),
+        "clap should list the valid values: {stderr}"
+    );
+}
+
+#[test]
+fn the_scheduled_command_is_bounded_to_due_secrets() {
+    // The single most important property: an unattended job must never rotate
+    // secrets that have no policy, and must never redefine a policy.
+    let (_cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    let (ok, out) = print_schedule(&store, &["--vault", "v"]);
+    assert!(ok, "{out}");
+
+    let command_line = out
+        .lines()
+        .find(|l| l.starts_with("# command:"))
+        .expect("print shows the command");
+    assert!(command_line.contains("--due"), "{command_line}");
+    assert!(command_line.contains("--force"), "{command_line}");
+    assert!(
+        !command_line.contains("--every"),
+        "a schedule must not redefine policies: {command_line}"
+    );
+    assert!(!command_line.contains("--native"), "{command_line}");
+}
+
+#[test]
+fn print_carries_the_config_environment_into_the_unit() {
+    // The classic failure: the job runs but resolves a different config than the
+    // user tested with, so it sweeps the wrong vault or none at all.
+    let (_cmd, tmp, store) = xv_isolated_local_with_opts(false, false);
+    let (ok, out) = print_schedule(&store, &["--vault", "v"]);
+    assert!(ok, "{out}");
+
+    if cfg!(target_os = "macos") || cfg!(target_os = "linux") {
+        let config_home = tmp.path().join(".config");
+        assert!(
+            out.contains(&config_home.to_string_lossy().to_string()),
+            "the unit must pin XDG_CONFIG_HOME ({}): {out}",
+            config_home.display()
+        );
+    }
+}
+
+#[test]
+fn no_unit_contains_secret_material() {
+    let (_cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    // Seed a secret so there is something that *could* leak.
+    xv_cmd_for(&store)
+        .args(["set", "CANARY", "--value", "canary-secret-value"])
+        .status()
+        .unwrap();
+
+    let (ok, out) = print_schedule(&store, &["--vault", "default"]);
+    assert!(ok, "{out}");
+    assert!(!out.contains("canary-secret-value"), "{out}");
+    for forbidden in ["AGE-SECRET-KEY", "client_secret", "password="] {
+        assert!(!out.contains(forbidden), "unit mentions {forbidden}: {out}");
+    }
+}
+
+#[test]
+fn status_reports_absence_without_installing() {
+    let (_cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    let out = xv_cmd_for(&store)
+        .args(["schedule", "status"])
+        .output()
+        .unwrap();
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // On a host with a supported scheduler this reports "not installed"; on one
+    // without (a container with no systemd), it explains that instead. Both are
+    // successful diagnoses, and neither may claim a schedule exists.
+    assert!(
+        combined.contains("No ")
+            || combined.contains("without systemd")
+            || combined.contains("not supported"),
+        "{combined}"
+    );
+    // Must not *affirm* a schedule. Checking for the bare phrase would match
+    // inside "No launchd rotation schedule is installed.", so anchor on the
+    // affirmative form the success path emits.
+    assert!(
+        !combined.contains("rotation schedule is installed.")
+            || combined.contains("No launchd rotation schedule is installed.")
+            || combined.contains("No systemd user timer rotation schedule is installed.")
+            || combined.contains("No Task Scheduler rotation schedule is installed."),
+        "nothing was installed, so status must not affirm one: {combined}"
+    );
+}
+
+#[test]
+fn uninstall_is_safe_when_nothing_is_installed() {
+    // Must converge on "absent" rather than erroring, so it is safe in teardown
+    // scripts. This does invoke the platform scheduler's delete/bootout, which
+    // is a no-op against a job that was never created.
+    let (_cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    let out = xv_cmd_for(&store)
+        .args(["schedule", "uninstall"])
+        .output()
+        .unwrap();
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    if out.status.success() {
+        assert!(
+            combined.contains("nothing to remove") || combined.contains("Removed"),
+            "{combined}"
+        );
+    } else {
+        // Only acceptable failure: this host has no scheduler we manage.
+        assert!(
+            combined.contains("without systemd") || combined.contains("not supported"),
+            "{combined}"
+        );
+    }
+}
+
+#[test]
+fn schedule_help_explains_it_is_not_a_daemon() {
+    let (_cmd, _tmp, store) = xv_isolated_local_with_opts(false, false);
+    let out = xv_cmd_for(&store)
+        .args(["schedule", "--help"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("launchd"), "{stdout}");
+    assert!(stdout.contains("systemd"), "{stdout}");
+    assert!(stdout.contains("Task Scheduler"), "{stdout}");
+    assert!(
+        stdout.contains("No daemon"),
+        "help should say what it does not do: {stdout}"
+    );
+}


### PR DESCRIPTION
Closes four capability gaps from the competitive feature review. Every feature is
**opt-in** — existing stores, configs, and workflows are byte-for-byte unchanged
until a flag is set.

## What's here

### 1. Rotation policies + automatic scheduling — all backends

A policy lives with the secret as `xv:rotate_every` + `xv:rotated_at` tags, so it
travels across backends and is visible to anything reading metadata.

```bash
xv update DB_PASSWORD --rotate-every 90d   # policy only; clock starts now
xv rotate DB_PASSWORD --every 90d          # rotate AND set the policy
xv rotate --check                          # report; exits 51 when anything is due
xv rotate --due --force                    # sweep

xv schedule install --vault prod-kv        # daily at 03:00, via the OS scheduler
xv schedule status
xv schedule uninstall
```

`xv schedule` installs a **per-user** job in the platform's own scheduler:

| Platform | Mechanism | Unit |
|---|---|---|
| macOS | launchd user agent | `~/Library/LaunchAgents/com.crosstache.xv-rotate.plist` |
| Linux | systemd **user** timer | `~/.config/systemd/user/xv-rotate.{service,timer}` |
| Windows | Task Scheduler | task `crosstache-xv-rotate` |

No daemon, nothing system-wide, no root. A resident process would reimplement
reboot survival, sleep catch-up, and log capture worse than launchd/systemd
already do, while holding decryption credentials for its whole lifetime.

Safety properties, each test-enforced:

- The scheduled command is always `rotate --due --force` — bounded to secrets that
  already have a policy and are already past it. `--every` is never passed, so a
  schedule can't redefine what it sweeps.
- Units contain only a binary path, those args, a log path, and
  `HOME`/`XDG_CONFIG_HOME`. A test asserts no credential-shaped string appears in
  any rendered unit.
- `--print` renders without writing or registering anything — also how to drive
  cron, a Kubernetes CronJob, or a CI schedule.
- Install requires confirmation and says plainly that unattended rotation breaks
  anything that doesn't re-read its secrets.
- Output is captured to `~/.local/state/xv/rotate.log` on all three platforms.
- Strict `HH:MM` — `3:0` is rejected rather than landing an hour off.
- `--due` **fails** rather than skipping when a policy tag is unparseable: unknown
  due-ness must not look like a clean run.

### 2. Local backend audit trail — `[local].audit`

Append-only JSONL under the store, each record chained by
`HMAC-SHA256(chain_key, prev_mac || record)` with the key HKDF-derived from the
age identity.

```console
$ xv audit --vault default
 Timestamp            Operation       Resource     Caller  Status
 2026-07-24 22:14:03  PutSecretValue  DB_PASSWORD  scott   Succeeded
 2026-07-24 22:15:40  GetSecretValue  GHOST        scott   NotFound
 2026-07-24 22:16:02  GetSecretValue  DB_PASSWORD  scott   DecryptionFailed

$ xv audit --verify
[ok] Audit chain intact: 12 record(s) verified for vault 'default'.
```

- **Failures are recorded, not just successes.** Status tokens come from a closed
  set keyed off the error *variant*, never its message, so no future error string
  can widen what the log captures. New `BackendError::Decryption` makes a failed
  decryption its own `DecryptionFailed` status rather than a generic internal
  error — that's the one worth alerting on (wrong age identity, or altered
  material).
- Secret **values** never appear; secret **names** do, exactly as on the success
  path.
- Fail-closed: a failed append fails the triggering operation.
- `has_audit` reflects the flag, so the capability can't claim a trail that isn't
  being written.
- `xv audit --verify` exits **52** (`xv-audit-chain-broken`) on tampering.

> [!IMPORTANT]
> **Tamper-evident, not tamper-proof.** It detects edits, reordering, and
> deletion. It cannot stop someone holding the age identity from re-chaining the
> log, or anyone with write access from truncating it — unlike Azure Activity Log
> and CloudTrail, which the platform holds rather than the caller. Documented at
> every surface, including in the `--verify` success output itself.

### 3. Git-native versioning for the local store — `[local].git`

The store becomes a real git repository committed after every mutation, so
`git log`/`diff`/`bisect`/`push` work on actual history — the `pass` model.
`xv git init|log|status|diff|push|pull`.

Only age ciphertext and metadata are committed. The identity is protected **twice**:
a managed `.gitignore`, *and* a pre-commit staged-path check that refuses the
commit outright. `.gitignore` alone is defeatable with `git add -f`, and a key
committed once is effectively permanent.

`xv git diff` reports names only, never contents. `xv git pull` is fast-forward
only, since a merge conflict inside ciphertext is unresolvable.

Additive — `xv history`/`xv rollback` unchanged on every backend.

**Local backend only, deliberately.** Mirroring Azure/AWS secret values into git
would create a second, effectively permanent copy of every secret version. Cloud
backends keep their native version history.

### 4. First-party CI/CD

```yaml
- uses: bziobnic/crosstache@v1
  with:
    version: v0.28.0
    vault: myproj-prod-kv
    client-id: ${{ vars.AZURE_CLIENT_ID }}
    tenant-id: ${{ vars.AZURE_TENANT_ID }}
    secrets: |
      DEPLOY_TOKEN=deploy-token
```

- Root `action.yml` composite action: per-OS release archive, **fail-closed
  SHA-256** verification, tool cache, PATH export, and masked secret export to
  `GITHUB_ENV` (masked per line — the runner matches masks per line, so a PEM key
  registered as one blob would still leak line by line).
- Optional `verify-signature: true` checks the release `.minisig` against the same
  minisign key embedded in `xv upgrade`. A test asserts those two keys can't drift.
- **OIDC-native Azure auth** (`AZURE_CREDENTIAL_PRIORITY=oidc`) federates the
  job's OIDC token as a `client_assertion` — no stored client secret, no
  `azure/login` step. Explicit `oidc` never falls back, so a misconfiguration
  can't authenticate as a different identity.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo clippy --all-targets --features tui,ui,aws -- -D warnings` | clean |
| `cargo test` | 44 binaries, 0 failures |
| `cargo test --features tui,ui,aws` | 44 binaries, 0 failures |

915 lib unit tests. ~145 new tests across the five areas, including adversarial
coverage: audit-record forgery and chain truncation, key material forced into a
commit with `git add -f`, shell-metacharacter and delimiter-injection values in the
Action's secret export, XML metacharacters in scheduler units, and
credential-shaped strings in every rendered unit.

Three bugs my own tests caught and fixed during development: `--no-patch`
silently suppressed `git show --name-status` output; `git status --branch` always
emits a `## main` line so the "clean tree" branch was dead code; and the
`GetSecretValue` audit hook initially landed in `get_secret_version` instead of
`get_secret`.

Also verified live: full `xv schedule` lifecycle on macOS (install → `launchctl
list` → status → reinstall → uninstall → no residue), with `plutil -lint` passing
on the generated plist.

## Known limits — tracked in `ROADMAP.md`

- **No test registers a real scheduled job.** `launchctl`, `systemctl --user`, and
  `schtasks` act on the invoking user's live session regardless of `HOME`, so a
  test that installed would leave a rotation job on whoever ran `cargo test`.
  Lifecycle logic is covered against a fake `CommandRunner`; `--print` is covered
  end-to-end through the CLI; the macOS path was verified by hand. systemd and
  Task Scheduler lifecycles remain manually unverified.
- **`.github/workflows/action-test.yml` has never executed** — it runs on the
  first PR touching `action.yml`, which is this one.
- **No off-box audit sink.** A git remote is the current answer.
- **Rotation has no external-system hook** (`--generator` / AWS `--native` are the
  escape hatches) and no rollout coordination — a rotated credential still needs
  the consumer to re-read it.
- **`xv rotate --check --format json` emits two JSON documents on stdout** when
  something is due (rows, then the error envelope). This matches `xv scan
  --format json`, which has behaved identically since it shipped; fixing it means
  deciding the contract for the whole 50–59 exit-code family rather than
  special-casing one command.
- **CI/CD is GitHub-only** as a first-party integration. GitLab/CircleCI use a
  documented plain install step; the OIDC exchange is already generic, so only the
  token-fetch step is GitHub-specific.

## Review pointers

Highest-risk areas, in order:

1. `src/backend/local/git.rs` — `assert_no_key_material_staged` is the gate that
   keeps private keys out of permanent history.
2. `src/backend/local/audit.rs` — `AuditRecord::canonical` uses length-prefixed
   field encoding so no combination of field contents can forge an equivalent
   preimage (local secret names may contain newlines and colons).
3. `src/backend/local/secrets.rs` — the nine trait methods are now
   `async { … }.await` wrappers so failures can be audited; operation logic itself
   did not move.
4. `action.yml` — the `GITHUB_ENV` heredoc uses a random per-value delimiter and
   rejects a value containing it, so a secret can't inject arbitrary env vars.

Docs: `docs/rotation.md`, `docs/git-versioning.md`, `docs/ci-cd.md`. No version
bump — `CHANGELOG.md` has an `Unreleased` section, matching the repo's
separate-bump convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches secret handling (CI env export, OIDC auth, local audit/git key guards) and large new surface area; mistakes could leak credentials, commit key material, or authenticate as the wrong Azure identity.
> 
> **Overview**
> Large capability release documented in **Unreleased** `CHANGELOG.md`: rotation policies and `xv schedule`, opt-in **local** audit and git versioning, and first-party **CI/CD**.
> 
> **Rotation & scheduling** (described in `docs/rotation.md` and README; implementation largely outside this diff slice) adds tag-based policies (`xv:rotate_every` / `xv:rotated_at`), `xv update --rotate-every`, vault-scoped `xv rotate --check` (exit **51**) and `--due`, and OS scheduler integration via `xv schedule install|status|uninstall` running `rotate --due --force`.
> 
> **Local backend** gains `[local].audit` and `[local].git` (defaults **false**). **`src/backend/local/audit.rs`** implements an HMAC-chained JSONL log with fail-closed appends, `xv audit --verify` (exit **52**), and **`record_failure`** with variant-based status tokens; **`BackendError::Decryption`** is split out in **`crypto.rs`** / **`error.rs`** for `DecryptionFailed` rows. **`src/backend/local/git.rs`** auto-commits mutations, subject-based `xv git log`, fast-forward-only pull, and pre-commit guards (managed `.gitignore` plus staged scan for `AGE-SECRET-KEY-1`).
> 
> **CI/CD**: new root **`action.yml`** installs pinned releases (SHA-256 always, optional minisign), caches per OS/arch, configures `auth: oidc|default|none`, and exports secrets to `GITHUB_ENV` with per-line masking and heredoc delimiters. **`src/backend/azure/oidc.rs`** federates GitHub Actions OIDC into Azure AD; **`auth.rs`** wires explicit `oidc` (no fallback) and prefers OIDC in the `default` chain when Actions env vars are present. **`.github/workflows/action-test.yml`** smoke-tests install on Linux/macOS/Windows and a local-backend set/get round trip.
> 
> Docs/README/ROADMAP/exit codes and feature matrices are updated to match; known limits (no off-box audit sink, GitHub-only action, JSON double-document on `--check`) are called out in ROADMAP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6e508e6d13f6959e9b2003bad7b98b3e5a0a8bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->