### PR TITLE
fix(web): polish typed editor fields for v0.32.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Keep the build context small & the room clean.
+target/
+.git/
+.github/
+tests/
+crosstache-wt/
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ spikes/
 
 # Superpowers visual brainstorming sessions — transient, machine-specific
 .superpowers/
+
+# Clean-room integration-test state and credentials — machine-specific
+.cleanroom/
+.cleanroom/azure.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.32.1 — Web editor field presentation (2026-08-01)
+
+### Fixed
+
+- Typed-secret property labels now begin with a capital letter and preserve a
+  readable space before the `Required` or `Protected` hint.
+- The secret Note field is now a vertically resizable multiline control, matching
+  the Value field.
+
 ## v0.32.0 — Bulk file downloads (2026-08-01)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.32.0"
+version = "0.32.1"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"

--- a/src/web/assets/index.html
+++ b/src/web/assets/index.html
@@ -295,7 +295,7 @@
         </div>
         <datalist id="group-suggestions"></datalist>
       </div>
-      <label class="form-field"><span class="field-label">Note</span><input name="note"></label>
+      <label class="form-field"><span class="field-label">Note</span><textarea name="note" rows="4"></textarea></label>
       <div class="form-field expiry-editor">
         <label class="field-label" for="secret-expires-on">Expires</label>
         <input id="secret-expires-on" name="expires_on" type="date">

--- a/src/web/assets/secrets.js
+++ b/src/web/assets/secrets.js
@@ -1669,12 +1669,12 @@ function fieldRow(name, kind, value, required, primary = false) {
   label.className = 'field-label';
   label.htmlFor = inputId;
   const heading = document.createElement('span');
-  heading.append(name);
+  heading.append(XvUiModel.propertyLabel(name));
   if (required || kind === 'secret') {
     const hint = document.createElement('span');
     hint.className = 'field-hint';
     hint.textContent = required ? 'Required' : 'Protected';
-    heading.appendChild(hint);
+    heading.append(' ', hint);
   }
   label.appendChild(heading);
   const input = document.createElement('input');

--- a/src/web/assets/typed-editor.test.js
+++ b/src/web/assets/typed-editor.test.js
@@ -1,5 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import * as model from './ui-model.js';
 import {
   buildTypedDraft,
   conversionSummary,
@@ -16,6 +18,17 @@ const login = {
     { name: 'password', kind: 'secret', required: true, primary: true },
   ],
 };
+
+test('property labels begin with a capital letter', () => {
+  assert.equal(model.propertyLabel?.('username'), 'Username');
+  assert.equal(model.propertyLabel?.('url'), 'Url');
+  assert.equal(model.propertyLabel?.('password'), 'Password');
+});
+
+test('production markup uses the same resizable control for Note as Value', async () => {
+  const html = await readFile(new URL('./index.html', import.meta.url), 'utf8');
+  assert.match(html, /<textarea[^>]*name="note"[^>]*><\/textarea>/);
+});
 
 test('type cards expose required protected and primary fields', () => {
   const card = typeCards([login])[0];

--- a/src/web/assets/ui-model.js
+++ b/src/web/assets/ui-model.js
@@ -10,6 +10,10 @@ const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: tr
   function expirationDate(value) {
     return typeof value === 'string' && value.length >= 10 ? value.slice(0, 10) : '';
   }
+  function propertyLabel(name) {
+    const value = String(name || '');
+    return value ? value[0].toUpperCase() + value.slice(1) : '';
+  }
   function typeCards(types = []) {
     return types.map((type) => {
       const fields = (type.fields || []).map((field) => ({ ...field }));
@@ -710,7 +714,7 @@ const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: tr
     });
   }
 
-export { PROTECTED_MASK, formatDate, expirationDate, createProtectedState,
+export { PROTECTED_MASK, formatDate, expirationDate, propertyLabel, createProtectedState,
   typeCards, buildTypedDraft, groupSuggestions, conversionSummary,
   protectedDisplay, revealProtected, editProtected, hideProtected, loadProtected,
   sortedCopy, normalizeWidths, resizeAdjacentWidths, contentMode, contentRows,

--- a/tests/web/ui-typed-editor.spec.js
+++ b/tests/web/ui-typed-editor.spec.js
@@ -72,6 +72,30 @@ test('guided cards create plain and typed secrets with only selected fields', as
   await expect(page.getByRole('button', { name: 'Edit secret guided-plain' })).toBeVisible();
 });
 
+test('typed property labels are capitalized and the note field is vertically resizable', async ({ page, baseURL }) => {
+  await page.goto(baseURL);
+  await putSecret(page, 'property-labels', {
+    value: JSON.stringify({ password: 'browser-password' }),
+    content_type: 'application/vnd.xv.record',
+    tags: {
+      'xv-type': 'login',
+      'f.username': 'alice',
+      'f.url': 'https://example.com',
+    },
+  });
+  await page.reload();
+  await page.getByRole('button', { name: 'Edit secret property-labels' }).click();
+
+  await expect(page.locator('#record-fields .field-label')).toHaveText([
+    'Username',
+    'Url',
+    'Password Protected',
+  ]);
+  const note = page.locator('#secret-form textarea[name="note"]');
+  await expect(note).toBeVisible();
+  await expect(note).toHaveCSS('resize', 'vertical');
+});
+
 test('chips suggestions folder autocomplete and expiry controls keep a durable draft', async ({ page, baseURL }) => {
   await page.goto(baseURL);
   await putSecret(page, 'suggestion-source', {


### PR DESCRIPTION
## Summary

- capitalize typed-secret property labels and preserve spacing before Required/Protected hints
- make the Note field a vertically resizable multiline control like Value
- add unit and Playwright regression coverage
- retain both sides of the clean-room ignore conflict and add the existing Docker build-context exclusions
- prepare patch release v0.32.1 in Cargo.toml, Cargo.lock, and CHANGELOG.md

## Verification

- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo clippy --features ui -- -D warnings`
- `npm run test:unit` — 207 passed
- `cargo test web:: --features ui` — 372 passed across lib and binary targets
- `cargo test --locked --features ui` — full suite passed
- `npx playwright test tests/web/ui-typed-editor.spec.js --project=functional-chromium` — 16 passed
- independent staged-diff review: passed with no security concerns or logic errors

## Release

This PR prepares v0.32.1. After merge, tag `v0.32.1` on the resulting main commit to trigger `.github/workflows/release.yml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only web UI and ignore-file changes; no secret handling, API, or auth logic is modified.
> 
> **Overview**
> **v0.32.1** polishes the embedded web secret editor’s typed-field presentation and bumps the crate to **0.32.1** with changelog notes.
> 
> Typed record fields now use a shared **`propertyLabel`** helper so labels are capitalized (e.g. `username` → **Username**), and **Required** / **Protected** hints are separated from the label with a space instead of running together. The drawer **Note** control is switched from a single-line input to a **multiline `<textarea>`** (same pattern as Value), so it can be resized vertically.
> 
> Coverage adds unit checks for `propertyLabel` and Note markup, plus a Playwright case for label text and `resize: vertical` on Note. **`.dockerignore`** trims Docker build context; **`.gitignore`** adds **`.cleanroom/`** integration-test state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0157d5074184f5cf2bbfd26a6ac935935a5fa971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->