### PR TITLE
fix(web): align typed editor field labels

### DIFF
--- a/src/web/assets/index.html
+++ b/src/web/assets/index.html
@@ -295,7 +295,7 @@
         </div>
         <datalist id="group-suggestions"></datalist>
       </div>
-      <label class="form-field"><span class="field-label">Note</span><textarea name="note" rows="4"></textarea></label>
+      <label class="form-field"><span class="field-label">Notes</span><textarea name="note" rows="4"></textarea></label>
       <div class="form-field expiry-editor">
         <label class="field-label" for="secret-expires-on">Expires</label>
         <input id="secret-expires-on" name="expires_on" type="date">

--- a/src/web/assets/secrets.js
+++ b/src/web/assets/secrets.js
@@ -1670,13 +1670,14 @@ function fieldRow(name, kind, value, required, primary = false) {
   label.htmlFor = inputId;
   const heading = document.createElement('span');
   heading.append(XvUiModel.propertyLabel(name));
+  label.appendChild(heading);
   if (required || kind === 'secret') {
     const hint = document.createElement('span');
     hint.className = 'field-hint';
     hint.textContent = required ? 'Required' : 'Protected';
-    heading.append(' ', hint);
+    heading.append(' ');
+    label.appendChild(hint);
   }
-  label.appendChild(heading);
   const input = document.createElement('input');
   input.id = inputId;
   input.dataset.fieldName = name;

--- a/src/web/assets/typed-editor.test.js
+++ b/src/web/assets/typed-editor.test.js
@@ -25,9 +25,14 @@ test('property labels begin with a capital letter', () => {
   assert.equal(model.propertyLabel?.('password'), 'Password');
 });
 
-test('production markup uses the same resizable control for Note as Value', async () => {
+test('production markup uses the same resizable control for Notes as Value', async () => {
   const html = await readFile(new URL('./index.html', import.meta.url), 'utf8');
   assert.match(html, /<textarea[^>]*name="note"[^>]*><\/textarea>/);
+});
+
+test('production markup labels the note field as Notes', async () => {
+  const html = await readFile(new URL('./index.html', import.meta.url), 'utf8');
+  assert.match(html, /<span class="field-label">Notes<\/span><textarea name="note"/);
 });
 
 test('type cards expose required protected and primary fields', () => {

--- a/tests/web/ui-typed-editor.spec.js
+++ b/tests/web/ui-typed-editor.spec.js
@@ -72,7 +72,7 @@ test('guided cards create plain and typed secrets with only selected fields', as
   await expect(page.getByRole('button', { name: 'Edit secret guided-plain' })).toBeVisible();
 });
 
-test('typed property labels are capitalized and the note field is vertically resizable', async ({ page, baseURL }) => {
+test('typed property hints align and the Notes field is vertically resizable', async ({ page, baseURL }) => {
   await page.goto(baseURL);
   await putSecret(page, 'property-labels', {
     value: JSON.stringify({ password: 'browser-password' }),
@@ -91,8 +91,23 @@ test('typed property labels are capitalized and the note field is vertically res
     'Url',
     'Password Protected',
   ]);
+  const protectedLabel = page.locator('#record-fields .field-label').filter({ hasText: 'Password' });
+  const protectedAlignment = await protectedLabel.evaluate((label) => {
+    const heading = label.firstElementChild;
+    const hint = label.querySelector('.field-hint');
+    const labelBox = label.getBoundingClientRect();
+    const headingBox = heading.getBoundingClientRect();
+    const hintBox = hint.getBoundingClientRect();
+    return {
+      headingLeft: Math.abs(labelBox.left - headingBox.left),
+      hintRight: Math.abs(labelBox.right - hintBox.right),
+    };
+  });
+  expect(protectedAlignment.headingLeft).toBeLessThan(1);
+  expect(protectedAlignment.hintRight).toBeLessThan(1);
   const note = page.locator('#secret-form textarea[name="note"]');
   await expect(note).toBeVisible();
+  await expect(note.locator('xpath=..').locator('.field-label')).toHaveText('Notes');
   await expect(note).toHaveCSS('resize', 'vertical');
 });
 


### PR DESCRIPTION
## Bug Description

Typed record fields rendered `Password` and `Protected` inside one flex child, so the hint appeared immediately after the field name instead of at the right edge. The shared note field also used the singular label `Note`.

## Root Cause

The dynamic field renderer nested the `.field-hint` inside the heading span, preventing the existing `.field-label` flex layout from distributing the two labels. The note label was a static singular string.

## Fix

- Render dynamic field headings and `Required`/`Protected` hints as sibling flex items while preserving semantic whitespace.
- Rename the user-facing label to `Notes` while keeping the serialized `name="note"` key unchanged.
- Add browser assertions for both left- and right-edge alignment and regression coverage for the Notes label.

## How to Verify

1. Open a typed secret containing a protected password field.
2. Confirm `Password` aligns to the left and `Protected` aligns to the right, matching `Name` and `Required`.
3. Confirm the shared textarea is labeled `Notes`.

## Test Plan

- [x] Added regression tests for both reported defects
- [x] 208 Node unit tests pass
- [x] 372 Rust web tests pass
- [x] 16 typed-editor Playwright tests pass
- [x] Formatting, syntax, diff, and security checks pass

## Risk Assessment

Low — the change only adjusts label DOM structure and display copy. Form names, data keys, and serialization remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only label DOM and copy; form field names and serialization are unchanged.
> 
> **Overview**
> Fixes typed secret field labels so **Required** / **Protected** hints line up with static fields like **Name**, and renames the shared textarea label from **Note** to **Notes**.
> 
> In `fieldRow` (`secrets.js`), the property name and `.field-hint` are now **sibling** children of `.field-label` instead of nesting the hint inside the heading span, so existing `display: flex; justify-content: space-between` can put the name on the left and the hint on the right. The secret form still uses `name="note"`; only the visible **Notes** copy in `index.html` changes.
> 
> Regression coverage adds a markup assertion for the **Notes** label and Playwright checks that protected-field headings and hints align to the label edges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180e6a1fd9a7a83c622119c408152bc53e8e1626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->