### PR TITLE
feat(web): download selected files as ZIP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,9 +113,9 @@ flate2 = "1"
 tar = "0.4"
 opener = "0.7"
 csv = "1"
+zip = "2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-zip = "2"
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Security",

--- a/docs/superpowers/plans/2026-07-31-files-bulk-download.md
+++ b/docs/superpowers/plans/2026-07-31-files-bulk-download.md
@@ -1,0 +1,943 @@
+# Files Bulk Download Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Files-tab bulk action that downloads the exact selected files as one backend-independent ZIP archive.
+
+**Architecture:** An authenticated, scoped Rust endpoint validates logical file names, reads and transparently decrypts each file through `FileBackend`, writes the archive to an unnamed temporary file, and streams the finished ZIP. The existing Files selection state calls that endpoint through a small JavaScript download primitive and keeps selection intact across success and failure.
+
+**Tech Stack:** Rust 2021, Axum 0.8, Tokio, `zip` 2, `tempfile` 3, JavaScript ES modules, Node test runner.
+
+## Global Constraints
+
+- The feature must work through `Backend::files()` and `FileBackend`; it must not dispatch on Local, AWS, or Azure types.
+- The request accepts 1 to 1,000 names, at most 512 KiB of JSON, with each UTF-8 name at most 1,024 bytes.
+- ZIP entry paths are relative forward-slash paths with no empty, `.` or `..` component, backslash, NUL, or duplicate name.
+- Plain and Crosstache age-encrypted files must match existing single-file download semantics.
+- The response is all-or-nothing and downloads as `crosstache-files.zip`.
+- Selection remains active and unchanged after either success or failure.
+- The server holds at most one downloaded file in memory while archive bytes live in an unnamed temporary file.
+
+---
+
+## File Structure
+
+- Create `src/web/archive.rs`: archive request model, validation, backend-neutral ZIP construction, streaming response, and focused Rust tests.
+- Modify `src/web/mod.rs`: declare the archive module and register the bounded `POST /api/files/archive` route before `/files/{name}`.
+- Modify `Cargo.toml`: make the already-locked `zip = "2"` dependency available on all platforms; keep only `windows-sys` target-specific.
+- Modify `Cargo.lock`: retain the resolved ZIP dependency metadata if Cargo rewrites the lockfile.
+- Modify `src/web/assets/files.js`: export the browser primitive that saves a raw archive response and always revokes its object URL.
+- Modify `src/web/assets/files.test.js`: test the archive browser primitive independently of selection UI.
+- Modify `src/web/assets/index.html`: add the Files bulk `Download` button.
+- Modify `src/web/assets/secrets.js`: bind the button to existing file selection, scoped routing, pending state, toast, and Files error UI.
+- Modify `src/web/assets/secrets.routes.test.js`: test selection enablement, exact request scope/body, retained selection, and failure recovery.
+
+---
+
+### Task 1: Archive Request Validation
+
+**Files:**
+- Create: `src/web/archive.rs`
+- Modify: `src/web/mod.rs:20-27`
+- Test: `src/web/archive.rs` inline `#[cfg(test)]` module
+
+**Interfaces:**
+- Consumes: `crate::backend::FileBackend`, `super::api::ApiError`.
+- Produces: `pub(crate) const MAX_ARCHIVE_BODY_BYTES: usize = 512 * 1024`, `pub(crate) ArchiveRequest { files: Vec<String> }`, and `fn validate_names(files: &dyn FileBackend, names: &[String]) -> Result<(), ApiError>`.
+
+- [ ] **Step 1: Declare the module and write failing validation tests**
+
+Add `#[cfg(feature = "file-ops")] mod archive;` beside `mod files;` in `src/web/mod.rs`. Create `src/web/archive.rs` with table-driven tests that use `testutil::stub::StubBackend` and require:
+
+```rust
+#[test]
+fn archive_names_are_relative_unique_backend_validated_paths() {
+    let backend = StubBackend::new();
+    assert!(validate_names(
+        &backend,
+        &["root.txt".into(), "docs/report.pdf".into()],
+    )
+    .is_ok());
+    assert_eq!(backend.file_name_validation_calls(), 2);
+
+    for names in [
+        vec![],
+        vec!["same.txt".into(), "same.txt".into()],
+        vec!["/absolute.txt".into()],
+        vec!["../outside.txt".into()],
+        vec!["docs//empty.txt".into()],
+        vec!["docs/./dot.txt".into()],
+        vec!["docs\\windows.txt".into()],
+        vec!["nul\0name.txt".into()],
+        vec!["x".repeat(1025)],
+    ] {
+        assert!(validate_names(&backend, &names).is_err(), "accepted {names:?}");
+    }
+}
+
+#[test]
+fn archive_selection_is_bounded() {
+    let backend = StubBackend::new();
+    let names = (0..=1000).map(|index| format!("{index}.txt")).collect::<Vec<_>>();
+    assert!(validate_names(&backend, &names).is_err());
+}
+
+#[test]
+fn archive_uses_the_selected_backends_name_rules() {
+    let backend = StubBackend::new().with_file_name_limit(4);
+    assert!(validate_names(&backend, &["five5".into()]).is_err());
+}
+```
+
+- [ ] **Step 2: Run the validation test and verify RED**
+
+Run:
+
+```bash
+cargo test web::archive::tests::archive_names --features ui,file-ops
+```
+
+Expected: compilation fails because `validate_names` and the archive request constants do not exist.
+
+- [ ] **Step 3: Implement the minimal validation contract**
+
+Add the exact request bounds and a denied-path check, call `files.validate_file_name(name)` for every otherwise-valid name, and reject duplicates with a `HashSet`:
+
+```rust
+pub(crate) const MAX_ARCHIVE_BODY_BYTES: usize = 512 * 1024;
+const MAX_ARCHIVE_FILES: usize = 1000;
+const MAX_ARCHIVE_NAME_BYTES: usize = 1024;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ArchiveRequest {
+    files: Vec<String>,
+}
+
+fn archive_validation(message: &'static str) -> ApiError {
+    ApiError::Validation {
+        status: StatusCode::BAD_REQUEST,
+        message,
+        field: Some("files"),
+    }
+}
+
+fn validate_names(files: &dyn FileBackend, names: &[String]) -> Result<(), ApiError> {
+    if names.is_empty() || names.len() > MAX_ARCHIVE_FILES {
+        return Err(archive_validation("Choose between 1 and 1000 files."));
+    }
+    let mut seen = HashSet::with_capacity(names.len());
+    for name in names {
+        let components = name.split('/').collect::<Vec<_>>();
+        if name.len() > MAX_ARCHIVE_NAME_BYTES
+            || name.starts_with('/')
+            || name.contains('\\')
+            || name.contains('\0')
+            || components.iter().any(|part| part.is_empty() || *part == "." || *part == "..")
+            || !seen.insert(name)
+        {
+            return Err(archive_validation("Choose valid unique file names."));
+        }
+        files.validate_file_name(name)?;
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run all archive validation tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test web::archive::tests::archive_ --features ui,file-ops
+```
+
+Expected: all three validation tests pass.
+
+- [ ] **Step 5: Commit the validation unit**
+
+```bash
+git add src/web/archive.rs src/web/mod.rs
+git commit -m "feat(web): validate bulk archive selections"
+```
+
+---
+
+### Task 2: Backend-Neutral ZIP Endpoint
+
+**Files:**
+- Modify: `Cargo.toml:103-122`
+- Modify: `Cargo.lock`
+- Modify: `src/web/archive.rs`
+- Modify: `src/web/mod.rs:320-346`
+- Test: `src/web/archive.rs` inline `#[cfg(test)]` module
+
+**Interfaces:**
+- Consumes: Task 1 `ArchiveRequest`, `MAX_ARCHIVE_BODY_BYTES`, and `validate_names`; `VaultQuery::target`; `attachments::download_decrypted`.
+- Produces: `pub(crate) async fn download(State<Arc<WebState>>, Query<VaultQuery>, Json<ArchiveRequest>) -> Result<Response, ApiError>` registered at `POST /api/files/archive`.
+
+- [ ] **Step 1: Write all failing endpoint behavior tests**
+
+First add concrete test helpers for stored files, authenticated JSON requests,
+and ZIP entry reads:
+
+```rust
+fn file_request(name: &str, content: &[u8]) -> FileUploadRequest {
+    FileUploadRequest {
+        name: name.into(),
+        content: content.to_vec(),
+        content_type: Some("application/octet-stream".into()),
+        groups: Vec::new(),
+        metadata: HashMap::new(),
+        tags: HashMap::new(),
+    }
+}
+
+fn archive_request(uri: &str, body: Value) -> Request<Body> {
+    Request::post(uri)
+        .header(header::HOST, "127.0.0.1:1")
+        .header(header::AUTHORIZATION, "Bearer test-token")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn read_entry<R: Read + Seek>(archive: &mut ZipArchive<R>, name: &str) -> Vec<u8> {
+    let mut entry = archive.by_name(name).unwrap();
+    let mut bytes = Vec::new();
+    entry.read_to_end(&mut bytes).unwrap();
+    bytes
+}
+```
+
+Use `testutil::test_state()`, upload two files through its trait object, request
+the archive, collect its body, and inspect it with `zip::ZipArchive`:
+
+```rust
+#[tokio::test]
+async fn archive_contains_exact_selected_plaintext_and_paths() {
+    let state = testutil::test_state();
+    let backend = state.base_backend();
+    let files = backend.files().unwrap();
+    for (name, content) in [("root.txt", b"root".as_slice()), ("docs/report.txt", b"report")]
+    {
+        files.upload_file("default", file_request(name, content), None).await.unwrap();
+    }
+
+    let response = web::build_router(state)
+        .oneshot(archive_request(
+            "/api/files/archive",
+            json!({"files": ["docs/report.txt", "root.txt"]}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()[header::CONTENT_TYPE], "application/zip");
+    assert_eq!(
+        response.headers()[header::CONTENT_DISPOSITION],
+        "attachment; filename=\"crosstache-files.zip\"",
+    );
+
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let mut archive = ZipArchive::new(Cursor::new(bytes)).unwrap();
+    assert_eq!(read_entry(&mut archive, "docs/report.txt"), b"report");
+    assert_eq!(read_entry(&mut archive, "root.txt"), b"root");
+    assert_eq!(archive.len(), 2);
+}
+```
+
+Before touching endpoint production code, also add the concrete decryption,
+immutable-scope, invalid-selection, unreadable-file, and body-limit tests shown
+in Step 6 below. They form one RED endpoint contract and must all exist before
+Step 2 runs.
+
+- [ ] **Step 2: Run the endpoint test and verify RED**
+
+Run:
+
+```bash
+cargo test web::archive::tests --features ui,file-ops
+```
+
+Expected: every route-level test fails with `404 Not Found` because
+`/api/files/archive` is not registered. The pure Task 1 validation tests remain
+green.
+
+- [ ] **Step 3: Make ZIP available cross-platform and implement archive writing**
+
+Move `zip = "2"` from `[target.'cfg(target_os = "windows")'.dependencies]` into normal `[dependencies]`; leave `windows-sys` in the Windows table. Run `cargo check --features ui,file-ops` once so Cargo normalizes `Cargo.lock`.
+
+In `src/web/archive.rs`, implement one-file-at-a-time ZIP writing by moving `ZipWriter<std::fs::File>` through `spawn_blocking`:
+
+```rust
+async fn add_entry(
+    writer: ZipWriter<std::fs::File>,
+    name: String,
+    bytes: Vec<u8>,
+) -> Result<ZipWriter<std::fs::File>, ApiError> {
+    tokio::task::spawn_blocking(move || {
+        let mut writer = writer;
+        writer
+            .start_file(
+                name,
+                SimpleFileOptions::default().compression_method(CompressionMethod::Deflated),
+            )
+            .map_err(zip_io)?;
+        writer.write_all(&bytes)?;
+        Ok::<_, std::io::Error>(writer)
+    })
+    .await
+    .map_err(join_error)?
+    .map_err(CrosstacheError::from)
+    .map_err(ApiError::from)
+}
+```
+
+Use these error and completion helpers; they deliberately omit selected names
+and backend diagnostics from response copy:
+
+```rust
+fn zip_io(error: ZipError) -> std::io::Error {
+    std::io::Error::other(error)
+}
+
+fn internal_archive_error(error: impl std::fmt::Display) -> ApiError {
+    ApiError::App(CrosstacheError::Unknown(format!(
+        "file archive creation failed: {error}",
+    )))
+}
+
+fn join_error(error: tokio::task::JoinError) -> ApiError {
+    internal_archive_error(error)
+}
+
+fn response_error(error: axum::http::Error) -> ApiError {
+    internal_archive_error(error)
+}
+
+fn files_unsupported() -> ApiError {
+    ApiError::Validation {
+        status: StatusCode::NOT_IMPLEMENTED,
+        message: "This backend does not provide file storage.",
+        field: None,
+    }
+}
+
+async fn finish_archive(
+    writer: ZipWriter<std::fs::File>,
+) -> Result<std::fs::File, ApiError> {
+    tokio::task::spawn_blocking(move || {
+        let mut file = writer.finish().map_err(zip_io)?;
+        file.seek(SeekFrom::Start(0))?;
+        Ok::<_, std::io::Error>(file)
+    })
+    .await
+    .map_err(join_error)?
+    .map_err(CrosstacheError::from)
+    .map_err(ApiError::from)
+}
+```
+
+- [ ] **Step 4: Implement the scoped handler and streamed response**
+
+Resolve the target once, validate through its `FileBackend`, then use the same helper as single-file downloads:
+
+```rust
+pub(crate) async fn download(
+    State(state): State<Arc<WebState>>,
+    Query(query): Query<VaultQuery>,
+    Json(request): Json<ArchiveRequest>,
+) -> Result<Response, ApiError> {
+    let target = query.target(&state)?;
+    let files = target.backend.files().ok_or_else(files_unsupported)?;
+    validate_names(files, &request.files)?;
+
+    let mut writer = ZipWriter::new(tempfile::tempfile().map_err(CrosstacheError::from)?);
+    for name in request.files {
+        let bytes = attachments::download_decrypted(
+            target.backend.secrets(),
+            files,
+            &target.context.vault,
+            &name,
+            None,
+        )
+        .await?;
+        writer = add_entry(writer, name, bytes).await?;
+    }
+
+    let file = finish_archive(writer).await?;
+    let stream = futures::stream::try_unfold(
+        tokio::fs::File::from_std(file),
+        |mut file| async move {
+            let mut buffer = vec![0; 64 * 1024];
+            let read = file.read(&mut buffer).await?;
+            if read == 0 {
+                Ok(None)
+            } else {
+                buffer.truncate(read);
+                Ok(Some((Bytes::from(buffer), file)))
+            }
+        },
+    );
+    Response::builder()
+        .header(header::CONTENT_TYPE, "application/zip")
+        .header(
+            header::CONTENT_DISPOSITION,
+            "attachment; filename=\"crosstache-files.zip\"",
+        )
+        .body(Body::from_stream(stream))
+        .map_err(response_error)
+}
+```
+
+`finish_archive` must call `ZipWriter::finish`, seek to `SeekFrom::Start(0)`, and return the still-open unnamed file from `spawn_blocking`. Register the route before `/files/{name}`:
+
+```rust
+.route(
+    "/files/archive",
+    post(archive::download).layer(
+        axum::extract::DefaultBodyLimit::max(archive::MAX_ARCHIVE_BODY_BYTES),
+    ),
+)
+```
+
+- [ ] **Step 5: Run the exact-content test and verify GREEN**
+
+Run:
+
+```bash
+cargo test web::archive::tests::archive_contains_exact --features ui,file-ops
+```
+
+Expected: PASS with two readable entries and the exact response headers.
+
+- [ ] **Step 6: Verify the complete endpoint contract is GREEN**
+
+The scoped-state helper and route tests added during Step 1 are:
+
+```rust
+fn scoped_state(
+    primary: Arc<testutil::stub::StubBackend>,
+    secondary: Arc<testutil::stub::StubBackend>,
+) -> Arc<web::WebState> {
+    let mut context = testutil::test_context(primary.as_ref(), "default", 30);
+    context.workspace.entries.push(
+        super::super::context::WorkspaceEntrySummary {
+            alias: "secondary-workspace".into(),
+            backend: "secondary".into(),
+            vault: "other".into(),
+            default: false,
+        },
+    );
+    let registry = Arc::new(crate::backend::BackendRegistry::for_test(
+        "primary",
+        vec![
+            ("primary", primary.clone()),
+            ("secondary", secondary.clone()),
+        ],
+    ));
+    Arc::new(web::WebState::new(
+        primary,
+        context,
+        "test-token".into(),
+        crate::records::builtin_types(),
+        super::super::preferences::PreferenceStore::new(
+            std::env::temp_dir()
+                .join(format!("xv-archive-scope-{}", uuid::Uuid::new_v4()))
+                .join("ui.json"),
+            30,
+        ),
+        registry,
+    ))
+}
+
+#[tokio::test]
+async fn archive_transparently_decrypts_crosstache_files() {
+    let state = testutil::test_state();
+    let backend = state.base_backend();
+    attachments::upload_encrypted(
+        backend.secrets(),
+        backend.files().unwrap(),
+        "default",
+        file_request("private/secret.txt", b"plaintext"),
+        None,
+    )
+    .await
+    .unwrap();
+    let response = web::build_router(state)
+        .oneshot(archive_request(
+            "/api/files/archive",
+            json!({"files": ["private/secret.txt"]}),
+        ))
+        .await
+        .unwrap();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let mut archive = ZipArchive::new(Cursor::new(bytes)).unwrap();
+    assert_eq!(read_entry(&mut archive, "private/secret.txt"), b"plaintext");
+}
+
+#[tokio::test]
+async fn archive_uses_the_exact_selected_workspace_backend_and_vault() {
+    let capabilities = crate::backend::BackendCapabilities {
+        has_file_storage: true,
+        ..Default::default()
+    };
+    let primary = Arc::new(testutil::stub::StubBackend::with_capabilities(
+        "primary",
+        capabilities.clone(),
+    ));
+    let secondary = Arc::new(testutil::stub::StubBackend::with_capabilities(
+        "secondary",
+        capabilities,
+    ));
+    primary
+        .upload_file("default", file_request("same.txt", b"primary"), None)
+        .await
+        .unwrap();
+    secondary
+        .upload_file("other", file_request("same.txt", b"secondary"), None)
+        .await
+        .unwrap();
+    let response = web::build_router(scoped_state(primary, secondary))
+        .oneshot(archive_request(
+            "/api/files/archive?alias=secondary-workspace&backend=secondary&vault=other",
+            json!({"files": ["same.txt"]}),
+        ))
+        .await
+        .unwrap();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let mut archive = ZipArchive::new(Cursor::new(bytes)).unwrap();
+    assert_eq!(read_entry(&mut archive, "same.txt"), b"secondary");
+}
+
+#[tokio::test]
+async fn invalid_or_unreadable_archive_never_returns_zip() {
+    for body in [
+        json!({"files": []}),
+        json!({"files": ["same", "same"]}),
+        json!({"files": ["../outside"]}),
+        json!({"files": ["missing.txt"]}),
+    ] {
+        let response = web::build_router(testutil::test_state())
+            .oneshot(archive_request("/api/files/archive", body))
+            .await
+            .unwrap();
+        assert_ne!(response.status(), StatusCode::OK);
+        assert_ne!(
+            response.headers().get(header::CONTENT_TYPE),
+            Some(&HeaderValue::from_static("application/zip")),
+        );
+    }
+}
+
+#[tokio::test]
+async fn archive_json_body_is_limited_to_512_kib() {
+    let names = (0..1000)
+        .map(|index| format!("{index}-{}", "x".repeat(600)))
+        .collect::<Vec<_>>();
+    let response = web::build_router(testutil::test_state())
+        .oneshot(archive_request(
+            "/api/files/archive",
+            json!({"files": names}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+```
+
+- [ ] **Step 7: Correct only defects exposed by the complete endpoint suite**
+
+Run twice:
+
+```bash
+cargo test web::archive::tests --features ui,file-ops
+```
+
+Expected: every archive test passes. If a test fails, adjust only handler error
+conversion, archive construction, or the concrete fixture setup, then rerun the
+same command until it exits 0.
+
+- [ ] **Step 8: Commit the backend endpoint**
+
+```bash
+git add Cargo.toml Cargo.lock src/web/archive.rs src/web/mod.rs
+git commit -m "feat(web): stream selected files as zip"
+```
+
+---
+
+### Task 3: Browser Archive Download Primitive
+
+**Files:**
+- Modify: `src/web/assets/files.js`
+- Modify: `src/web/assets/files.test.js`
+
+**Interfaces:**
+- Consumes: the existing `api(method, path, body, raw)` contract.
+- Produces: `downloadFileArchive({ api, path, names, document, objectUrls }) -> Promise<void>`.
+
+- [ ] **Step 1: Write failing save-and-cleanup tests**
+
+Import `downloadFileArchive` in `files.test.js` and add:
+
+```javascript
+test('archive download posts exact names, clicks one zip anchor, and revokes its URL', async () => {
+  const calls = [];
+  const anchors = [];
+  const api = async (...args) => {
+    calls.push(args);
+    return { blob: async () => new Blob(['zip']) };
+  };
+  const document = { createElement: () => {
+    const anchor = { clickCount: 0, click() { this.clickCount++; } };
+    anchors.push(anchor);
+    return anchor;
+  } };
+  const revoked = [];
+  const objectUrls = {
+    createObjectURL: () => 'blob:archive',
+    revokeObjectURL: (value) => revoked.push(value),
+  };
+
+  await downloadFileArchive({
+    api,
+    path: '/api/files/archive?alias=primary&backend=local&vault=one',
+    names: ['docs/a.txt', 'b.txt'],
+    document,
+    objectUrls,
+  });
+
+  assert.deepEqual(calls, [[
+    'POST',
+    '/api/files/archive?alias=primary&backend=local&vault=one',
+    { files: ['docs/a.txt', 'b.txt'] },
+    true,
+  ]]);
+  assert.equal(anchors[0].download, 'crosstache-files.zip');
+  assert.equal(anchors[0].href, 'blob:archive');
+  assert.equal(anchors[0].clickCount, 1);
+  assert.deepEqual(revoked, ['blob:archive']);
+});
+
+test('archive download does not create an anchor when the API fails', async () => {
+  let created = 0;
+  await assert.rejects(() => downloadFileArchive({
+    api: async () => { throw new Error('failed'); },
+    path: '/api/files/archive',
+    names: ['a.txt'],
+    document: { createElement() { created++; } },
+    objectUrls: {},
+  }), /failed/);
+  assert.equal(created, 0);
+});
+```
+
+- [ ] **Step 2: Run the focused JavaScript test and verify RED**
+
+Run:
+
+```bash
+node --test --test-name-pattern="archive download" src/web/assets/files.test.js
+```
+
+Expected: import failure because `downloadFileArchive` is not exported.
+
+- [ ] **Step 3: Implement the minimal browser primitive**
+
+Add to `files.js`:
+
+```javascript
+export async function downloadFileArchive({
+  api,
+  path,
+  names,
+  document = globalThis.document,
+  objectUrls = globalThis.URL,
+}) {
+  const response = await api('POST', path, { files: [...names] }, true);
+  const blob = await response.blob();
+  const href = objectUrls.createObjectURL(blob);
+  try {
+    const anchor = document.createElement('a');
+    anchor.href = href;
+    anchor.download = 'crosstache-files.zip';
+    anchor.click();
+  } finally {
+    objectUrls.revokeObjectURL(href);
+  }
+}
+```
+
+- [ ] **Step 4: Run the focused and complete files tests**
+
+Run:
+
+```bash
+node --test --test-name-pattern="archive download" src/web/assets/files.test.js
+node --test src/web/assets/files.test.js
+```
+
+Expected: both commands pass with zero failures.
+
+- [ ] **Step 5: Commit the browser primitive**
+
+```bash
+git add src/web/assets/files.js src/web/assets/files.test.js
+git commit -m "feat(web): add zip download primitive"
+```
+
+---
+
+### Task 4: Files Selection Toolbar Integration
+
+**Files:**
+- Modify: `src/web/assets/index.html:148-153`
+- Modify: `src/web/assets/secrets.js:920-1025,3470-3820`
+- Modify: `src/web/assets/secrets.routes.test.js:15-115,730-820`
+
+**Interfaces:**
+- Consumes: Task 3 `downloadFileArchive`, existing `fileSelection.ids`, `vaultQS`, `canStartScopedAction`, `showListError`, and `toast`.
+- Produces: `#bulk-download-files` and private `bulkDownloadFiles() -> Promise<void>`.
+
+- [ ] **Step 1: Write failing success and recovery route tests**
+
+Extend the route-test `Element` with a real no-navigation click recorder:
+
+```javascript
+click() {
+  this.clickCount = (this.clickCount || 0) + 1;
+  return this.onclick?.({ preventDefault() {}, stopPropagation() {}, currentTarget: this });
+}
+```
+
+Set `this.tagName = id.startsWith('#') ? '' : id.toUpperCase()` in the test
+element constructor. In `createDocument`, retain created elements so the test
+can inspect the generated anchor:
+
+```javascript
+const createdElements = [];
+document.createdElements = createdElements;
+document.createElement = (name) => {
+  const element = new Element(name, document);
+  createdElements.push(element);
+  return element;
+};
+```
+
+Then mount a files-capable context with two listed files and a raw archive response. Enter Files selection mode, select the folder or both item checkboxes, and assert:
+
+```javascript
+assert.equal(ui.elements.get('#bulk-download-files').disabled, false);
+await ui.elements.get('#bulk-download-files').onclick();
+assert.deepEqual(archiveCalls, [{
+  method: 'POST',
+  path: '/api/files/archive?alias=primary&backend=local&vault=one',
+  body: { files: ['docs/a.txt', 'docs/b.txt'] },
+  raw: true,
+}]);
+assert.equal(ui.elements.get('#file-selection-count').textContent, '2 selected');
+assert.equal(ui.elements.get('#file-bulk-bar').hidden, false);
+assert.equal(ui.elements.get('#bulk-download-files').textContent, 'Download');
+assert.equal(ui.elements.get('#bulk-download-files').disabled, false);
+```
+
+Capture dynamically created anchors in `createDocument()` and assert exactly one has `download === 'crosstache-files.zip'` and `clickCount === 1`.
+
+Before changing `index.html` or `secrets.js`, also add the concrete rejected-API
+recovery test and assertions shown in Step 6 below. Both UI behaviors must be
+RED together.
+
+- [ ] **Step 2: Run the route test and verify RED**
+
+Run:
+
+```bash
+node --test --test-name-pattern="selected files as one zip|zip download failure retains file selection" src/web/assets/secrets.routes.test.js
+```
+
+Expected: both tests fail because `#bulk-download-files` has no behavior and no
+request is sent.
+
+- [ ] **Step 3: Add the toolbar button and selection-state integration**
+
+Add this button before Delete in the Files bulk bar:
+
+```html
+<button id="bulk-download-files" class="button secondary" type="button">
+  <svg class="icon" aria-hidden="true"><use href="#icon-download"></use></svg>Download
+</button>
+```
+
+Import `downloadFileArchive` from `files.js`. Add `downloadButton` to `selectionElements('files')`, disable it in `updateSelectionControls` when pending or empty, and reset it to `Download` when file selection mode clears.
+
+Implement pending state without reusing the destructive confirmation state:
+
+```javascript
+function setFileDownloadPending(pending) {
+  fileSelection.pending = pending;
+  $('#cancel-file-selection').disabled = pending;
+  const button = $('#bulk-download-files');
+  if (pending) beginPendingAction(button, 'Downloading…');
+  else resetConfirmation(button, 'Download');
+  updateSelectionControls('files');
+  renderFiles();
+}
+```
+
+Because `updateSelectionControls` now knows `downloadButton`, an in-progress bulk delete also disables Download automatically.
+
+- [ ] **Step 4: Implement the exact scoped bulk action**
+
+Add and bind:
+
+```javascript
+async function bulkDownloadFiles() {
+  const state = fileSelection;
+  const names = [...state.ids];
+  if (!names.length || state.pending) return;
+  const scope = captureOperationScope();
+  if (!canStartScopedAction(scope)) return;
+  const generation = state.generation;
+  setFileDownloadPending(true);
+  try {
+    await downloadFileArchive({
+      api,
+      path: `/api/files/archive${vaultQS(scope.vault, scope)}`,
+      names,
+    });
+    if (generation === state.generation && scopeMatchesCurrent(scope)) {
+      toast(`Downloaded ${names.length} file${names.length === 1 ? '' : 's'} in ${formatContextLine(scope)}`);
+    }
+  } catch (error) {
+    if (generation === state.generation && scopeMatchesCurrent(scope)) {
+      showListError('files', error);
+    }
+  } finally {
+    if (generation === state.generation) setFileDownloadPending(false);
+  }
+}
+
+$('#bulk-download-files').onclick = () => bulkDownloadFiles();
+```
+
+Do not clear `fileSelection.ids` in any path.
+
+- [ ] **Step 5: Run the success route test and verify GREEN**
+
+Run:
+
+```bash
+node --test --test-name-pattern="selected files as one zip" src/web/assets/secrets.routes.test.js
+```
+
+Expected: PASS with one scoped POST, one clicked archive anchor, and two selected files retained.
+
+- [ ] **Step 6: Verify failure recovery is GREEN**
+
+The second route test added during Step 1 makes the archive API call reject.
+Hold the promise long enough to assert that Download, Delete, checkboxes, and
+Cancel are disabled and the button reads `Downloading…`; reject it and then
+assert:
+
+```javascript
+assert.equal(createdArchiveAnchors.length, 0);
+assert.equal(ui.elements.get('#file-error').hidden, false);
+assert.equal(ui.elements.get('#file-selection-count').textContent, '2 selected');
+assert.equal(ui.elements.get('#bulk-download-files').textContent, 'Download');
+assert.equal(ui.elements.get('#bulk-download-files').disabled, false);
+assert.equal(ui.elements.get('#bulk-delete-files').disabled, false);
+assert.equal(ui.elements.get('#cancel-file-selection').disabled, false);
+```
+
+Run:
+
+```bash
+node --test --test-name-pattern="zip download failure retains file selection" src/web/assets/secrets.routes.test.js
+```
+
+Expected: PASS. If it fails, correct only `setFileDownloadPending`, generation
+checks, or the explicit Files error routing, then rerun the same command until
+it exits 0.
+
+- [ ] **Step 7: Run all affected JavaScript tests**
+
+Run:
+
+```bash
+node --test src/web/assets/files.test.js src/web/assets/secrets.routes.test.js src/web/assets/module-contracts.test.js
+```
+
+Expected: all tests pass with zero failures and no warnings.
+
+- [ ] **Step 8: Commit the UI integration**
+
+```bash
+git add src/web/assets/index.html src/web/assets/secrets.js src/web/assets/secrets.routes.test.js
+git commit -m "feat(web): download selected files as zip"
+```
+
+---
+
+### Task 5: Full Verification and Branch Handoff
+
+**Files:**
+- Verify only; modify a file only if a command exposes a defect in the feature.
+
+**Interfaces:**
+- Consumes: Tasks 1-4 complete implementation.
+- Produces: a clean, rebased, pushed feature branch with fresh verification evidence.
+
+- [ ] **Step 1: Run formatting checks**
+
+```bash
+cargo fmt --all -- --check
+git diff --check
+```
+
+Expected: both commands exit 0 with no formatting or whitespace errors.
+
+- [ ] **Step 2: Run the complete JavaScript unit suite**
+
+```bash
+npm run test:unit
+```
+
+Expected: every `src/web/assets/*.test.js` test passes with zero failures.
+
+- [ ] **Step 3: Run Rust web and default test coverage**
+
+```bash
+cargo test web:: --features ui,file-ops
+cargo test
+```
+
+Expected: both commands exit 0 with zero failed tests.
+
+- [ ] **Step 4: Run lint and compile checks**
+
+```bash
+cargo clippy --all-targets --features ui,file-ops -- -D warnings
+cargo check --all-targets --features ui,file-ops
+```
+
+Expected: both commands exit 0 with no warnings or errors.
+
+- [ ] **Step 5: Inspect the exact change set against the approved spec**
+
+```bash
+git status --short
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD -- Cargo.toml src/web/archive.rs src/web/mod.rs src/web/assets/files.js src/web/assets/index.html src/web/assets/secrets.js
+```
+
+Confirm that the diff contains one ZIP endpoint, one bulk toolbar action, test coverage, and no backend-specific branch or unrelated refactor.
+
+- [ ] **Step 6: Rebase and push**
+
+```bash
+git pull --rebase
+git push origin codex/files-bulk-download
+```
+
+Expected: the branch tracks `origin/codex/files-bulk-download`, is up to date, and the worktree is clean.

