### PR TITLE
chore: bump version to 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.31.0 — Hierarchical tree grid for the web UI (2026-07-29)
+
+### Changed
+
+- **Web UI: folder sidebar replaced with a hierarchical tree grid.** Folders
+  and their contents now live in one table on both the secrets and files
+  surfaces, sharing a single tree-grid implementation.
+
+### Fixed
+
+- **"Expand/collapse does nothing"**: the old folder tree modelled folders
+  only, so a folder counted as expandable only when it held sub-folders. A
+  vault of single-segment folders had zero expandable nodes, every chevron
+  rendered empty, and Expand all / Collapse all were no-ops while staying
+  visible and enabled.
+- Saved expansion state was re-hydrated on every list refresh, clobbering
+  what the user had opened.
+- A prune that ran before the scope's token index arrived silently dropped
+  its write.
+
 ## v0.30.0 — Rotation scheduling, local audit trail, git-native versioning, first-party CI/CD (2026-07-25)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
## Summary
- Retitles the CHANGELOG Unreleased section as v0.31.0 (2026-07-29): the web UI folder sidebar is replaced with a hierarchical tree grid (#386), fixing expand/collapse and two expansion-state bugs.
- Bumps `Cargo.toml`/`Cargo.lock` to 0.31.0.
- Tag `v0.31.0` already pushed.

## Test plan
- [x] `cargo check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only change with no runtime or security behavior modifications.
> 
> **Overview**
> **Release v0.31.0** — no application code in this diff; it finalizes the version and documents what shipped in the prior web UI work (#386).
> 
> `Cargo.toml` and `Cargo.lock` move **crosstache** from `0.30.0` to **`0.31.0`**. **CHANGELOG** gains a dated **v0.31.0** section: the folder sidebar is replaced by a **hierarchical tree grid** on secrets and files, plus fixes for expand/collapse on flat folder layouts, expansion state being reset on list refresh, and a prune race when the scope token index was not ready yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7bf214159d1d7c715db2d8b766692b56882b0de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->