### PR TITLE
chore: prepare v0.32.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.32.0 — Bulk file downloads (2026-08-01)
+
+### Added
+
+- **Download selected files as one ZIP from the Files tab.** The new bulk
+  Download action works through the shared file-backend interface, so local,
+  Azure, and AWS files—including Crosstache-encrypted attachments—use the same
+  existing download and decryption behavior. Selection remains available for
+  retry or reuse, and a response from a workspace the user has left is never
+  saved.
+- **Bounded authenticated archive endpoint.** ZIP exports validate portable
+  paths, enforce request, file, aggregate-size, and process-wide concurrency
+  limits, build all-or-nothing in temporary storage, and stream only completed
+  archives. A file literally named `archive` remains addressable.
+
+### Changed
+
+- Updated `quinn-proto` from 0.11.14 to 0.11.16 and refreshed its minimal
+  transitive lockfile dependencies.
+- Expanded the operator documentation for secret file attachments and clarified
+  scanner-hook hardening and validation guidance.
+
 ## v0.31.0 — Hierarchical tree grid for the web UI (2026-07-29)
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
## Summary

- bump the package and lockfile version from 0.31.0 to 0.32.0
- add release notes for Files-tab bulk ZIP downloads
- include the quinn-proto update and documentation improvements shipped since v0.31.0

## Validation

- `cargo metadata --locked`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --locked` (full suite)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no application logic in the diff.
> 
> **Overview**
> Prepares the **v0.32.0** release by bumping `crosstache` from **0.31.0** to **0.32.0** in `Cargo.toml` and the lockfile.
> 
> The new **CHANGELOG** section documents what ships in this tag: **bulk Download** on the Files tab (multi-backend ZIP via the shared file backend, including encrypted attachments), a **bounded authenticated archive** endpoint with path and size/concurrency limits, **`quinn-proto`** updated to **0.11.16**, and expanded operator docs for secret file attachments and scanner-hook guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182995178908ee0445c09d0bc24ba922c46f338f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->