--- a/docs/superpowers/specs/2026-07-31-files-bulk-download-design.md
+++ b/docs/superpowers/specs/2026-07-31-files-bulk-download-design.md
@@ -1,0 +1,126 @@
+# Files Bulk Download Design
+
+## Goal
+
+Allow a user in the web UI Files tab to select files and download the exact
+selection as one ZIP archive. The behavior must work through every backend that
+implements Crosstache's file-storage capability.
+
+## User Experience
+
+The existing Files selection toolbar gains a `Download` button beside the
+existing bulk actions. The button is disabled when the selection is empty or a
+bulk file operation is pending.
+
+Activating `Download` captures the current workspace, backend, vault, and the
+selected logical file names. While the request runs, the button reads
+`Downloading…` and conflicting selection actions are disabled. A successful
+request downloads `crosstache-files.zip`, reports the number of downloaded
+files, and leaves selection mode and the selected file set intact.
+
+If the archive cannot be created, no partial ZIP is downloaded. The existing
+Files error panel reports the failure, and the selection remains available so
+the user can retry.
+
+## API and Backend Architecture
+
+Add an authenticated `POST /api/files/archive` route. The request body contains
+the selected logical file names, while the existing scoped query parameters
+identify the exact workspace, backend, and vault. The handler resolves that
+scope through the same `WebState` mechanism used by existing file routes.
+
+The handler operates only through `Backend::files()` and the shared
+`FileBackend` trait. It must not dispatch on Local, AWS, or Azure backend types.
+Consequently, the feature works for every current or future backend that exposes
+the file-storage capability. Backends without that capability continue to make
+the Files surface unavailable.
+
+For each requested logical name, the handler uses the same transparent download
+and decryption helper as the existing single-file route. Plain files pass
+through unchanged; files marked with Crosstache's age-encryption metadata are
+decrypted using the selected vault's attachment key before being placed in the
+archive.
+
+## Archive Construction
+
+The server validates the request before returning archive bytes:
+
+- The selection must contain between 1 and 1,000 names, the JSON body must be no
+  larger than 512 KiB, and each UTF-8 name must be no larger than 1,024 bytes.
+- Every name must pass the selected backend's file-name validation.
+- Archive entries must be relative, use forward-slash separators, and contain
+  no empty, `.` or `..` path components.
+- Duplicate logical names are rejected.
+
+Logical folder paths are preserved as ZIP entry paths. Because stored file names
+are unique, valid requests cannot create colliding archive entries.
+
+The server downloads and decrypts one file at a time and writes entries to an
+unnamed temporary file with the existing ZIP library. After every entry is
+written successfully, the finished archive is rewound and streamed as
+`application/zip` with an attachment filename of `crosstache-files.zip`. The
+temporary file is released when the response finishes or is abandoned. This
+keeps server memory bounded by the largest individual downloaded file instead
+of the total archive size.
+
+If any backend read, decryption, validation, or ZIP operation fails, archive
+creation stops and the temporary file is discarded. The handler returns the
+normal structured API error response before any ZIP response begins.
+
+## UI Data Flow
+
+The bulk action reads from the existing `fileSelection.ids` set, so item,
+folder, select-all, filtering, and tree-grid selection semantics remain
+unchanged. The client sends one request containing exactly those identifiers and
+the immutable scope captured when the action starts.
+
+The authenticated API client receives the archive as a raw response, converts
+it to a browser Blob, and triggers one download through a temporary anchor. The
+object URL is always revoked. Scope changes and pending mutations use the same
+guards as other scoped bulk actions; the request always targets its captured
+scope rather than whatever context may later be displayed.
+
+## Error Handling
+
+Archive download is all-or-nothing. An error does not clear selection or claim
+that a partial set succeeded. The Files error panel uses its existing safe error
+copy and diagnostic behavior; backend details are not exposed directly. The
+Download button and the rest of the bulk toolbar return to their normal state in
+a `finally` path.
+
+## Testing
+
+Rust API tests will verify:
+
+- A ZIP response contains the exact requested entries and bytes, including
+  preserved folder paths.
+- Plain and age-encrypted stored files have the same downloaded content as the
+  existing single-file endpoint.
+- The captured workspace/backend/vault scope selects the correct backend.
+- The handler depends only on `FileBackend` behavior by exercising the shared
+  web test backend.
+- Empty, duplicate, excessive, unsafe, unknown, and unreadable selections fail
+  without returning a ZIP.
+- Response content type and content disposition are correct.
+
+UI route/DOM tests will verify:
+
+- The Download button appears in Files selection mode and follows selection and
+  pending-state enablement.
+- The request contains exactly the selected logical names and captured scope.
+- A successful response triggers one ZIP download, retains selection, and
+  restores controls.
+- A failed response triggers no download, retains selection, restores controls,
+  and uses the Files error surface.
+
+The focused Rust and JavaScript tests will be run first, followed by the
+repository's applicable unit, formatting, linting, and build checks.
+
+## Non-Goals
+
+- Multiple independent browser downloads.
+- Client-side ZIP construction.
+- Download progress reporting or cancellation beyond the browser/network's
+  existing behavior.
+- Changing file selection, filtering, upload, deletion, or single-file download
+  semantics.

