### PR TITLE
chore: bump version to 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.30.0 — Rotation scheduling, local audit trail, git-native versioning, first-party CI/CD (2026-07-25)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Version-bump PR per the documented release process (README § Release process, `.omc/RELEASE_RULE.md`):

- `Cargo.toml` `0.29.0` → `0.30.0` (the only version source); `Cargo.lock` refreshed via cargo
- CHANGELOG `## Unreleased` retitled `## v0.30.0 — Rotation scheduling, local audit trail, git-native versioning, first-party CI/CD (2026-07-25)` (house style)

Verification: `cargo fmt --check` clean, `cargo clippy -- -D warnings` (CI gate) 0 errors, full default-features suite 2,715 passed / 0 failed, and the built binary self-reports `xv 0.30.0`.

After merge: annotated `v0.30.0` tag on the merge commit triggers `release.yml` (`verify-version` → GitHub release → minisign-signed binaries for all four platforms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no runtime logic; risk is limited to release/tag alignment if the tag or lockfile were wrong.
> 
> **Overview**
> **Release housekeeping for v0.30.0** — no application or feature code changes in this diff.
> 
> The crate version in `Cargo.toml` moves **0.29.0 → 0.30.0** (the documented single source of truth); `Cargo.lock` is updated so the `crosstache` package entry matches. **CHANGELOG** retitles `## Unreleased` to **`## v0.30.0 — Rotation scheduling, local audit trail, git-native versioning, first-party CI/CD (2026-07-25)`**, keeping the existing bullet list under that release heading.
> 
> After merge, tagging **`v0.30.0`** is expected to drive the existing release workflow (version check, GitHub release, signed binaries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce165b231b6e681cd8ee6d0221a5eb36822ac00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->