--- a/src/web/archive.rs
+++ b/src/web/archive.rs
@@ -1,11 +1,23 @@
 use std::collections::HashSet;
+use std::io::{Seek, SeekFrom, Write};
+use std::sync::Arc;
 
-use axum::http::StatusCode;
+use axum::body::{Body, Bytes};
+use axum::extract::{Json, Query, State};
+use axum::http::{header, StatusCode};
+use axum::response::Response;
 use serde::Deserialize;
+use tokio::io::AsyncReadExt;
+use zip::result::ZipError;
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipWriter};
 
 use crate::backend::FileBackend;
+use crate::error::CrosstacheError;
+use crate::secret::attachments;
 
-use super::api::ApiError;
+use super::api::{ApiError, VaultQuery};
+use super::WebState;
 
 pub(crate) const MAX_ARCHIVE_BODY_BYTES: usize = 512 * 1024;
 const MAX_ARCHIVE_FILES: usize = 1000;
@@ -49,10 +61,323 @@ fn validate_names(files: &dyn FileBackend, names: &[String]) -> Result<(), ApiEr
     Ok(())
 }
 
+fn zip_io(error: ZipError) -> std::io::Error {
+    std::io::Error::other(error)
+}
+
+fn internal_archive_error(error: impl std::fmt::Display) -> ApiError {
+    ApiError::App(CrosstacheError::Unknown(format!(
+        "file archive creation failed: {error}",
+    )))
+}
+
+fn join_error(error: tokio::task::JoinError) -> ApiError {
+    internal_archive_error(error)
+}
+
+fn response_error(error: axum::http::Error) -> ApiError {
+    internal_archive_error(error)
+}
+
+fn files_unsupported() -> ApiError {
+    ApiError::Validation {
+        status: StatusCode::NOT_IMPLEMENTED,
+        message: "This backend does not provide file storage.",
+        field: None,
+    }
+}
+
+async fn add_entry(
+    writer: ZipWriter<std::fs::File>,
+    name: String,
+    bytes: Vec<u8>,
+) -> Result<ZipWriter<std::fs::File>, ApiError> {
+    tokio::task::spawn_blocking(move || {
+        let mut writer = writer;
+        writer
+            .start_file(
+                name,
+                SimpleFileOptions::default().compression_method(CompressionMethod::Deflated),
+            )
+            .map_err(zip_io)?;
+        writer.write_all(&bytes)?;
+        Ok::<_, std::io::Error>(writer)
+    })
+    .await
+    .map_err(join_error)?
+    .map_err(CrosstacheError::from)
+    .map_err(ApiError::from)
+}
+
+async fn finish_archive(writer: ZipWriter<std::fs::File>) -> Result<std::fs::File, ApiError> {
+    tokio::task::spawn_blocking(move || {
+        let mut file = writer.finish().map_err(zip_io)?;
+        file.seek(SeekFrom::Start(0))?;
+        Ok::<_, std::io::Error>(file)
+    })
+    .await
+    .map_err(join_error)?
+    .map_err(CrosstacheError::from)
+    .map_err(ApiError::from)
+}
+
+pub(crate) async fn download(
+    State(state): State<Arc<WebState>>,
+    Query(query): Query<VaultQuery>,
+    Json(request): Json<ArchiveRequest>,
+) -> Result<Response, ApiError> {
+    let target = query.target(&state)?;
+    let files = target.backend.files().ok_or_else(files_unsupported)?;
+    validate_names(files, &request.files)?;
+
+    let mut writer = ZipWriter::new(tempfile::tempfile().map_err(CrosstacheError::from)?);
+    for name in request.files {
+        let bytes = attachments::download_decrypted(
+            target.backend.secrets(),
+            files,
+            &target.context.vault,
+            &name,
+            None,
+        )
+        .await?;
+        writer = add_entry(writer, name, bytes).await?;
+    }
+
+    let file = finish_archive(writer).await?;
+    let stream =
+        futures::stream::try_unfold(tokio::fs::File::from_std(file), |mut file| async move {
+            let mut buffer = vec![0; 64 * 1024];
+            let read = file.read(&mut buffer).await?;
+            if read == 0 {
+                Ok::<_, std::io::Error>(None)
+            } else {
+                buffer.truncate(read);
+                Ok(Some((Bytes::from(buffer), file)))
+            }
+        });
+    Response::builder()
+        .header(header::CONTENT_TYPE, "application/zip")
+        .header(
+            header::CONTENT_DISPOSITION,
+            "attachment; filename=\"crosstache-files.zip\"",
+        )
+        .body(Body::from_stream(stream))
+        .map_err(response_error)
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::io::{Cursor, Read, Seek};
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{header, HeaderValue, Request, StatusCode};
+    use http_body_util::BodyExt;
+    use serde_json::{json, Value};
+    use tower::ServiceExt;
+    use zip::ZipArchive;
+
     use super::validate_names;
-    use crate::web::testutil::stub::StubBackend;
+    use crate::backend::FileBackend;
+    use crate::blob::models::FileUploadRequest;
+    use crate::secret::attachments;
+    use crate::web::{self, testutil};
+
+    use testutil::stub::StubBackend;
+
+    fn file_request(name: &str, content: &[u8]) -> FileUploadRequest {
+        FileUploadRequest {
+            name: name.into(),
+            content: content.to_vec(),
+            content_type: Some("application/octet-stream".into()),
+            groups: Vec::new(),
+            metadata: HashMap::new(),
+            tags: HashMap::new(),
+        }
+    }
+
+    fn archive_request(uri: &str, body: Value) -> Request<Body> {
+        Request::post(uri)
+            .header(header::HOST, "127.0.0.1:1")
+            .header(header::AUTHORIZATION, "Bearer test-token")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    fn read_entry<R: Read + Seek>(archive: &mut ZipArchive<R>, name: &str) -> Vec<u8> {
+        let mut entry = archive.by_name(name).unwrap();
+        let mut bytes = Vec::new();
+        entry.read_to_end(&mut bytes).unwrap();
+        bytes
+    }
+
+    fn scoped_state(
+        primary: Arc<testutil::stub::StubBackend>,
+        secondary: Arc<testutil::stub::StubBackend>,
+    ) -> Arc<web::WebState> {
+        let mut context = testutil::test_context(primary.as_ref(), "default", 30);
+        context
+            .workspace
+            .entries
+            .push(super::super::context::WorkspaceEntrySummary {
+                alias: "secondary-workspace".into(),
+                backend: "secondary".into(),
+                vault: "other".into(),
+                default: false,
+            });
+        let registry = Arc::new(crate::backend::BackendRegistry::for_test(
+            "primary",
+            vec![
+                ("primary", primary.clone()),
+                ("secondary", secondary.clone()),
+            ],
+        ));
+        Arc::new(web::WebState::new(
+            primary,
+            context,
+            "test-token".into(),
+            crate::records::builtin_types(),
+            super::super::preferences::PreferenceStore::new(
+                std::env::temp_dir()
+                    .join(format!("xv-archive-scope-{}", uuid::Uuid::new_v4()))
+                    .join("ui.json"),
+                30,
+            ),
+            registry,
+        ))
+    }
+
+    #[tokio::test]
+    async fn archive_contains_exact_selected_plaintext_and_paths() {
+        let state = testutil::test_state();
+        let backend = state.base_backend();
+        let files = backend.files().unwrap();
+        for (name, content) in [
+            ("root.txt", b"root".as_slice()),
+            ("docs/report.txt", b"report"),
+        ] {
+            files
+                .upload_file("default", file_request(name, content), None)
+                .await
+                .unwrap();
+        }
+
+        let response = web::build_router(state)
+            .oneshot(archive_request(
+                "/api/files/archive",
+                json!({"files": ["docs/report.txt", "root.txt"]}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[header::CONTENT_TYPE], "application/zip");
+        assert_eq!(
+            response.headers()[header::CONTENT_DISPOSITION],
+            "attachment; filename=\"crosstache-files.zip\"",
+        );
+
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let mut archive = ZipArchive::new(Cursor::new(bytes)).unwrap();
+        assert_eq!(read_entry(&mut archive, "docs/report.txt"), b"report");
+        assert_eq!(read_entry(&mut archive, "root.txt"), b"root");
+        assert_eq!(archive.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn archive_transparently_decrypts_crosstache_files() {
+        let state = testutil::test_state();
+        let backend = state.base_backend();
+        attachments::upload_encrypted(
+            backend.secrets(),
+            backend.files().unwrap(),
+            "default",
+            file_request("private/secret.txt", b"plaintext"),
+            None,
+        )
+        .await
+        .unwrap();
+        let response = web::build_router(state)
+            .oneshot(archive_request(
+                "/api/files/archive",
+                json!({"files": ["private/secret.txt"]}),
+            ))
+            .await
+            .unwrap();
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let mut archive = ZipArchive::new(Cursor::new(bytes)).unwrap();
+        assert_eq!(read_entry(&mut archive, "private/secret.txt"), b"plaintext");
+    }
+
+    #[tokio::test]
+    async fn archive_uses_the_exact_selected_workspace_backend_and_vault() {
+        let capabilities = crate::backend::BackendCapabilities {
+            has_file_storage: true,
+            ..Default::default()
+        };
+        let primary = Arc::new(testutil::stub::StubBackend::with_capabilities(
+            "primary",
+            capabilities.clone(),
+        ));
+        let secondary = Arc::new(testutil::stub::StubBackend::with_capabilities(
+            "secondary",
+            capabilities,
+        ));
+        primary
+            .upload_file("default", file_request("same.txt", b"primary"), None)
+            .await
+            .unwrap();
+        secondary
+            .upload_file("other", file_request("same.txt", b"secondary"), None)
+            .await
+            .unwrap();
+        let response = web::build_router(scoped_state(primary, secondary))
+            .oneshot(archive_request(
+                "/api/files/archive?alias=secondary-workspace&backend=secondary&vault=other",
+                json!({"files": ["same.txt"]}),
+            ))
+            .await
+            .unwrap();
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let mut archive = ZipArchive::new(Cursor::new(bytes)).unwrap();
+        assert_eq!(read_entry(&mut archive, "same.txt"), b"secondary");
+    }
+
+    #[tokio::test]
+    async fn invalid_or_unreadable_archive_never_returns_zip() {
+        for body in [
+            json!({"files": []}),
+            json!({"files": ["same", "same"]}),
+            json!({"files": ["../outside"]}),
+            json!({"files": ["missing.txt"]}),
+        ] {
+            let response = web::build_router(testutil::test_state())
+                .oneshot(archive_request("/api/files/archive", body))
+                .await
+                .unwrap();
+            assert_ne!(response.status(), StatusCode::OK);
+            assert_ne!(
+                response.headers().get(header::CONTENT_TYPE),
+                Some(&HeaderValue::from_static("application/zip")),
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn archive_json_body_is_limited_to_512_kib() {
+        let names = (0..1000)
+            .map(|index| format!("{index}-{}", "x".repeat(600)))
+            .collect::<Vec<_>>();
+        let response = web::build_router(testutil::test_state())
+            .oneshot(archive_request(
+                "/api/files/archive",
+                json!({"files": names}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
 
     #[test]
     fn archive_names_are_relative_unique_backend_validated_paths() {

--- a/src/web/archive.rs
+++ b/src/web/archive.rs
@@ -3,7 +3,7 @@ use std::io::{Seek, SeekFrom, Write};
 use std::sync::Arc;
 
 use axum::body::{Body, Bytes};
-use axum::extract::{Json, Query, State};
+use axum::extract::{Json, Path, Query, State};
 use axum::http::{header, StatusCode};
 use axum::response::Response;
 use serde::Deserialize;
@@ -20,8 +20,44 @@ use super::api::{ApiError, VaultQuery};
 use super::WebState;
 
 pub(crate) const MAX_ARCHIVE_BODY_BYTES: usize = 512 * 1024;
+pub(crate) const MAX_ARCHIVE_FILE_BYTES: u64 = 100 * 1024 * 1024;
+pub(crate) const MAX_ARCHIVE_TOTAL_BYTES: u64 = 512 * 1024 * 1024;
+pub(crate) const MAX_CONCURRENT_ARCHIVES: usize = 2;
 const MAX_ARCHIVE_FILES: usize = 1000;
 const MAX_ARCHIVE_NAME_BYTES: usize = 1024;
+
+const _: () = assert!(MAX_ARCHIVE_FILE_BYTES < u32::MAX as u64);
+
+#[derive(Clone, Copy)]
+pub(crate) struct ArchiveLimits {
+    max_file_bytes: u64,
+    max_total_bytes: u64,
+}
+
+impl Default for ArchiveLimits {
+    fn default() -> Self {
+        Self {
+            max_file_bytes: MAX_ARCHIVE_FILE_BYTES,
+            max_total_bytes: MAX_ARCHIVE_TOTAL_BYTES,
+        }
+    }
+}
+
+#[cfg(test)]
+impl ArchiveLimits {
+    const fn for_test(max_file_bytes: u64, max_total_bytes: u64) -> Self {
+        Self {
+            max_file_bytes,
+            max_total_bytes,
+        }
+    }
+}
+
+pub(crate) fn archive_job_limiter() -> Arc<tokio::sync::Semaphore> {
+    static LIMITER: std::sync::LazyLock<Arc<tokio::sync::Semaphore>> =
+        std::sync::LazyLock::new(|| Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_ARCHIVES)));
+    LIMITER.clone()
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -37,6 +73,35 @@ fn archive_validation(message: &'static str) -> ApiError {
     }
 }
 
+fn archive_status_error(status: StatusCode) -> ApiError {
+    ApiError::Structured {
+        status,
+        error: Box::new(super::errors::status_error(status)),
+    }
+}
+
+fn reserve_archive_bytes(
+    total: &mut u64,
+    file_bytes: u64,
+    limits: ArchiveLimits,
+) -> Result<(), ApiError> {
+    let next_total = total
+        .checked_add(file_bytes)
+        .filter(|total| *total <= limits.max_total_bytes);
+    if file_bytes > limits.max_file_bytes || next_total.is_none() {
+        return Err(archive_status_error(StatusCode::PAYLOAD_TOO_LARGE));
+    }
+    *total = next_total.expect("archive total was checked");
+    Ok(())
+}
+
+fn is_windows_drive_qualified(name: &str) -> bool {
+    matches!(
+        name.as_bytes(),
+        [drive, b':', ..] if drive.is_ascii_alphabetic()
+    )
+}
+
 fn validate_names(files: &dyn FileBackend, names: &[String]) -> Result<(), ApiError> {
     if names.is_empty() || names.len() > MAX_ARCHIVE_FILES {
         return Err(archive_validation("Choose between 1 and 1000 files."));
@@ -49,6 +114,7 @@ fn validate_names(files: &dyn FileBackend, names: &[String]) -> Result<(), ApiEr
             || name.starts_with('/')
             || name.contains('\\')
             || name.contains('\0')
+            || is_windows_drive_qualified(name)
             || components
                 .iter()
                 .any(|part| part.is_empty() || *part == "." || *part == "..")
@@ -97,7 +163,10 @@ async fn add_entry(
         writer
             .start_file(
                 name,
-                SimpleFileOptions::default().compression_method(CompressionMethod::Deflated),
+                // Accepted entries are capped well below ZIP32's 4 GiB boundary.
+                SimpleFileOptions::default()
+                    .compression_method(CompressionMethod::Deflated)
+                    .large_file(false),
             )
             .map_err(zip_io)?;
         writer.write_all(&bytes)?;
@@ -130,7 +199,20 @@ pub(crate) async fn download(
     let files = target.backend.files().ok_or_else(files_unsupported)?;
     validate_names(files, &request.files)?;
 
+    let permit = state
+        .archive_jobs
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| archive_status_error(StatusCode::TOO_MANY_REQUESTS))?;
+
+    let mut reported_total = 0;
+    for name in &request.files {
+        let info = files.get_file_info(&target.context.vault, name).await?;
+        reserve_archive_bytes(&mut reported_total, info.size, state.archive_limits)?;
+    }
+
     let mut writer = ZipWriter::new(tempfile::tempfile().map_err(CrosstacheError::from)?);
+    let mut actual_total = 0;
     for name in request.files {
         let bytes = attachments::download_decrypted(
             target.backend.secrets(),
@@ -140,21 +222,24 @@ pub(crate) async fn download(
             None,
         )
         .await?;
+        reserve_archive_bytes(&mut actual_total, bytes.len() as u64, state.archive_limits)?;
         writer = add_entry(writer, name, bytes).await?;
     }
 
     let file = finish_archive(writer).await?;
-    let stream =
-        futures::stream::try_unfold(tokio::fs::File::from_std(file), |mut file| async move {
+    let stream = futures::stream::try_unfold(
+        (tokio::fs::File::from_std(file), permit),
+        |(mut file, permit)| async move {
             let mut buffer = vec![0; 64 * 1024];
             let read = file.read(&mut buffer).await?;
             if read == 0 {
                 Ok::<_, std::io::Error>(None)
             } else {
                 buffer.truncate(read);
-                Ok(Some((Bytes::from(buffer), file)))
+                Ok(Some((Bytes::from(buffer), (file, permit))))
             }
-        });
+        },
+    );
     Response::builder()
         .header(header::CONTENT_TYPE, "application/zip")
         .header(
@@ -163,6 +248,20 @@ pub(crate) async fn download(
         )
         .body(Body::from_stream(stream))
         .map_err(response_error)
+}
+
+pub(crate) async fn download_literal_file(
+    state: State<Arc<WebState>>,
+    query: Query<VaultQuery>,
+) -> Result<Response, ApiError> {
+    super::api::files::download_file(state, Path("archive".to_string()), query).await
+}
+
+pub(crate) async fn delete_literal_file(
+    state: State<Arc<WebState>>,
+    query: Query<VaultQuery>,
+) -> Result<StatusCode, ApiError> {
+    super::api::files::delete_file(state, Path("archive".to_string()), query).await
 }
 
 #[cfg(test)]
@@ -178,7 +277,7 @@ mod tests {
     use tower::ServiceExt;
     use zip::ZipArchive;
 
-    use super::validate_names;
+    use super::{validate_names, ArchiveLimits};
     use crate::backend::FileBackend;
     use crate::blob::models::FileUploadRequest;
     use crate::secret::attachments;
@@ -213,10 +312,10 @@ mod tests {
         bytes
     }
 
-    fn scoped_state(
+    fn scoped_state_value(
         primary: Arc<testutil::stub::StubBackend>,
         secondary: Arc<testutil::stub::StubBackend>,
-    ) -> Arc<web::WebState> {
+    ) -> web::WebState {
         let mut context = testutil::test_context(primary.as_ref(), "default", 30);
         context
             .workspace
@@ -234,7 +333,7 @@ mod tests {
                 ("secondary", secondary.clone()),
             ],
         ));
-        Arc::new(web::WebState::new(
+        web::WebState::new(
             primary,
             context,
             "test-token".into(),
@@ -242,6 +341,48 @@ mod tests {
             super::super::preferences::PreferenceStore::new(
                 std::env::temp_dir()
                     .join(format!("xv-archive-scope-{}", uuid::Uuid::new_v4()))
+                    .join("ui.json"),
+                30,
+            ),
+            registry,
+        )
+    }
+
+    fn scoped_state(
+        primary: Arc<testutil::stub::StubBackend>,
+        secondary: Arc<testutil::stub::StubBackend>,
+    ) -> Arc<web::WebState> {
+        Arc::new(
+            scoped_state_value(primary, secondary).with_archive_jobs(Arc::new(
+                tokio::sync::Semaphore::new(super::MAX_CONCURRENT_ARCHIVES),
+            )),
+        )
+    }
+
+    fn limited_state(
+        primary: Arc<testutil::stub::StubBackend>,
+        limits: ArchiveLimits,
+    ) -> Arc<web::WebState> {
+        Arc::new(
+            scoped_state_value(primary, Arc::new(StubBackend::new()))
+                .with_archive_jobs(Arc::new(tokio::sync::Semaphore::new(
+                    super::MAX_CONCURRENT_ARCHIVES,
+                )))
+                .with_archive_limits(limits),
+        )
+    }
+
+    fn process_state(backend: Arc<testutil::stub::StubBackend>) -> Arc<web::WebState> {
+        let context = testutil::test_context(backend.as_ref(), "default", 30);
+        let registry = Arc::new(crate::backend::BackendRegistry::new(backend.clone()));
+        Arc::new(web::WebState::new(
+            backend,
+            context,
+            "test-token".into(),
+            crate::records::builtin_types(),
+            super::super::preferences::PreferenceStore::new(
+                std::env::temp_dir()
+                    .join(format!("xv-archive-process-{}", uuid::Uuid::new_v4()))
                     .join("ui.json"),
                 30,
             ),
@@ -283,6 +424,48 @@ mod tests {
         assert_eq!(read_entry(&mut archive, "docs/report.txt"), b"report");
         assert_eq!(read_entry(&mut archive, "root.txt"), b"root");
         assert_eq!(archive.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn literal_archive_file_can_be_downloaded_and_deleted() {
+        let state = testutil::test_state();
+        state
+            .base_backend()
+            .files()
+            .unwrap()
+            .upload_file("default", file_request("archive", b"literal file"), None)
+            .await
+            .unwrap();
+        let app = web::build_router(state);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get("/api/files/archive")
+                    .header(header::HOST, "127.0.0.1:1")
+                    .header(header::AUTHORIZATION, "Bearer test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.into_body().collect().await.unwrap().to_bytes(),
+            "literal file"
+        );
+
+        let response = app
+            .oneshot(
+                Request::delete("/api/files/archive")
+                    .header(header::HOST, "127.0.0.1:1")
+                    .header(header::AUTHORIZATION, "Bearer test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]
@@ -379,6 +562,197 @@ mod tests {
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
+    #[tokio::test]
+    async fn archive_rejects_a_file_over_100_mib_before_downloading_it() {
+        let primary = Arc::new(
+            StubBackend::new().with_reported_file_size("large.bin", 100 * 1024 * 1024 + 1),
+        );
+        primary
+            .upload_file("default", file_request("large.bin", b"x"), None)
+            .await
+            .unwrap();
+        let state = scoped_state(primary.clone(), Arc::new(StubBackend::new()));
+
+        let response = web::build_router(state)
+            .oneshot(archive_request(
+                "/api/files/archive",
+                json!({"files": ["large.bin"]}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let body: Value =
+            serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes())
+                .unwrap();
+        assert_eq!(body["error"]["code"], "xv-request-too-large");
+        assert_eq!(primary.download_file_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn archive_rejects_more_than_512_mib_aggregate_before_downloading_any_file() {
+        let mut backend = StubBackend::new();
+        let names = (0..6)
+            .map(|index| format!("file-{index}.bin"))
+            .collect::<Vec<_>>();
+        for name in &names {
+            backend = backend.with_reported_file_size(name, 100 * 1024 * 1024);
+        }
+        let primary = Arc::new(backend);
+        for name in &names {
+            primary
+                .upload_file("default", file_request(name, b"x"), None)
+                .await
+                .unwrap();
+        }
+        let state = scoped_state(primary.clone(), Arc::new(StubBackend::new()));
+
+        let response = web::build_router(state)
+            .oneshot(archive_request(
+                "/api/files/archive",
+                json!({"files": names}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let body: Value =
+            serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes())
+                .unwrap();
+        assert_eq!(body["error"]["code"], "xv-request-too-large");
+        assert_eq!(primary.download_file_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn archive_actual_file_limit_accepts_exact_and_rejects_underreported_plus_one() {
+        let exact = Arc::new(StubBackend::new().with_reported_file_size("exact.bin", 3));
+        exact
+            .upload_file("default", file_request("exact.bin", b"123"), None)
+            .await
+            .unwrap();
+        let response = web::build_router(limited_state(exact, ArchiveLimits::for_test(3, 5)))
+            .oneshot(archive_request(
+                "/api/files/archive",
+                json!({"files": ["exact.bin"]}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        response.into_body().collect().await.unwrap();
+
+        let underreported =
+            Arc::new(StubBackend::new().with_reported_file_size("too-large.bin", 1));
+        underreported
+            .upload_file("default", file_request("too-large.bin", b"1234"), None)
+            .await
+            .unwrap();
+        let response = web::build_router(limited_state(
+            underreported.clone(),
+            ArchiveLimits::for_test(3, 5),
+        ))
+        .oneshot(archive_request(
+            "/api/files/archive",
+            json!({"files": ["too-large.bin"]}),
+        ))
+        .await
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(underreported.download_file_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn archive_actual_total_limit_accepts_exact_and_rejects_underreported_plus_one() {
+        let exact = Arc::new(StubBackend::new());
+        for (name, bytes) in [("two.bin", b"12".as_slice()), ("three.bin", b"123")] {
+            exact
+                .upload_file("default", file_request(name, bytes), None)
+                .await
+                .unwrap();
+        }
+        let response = web::build_router(limited_state(exact, ArchiveLimits::for_test(3, 5)))
+            .oneshot(archive_request(
+                "/api/files/archive",
+                json!({"files": ["two.bin", "three.bin"]}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        response.into_body().collect().await.unwrap();
+
+        let underreported = Arc::new(
+            StubBackend::new()
+                .with_reported_file_size("first.bin", 1)
+                .with_reported_file_size("second.bin", 1),
+        );
+        for name in ["first.bin", "second.bin"] {
+            underreported
+                .upload_file("default", file_request(name, b"123"), None)
+                .await
+                .unwrap();
+        }
+        let response = web::build_router(limited_state(
+            underreported.clone(),
+            ArchiveLimits::for_test(3, 5),
+        ))
+        .oneshot(archive_request(
+            "/api/files/archive",
+            json!({"files": ["first.bin", "second.bin"]}),
+        ))
+        .await
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(underreported.download_file_calls(), 2);
+    }
+
+    #[tokio::test]
+    async fn archive_process_limit_is_shared_across_states_until_a_stream_is_dropped() {
+        let first_backend = Arc::new(StubBackend::new());
+        let second_backend = Arc::new(StubBackend::new());
+        for backend in [&first_backend, &second_backend] {
+            backend
+                .upload_file("default", file_request("small.txt", b"small"), None)
+                .await
+                .unwrap();
+        }
+        let first_app = web::build_router(process_state(first_backend));
+        let second_app = web::build_router(process_state(second_backend));
+        let mut active = Vec::new();
+        for app in [&first_app, &second_app] {
+            let response = app
+                .to_owned()
+                .oneshot(archive_request(
+                    "/api/files/archive",
+                    json!({"files": ["small.txt"]}),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            active.push(response);
+        }
+
+        let response = second_app
+            .clone()
+            .oneshot(archive_request(
+                "/api/files/archive",
+                json!({"files": ["small.txt"]}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        let body: Value =
+            serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes())
+                .unwrap();
+        assert_eq!(body["error"]["code"], "xv-rate-limited");
+
+        active.pop();
+        let response = second_app
+            .oneshot(archive_request(
+                "/api/files/archive",
+                json!({"files": ["small.txt"]}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
     #[test]
     fn archive_names_are_relative_unique_backend_validated_paths() {
         let backend = StubBackend::new();
@@ -401,6 +775,22 @@ mod tests {
                 "accepted {names:?}"
             );
         }
+    }
+
+    #[test]
+    fn archive_rejects_windows_drive_qualified_names_but_allows_other_colons() {
+        let backend = StubBackend::new();
+        for name in ["C:/escape.txt", "C:escape.txt"] {
+            assert!(
+                validate_names(&backend, &[name.to_string()]).is_err(),
+                "accepted {name:?}"
+            );
+        }
+        assert!(validate_names(
+            &backend,
+            &["report:final.txt".into(), "docs/report:final.txt".into()],
+        )
+        .is_ok());
     }
 
     #[test]

--- a/src/web/archive.rs
+++ b/src/web/archive.rs
@@ -1,0 +1,95 @@
+use std::collections::HashSet;
+
+use axum::http::StatusCode;
+use serde::Deserialize;
+
+use crate::backend::FileBackend;
+
+use super::api::ApiError;
+
+pub(crate) const MAX_ARCHIVE_BODY_BYTES: usize = 512 * 1024;
+const MAX_ARCHIVE_FILES: usize = 1000;
+const MAX_ARCHIVE_NAME_BYTES: usize = 1024;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ArchiveRequest {
+    files: Vec<String>,
+}
+
+fn archive_validation(message: &'static str) -> ApiError {
+    ApiError::Validation {
+        status: StatusCode::BAD_REQUEST,
+        message,
+        field: Some("files"),
+    }
+}
+
+fn validate_names(files: &dyn FileBackend, names: &[String]) -> Result<(), ApiError> {
+    if names.is_empty() || names.len() > MAX_ARCHIVE_FILES {
+        return Err(archive_validation("Choose between 1 and 1000 files."));
+    }
+
+    let mut seen = HashSet::with_capacity(names.len());
+    for name in names {
+        let components = name.split('/').collect::<Vec<_>>();
+        if name.len() > MAX_ARCHIVE_NAME_BYTES
+            || name.starts_with('/')
+            || name.contains('\\')
+            || name.contains('\0')
+            || components
+                .iter()
+                .any(|part| part.is_empty() || *part == "." || *part == "..")
+            || !seen.insert(name)
+        {
+            return Err(archive_validation("Choose valid unique file names."));
+        }
+        files.validate_file_name(name)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_names;
+    use crate::web::testutil::stub::StubBackend;
+
+    #[test]
+    fn archive_names_are_relative_unique_backend_validated_paths() {
+        let backend = StubBackend::new();
+        assert!(validate_names(&backend, &["root.txt".into(), "docs/report.pdf".into()],).is_ok());
+        assert_eq!(backend.file_name_validation_calls(), 2);
+
+        for names in [
+            vec![],
+            vec!["same.txt".into(), "same.txt".into()],
+            vec!["/absolute.txt".into()],
+            vec!["../outside.txt".into()],
+            vec!["docs//empty.txt".into()],
+            vec!["docs/./dot.txt".into()],
+            vec!["docs\\windows.txt".into()],
+            vec!["nul\0name.txt".into()],
+            vec!["x".repeat(1025)],
+        ] {
+            assert!(
+                validate_names(&backend, &names).is_err(),
+                "accepted {names:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn archive_selection_is_bounded() {
+        let backend = StubBackend::new();
+        let names = (0..=1000)
+            .map(|index| format!("{index}.txt"))
+            .collect::<Vec<_>>();
+        assert!(validate_names(&backend, &names).is_err());
+    }
+
+    #[test]
+    fn archive_uses_the_selected_backends_name_rules() {
+        let backend = StubBackend::new().with_file_name_limit(4);
+        assert!(validate_names(&backend, &["five5".into()]).is_err());
+    }
+}

--- a/src/web/assets/files.js
+++ b/src/web/assets/files.js
@@ -1,5 +1,25 @@
 import { activeFilterChips } from './ui-model.js';
 
+export async function downloadFileArchive({
+  api,
+  path,
+  names,
+  document = globalThis.document,
+  objectUrls = globalThis.URL,
+}) {
+  const response = await api('POST', path, { files: [...names] }, true);
+  const blob = await response.blob();
+  const href = objectUrls.createObjectURL(blob);
+  try {
+    const anchor = document.createElement('a');
+    anchor.href = href;
+    anchor.download = 'crosstache-files.zip';
+    anchor.click();
+  } finally {
+    objectUrls.revokeObjectURL(href);
+  }
+}
+
 export const UPLOAD_STATES = Object.freeze([
   'queued',
   'preflighting',

--- a/src/web/assets/files.js
+++ b/src/web/assets/files.js
@@ -6,9 +6,11 @@ export async function downloadFileArchive({
   names,
   document = globalThis.document,
   objectUrls = globalThis.URL,
+  shouldSave = () => true,
 }) {
   const response = await api('POST', path, { files: [...names] }, true);
   const blob = await response.blob();
+  if (!shouldSave()) return;
   const href = objectUrls.createObjectURL(blob);
   try {
     const anchor = document.createElement('a');

--- a/src/web/assets/files.test.js
+++ b/src/web/assets/files.test.js
@@ -2,12 +2,63 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   createUploadQueue,
+  downloadFileArchive,
   nextUploadState,
   uploadConflictDecision,
   uploadEvidenceState,
   validateUploadConfirmation,
   validatePreflightResults,
 } from './files.js';
+
+test('archive download posts exact names, clicks one zip anchor, and revokes its URL', async () => {
+  const calls = [];
+  const anchors = [];
+  const api = async (...args) => {
+    calls.push(args);
+    return { blob: async () => new Blob(['zip']) };
+  };
+  const document = { createElement: () => {
+    const anchor = { clickCount: 0, click() { this.clickCount++; } };
+    anchors.push(anchor);
+    return anchor;
+  } };
+  const revoked = [];
+  const objectUrls = {
+    createObjectURL: () => 'blob:archive',
+    revokeObjectURL: (value) => revoked.push(value),
+  };
+
+  await downloadFileArchive({
+    api,
+    path: '/api/files/archive?alias=primary&backend=local&vault=one',
+    names: ['docs/a.txt', 'b.txt'],
+    document,
+    objectUrls,
+  });
+
+  assert.deepEqual(calls, [[
+    'POST',
+    '/api/files/archive?alias=primary&backend=local&vault=one',
+    { files: ['docs/a.txt', 'b.txt'] },
+    true,
+  ]]);
+  assert.equal(anchors[0].download, 'crosstache-files.zip');
+  assert.equal(anchors[0].href, 'blob:archive');
+  assert.equal(anchors[0].clickCount, 1);
+  assert.deepEqual(revoked, ['blob:archive']);
+});
+
+test('archive download does not create an anchor when the API fails', async () => {
+  let created = 0;
+  await assert.rejects(() => downloadFileArchive({
+    api: async () => { throw new Error('failed'); },
+    path: '/api/files/archive',
+    names: ['a.txt'],
+    document: { createElement() { created++; } },
+    objectUrls: {},
+  }), /failed/);
+  assert.equal(created, 0);
+});
 
 test('retry selects only failed cancelled and ambiguous entries', () => {
   const queue = createUploadQueue([{ id: 'a' }, { id: 'b' }, { id: 'c' }]);

--- a/src/web/assets/index.html
+++ b/src/web/assets/index.html
@@ -148,6 +148,9 @@
     <div id="file-bulk-bar" class="bulk-toolbar" hidden>
       <span id="file-selection-count" aria-live="polite">0 selected</span>
       <small data-context-copy></small>
+      <button id="bulk-download-files" class="button secondary" type="button">
+        <svg class="icon" aria-hidden="true"><use href="#icon-download"></use></svg>Download
+      </button>
       <button id="bulk-delete-files" class="button danger" type="button" data-default-label="Delete">Delete</button>
       <button id="cancel-file-selection" class="button ghost" type="button">Cancel</button>
     </div>

--- a/src/web/assets/secrets.js
+++ b/src/web/assets/secrets.js
@@ -3676,6 +3676,7 @@ async function bulkDownloadFiles() {
       api,
       path: `/api/files/archive${vaultQS(scope.vault, scope)}`,
       names,
+      shouldSave: () => generation === state.generation && scopeMatchesCurrent(scope),
     });
     if (generation === state.generation && scopeMatchesCurrent(scope)) {
       toast(`Downloaded ${names.length} file${names.length === 1 ? '' : 's'} in ${formatContextLine(scope)}`);

--- a/src/web/assets/secrets.js
+++ b/src/web/assets/secrets.js
@@ -1,6 +1,6 @@
 import * as XvUiModel from './ui-model.js';
 import { buildMetadataIndex, searchIndex } from './commands.js';
-import { mountFilterControls, mountUploadQueue } from './files.js';
+import { downloadFileArchive, mountFilterControls, mountUploadQueue } from './files.js';
 import { renderTreeGrid } from './tree-grid.js';
 import { guardNavigation } from './dialogs.js';
 import {
@@ -934,6 +934,7 @@ function selectionElements(kind) {
     bulkBar: $(`#${singular}-bulk-bar`),
     count: $(`#${singular}-selection-count`),
     deleteButton: $(`#bulk-delete-${kind}`),
+    downloadButton: kind === 'files' ? $('#bulk-download-files') : null,
   };
 }
 
@@ -955,6 +956,8 @@ function resetSelectionControls(kind) {
     const moveButton = $('#bulk-move-secrets');
     resetConfirmation(moveButton, 'Move');
     $('#secret-move-folder').disabled = false;
+  } else {
+    resetConfirmation($('#bulk-download-files'), 'Download');
   }
 }
 
@@ -1021,6 +1024,9 @@ function updateSelectionControls(kind) {
   elements.selectAll.disabled = visible.visibleCount === 0;
   elements.count.textContent = `${state.ids.size} selected`;
   elements.deleteButton.disabled = state.pending || state.ids.size === 0;
+  if (elements.downloadButton) {
+    elements.downloadButton.disabled = state.pending || state.ids.size === 0;
+  }
   elements.selectAll.disabled = state.pending || visible.visibleCount === 0;
   if (kind === 'secrets') $('#bulk-move-secrets').disabled = state.pending || state.ids.size === 0;
 }
@@ -3647,6 +3653,42 @@ function setBulkPending(kind, pending, label) {
   renderSelectionKind(kind);
 }
 
+function setFileDownloadPending(pending) {
+  fileSelection.pending = pending;
+  $('#cancel-file-selection').disabled = pending;
+  const button = $('#bulk-download-files');
+  if (pending) beginPendingAction(button, 'Downloading…');
+  else resetConfirmation(button, 'Download');
+  updateSelectionControls('files');
+  renderFiles();
+}
+
+async function bulkDownloadFiles() {
+  const state = fileSelection;
+  const names = [...state.ids];
+  if (!names.length || state.pending) return;
+  const scope = captureOperationScope();
+  if (!canStartScopedAction(scope)) return;
+  const generation = state.generation;
+  setFileDownloadPending(true);
+  try {
+    await downloadFileArchive({
+      api,
+      path: `/api/files/archive${vaultQS(scope.vault, scope)}`,
+      names,
+    });
+    if (generation === state.generation && scopeMatchesCurrent(scope)) {
+      toast(`Downloaded ${names.length} file${names.length === 1 ? '' : 's'} in ${formatContextLine(scope)}`);
+    }
+  } catch (error) {
+    if (generation === state.generation && scopeMatchesCurrent(scope)) {
+      showListError('files', error);
+    }
+  } finally {
+    if (generation === state.generation) setFileDownloadPending(false);
+  }
+}
+
 async function bulkDelete(kind) {
   const state = selectionState(kind);
   const items = [...state.ids];
@@ -3799,6 +3841,7 @@ $('#select-all-secrets').onchange = (e) => setVisibleSelection('secrets', e.targ
 $('#select-all-files').onchange = (e) => setVisibleSelection('files', e.target.checked);
 $('#bulk-delete-secrets').onclick = () => bulkDelete('secrets').catch(fail);
 $('#bulk-delete-files').onclick = () => bulkDelete('files').catch(fail);
+$('#bulk-download-files').onclick = () => bulkDownloadFiles();
 $('#bulk-move-secrets').onclick = () => bulkMoveSecrets().catch(fail);
 
 async function downloadFile(name, saveAs = name) {

--- a/src/web/assets/secrets.routes.test.js
+++ b/src/web/assets/secrets.routes.test.js
@@ -17,6 +17,7 @@ class Element {
   constructor(id, document) {
     this.key = id;
     this.id = id.startsWith('#') ? id.slice(1) : id;
+    this.tagName = id.startsWith('#') ? '' : id.toUpperCase();
     this.document = document;
     this.hidden = false;
     this.disabled = false;
@@ -70,6 +71,10 @@ class Element {
   querySelector(selector) { return this.document.element(`${this.key} ${selector}`); }
   addEventListener(type, listener) { this.listeners.set(type, listener); }
   dispatch(type, event = {}) { return this.listeners.get(type)?.({ preventDefault() {}, target: this, ...event }); }
+  click() {
+    this.clickCount = (this.clickCount || 0) + 1;
+    return this.onclick?.({ preventDefault() {}, stopPropagation() {}, currentTarget: this });
+  }
   focus() { this.document.activeElement = this; }
   contains(target) {
     if (this === target) return true;
@@ -79,8 +84,10 @@ class Element {
 
 function createDocument() {
   const elements = new Map();
+  const createdElements = [];
   const document = {
     activeElement: null,
+    createdElements,
     listeners: new Map(),
     element(id) {
       if (!elements.has(id)) elements.set(id, new Element(id, document));
@@ -96,7 +103,11 @@ function createDocument() {
       return document.element(selector);
     },
     querySelectorAll() { return []; },
-    createElement(name) { return new Element(name, document); },
+    createElement(name) {
+      const element = new Element(name, document);
+      createdElements.push(element);
+      return element;
+    },
     createElementNS(_namespace, name) { return new Element(name, document); },
     createTextNode(value) { return value; },
     addEventListener(type, listener) { document.listeners.set(type, listener); },
@@ -789,6 +800,131 @@ test('tree selection propagates through folders and keeps bulk actions scoped to
     ui.elements.get('#cancel-secret-selection').onclick();
     assert.equal(ui.elements.get('#secret-selection-count').textContent, '0 selected');
     assert.equal(ui.elements.get('#select-all-secrets').hidden, true);
+  } finally {
+    ui.restore();
+  }
+});
+
+test('downloads selected files as one zip', async () => {
+  const context = {
+    ...routedContext('primary', 'one'),
+    capabilities: { ...routedContext('primary', 'one').capabilities, files: true },
+  };
+  const listed = [
+    { name: 'docs/a.txt', size: 1, content_type: 'text/plain' },
+    { name: 'docs/b.txt', size: 1, content_type: 'text/plain' },
+  ];
+  const archiveCalls = [];
+  const archiveResponse = { blob: async () => new Blob(['zip']) };
+  const api = async (method, requestPath, body, raw) => {
+    if (method === 'GET' && requestPath === '/api/context') return context;
+    if (requestPath === '/api/types') return { types: [] };
+    if (requestPath === '/api/vaults') return { vaults: [{ name: 'one' }] };
+    if (method === 'POST' && requestPath.startsWith('/api/folder-tokens')) {
+      return {
+        version: 1,
+        scope_token: 'S'.repeat(43),
+        folders: body.folders.map((folder) => ({ path: folder, token: 'F'.repeat(43) })),
+      };
+    }
+    if (method === 'POST' && requestPath.startsWith('/api/files/archive')) {
+      archiveCalls.push({ method, path: requestPath, body, raw });
+      return archiveResponse;
+    }
+    if (method === 'GET' && requestPath.startsWith('/api/secrets')) return [];
+    if (method === 'GET' && requestPath.startsWith('/api/files')) return listed;
+    return [];
+  };
+  const ui = await mountRouteUi({ apiImpl: api });
+  try {
+    await ui.elements.get('#tab-files').onclick();
+    ui.elements.get('#select-files').onclick();
+    ui.elements.get('#select-all-files').onchange({ target: { checked: true } });
+
+    assert.equal(ui.elements.get('#bulk-download-files').disabled, false);
+    await ui.elements.get('#bulk-download-files').onclick();
+    assert.deepEqual(archiveCalls, [{
+      method: 'POST',
+      path: '/api/files/archive?alias=primary&backend=local&vault=one',
+      body: { files: ['docs/a.txt', 'docs/b.txt'] },
+      raw: true,
+    }]);
+    assert.equal(ui.elements.get('#file-selection-count').textContent, '2 selected');
+    assert.equal(ui.elements.get('#file-bulk-bar').hidden, false);
+    assert.equal(ui.elements.get('#bulk-download-files').textContent, 'Download');
+    assert.equal(ui.elements.get('#bulk-download-files').disabled, false);
+    const createdArchiveAnchors = ui.document.createdElements.filter((element) => (
+      element.tagName === 'A' && element.download === 'crosstache-files.zip'
+    ));
+    assert.equal(createdArchiveAnchors.length, 1);
+    assert.equal(createdArchiveAnchors[0].clickCount, 1);
+  } finally {
+    ui.restore();
+  }
+});
+
+test('zip download failure retains file selection', async () => {
+  const context = {
+    ...routedContext('primary', 'one'),
+    capabilities: { ...routedContext('primary', 'one').capabilities, files: true },
+  };
+  const listed = [
+    { name: 'docs/a.txt', size: 1, content_type: 'text/plain' },
+    { name: 'docs/b.txt', size: 1, content_type: 'text/plain' },
+  ];
+  const archiveCalls = [];
+  let rejectArchive;
+  const archiveResponse = new Promise((_resolve, reject) => { rejectArchive = reject; });
+  const api = async (method, requestPath, body, raw) => {
+    if (method === 'GET' && requestPath === '/api/context') return context;
+    if (requestPath === '/api/types') return { types: [] };
+    if (requestPath === '/api/vaults') return { vaults: [{ name: 'one' }] };
+    if (method === 'POST' && requestPath.startsWith('/api/folder-tokens')) {
+      return {
+        version: 1,
+        scope_token: 'S'.repeat(43),
+        folders: body.folders.map((folder) => ({ path: folder, token: 'F'.repeat(43) })),
+      };
+    }
+    if (method === 'POST' && requestPath.startsWith('/api/files/archive')) {
+      archiveCalls.push({ method, path: requestPath, body, raw });
+      return archiveResponse;
+    }
+    if (method === 'GET' && requestPath.startsWith('/api/secrets')) return [];
+    if (method === 'GET' && requestPath.startsWith('/api/files')) return listed;
+    return [];
+  };
+  const ui = await mountRouteUi({ apiImpl: api });
+  try {
+    await ui.elements.get('#tab-files').onclick();
+    ui.elements.get('#select-files').onclick();
+    ui.elements.get('#select-all-files').onchange({ target: { checked: true } });
+
+    const download = ui.elements.get('#bulk-download-files').onclick();
+    await settleUntil(() => archiveCalls.length === 1);
+    assert.equal(ui.elements.get('#bulk-download-files').textContent, 'Downloading…');
+    assert.equal(ui.elements.get('#bulk-download-files').disabled, true);
+    assert.equal(ui.elements.get('#bulk-delete-files').disabled, true);
+    assert.equal(ui.elements.get('#cancel-file-selection').disabled, true);
+    const fileCheckboxes = ui.findAll('#files-table tbody', (element) => (
+      element.tagName === 'INPUT' && element.getAttribute('aria-label')?.startsWith('Select file ')
+    ));
+    assert.equal(fileCheckboxes.length, 2);
+    assert.equal(fileCheckboxes.every((checkbox) => checkbox.disabled), true);
+
+    rejectArchive(new Error('archive failed'));
+    await download;
+
+    const createdArchiveAnchors = ui.document.createdElements.filter((element) => (
+      element.tagName === 'A' && element.download === 'crosstache-files.zip'
+    ));
+    assert.equal(createdArchiveAnchors.length, 0);
+    assert.equal(ui.elements.get('#file-error').hidden, false);
+    assert.equal(ui.elements.get('#file-selection-count').textContent, '2 selected');
+    assert.equal(ui.elements.get('#bulk-download-files').textContent, 'Download');
+    assert.equal(ui.elements.get('#bulk-download-files').disabled, false);
+    assert.equal(ui.elements.get('#bulk-delete-files').disabled, false);
+    assert.equal(ui.elements.get('#cancel-file-selection').disabled, false);
   } finally {
     ui.restore();
   }

--- a/src/web/assets/secrets.routes.test.js
+++ b/src/web/assets/secrets.routes.test.js
@@ -863,6 +863,65 @@ test('downloads selected files as one zip', async () => {
   }
 });
 
+test('a zip response from a previous workspace is not saved', async () => {
+  const primary = {
+    ...routedContext('primary', 'one'),
+    capabilities: { ...routedContext('primary', 'one').capabilities, files: true },
+  };
+  const stage = {
+    ...routedContext('stage', 'two'),
+    capabilities: { ...routedContext('stage', 'two').capabilities, files: true },
+  };
+  const archive = deferred();
+  let archiveStarted = false;
+  const api = async (method, requestPath) => {
+    if (method === 'GET' && requestPath === '/api/context') return primary;
+    if (method === 'POST' && requestPath === '/api/workspaces/activate') {
+      return { context: stage, secrets: [] };
+    }
+    if (requestPath === '/api/types') return { types: [] };
+    if (requestPath === '/api/vaults') return { vaults: [{ name: 'one' }, { name: 'two' }] };
+    if (method === 'POST' && requestPath.startsWith('/api/folder-tokens')) {
+      return { version: 1, scope_token: 'S'.repeat(43), folders: [] };
+    }
+    if (method === 'POST' && requestPath.startsWith('/api/files/archive')) {
+      archiveStarted = true;
+      return archive.promise;
+    }
+    if (method === 'GET' && requestPath.startsWith('/api/secrets')) return [];
+    if (method === 'GET' && requestPath.startsWith('/api/files')) {
+      return requestPath.includes('vault=two')
+        ? []
+        : [{ name: 'docs/a.txt', size: 1, content_type: 'text/plain' }];
+    }
+    return [];
+  };
+  const ui = await mountRouteUi({ apiImpl: api, withContextRail: true });
+  let download;
+  try {
+    await ui.elements.get('#tab-files').onclick();
+    ui.elements.get('#select-files').onclick();
+    ui.elements.get('#select-all-files').onchange({ target: { checked: true } });
+
+    download = ui.elements.get('#bulk-download-files').onclick();
+    await settleUntil(() => archiveStarted);
+    assert.equal(await ui.contextRail.switchTo('stage'), true);
+
+    archive.resolve({ blob: async () => new Blob(['zip']) });
+    await download;
+
+    const createdArchiveAnchors = ui.document.createdElements.filter((element) => (
+      element.tagName === 'A' && element.download === 'crosstache-files.zip'
+    ));
+    assert.equal(createdArchiveAnchors.length, 0);
+    assert.doesNotMatch(ui.document.getElementById('toast').textContent, /Downloaded/);
+  } finally {
+    archive.resolve({ blob: async () => new Blob(['zip']) });
+    await Promise.allSettled(download ? [download] : []);
+    ui.restore();
+  }
+});
+
 test('zip download failure retains file selection', async () => {
   const context = {
     ...routedContext('primary', 'one'),

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -151,6 +151,10 @@ pub(crate) struct WebState {
     pub(crate) preferences: preferences::PreferenceStore,
     pub(crate) folder_tokens: folder_tokens::FolderTokenService,
     pub(crate) registry: Arc<BackendRegistry>,
+    #[cfg(feature = "file-ops")]
+    pub(crate) archive_jobs: Arc<tokio::sync::Semaphore>,
+    #[cfg(feature = "file-ops")]
+    pub(crate) archive_limits: archive::ArchiveLimits,
     backend: Arc<dyn Backend>,
     context: context::EffectiveUiContext,
 }
@@ -175,6 +179,10 @@ impl WebState {
             preferences,
             folder_tokens: folder_tokens::FolderTokenService::random(),
             registry,
+            #[cfg(feature = "file-ops")]
+            archive_jobs: archive::archive_job_limiter(),
+            #[cfg(feature = "file-ops")]
+            archive_limits: archive::ArchiveLimits::default(),
             backend,
             context,
         }
@@ -182,6 +190,18 @@ impl WebState {
 
     fn with_folder_tokens(mut self, folder_tokens: folder_tokens::FolderTokenService) -> Self {
         self.folder_tokens = folder_tokens;
+        self
+    }
+
+    #[cfg(all(test, feature = "file-ops"))]
+    pub(crate) fn with_archive_jobs(mut self, archive_jobs: Arc<tokio::sync::Semaphore>) -> Self {
+        self.archive_jobs = archive_jobs;
+        self
+    }
+
+    #[cfg(all(test, feature = "file-ops"))]
+    pub(crate) fn with_archive_limits(mut self, archive_limits: archive::ArchiveLimits) -> Self {
+        self.archive_limits = archive_limits;
         self
     }
 
@@ -341,9 +361,12 @@ pub(crate) fn build_router(state: Arc<WebState>) -> Router {
         )
         .route(
             "/files/archive",
-            post(archive::download).layer(axum::extract::DefaultBodyLimit::max(
-                archive::MAX_ARCHIVE_BODY_BYTES,
-            )),
+            post(archive::download)
+                .get(archive::download_literal_file)
+                .delete(archive::delete_literal_file)
+                .layer(axum::extract::DefaultBodyLimit::max(
+                    archive::MAX_ARCHIVE_BODY_BYTES,
+                )),
         )
         .route(
             "/files/{name}",

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -340,6 +340,12 @@ pub(crate) fn build_router(state: Arc<WebState>) -> Router {
                 .layer(axum::middleware::from_fn(files::enforce_upload_envelope)),
         )
         .route(
+            "/files/archive",
+            post(archive::download).layer(axum::extract::DefaultBodyLimit::max(
+                archive::MAX_ARCHIVE_BODY_BYTES,
+            )),
+        )
+        .route(
             "/files/{name}",
             get(api::files::download_file).delete(api::files::delete_file),
         )

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -17,6 +17,8 @@ use crate::config::Config;
 use crate::error::{CrosstacheError, Result};
 
 pub(crate) mod api;
+#[cfg(feature = "file-ops")]
+mod archive;
 pub(crate) mod auth;
 mod context;
 pub(crate) mod errors;

--- a/src/web/testutil.rs
+++ b/src/web/testutil.rs
@@ -20,14 +20,19 @@ fn test_state_with_token_and_preferences(
     let backend: Arc<dyn crate::backend::Backend> = Arc::new(stub::StubBackend::new());
     let context = test_context(backend.as_ref(), "default", clipboard_timeout);
     let registry = Arc::new(crate::backend::BackendRegistry::new(backend.clone()));
-    Arc::new(WebState::new(
-        backend,
-        context,
-        token.to_string(),
-        crate::records::builtin_types(),
-        super::preferences::PreferenceStore::new(path, clipboard_timeout),
-        registry,
-    ))
+    Arc::new(
+        WebState::new(
+            backend,
+            context,
+            token.to_string(),
+            crate::records::builtin_types(),
+            super::preferences::PreferenceStore::new(path, clipboard_timeout),
+            registry,
+        )
+        .with_archive_jobs(Arc::new(tokio::sync::Semaphore::new(
+            super::archive::MAX_CONCURRENT_ARCHIVES,
+        ))),
+    )
 }
 
 pub(crate) fn test_context(
@@ -130,9 +135,13 @@ pub(crate) mod stub {
         #[cfg(feature = "file-ops")]
         file_info_calls: AtomicUsize,
         #[cfg(feature = "file-ops")]
+        download_file_calls: AtomicUsize,
+        #[cfg(feature = "file-ops")]
         file_name_validation_calls: AtomicUsize,
         #[cfg(feature = "file-ops")]
         file_name_limit: Option<usize>,
+        #[cfg(feature = "file-ops")]
+        reported_file_sizes: Mutex<HashMap<String, u64>>,
     }
 
     impl StubBackend {
@@ -189,9 +198,13 @@ pub(crate) mod stub {
                 #[cfg(feature = "file-ops")]
                 file_info_calls: AtomicUsize::new(0),
                 #[cfg(feature = "file-ops")]
+                download_file_calls: AtomicUsize::new(0),
+                #[cfg(feature = "file-ops")]
                 file_name_validation_calls: AtomicUsize::new(0),
                 #[cfg(feature = "file-ops")]
                 file_name_limit: None,
+                #[cfg(feature = "file-ops")]
+                reported_file_sizes: Mutex::new(HashMap::new()),
             }
         }
 
@@ -265,6 +278,11 @@ pub(crate) mod stub {
         }
 
         #[cfg(feature = "file-ops")]
+        pub(crate) fn download_file_calls(&self) -> usize {
+            self.download_file_calls.load(Ordering::SeqCst)
+        }
+
+        #[cfg(feature = "file-ops")]
         pub(crate) fn file_name_validation_calls(&self) -> usize {
             self.file_name_validation_calls.load(Ordering::SeqCst)
         }
@@ -278,6 +296,15 @@ pub(crate) mod stub {
         #[cfg(feature = "file-ops")]
         pub(crate) fn with_file_name_limit(mut self, limit: usize) -> Self {
             self.file_name_limit = Some(limit);
+            self
+        }
+
+        #[cfg(feature = "file-ops")]
+        pub(crate) fn with_reported_file_size(self, name: &str, size: u64) -> Self {
+            self.reported_file_sizes
+                .lock()
+                .unwrap()
+                .insert(name.to_string(), size);
             self
         }
     }
@@ -814,6 +841,7 @@ pub(crate) mod stub {
             name: &str,
             _reporter: Option<&dyn crate::utils::progress::ProgressReporter>,
         ) -> Result<Vec<u8>, BackendError> {
+            self.download_file_calls.fetch_add(1, Ordering::SeqCst);
             self.files
                 .lock()
                 .unwrap()
@@ -862,7 +890,16 @@ pub(crate) mod stub {
                 .lock()
                 .unwrap()
                 .get(name)
-                .map(|(b, ct, m)| file_info(name, b.len() as u64, ct, m.clone()))
+                .map(|(b, ct, m)| {
+                    let size = self
+                        .reported_file_sizes
+                        .lock()
+                        .unwrap()
+                        .get(name)
+                        .copied()
+                        .unwrap_or(b.len() as u64);
+                    file_info(name, size, ct, m.clone())
+                })
                 .ok_or_else(|| BackendError::NotFound {
                     name: name.to_string(),
                     suggestion: None,


### PR DESCRIPTION
## What changed

- add a Files-tab **Download** bulk action that packages the current selection as `crosstache-files.zip`
- add authenticated `POST /api/files/archive` handling with bounded request validation
- retrieve files only through `Backend::files()` / `FileBackend`, preserving local, AWS, Azure, plaintext, and Crosstache age-encrypted download behavior
- build archives all-or-nothing in an unnamed temporary file and stream the completed ZIP
- retain the Files selection after success or failure and surface failures on the Files error UI
- preserve GET/DELETE behavior for a literal file named `archive`
- reject traversal and Windows drive-qualified ZIP paths

## Why

The Files UI already supports multi-selection, but users could only act on files individually. This adds a backend-neutral bulk export without coupling the web layer to any storage implementation.

The archive endpoint is deliberately bounded to avoid turning a large selection into unbounded memory or temporary-disk pressure:

- 1–1,000 selected names
- 512 KiB maximum JSON request body
- 1,024-byte maximum logical name
- 100 MiB per file
- 512 MiB total uncompressed content
- 2 process-wide live archive responses

## User impact

When checkbox selection is active on the Files tab, users can download every selected file in one ZIP. Selection remains active after the operation so it can be retried or reused.

## Root causes addressed during review

- Axum static-route precedence initially shadowed a valid file literally named `archive`
- portable ZIP validation needed to reject Windows drive-qualified names
- archive construction needed explicit file, aggregate, and concurrent-response resource limits

Focused regressions cover each case, including process-global admission across separate app states and stale/underreported backend metadata.

## Validation

- `npm run test:unit` — 204 passed
- `cargo test web:: --features ui,file-ops` — 372 test executions passed
- `cargo test` — passed
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --all-targets --features ui,file-ops -- -D warnings`
- `cargo check --all-targets --features ui,file-ops`

All completion checks passed on commit `773e8f39d5de6266b1b2066cda2b4ae475e8dfce`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated bulk read/decrypt path with explicit size and concurrency limits; route ordering and literal `archive` file handling were regression-tested but remain sensitive for file APIs.
> 
> **Overview**
> Adds **bulk ZIP export** for the Files tab: a **Download** button in the selection toolbar posts the current scoped selection to a new authenticated **`POST /api/files/archive`** endpoint and saves **`crosstache-files.zip`** in the browser.
> 
> The server builds archives only through **`FileBackend`** (same decrypt path as single-file download), validates names (counts, path safety including Windows drive-qualified paths), enforces **per-file / aggregate size caps**, a **512 KiB** JSON body limit, and a **process-wide cap of two concurrent** archive streams written to a temp file then streamed. **`GET`/`DELETE` on `/api/files/archive`** still target a literal file named `archive` so static routing does not shadow that object.
> 
> The UI wires pending state, errors, and **`shouldSave`** so a ZIP is not saved after the user changes workspace mid-request. **`zip`** is enabled on all platforms in **`Cargo.toml`**. Design/plan docs and Rust/JS route tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e60c02f2297c3b73d437bd32ed1d738e29e412c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->