### PR TITLE
feat(web): add customizable color themes

### DIFF
--- a/src/web/assets/index.html
+++ b/src/web/assets/index.html
@@ -436,13 +436,50 @@
   <div class="utility-sheet-body">
     <section class="utility-group" aria-labelledby="settings-appearance-title">
       <h3 id="settings-appearance-title">Appearance</h3>
-      <label class="form-field" for="theme-select"><span class="field-label">Theme</span>
+      <label class="form-field" for="theme-select"><span class="field-label">Mode</span>
         <select id="theme-select">
           <option value="system">System</option>
           <option value="light">Light</option>
           <option value="dark">Dark</option>
         </select>
       </label>
+      <label class="form-field" for="palette-select"><span class="field-label">Color palette</span>
+        <select id="palette-select">
+          <option value="forest">Forest</option>
+          <option value="nord">Nord</option>
+          <option value="solarized">Solarized</option>
+          <option value="high-contrast">High Contrast</option>
+          <option value="custom">Custom</option>
+        </select>
+      </label>
+      <fieldset id="custom-theme-fieldset" class="custom-theme-fieldset" hidden>
+        <legend class="field-label">Custom palette</legend>
+        <label class="form-field" for="custom-variant-select"><span class="field-label">Edit variant</span>
+          <select id="custom-variant-select">
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+        <div class="custom-color-grid">
+          <label class="form-field" for="custom-color-canvas"><span class="field-label">Canvas</span>
+            <input id="custom-color-canvas" type="text" inputmode="text" autocomplete="off" pattern="^#[0-9a-fA-F]{6}$" maxlength="7" aria-describedby="custom-theme-status">
+          </label>
+          <label class="form-field" for="custom-color-surface"><span class="field-label">Surface</span>
+            <input id="custom-color-surface" type="text" inputmode="text" autocomplete="off" pattern="^#[0-9a-fA-F]{6}$" maxlength="7" aria-describedby="custom-theme-status">
+          </label>
+          <label class="form-field" for="custom-color-text"><span class="field-label">Text</span>
+            <input id="custom-color-text" type="text" inputmode="text" autocomplete="off" pattern="^#[0-9a-fA-F]{6}$" maxlength="7" aria-describedby="custom-theme-status">
+          </label>
+          <label class="form-field" for="custom-color-accent"><span class="field-label">Accent</span>
+            <input id="custom-color-accent" type="text" inputmode="text" autocomplete="off" pattern="^#[0-9a-fA-F]{6}$" maxlength="7" aria-describedby="custom-theme-status">
+          </label>
+          <label class="form-field" for="custom-color-danger"><span class="field-label">Danger</span>
+            <input id="custom-color-danger" type="text" inputmode="text" autocomplete="off" pattern="^#[0-9a-fA-F]{6}$" maxlength="7" aria-describedby="custom-theme-status">
+          </label>
+        </div>
+        <p id="custom-theme-status" class="field-help" role="status" aria-live="polite"></p>
+        <button type="button" id="custom-theme-reset" class="button secondary">Reset custom colors</button>
+      </fieldset>
     </section>
     <section class="utility-group" aria-labelledby="settings-protection-title">
       <h3 id="settings-protection-title">Protected values</h3>

--- a/src/web/assets/preferences.js
+++ b/src/web/assets/preferences.js
@@ -1,3 +1,27 @@
+import { CUSTOM_COLOR_KEYS, PALETTE_NAMES, PALETTES, isValidHex, validateCustomVariantContrast } from './theme.js';
+
+const FOREST_CUSTOM_THEME = Object.freeze({
+  light: Object.freeze({ ...PALETTES.forest.light }),
+  dark: Object.freeze({ ...PALETTES.forest.dark }),
+});
+
+const PALETTE_VALUES = new Set([...PALETTE_NAMES, 'custom']);
+
+function isValidCustomThemeVariant(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  if (keys.length !== CUSTOM_COLOR_KEYS.length) return false;
+  if (!CUSTOM_COLOR_KEYS.every((key) => isValidHex(value[key]))) return false;
+  return validateCustomVariantContrast(value).valid;
+}
+
+function isValidCustomTheme(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  if (keys.length !== 2 || !keys.includes('light') || !keys.includes('dark')) return false;
+  return isValidCustomThemeVariant(value.light) && isValidCustomThemeVariant(value.dark);
+}
+
 const LEGACY_WIDTH_SCHEMAS = {
   'xv.ui.columns.secrets.v1': (value) => Array.isArray(value)
     && value.length === 5
@@ -8,8 +32,10 @@ const LEGACY_WIDTH_SCHEMAS = {
 };
 
 const DEFAULTS = Object.freeze({
-  version: 1,
+  version: 2,
   theme: 'system',
+  palette: 'forest',
+  custom_theme: FOREST_CUSTOM_THEME,
   exposure_timeout_seconds: 30,
   density: 'comfortable',
   folder_expansion: true,
@@ -21,6 +47,8 @@ const DEFAULTS = Object.freeze({
 
 const FIELD_SCHEMAS = {
   theme: (value) => ['system', 'light', 'dark'].includes(value),
+  palette: (value) => PALETTE_VALUES.has(value),
+  custom_theme: (value) => isValidCustomTheme(value),
   exposure_timeout_seconds: (value) => Number.isSafeInteger(value) && value >= 0,
   density: (value) => ['comfortable', 'compact'].includes(value),
   folder_expansion: (value) => typeof value === 'boolean',
@@ -58,12 +86,21 @@ function immutable(value) {
 }
 
 function sanitize(input) {
-  const source = input !== null && typeof input === 'object' ? input : {};
+  const inputSource = input !== null && typeof input === 'object' ? input : {};
+  const version = Number.isSafeInteger(inputSource.version) && inputSource.version >= 0
+    ? inputSource.version
+    : 0;
+  if (version > DEFAULTS.version) return clone(DEFAULTS);
+
+  const source = version < 2
+    ? Object.fromEntries(Object.entries(inputSource)
+      .filter(([key]) => key !== 'palette' && key !== 'custom_theme'))
+    : inputSource;
   const clean = clone(DEFAULTS);
   for (const [key, isValid] of Object.entries(FIELD_SCHEMAS)) {
     if (isValid(source[key])) clean[key] = clone(source[key]);
   }
-  clean.version = 1;
+  clean.version = 2;
   return clean;
 }
 

--- a/src/web/assets/preferences.test.js
+++ b/src/web/assets/preferences.test.js
@@ -4,8 +4,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createPreferenceClient } from './preferences.js';
+import { PALETTES } from './theme.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const FOREST_CUSTOM_THEME = { light: { ...PALETTES.forest.light }, dark: { ...PALETTES.forest.dark } };
 
 function withStorage(run) {
   const original = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
@@ -108,8 +111,8 @@ test('preference saves are debounced and contain only whitelisted keys', async (
   assert.equal(calls[1].method, 'PUT');
   assert.equal(calls[1].path, '/api/preferences');
   assert.deepEqual(Object.keys(calls[1].body).sort(), [
-    'column_widths', 'density', 'exposure_timeout_seconds',
-    'folder_expansion', 'theme', 'version',
+    'column_widths', 'custom_theme', 'density', 'exposure_timeout_seconds',
+    'folder_expansion', 'palette', 'theme', 'version',
   ]);
   assert.equal(calls[1].body.theme, 'dark');
   assert.equal(calls[1].body.density, 'compact');
@@ -243,4 +246,142 @@ test('default Settings renderer shows failures and clears after a successful ret
     if (original) Object.defineProperty(globalThis, 'document', original);
     else delete globalThis.document;
   }
+});
+
+test('version-2 defaults include palette forest and matching Forest custom-theme defaults', () => {
+  const preferences = createPreferenceClient(null);
+  const snapshot = preferences.snapshot();
+  assert.equal(snapshot.version, 2);
+  assert.equal(snapshot.palette, 'forest');
+  assert.deepEqual(snapshot.custom_theme, FOREST_CUSTOM_THEME);
+});
+
+test('v0/v1 data migrates to v2 by retaining prior fields and supplying palette+custom defaults', async () => {
+  const preferences = createPreferenceClient(async (method) => {
+    if (method === 'GET') return { theme: 'dark', density: 'compact' };
+    throw new Error('unexpected write');
+  });
+  const loaded = await preferences.load();
+  assert.equal(loaded.version, 2);
+  assert.equal(loaded.theme, 'dark');
+  assert.equal(loaded.density, 'compact');
+  assert.equal(loaded.palette, 'forest');
+  assert.deepEqual(loaded.custom_theme, FOREST_CUSTOM_THEME);
+});
+
+test('missing, v0, and v1 preference data ignores same-named v2 extension fields', async () => {
+  for (const version of [undefined, 0, 1]) {
+    const legacy = {
+      theme: 'dark',
+      density: 'compact',
+      palette: 'custom',
+      custom_theme: {
+        light: { canvas: '#ffffff', surface: '#ffffff', text: '#000000', accent: '#000000', danger: '#000000' },
+        dark: { canvas: '#000000', surface: '#000000', text: '#ffffff', accent: '#ffffff', danger: '#ffffff' },
+      },
+    };
+    if (version !== undefined) legacy.version = version;
+    const preferences = createPreferenceClient(async (method) => {
+      if (method === 'GET') return legacy;
+      throw new Error('unexpected write');
+    });
+    const loaded = await preferences.load();
+    assert.equal(loaded.theme, 'dark', `version ${String(version)}`);
+    assert.equal(loaded.density, 'compact', `version ${String(version)}`);
+    assert.equal(loaded.palette, 'forest', `version ${String(version)}`);
+    assert.deepEqual(loaded.custom_theme, FOREST_CUSTOM_THEME, `version ${String(version)}`);
+  }
+});
+
+test('future preference versions fail safe to defaults without retaining future fields', async () => {
+  const preferences = createPreferenceClient(async (method) => {
+    if (method === 'GET') return {
+      version: 3,
+      theme: 'dark',
+      density: 'compact',
+      palette: 'custom',
+      custom_theme: {
+        light: { canvas: '#ffffff', surface: '#ffffff', text: '#000000', accent: '#000000', danger: '#000000' },
+        dark: { canvas: '#000000', surface: '#000000', text: '#ffffff', accent: '#ffffff', danger: '#ffffff' },
+      },
+    };
+    throw new Error('unexpected write');
+  });
+  const loaded = await preferences.load();
+  assert.equal(loaded.theme, 'system');
+  assert.equal(loaded.density, 'comfortable');
+  assert.equal(loaded.palette, 'forest');
+  assert.deepEqual(loaded.custom_theme, FOREST_CUSTOM_THEME);
+});
+
+test('unknown palette values fall back to the forest default', async () => {
+  const preferences = createPreferenceClient(async (method) => {
+    if (method === 'GET') return { version: 2, palette: 'not-a-real-palette' };
+    throw new Error('unexpected write');
+  });
+  const loaded = await preferences.load();
+  assert.equal(loaded.palette, 'forest');
+});
+
+test('set(palette, ...) only accepts the five known palette values', () => {
+  const preferences = createPreferenceClient(null);
+  for (const value of ['forest', 'nord', 'solarized', 'high-contrast', 'custom']) {
+    assert.equal(preferences.set('palette', value), true, value);
+  }
+  for (const value of ['Forest', 'unknown', '', null, 42]) {
+    assert.equal(preferences.set('palette', value), false, String(value));
+  }
+});
+
+test('set(custom_theme, ...) requires exact shape, strict hex, and passing contrast in both variants', () => {
+  const preferences = createPreferenceClient(null);
+  const valid = {
+    light: { canvas: '#ffffff', surface: '#fafafa', text: '#000000', accent: '#003399', danger: '#a30000' },
+    dark: { canvas: '#000000', surface: '#0a0a0a', text: '#ffffff', accent: '#3399ff', danger: '#ff5555' },
+  };
+  assert.equal(preferences.set('custom_theme', valid), true);
+  assert.deepEqual(preferences.get('custom_theme'), valid);
+
+  const missingDark = { light: valid.light };
+  assert.equal(preferences.set('custom_theme', missingDark), false);
+
+  const extraKey = { ...valid, light: { ...valid.light, extra: '#000000' } };
+  assert.equal(preferences.set('custom_theme', extraKey), false);
+
+  const badHex = { ...valid, light: { ...valid.light, accent: 'not-a-hex' } };
+  assert.equal(preferences.set('custom_theme', badHex), false);
+
+  const lowContrast = {
+    light: { canvas: '#808080', surface: '#888888', text: '#7a7a7a', accent: '#8a8a8a', danger: '#8f8f8f' },
+    dark: valid.dark,
+  };
+  assert.equal(preferences.set('custom_theme', lowContrast), false);
+
+  assert.deepEqual(preferences.get('custom_theme'), valid, 'last valid custom theme must remain after rejected writes');
+});
+
+test('valid custom_theme round-trips through save and reload unchanged', async () => {
+  let stored = null;
+  const api = async (method, _path, body) => {
+    if (method === 'GET') return stored ?? { version: 2 };
+    stored = body;
+    return body;
+  };
+  const preferences = createPreferenceClient(api, {
+    setTimeoutImpl: (callback) => { callback(); return 1; },
+    clearTimeoutImpl() {},
+  });
+  await preferences.load();
+  const custom = {
+    light: { canvas: '#ffffff', surface: '#fafafa', text: '#000000', accent: '#003399', danger: '#a30000' },
+    dark: { canvas: '#000000', surface: '#0a0a0a', text: '#ffffff', accent: '#3399ff', danger: '#ff5555' },
+  };
+  assert.equal(preferences.set('palette', 'custom'), true);
+  assert.equal(preferences.set('custom_theme', custom), true);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const reloaded = createPreferenceClient(async (method) => (method === 'GET' ? stored : stored));
+  const snapshot = await reloaded.load();
+  assert.equal(snapshot.palette, 'custom');
+  assert.deepEqual(snapshot.custom_theme, custom);
 });

--- a/src/web/assets/settings.js
+++ b/src/web/assets/settings.js
@@ -1,10 +1,57 @@
 import { boundTimeout } from './preferences.js';
+import {
+  CUSTOM_COLOR_KEYS,
+  PALETTES,
+  PALETTE_NAMES,
+  isValidHex,
+  isValidCustomVariant,
+  resolveTokens,
+  validateCustomVariantContrast,
+} from './theme.js';
 
 const THEMES = new Set(['system', 'light', 'dark']);
 const DENSITIES = new Set(['comfortable', 'compact']);
+const VARIANTS = new Set(['light', 'dark']);
+const PALETTE_VALUES = new Set([...PALETTE_NAMES, 'custom']);
+const FOREST_CUSTOM_THEME = Object.freeze({
+  light: Object.freeze({ ...PALETTES.forest.light }),
+  dark: Object.freeze({ ...PALETTES.forest.dark }),
+});
 const DEFAULT_COLUMN_WIDTHS = Object.freeze({
   secrets: Object.freeze([28, 15, 14, 25, 18]),
   files: Object.freeze([42, 12, 24, 22]),
+});
+const TOKEN_CSS_VARS = Object.freeze({
+  canvas: '--color-canvas',
+  surface: '--color-surface',
+  text: '--color-text',
+  accent: '--color-accent',
+  danger: '--color-danger',
+  surfaceSubtle: '--color-surface-subtle',
+  textMuted: '--color-text-muted',
+  border: '--color-border',
+  accentHover: '--color-accent-hover',
+  accentQuiet: '--color-accent-quiet',
+  accentText: '--color-accent-text',
+  accentTextHover: '--color-accent-text-hover',
+  dangerQuiet: '--color-danger-quiet',
+  primaryForeground: '--color-primary-foreground',
+  focusColor: '--color-focus',
+  focusRing: '--focus-ring',
+  shadowRaised: '--shadow-raised',
+  railBg: '--rail-bg',
+  railBorder: '--rail-border',
+  railFg: '--rail-fg',
+  railFgMuted: '--rail-fg-muted',
+  railAccent: '--rail-accent',
+  railAccentFg: '--rail-accent-fg',
+  railHoverBg: '--rail-hover-bg',
+  railConnectionOk: '--rail-connection-ok',
+  railConnectionBad: '--rail-connection-bad',
+  railErrorBg: '--rail-error-bg',
+  railErrorBorder: '--rail-error-border',
+  railErrorFg: '--rail-error-fg',
+  railErrorAccent: '--rail-error-accent',
 });
 
 function nonNegativeInteger(value) {
@@ -23,13 +70,28 @@ export function effectiveTheme(preference, mediaQuery) {
 
 export { boundTimeout };
 
-function applyPresentation(document, preference, density, mediaQuery) {
+function cloneCustomTheme(customTheme) {
+  return {
+    light: { ...(customTheme?.light ?? FOREST_CUSTOM_THEME.light) },
+    dark: { ...(customTheme?.dark ?? FOREST_CUSTOM_THEME.dark) },
+  };
+}
+
+function applyPresentation(document, { theme, density, palette, customTheme, mediaQuery } = {}) {
   const root = document?.documentElement;
   if (!root) return;
-  const theme = THEMES.has(preference) ? preference : 'system';
-  root.dataset.theme = theme;
-  root.dataset.effectiveTheme = effectiveTheme(theme, mediaQuery);
+  const resolvedTheme = THEMES.has(theme) ? theme : 'system';
+  const resolvedPalette = PALETTE_VALUES.has(palette) ? palette : 'forest';
+  const effective = effectiveTheme(resolvedTheme, mediaQuery);
+  root.dataset.theme = resolvedTheme;
+  root.dataset.effectiveTheme = effective;
   root.dataset.density = DENSITIES.has(density) ? density : 'comfortable';
+  root.dataset.palette = resolvedPalette;
+  root.style?.setProperty?.('color-scheme', effective);
+  const tokens = resolveTokens(resolvedPalette, effective, customTheme);
+  for (const [key, cssVar] of Object.entries(TOKEN_CSS_VARS)) {
+    root.style?.setProperty?.(cssVar, tokens[key]);
+  }
 }
 
 function setControlValue(control, value) {
@@ -60,6 +122,18 @@ export function mountSettings({
   const reset = document?.getElementById?.('layout-reset');
   const status = document?.getElementById?.('settings-live');
   const policyCopy = document?.getElementById?.('timeout-policy-copy');
+  const palette = document?.getElementById?.('palette-select');
+  const customFieldset = document?.getElementById?.('custom-theme-fieldset');
+  const customVariantSelect = document?.getElementById?.('custom-variant-select');
+  const customReset = document?.getElementById?.('custom-theme-reset');
+  const customStatus = document?.getElementById?.('custom-theme-status');
+  const customColorInputs = Object.fromEntries(
+    CUSTOM_COLOR_KEYS.map((key) => [key, document?.getElementById?.(`custom-color-${key}`)]),
+  );
+
+  function announceCustom(message) {
+    if (customStatus) customStatus.textContent = message;
+  }
 
   function policyLimit() {
     const policy = resolve(securityPolicy);
@@ -68,9 +142,53 @@ export function mountSettings({
     );
   }
 
+  function currentCustomTheme() {
+    return cloneCustomTheme(preferences.get('custom_theme', FOREST_CUSTOM_THEME));
+  }
+
+  function currentVariant() {
+    return VARIANTS.has(customVariantSelect?.value) ? customVariantSelect.value : 'light';
+  }
+
+  const customDraft = currentCustomTheme();
+  const dirtyDraftVariants = new Set();
+
+  function renderCustomInputs(variant) {
+    const core = customDraft[variant] ?? FOREST_CUSTOM_THEME[variant];
+    const shapeValid = isValidCustomVariant(core);
+    const contrastResult = shapeValid
+      ? validateCustomVariantContrast(core)
+      : { valid: false, failures: [] };
+    const invalidContrastKeys = new Set(contrastResult.failures
+      .flatMap(({ pair }) => pair.split('-')));
+    for (const key of CUSTOM_COLOR_KEYS) {
+      const input = customColorInputs[key];
+      if (!input) continue;
+      input.value = core[key];
+      input.ariaInvalid = isValidHex(core[key]) && !invalidContrastKeys.has(key) ? 'false' : 'true';
+    }
+  }
+
+  function applyCurrentPresentation() {
+    applyPresentation(document, {
+      theme: preferences.get('theme', 'system'),
+      density: preferences.get('density', 'comfortable'),
+      palette: preferences.get('palette', 'forest'),
+      customTheme: currentCustomTheme(),
+      mediaQuery,
+    });
+  }
+
   function refresh() {
     const selectedTheme = preferences.get('theme', 'system');
     const selectedDensity = preferences.get('density', 'comfortable');
+    const selectedPalette = PALETTE_VALUES.has(preferences.get('palette', 'forest'))
+      ? preferences.get('palette', 'forest')
+      : 'forest';
+    const customTheme = currentCustomTheme();
+    for (const variant of VARIANTS) {
+      if (!dirtyDraftVariants.has(variant)) customDraft[variant] = { ...customTheme[variant] };
+    }
     const requestedTimeout = nonNegativeInteger(
       preferences.get('exposure_timeout_seconds', 30),
     );
@@ -82,7 +200,17 @@ export function mountSettings({
     setControlValue(theme, selectedTheme);
     setControlValue(density, selectedDensity);
     setControlValue(timeout, selectedTimeout);
-    applyPresentation(document, selectedTheme, selectedDensity, mediaQuery);
+    setControlValue(palette, selectedPalette);
+    if (customFieldset) customFieldset.hidden = selectedPalette !== 'custom';
+    setControlValue(customVariantSelect, currentVariant());
+    renderCustomInputs(currentVariant());
+    applyPresentation(document, {
+      theme: selectedTheme,
+      density: selectedDensity,
+      palette: selectedPalette,
+      customTheme,
+      mediaQuery,
+    });
 
     for (const option of timeout?.querySelectorAll?.('option') ?? []) {
       const value = nonNegativeInteger(option.value);
@@ -96,12 +224,12 @@ export function mountSettings({
   const onTheme = () => {
     const value = THEMES.has(theme?.value) ? theme.value : 'system';
     preferences.set('theme', value);
-    applyPresentation(document, value, preferences.get('density', 'comfortable'), mediaQuery);
+    applyCurrentPresentation();
   };
   const onDensity = () => {
     const value = DENSITIES.has(density?.value) ? density.value : 'comfortable';
     preferences.set('density', value);
-    applyPresentation(document, preferences.get('theme', 'system'), value, mediaQuery);
+    applyCurrentPresentation();
   };
   const onTimeout = () => {
     const value = boundTimeout(timeout?.value, policyLimit());
@@ -110,6 +238,76 @@ export function mountSettings({
     if (status) status.textContent = value > 0
       ? `Protected values hide after ${value} seconds.`
       : 'Protected values hide immediately.';
+  };
+  const onPalette = () => {
+    const value = PALETTE_VALUES.has(palette?.value) ? palette.value : 'forest';
+    preferences.set('palette', value);
+    if (customFieldset) customFieldset.hidden = value !== 'custom';
+    applyCurrentPresentation();
+  };
+  const onCustomVariant = () => {
+    renderCustomInputs(currentVariant());
+  };
+  function onCustomColorChange(key) {
+    return () => {
+      const input = customColorInputs[key];
+      const variant = currentVariant();
+      customDraft[variant][key] = input?.value;
+      dirtyDraftVariants.add(variant);
+      const candidateVariant = { ...customDraft[variant] };
+      if (candidateVariant[key] === '' || /^#[0-9a-fA-F]{0,5}$/.test(candidateVariant[key])) {
+        if (input) input.ariaInvalid = 'true';
+        announceCustom('');
+        return;
+      }
+      const shapeValid = isValidCustomVariant(candidateVariant);
+      const contrastResult = shapeValid
+        ? validateCustomVariantContrast(candidateVariant)
+        : { valid: false, failures: [] };
+      const valid = shapeValid && contrastResult.valid;
+      renderCustomInputs(variant);
+      if (!valid) {
+        announceCustom(shapeValid
+          ? `Increase contrast to update the preview: ${contrastResult.failures
+            .map((failure) => `${failure.pair.replace('-', ' vs ')} is ${failure.ratio.toFixed(2)}:1, needs 4.5:1`)
+            .join('; ')}.`
+          : 'Enter a six-digit hex color, for example #216446.');
+        return;
+      }
+      const updated = { ...currentCustomTheme(), [variant]: candidateVariant };
+      preferences.set('custom_theme', updated);
+      if (preferences.get('palette', 'forest') === 'custom') {
+        applyPresentation(document, {
+          theme: preferences.get('theme', 'system'),
+          density: preferences.get('density', 'comfortable'),
+          palette: 'custom',
+          customTheme: updated,
+          mediaQuery,
+        });
+      }
+      announceCustom('Custom color preview updated; persistence is pending.');
+    };
+  }
+  const customColorHandlers = Object.fromEntries(
+    CUSTOM_COLOR_KEYS.map((key) => [key, onCustomColorChange(key)]),
+  );
+  const onCustomReset = () => {
+    const resetTheme = cloneCustomTheme(FOREST_CUSTOM_THEME);
+    customDraft.light = { ...resetTheme.light };
+    customDraft.dark = { ...resetTheme.dark };
+    dirtyDraftVariants.clear();
+    preferences.set('custom_theme', resetTheme);
+    renderCustomInputs(currentVariant());
+    if (preferences.get('palette', 'forest') === 'custom') {
+      applyPresentation(document, {
+        theme: preferences.get('theme', 'system'),
+        density: preferences.get('density', 'comfortable'),
+        palette: 'custom',
+        customTheme: resetTheme,
+        mediaQuery,
+      });
+    }
+    announceCustom('Custom color preview reset to Forest defaults; persistence is pending.');
   };
   const onReset = () => {
     const widths = {
@@ -132,6 +330,12 @@ export function mountSettings({
   theme?.addEventListener?.('change', onTheme);
   density?.addEventListener?.('change', onDensity);
   timeout?.addEventListener?.('change', onTimeout);
+  palette?.addEventListener?.('change', onPalette);
+  customVariantSelect?.addEventListener?.('change', onCustomVariant);
+  for (const key of CUSTOM_COLOR_KEYS) {
+    customColorInputs[key]?.addEventListener?.('input', customColorHandlers[key]);
+  }
+  customReset?.addEventListener?.('click', onCustomReset);
   reset?.addEventListener?.('click', onReset);
   mediaQuery?.addEventListener?.('change', onSystemTheme);
 
@@ -145,6 +349,12 @@ export function mountSettings({
       theme?.removeEventListener?.('change', onTheme);
       density?.removeEventListener?.('change', onDensity);
       timeout?.removeEventListener?.('change', onTimeout);
+      palette?.removeEventListener?.('change', onPalette);
+      customVariantSelect?.removeEventListener?.('change', onCustomVariant);
+      for (const key of CUSTOM_COLOR_KEYS) {
+        customColorInputs[key]?.removeEventListener?.('input', customColorHandlers[key]);
+      }
+      customReset?.removeEventListener?.('click', onCustomReset);
       reset?.removeEventListener?.('click', onReset);
       mediaQuery?.removeEventListener?.('change', onSystemTheme);
     },

--- a/src/web/assets/settings.test.js
+++ b/src/web/assets/settings.test.js
@@ -9,6 +9,21 @@ import {
   mountHelp,
   mountSettings,
 } from './settings.js';
+import { PALETTES, resolveTokens } from './theme.js';
+
+class FakeStyle {
+  constructor() {
+    this.properties = new Map();
+  }
+
+  setProperty(name, value) {
+    this.properties.set(name, value);
+  }
+
+  getPropertyValue(name) {
+    return this.properties.get(name) ?? '';
+  }
+}
 
 class FakeElement {
   constructor(value = '') {
@@ -17,6 +32,8 @@ class FakeElement {
     this.dataset = {};
     this.disabled = false;
     this.hidden = false;
+    this.ariaInvalid = null;
+    this.style = new FakeStyle();
     this.listeners = new Map();
     this.children = [];
   }
@@ -48,6 +65,73 @@ function fakeDocument(ids, { createElements = false } = {}) {
     documentElement: new FakeElement(),
     getElementById: (id) => elements.get(id) ?? null,
     ...(createElements ? { createElement: () => new FakeElement() } : {}),
+  };
+}
+
+const FOREST_CUSTOM_THEME = { light: { ...PALETTES.forest.light }, dark: { ...PALETTES.forest.dark } };
+
+function fakeThemeSettingsDocument() {
+  const paletteSelect = new FakeElement('forest');
+  const customFieldset = new FakeElement();
+  const variantSelect = new FakeElement('light');
+  const colorInputs = {
+    canvas: new FakeElement(),
+    surface: new FakeElement(),
+    text: new FakeElement(),
+    accent: new FakeElement(),
+    danger: new FakeElement(),
+  };
+  const resetCustom = new FakeElement();
+  const settingsStatus = new FakeElement();
+  const customStatus = new FakeElement();
+  const layoutReset = new FakeElement();
+  const document = fakeDocument({
+    'palette-select': paletteSelect,
+    'custom-theme-fieldset': customFieldset,
+    'custom-variant-select': variantSelect,
+    'custom-color-canvas': colorInputs.canvas,
+    'custom-color-surface': colorInputs.surface,
+    'custom-color-text': colorInputs.text,
+    'custom-color-accent': colorInputs.accent,
+    'custom-color-danger': colorInputs.danger,
+    'custom-theme-reset': resetCustom,
+    'settings-live': settingsStatus,
+    'custom-theme-status': customStatus,
+    'layout-reset': layoutReset,
+  });
+  return {
+    document,
+    paletteSelect,
+    customFieldset,
+    variantSelect,
+    colorInputs,
+    resetCustom,
+    status: customStatus,
+    customStatus,
+    settingsStatus,
+    layoutReset,
+  };
+}
+
+function fakePreferences(initial = {}) {
+  const values = {
+    theme: 'system',
+    density: 'comfortable',
+    palette: 'forest',
+    custom_theme: { light: { ...FOREST_CUSTOM_THEME.light }, dark: { ...FOREST_CUSTOM_THEME.dark } },
+    ...initial,
+  };
+  const changes = [];
+  return {
+    values,
+    changes,
+    async load() { return { ...values }; },
+    get(key, fallback) { return values[key] ?? fallback; },
+    set(key, value) {
+      changes.push([key, value]);
+      values[key] = value;
+      return true;
+    },
   };
 }
 
@@ -321,4 +405,230 @@ test('mountHelp loads server preferences before copying the effective timeout', 
   copy.dispatch('click');
   await new Promise((resolve) => setTimeout(resolve, 0));
   assert.match(writes[0], /Effective protected-value timeout \(seconds\): 17/);
+});
+
+test('a built-in palette applies its resolved tokens as inline custom properties and sets data-palette', async () => {
+  const { document } = fakeThemeSettingsDocument();
+  const preferences = fakePreferences({ palette: 'nord' });
+  const mounted = mountSettings({ preferences, securityPolicy: 0, document, mediaQuery: { matches: false } });
+  await mounted.ready;
+
+  const root = document.documentElement;
+  assert.equal(root.dataset.palette, 'nord');
+  assert.equal(root.style.getPropertyValue('color-scheme'), 'light');
+  const tokens = resolveTokens('nord', 'light', preferences.get('custom_theme'));
+  assert.equal(root.style.getPropertyValue('--color-canvas'), tokens.canvas);
+  assert.equal(root.style.getPropertyValue('--color-accent'), tokens.accent);
+  assert.equal(root.style.getPropertyValue('--rail-bg'), tokens.railBg);
+});
+
+test('mode and palette stay independent: System mode follows prefers-color-scheme for a non-Forest palette', async () => {
+  const { document } = fakeThemeSettingsDocument();
+  const preferences = fakePreferences({ theme: 'system', palette: 'solarized' });
+  const listeners = new Map();
+  const mediaQuery = {
+    matches: false,
+    addEventListener(type, listener) { listeners.set(type, listener); },
+    removeEventListener(type) { listeners.delete(type); },
+  };
+  const mounted = mountSettings({ preferences, securityPolicy: 0, document, mediaQuery });
+  await mounted.ready;
+
+  const root = document.documentElement;
+  assert.equal(root.dataset.effectiveTheme, 'light');
+  assert.equal(root.style.getPropertyValue('--color-canvas'), resolveTokens('solarized', 'light', preferences.get('custom_theme')).canvas);
+
+  mediaQuery.matches = true;
+  listeners.get('change')?.();
+  assert.equal(root.dataset.effectiveTheme, 'dark');
+  assert.equal(root.style.getPropertyValue('color-scheme'), 'dark');
+  assert.equal(root.style.getPropertyValue('--color-canvas'), resolveTokens('solarized', 'dark', preferences.get('custom_theme')).canvas);
+  assert.equal(preferences.get('palette'), 'solarized', 'palette is untouched by mode changes');
+});
+
+test('the custom fieldset is only shown when palette is custom', async () => {
+  const forest = fakeThemeSettingsDocument();
+  const forestPreferences = fakePreferences({ palette: 'forest' });
+  await (await mountSettings({ preferences: forestPreferences, securityPolicy: 0, document: forest.document, mediaQuery: { matches: false } })).ready;
+  assert.equal(forest.customFieldset.hidden, true);
+
+  const custom = fakeThemeSettingsDocument();
+  const customPreferences = fakePreferences({ palette: 'custom' });
+  await (await mountSettings({ preferences: customPreferences, securityPolicy: 0, document: custom.document, mediaQuery: { matches: false } })).ready;
+  assert.equal(custom.customFieldset.hidden, false);
+});
+
+test('selecting a palette persists it, applies its tokens, and toggles the custom fieldset', async () => {
+  const { document, paletteSelect, customFieldset } = fakeThemeSettingsDocument();
+  const preferences = fakePreferences({ palette: 'forest' });
+  const mounted = mountSettings({ preferences, securityPolicy: 0, document, mediaQuery: { matches: false } });
+  await mounted.ready;
+
+  paletteSelect.value = 'custom';
+  paletteSelect.dispatch('change');
+  assert.equal(preferences.get('palette'), 'custom');
+  assert.equal(customFieldset.hidden, false);
+  assert.equal(document.documentElement.dataset.palette, 'custom');
+});
+
+test('valid custom color edits apply a live preview and persist through preferences', async () => {
+  const { document, paletteSelect, colorInputs } = fakeThemeSettingsDocument();
+  const preferences = fakePreferences({ palette: 'custom' });
+  const mounted = mountSettings({ preferences, securityPolicy: 0, document, mediaQuery: { matches: false } });
+  await mounted.ready;
+  paletteSelect.value = 'custom';
+  paletteSelect.dispatch('change');
+
+  colorInputs.accent.value = '#003399';
+  colorInputs.accent.dispatch('input');
+
+  assert.equal(preferences.get('custom_theme').light.accent, '#003399');
+  assert.equal(document.documentElement.style.getPropertyValue('--color-accent'), '#003399');
+  assert.equal(colorInputs.accent.ariaInvalid, 'false');
+});
+
+test('invalid custom colors show an actionable status and never replace the last valid applied theme', async () => {
+  const {
+    document, paletteSelect, colorInputs, customStatus, settingsStatus,
+  } = fakeThemeSettingsDocument();
+  const preferences = fakePreferences({ palette: 'custom' });
+  const mounted = mountSettings({ preferences, securityPolicy: 0, document, mediaQuery: { matches: false } });
+  await mounted.ready;
+  paletteSelect.value = 'custom';
+  paletteSelect.dispatch('change');
+
+  const beforeAccent = document.documentElement.style.getPropertyValue('--color-accent');
+  const setCallsBefore = preferences.changes.length;
+
+  colorInputs.accent.value = '#cccccc';
+  colorInputs.accent.dispatch('input');
+
+  assert.equal(document.documentElement.style.getPropertyValue('--color-accent'), beforeAccent);
+  assert.equal(preferences.get('custom_theme').light.accent, PALETTES.forest.light.accent);
+  assert.equal(preferences.changes.length, setCallsBefore, 'an invalid edit must not be persisted');
+  assert.equal(colorInputs.accent.ariaInvalid, 'true');
+  assert.match(customStatus.textContent, /accent vs surface is [0-9.]+:1, needs 4.5:1/);
+  assert.equal(settingsStatus.textContent, '', 'custom validation must not duplicate into the general Settings live region');
+
+  colorInputs.accent.value = 'not-a-hex';
+  colorInputs.accent.dispatch('input');
+  assert.equal(colorInputs.accent.ariaInvalid, 'true');
+});
+
+test('incomplete hex typing is retained without live-region spam or persistence', async () => {
+  const {
+    document, colorInputs, customStatus, settingsStatus,
+  } = fakeThemeSettingsDocument();
+  const preferences = fakePreferences({ palette: 'custom' });
+  const mounted = mountSettings({ preferences, securityPolicy: 0, document, mediaQuery: { matches: false } });
+  await mounted.ready;
+  const before = preferences.changes.length;
+
+  colorInputs.accent.value = '#12';
+  colorInputs.accent.dispatch('input');
+
+  assert.equal(colorInputs.accent.value, '#12');
+  assert.equal(colorInputs.accent.ariaInvalid, 'true');
+  assert.equal(customStatus.textContent, '');
+  assert.equal(settingsStatus.textContent, '');
+  assert.equal(preferences.changes.length, before);
+});
+
+test('per-variant drafts permit an invalid multi-field transition and persist only the completed valid variant', async () => {
+  const { document, variantSelect, colorInputs, customStatus } = fakeThemeSettingsDocument();
+  const initial = {
+    light: { canvas: '#ffffff', surface: '#ffffff', text: '#000000', accent: '#000000', danger: '#000000' },
+    dark: { canvas: '#000000', surface: '#000000', text: '#ffffff', accent: '#ffffff', danger: '#ffffff' },
+  };
+  const preferences = fakePreferences({ palette: 'custom', custom_theme: structuredClone(initial) });
+  const mounted = mountSettings({ preferences, securityPolicy: 0, document, mediaQuery: { matches: false } });
+  await mounted.ready;
+  const beforeCanvas = document.documentElement.style.getPropertyValue('--color-canvas');
+
+  for (const [key, value] of [
+    ['canvas', '#000000'],
+    ['surface', '#000000'],
+    ['text', '#ffffff'],
+    ['accent', '#ffffff'],
+  ]) {
+    colorInputs[key].value = value;
+    colorInputs[key].dispatch('input');
+    assert.equal(colorInputs[key].value, value, `${key} draft remains visible`);
+    assert.deepEqual(preferences.get('custom_theme').light, initial.light, `${key} invalid draft is not persisted`);
+    assert.equal(document.documentElement.style.getPropertyValue('--color-canvas'), beforeCanvas);
+  }
+
+  colorInputs.danger.value = '#ffffff';
+  colorInputs.danger.dispatch('input');
+  assert.deepEqual(preferences.get('custom_theme').light, {
+    canvas: '#000000', surface: '#000000', text: '#ffffff', accent: '#ffffff', danger: '#ffffff',
+  });
+  assert.deepEqual(preferences.get('custom_theme').dark, initial.dark);
+  assert.equal(document.documentElement.style.getPropertyValue('--color-canvas'), '#000000');
+  assert.match(customStatus.textContent, /preview updated/i);
+  assert.doesNotMatch(customStatus.textContent, /saved/i);
+
+  variantSelect.value = 'dark';
+  variantSelect.dispatch('change');
+  colorInputs.accent.value = '#12';
+  colorInputs.accent.dispatch('input');
+  variantSelect.value = 'light';
+  variantSelect.dispatch('change');
+  variantSelect.value = 'dark';
+  variantSelect.dispatch('change');
+  assert.equal(colorInputs.accent.value, '#12', 'invalid dark draft survives variant switches');
+  assert.deepEqual(preferences.get('custom_theme').dark, initial.dark);
+});
+
+test('the custom variant selector edits light and dark independently', async () => {
+  const { document, paletteSelect, variantSelect, colorInputs } = fakeThemeSettingsDocument();
+  const preferences = fakePreferences({ palette: 'custom' });
+  const mounted = mountSettings({ preferences, securityPolicy: 0, document, mediaQuery: { matches: false } });
+  await mounted.ready;
+  paletteSelect.value = 'custom';
+  paletteSelect.dispatch('change');
+
+  variantSelect.value = 'dark';
+  variantSelect.dispatch('change');
+  assert.equal(colorInputs.accent.value, PALETTES.forest.dark.accent);
+
+  colorInputs.accent.value = '#3399ff';
+  colorInputs.accent.dispatch('input');
+  assert.equal(preferences.get('custom_theme').dark.accent, '#3399ff');
+  assert.equal(preferences.get('custom_theme').light.accent, PALETTES.forest.light.accent);
+});
+
+test('reset restores both custom variants to Forest defaults and re-applies when active', async () => {
+  const { document, paletteSelect, colorInputs, resetCustom } = fakeThemeSettingsDocument();
+  const preferences = fakePreferences({ palette: 'custom' });
+  const mounted = mountSettings({ preferences, securityPolicy: 0, document, mediaQuery: { matches: false } });
+  await mounted.ready;
+  paletteSelect.value = 'custom';
+  paletteSelect.dispatch('change');
+
+  colorInputs.accent.value = '#003399';
+  colorInputs.accent.dispatch('input');
+  assert.notEqual(preferences.get('custom_theme').light.accent, PALETTES.forest.light.accent);
+
+  resetCustom.dispatch('click');
+  assert.deepEqual(preferences.get('custom_theme'), FOREST_CUSTOM_THEME);
+  assert.equal(document.documentElement.style.getPropertyValue('--color-accent'), PALETTES.forest.light.accent);
+});
+
+test('layout reset preserves theme, palette, and custom theme state', async () => {
+  const { document, paletteSelect, colorInputs, layoutReset } = fakeThemeSettingsDocument();
+  const preferences = fakePreferences({ palette: 'custom', theme: 'dark' });
+  const mounted = mountSettings({ preferences, securityPolicy: 0, document, mediaQuery: { matches: false } });
+  await mounted.ready;
+  paletteSelect.value = 'custom';
+  paletteSelect.dispatch('change');
+  colorInputs.accent.value = '#003399';
+  colorInputs.accent.dispatch('input');
+
+  const customBefore = preferences.get('custom_theme');
+  layoutReset.dispatch('click');
+
+  assert.equal(preferences.get('theme'), 'dark');
+  assert.equal(preferences.get('palette'), 'custom');
+  assert.deepEqual(preferences.get('custom_theme'), customBefore);
 });

--- a/src/web/assets/static-contract.test.js
+++ b/src/web/assets/static-contract.test.js
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import { PALETTES, contrastRatio, deriveTokens } from './theme.js';
+
+const html = await readFile(new URL('./index.html', import.meta.url), 'utf8');
+const css = await readFile(new URL('./style.css', import.meta.url), 'utf8');
+
+test('Settings renames the Theme control to Mode and keeps #theme-select', () => {
+  const settingsSection = html.split('id="settings-dialog"')[1];
+  assert.match(settingsSection, /for="theme-select"><span class="field-label">Mode<\/span>/);
+  assert.doesNotMatch(settingsSection, />Theme<\/span>\s*<select id="theme-select"/);
+});
+
+test('Settings exposes a Color palette select with the five expected values', () => {
+  const match = html.match(/<select id="palette-select">([\s\S]*?)<\/select>/);
+  assert.ok(match, 'expected #palette-select to exist');
+  const values = [...match[1].matchAll(/<option value="([^"]+)">/g)].map((m) => m[1]);
+  assert.deepEqual(values, ['forest', 'nord', 'solarized', 'high-contrast', 'custom']);
+});
+
+test('Settings exposes an accessible custom-theme fieldset with variant, five color controls, status, and reset', () => {
+  const match = html.match(/<fieldset id="custom-theme-fieldset"[^>]*>([\s\S]*?)<\/fieldset>/);
+  assert.ok(match, 'expected #custom-theme-fieldset to exist');
+  const fieldset = match[1];
+  assert.match(fieldset, /<legend/);
+  assert.match(fieldset, /id="custom-variant-select"/);
+  assert.match(fieldset, /<option value="light">/);
+  assert.match(fieldset, /<option value="dark">/);
+  for (const key of ['canvas', 'surface', 'text', 'accent', 'danger']) {
+    assert.match(fieldset, new RegExp(`for="custom-color-${key}"`), `missing label for custom-color-${key}`);
+    assert.match(fieldset, new RegExp(`id="custom-color-${key}"`), `missing input custom-color-${key}`);
+  }
+  assert.match(fieldset, /id="custom-theme-reset"/);
+});
+
+test('style.css defines semantic rail custom properties consumed by the context rail', () => {
+  for (const token of [
+    '--rail-bg', '--rail-border', '--rail-fg', '--rail-fg-muted', '--rail-accent',
+    '--rail-accent-fg', '--rail-hover-bg', '--rail-connection-ok', '--rail-connection-bad',
+    '--rail-error-bg', '--rail-error-border', '--rail-error-fg', '--rail-error-accent',
+  ]) {
+    assert.match(css, new RegExp(`var\\(${token.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')}\\)`), `${token} not consumed via var()`);
+  }
+});
+
+test('the context-rail and related rules no longer hardcode the old Forest-only literal colors', () => {
+  const railBlockStart = css.indexOf('.context-rail {');
+  assert.ok(railBlockStart >= 0, 'expected a .context-rail rule');
+  const railSection = css.slice(railBlockStart, css.indexOf('.app-header {'));
+  for (const literal of ['#123426', '#365747', '#f4faf6', '#8bd2a8', '#557668', '#1b4534', '#88d4a5', '#f4a39a', '#5a2925', '#a95c54', '#46665a', '#acd1bc', '#cee3d6', '#bcd2c5', '#f0b8a8', '#ffe4dc']) {
+    assert.ok(!railSection.includes(literal), `rail section still hardcodes ${literal}`);
+  }
+});
+
+test('style.css collapses the old root/media/data-theme triplication into a single JS-driven token path', () => {
+  assert.doesNotMatch(css, /:root\[data-theme="light"\]/);
+  assert.doesNotMatch(css, /:root\[data-theme="dark"\]/);
+});
+
+test('palette-independent component rules do not retain Forest-tinted shadows or accents', () => {
+  const themedComponentCss = css.slice(css.indexOf('.context-rail {'), css.indexOf('@media (prefers-color-scheme: dark)'));
+  for (const literal of [
+    'rgb(10 32 23 / 10%)',
+    'rgb(33 100 70 / 24%)',
+    'rgb(28 44 34 / 8%)',
+    'rgb(24 34 28 / 5%)',
+    'rgb(33 100 70 / 20%)',
+    'rgb(18 30 22 / 16%)',
+    'rgb(18 30 22 / 24%)',
+    'rgb(18 30 22 / 32%)',
+    'rgb(33 76 50 / 6%)',
+    'rgb(24 34 28 / 18%)',
+  ]) {
+    assert.ok(!themedComponentCss.includes(literal), `component rules still hardcode ${literal}`);
+  }
+  assert.doesNotMatch(themedComponentCss, /\.utility-sheet[^}]*border-left:3px solid #8bd2a8/);
+  assert.match(themedComponentCss, /\.eyebrow\s*\{[^}]*color:var\(--color-accent-text\)/);
+});
+
+test('pre-JS Forest light and dark fallbacks match accessible runtime tokens', () => {
+  const rootBlock = css.match(/^:root \{([\s\S]*?)\n\}/)?.[1] ?? '';
+  const darkBlock = css.match(/@media \(prefers-color-scheme: dark\) \{\s*:root \{([\s\S]*?)\n\s*\}/)?.[1] ?? '';
+  const readToken = (block, name) => block.match(new RegExp(`${name}\\s*:\\s*([^;]+);`))?.[1].trim();
+  const cssNames = {
+    canvas: '--color-canvas', surface: '--color-surface', surfaceSubtle: '--color-surface-subtle',
+    text: '--color-text', textMuted: '--color-text-muted', border: '--color-border',
+    accent: '--color-accent', accentText: '--color-accent-text',
+    accentTextHover: '--color-accent-text-hover', danger: '--color-danger', dangerQuiet: '--color-danger-quiet',
+    primaryForeground: '--color-primary-foreground', railBg: '--rail-bg', railBorder: '--rail-border',
+    railFg: '--rail-fg', railFgMuted: '--rail-fg-muted', railAccentFg: '--rail-accent-fg',
+    focusColor: '--color-focus',
+  };
+
+  for (const [variant, block] of [['light', rootBlock], ['dark', darkBlock]]) {
+    const core = PALETTES.forest[variant];
+    const expected = { ...core, ...deriveTokens(core, variant) };
+    for (const [key, cssName] of Object.entries(cssNames)) {
+      assert.equal(readToken(block, cssName), expected[key], `${variant} ${cssName}`);
+    }
+    assert.ok(contrastRatio(readToken(block, '--color-text'), readToken(block, '--color-canvas')) >= 4.5);
+    assert.ok(contrastRatio(readToken(block, '--color-text-muted'), readToken(block, '--color-surface-subtle')) >= 4.5);
+    assert.ok(contrastRatio(readToken(block, '--color-primary-foreground'), readToken(block, '--color-accent')) >= 4.5);
+    assert.ok(contrastRatio(readToken(block, '--rail-fg'), readToken(block, '--rail-bg')) >= 4.5);
+    assert.ok(contrastRatio(readToken(block, '--rail-fg-muted'), readToken(block, '--rail-bg')) >= 4.5);
+  }
+});

--- a/src/web/assets/style.css
+++ b/src/web/assets/style.css
@@ -2,19 +2,36 @@
   color-scheme: light dark;
   --color-canvas: #f3f1eb;
   --color-surface: #ffffff;
-  --color-surface-subtle: #f8f8f5;
+  --color-surface-subtle: #f9f8f5;
   --color-text: #18221c;
-  --color-text-muted: #626c65;
-  --color-border: #d7dad5;
+  --color-text-muted: #686f6b;
+  --color-border: #878c89;
   --color-accent: #216446;
-  --color-accent-hover: #174c36;
-  --color-accent-quiet: #e7f0e9;
+  --color-accent-hover: #1b5239;
+  --color-accent-quiet: #edf3f0;
+  --color-accent-text: #216446;
+  --color-accent-text-hover: #1f583e;
   --color-danger: #9f332e;
-  --color-danger-quiet: #fff8f7;
+  --color-danger-quiet: #f9f3f2;
+  --color-primary-foreground: #ffffff;
   --radius-control: .5625rem;
   --radius-surface: .75rem;
-  --shadow-raised: 0 14px 34px rgb(37 54 43 / 8%);
-  --focus-ring: 0 0 0 3px rgb(61 131 92 / 18%);
+  --shadow-raised: 0 14px 34px rgba(14, 20, 17, 0.1);
+  --color-focus: #216446;
+  --focus-ring: 0 0 0 3px #216446;
+  --rail-bg: #0f2d1f;
+  --rail-border: #62756c;
+  --rail-fg: #ffffff;
+  --rail-fg-muted: #82928b;
+  --rail-accent: #216446;
+  --rail-accent-fg: #ffffff;
+  --rail-hover-bg: #274235;
+  --rail-connection-ok: #6f9a87;
+  --rail-connection-bad: #c17c78;
+  --rail-error-bg: #481715;
+  --rail-error-border: #886967;
+  --rail-error-fg: #ffffff;
+  --rail-error-accent: #c17a77;
   font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 * { box-sizing: border-box; }
@@ -26,36 +43,36 @@ body { min-height:100vh; margin:0; min-width:20rem; display:grid; grid-template-
   font-size:.875rem; line-height:1.5; }
 button, input, select, textarea { font:inherit; }
 .context-rail { position:sticky; z-index:10; top:0; grid-column:1; grid-row:1 / span 2; height:100vh;
-  display:flex; flex-direction:column; gap:1rem; padding:1.2rem; overflow:auto; color:#f4faf6;
-  background:#123426; border-right:1px solid #365747; box-shadow:8px 0 24px rgb(10 32 23 / 10%); }
-.context-rail .brand { padding-bottom:1rem; border-bottom:1px solid #46665a; }
-.context-rail .brand-mark { color:#123426; background:#8bd2a8; box-shadow:none; }
+  display:flex; flex-direction:column; gap:1rem; padding:1.2rem; overflow:auto; color:var(--rail-fg);
+  background:var(--rail-bg); border-right:1px solid var(--rail-border); box-shadow:8px 0 24px color-mix(in srgb, var(--rail-bg) 18%, transparent); }
+.context-rail .brand { padding-bottom:1rem; border-bottom:1px solid var(--rail-border); }
+.context-rail .brand-mark { color:var(--rail-accent-fg); background:var(--rail-accent); box-shadow:none; }
 .context-primary { display:grid; gap:.3rem; }
-.context-kicker { color:#acd1bc; font-size:.68rem; font-weight:760; letter-spacing:.1em; text-transform:uppercase; }
+.context-kicker { color:var(--rail-fg-muted); font-size:.68rem; font-weight:760; letter-spacing:.1em; text-transform:uppercase; }
 #context-line { font-size:1rem; line-height:1.35; overflow-wrap:anywhere; }
-.context-kind { width:max-content; padding:.12rem .45rem; border:1px solid #557668; border-radius:999px;
-  color:#cee3d6; font-size:.67rem; }
+.context-kind { width:max-content; padding:.12rem .45rem; border:1px solid var(--rail-border); border-radius:999px;
+  color:var(--rail-fg-muted); font-size:.67rem; }
 .vault-context { display:block; margin:0; padding:0; border:0; }
-.workspace-picker { display:grid; gap:.35rem; color:#cee3d6; font-size:.72rem; font-weight:680; }
-.workspace-picker select { min-height:2.5rem; color:#f4faf6; border-color:#557668; background:#1b4534; }
-.context-status { display:grid; gap:.4rem; color:#bcd2c5; font-size:.72rem; }
+.workspace-picker { display:grid; gap:.35rem; color:var(--rail-fg-muted); font-size:.72rem; font-weight:680; }
+.workspace-picker select { min-height:2.5rem; color:var(--rail-fg); border-color:var(--rail-border); background:var(--rail-hover-bg); }
+.context-status { display:grid; gap:.4rem; color:var(--rail-fg-muted); font-size:.72rem; }
 .connection-state::before { content:""; width:.5rem; height:.5rem; display:inline-block; margin-right:.45rem;
-  border-radius:50%; background:#88d4a5; }
-.connection-state[data-state="unavailable"]::before { background:#f4a39a; }
-.context-error { padding:.65rem; border:1px solid #a95c54; border-radius:var(--radius-control);
-  color:#fff; background:#5a2925; font-size:.72rem; }
-.context-details { border-top:1px solid #46665a; border-bottom:1px solid #46665a; padding:.65rem 0; }
+  border-radius:50%; background:var(--rail-connection-ok); }
+.connection-state[data-state="unavailable"]::before { background:var(--rail-connection-bad); }
+.context-error { padding:.65rem; border:1px solid var(--rail-error-border); border-radius:var(--radius-control);
+  color:var(--rail-error-fg); background:var(--rail-error-bg); font-size:.72rem; }
+.context-details { border-top:1px solid var(--rail-border); border-bottom:1px solid var(--rail-border); padding:.65rem 0; }
 .context-details summary { cursor:pointer; font-weight:700; }
 .context-details dl { display:grid; grid-template-columns:auto 1fr; gap:.35rem .6rem; margin:.7rem 0 0; font-size:.68rem; }
-.context-details dt { color:#acd1bc; }
+.context-details dt { color:var(--rail-fg-muted); }
 .context-details dd { margin:0; overflow-wrap:anywhere; }
 .context-actions { display:grid; gap:.3rem; }
 .context-actions button { min-height:2.35rem; display:flex; align-items:center; justify-content:space-between;
-  color:#f4faf6; border-color:transparent; background:transparent; text-align:left; }
-.context-actions button:hover { border-color:#557668; background:#1b4534; }
-.context-actions button[data-error="true"] { border-color:#f0b8a8; color:#ffe4dc; }
-.context-actions kbd { color:#acd1bc; font-size:.65rem; }
-.context-version { margin-top:auto; color:#acd1bc; font-size:.68rem; }
+  color:var(--rail-fg); border-color:transparent; background:transparent; text-align:left; }
+.context-actions button:hover { border-color:var(--rail-border); background:var(--rail-hover-bg); }
+.context-actions button[data-error="true"] { border-color:var(--rail-error-accent); color:var(--rail-connection-bad); }
+.context-actions kbd { color:var(--rail-fg-muted); font-size:.65rem; }
+.context-version { margin-top:auto; color:var(--rail-fg-muted); font-size:.68rem; }
 .context-rail.auth-recovery-mode {
   grid-row:1 / span 2;
 }
@@ -65,8 +82,8 @@ button, input, select, textarea { font:inherit; }
   display:flex; align-items:center; gap:.875rem; }
 .brand { display:flex; align-items:center; gap:.625rem; font-weight:720; letter-spacing:-.025em; }
 .brand-mark { width:2.125rem; height:2.125rem; display:grid; place-items:center; border-radius:.625rem;
-  color:#fff; background:var(--color-accent); font-weight:850; letter-spacing:-.08em;
-  box-shadow:0 5px 12px rgb(33 100 70 / 24%); }
+  color:var(--color-primary-foreground); background:var(--color-accent); font-weight:850; letter-spacing:-.08em;
+  box-shadow:0 5px 12px color-mix(in srgb, var(--color-accent) 24%, transparent); }
 .backend-badge { padding:.2rem .5rem; border:1px solid var(--color-border); border-radius:999px;
   color:var(--color-text-muted); background:var(--color-surface-subtle); font-size:.7rem; font-weight:650; }
 .vault-picker { display:flex; align-items:center; gap:.4rem; }
@@ -77,12 +94,12 @@ button, input, select, textarea { font:inherit; }
   border-radius:.625rem; background:color-mix(in srgb, var(--color-text) 4%, transparent); }
 .tab { min-height:2.25rem; padding:.4rem .75rem; border:0; border-radius:.4375rem; color:var(--color-text-muted);
   background:transparent; cursor:pointer; font-weight:650; }
-.tab[aria-selected="true"] { color:var(--color-accent-hover); background:var(--color-surface); box-shadow:0 1px 4px rgb(28 44 34 / 8%); }
+.tab[aria-selected="true"] { color:var(--color-accent-text-hover); background:var(--color-surface); box-shadow:0 1px 4px color-mix(in srgb, var(--color-text) 8%, transparent); }
 main { grid-column:2; width:min(100%, 76rem); margin:0 auto; padding:2rem 1.5rem 3rem; }
 .view-heading { display:flex; align-items:flex-end; justify-content:space-between; gap:1.5rem; margin-bottom:1.375rem; }
 .view-heading h1 { margin:.2rem 0 0; font-size:1.625rem; line-height:1.15; letter-spacing:-.04em; }
 .view-heading p { margin:.4rem 0 0; color:var(--color-text-muted); }
-.eyebrow { color:var(--color-accent); font-size:.6875rem; font-weight:750; letter-spacing:.1em; text-transform:uppercase; }
+.eyebrow { color:var(--color-accent-text); font-size:.6875rem; font-weight:750; letter-spacing:.1em; text-transform:uppercase; }
 .item-count { flex:none; color:var(--color-text-muted); font-size:.75rem; }
 .recovery { max-width:36rem; margin:4rem auto; padding:2rem; border:1px solid var(--color-border);
   border-radius:var(--radius-surface); background:var(--color-surface); box-shadow:var(--shadow-raised); text-align:center; }
@@ -115,7 +132,7 @@ button.danger { color:var(--color-danger); }
 #dropzone { margin-bottom:1rem; padding:2rem; border:2px dashed var(--color-border);
   border-radius:.5rem; color:var(--color-text-muted); text-align:center; }
 #dropzone.over { border-color:var(--color-accent); }
-.linkish { color:var(--color-accent); cursor:pointer; text-decoration:underline; }
+.linkish { color:var(--color-accent-text); cursor:pointer; text-decoration:underline; }
 #progress { position:fixed; z-index:40; top:.65rem; right:.65rem; max-width:min(30rem, calc(100vw - 1.3rem));
   padding:.45rem .7rem .45rem 1.6rem; overflow:hidden; border:1px solid var(--color-border);
   border-radius:999px; color:var(--color-text); background:var(--color-surface); box-shadow:var(--shadow-raised);
@@ -135,7 +152,7 @@ tr.selected-row { background:color-mix(in srgb, var(--color-accent) 12%, transpa
 .vault-content { min-width:0; }
 .tree-toolbar-actions { display:flex; gap:.2rem; }
 tbody tr.tree-row { cursor:default; }
-tbody tr.tree-row:focus-visible { outline:2px solid var(--color-accent); outline-offset:-2px; }
+tbody tr.tree-row:focus-visible { outline:2px solid var(--color-focus); outline-offset:-2px; }
 tbody tr.tree-row-item { cursor:pointer; }
 tbody tr.selected-row { background:var(--color-accent-quiet); }
 .data-surface td.tree-cell { padding-inline-start:calc(1rem + (min(var(--tree-depth, 0), 12) * 1rem)); }
@@ -161,7 +178,7 @@ tbody tr.selected-row { background:var(--color-accent-quiet); }
   padding:0 1rem; border:0; color:inherit; background:transparent; box-shadow:none;
   font:inherit; letter-spacing:inherit; text-transform:inherit; text-align:left; }
 .sort-button:hover { color:var(--color-text); border-color:transparent; }
-.sort-indicator { margin-left:auto; color:var(--color-accent); font-size:.6rem; }
+.sort-indicator { margin-left:auto; color:var(--color-accent-text); font-size:.6rem; }
 .column-resizer { position:absolute; z-index:2; inset-block:0; inset-inline-end:-.25rem;
   width:.5rem; cursor:col-resize; touch-action:none; }
 .column-resizer::after { content:""; position:absolute; inset-block:.4rem; inset-inline-start:.22rem;
@@ -188,7 +205,7 @@ tbody tr.selected-row { background:var(--color-accent-quiet); }
   border:0; border-radius:0; color:var(--color-text); background:transparent;
   box-shadow:none; text-align:left; text-decoration:none; }
 .stacked-activation:hover { border-color:transparent; background:color-mix(in srgb, var(--color-accent) 6%, transparent); }
-.stacked-activation:focus-visible { position:relative; z-index:1; outline:2px solid var(--color-accent); outline-offset:-2px; }
+.stacked-activation:focus-visible { position:relative; z-index:1; outline:2px solid var(--color-focus); outline-offset:-2px; }
 .stacked-identifier { min-width:0; overflow-wrap:anywhere; word-break:break-word; }
 .stacked-metadata { min-width:0; display:flex; flex-wrap:wrap; gap:.2rem .8rem;
   color:var(--color-text-muted); font-size:.72rem; }
@@ -198,12 +215,12 @@ tbody tr.selected-row { background:var(--color-accent-quiet); }
 .item-name { color:var(--color-text); }
 .item-name-content { display:flex; align-items:center; gap:.625rem; min-width:0; }
 .item-name-content > .icon { width:1.5rem; height:1.5rem; padding:.32rem; border-radius:.4375rem;
-  color:var(--color-accent); background:var(--color-accent-quiet); }
+  color:var(--color-accent-text); background:var(--color-accent-quiet); }
 .item-name-content strong { overflow:hidden; text-overflow:ellipsis; }
-.file-link { color:var(--color-accent); text-decoration:none; }
+.file-link { color:var(--color-accent-text); text-decoration:none; }
 .file-link strong { text-decoration:underline; text-underline-offset:.18em; }
-.file-link:hover { color:var(--color-accent-hover); }
-.file-link:focus-visible { outline:2px solid var(--color-accent); outline-offset:2px; border-radius:.25rem; }
+.file-link:hover { color:var(--color-accent-text-hover); }
+.file-link:focus-visible { outline:2px solid var(--color-focus); outline-offset:2px; border-radius:.25rem; }
 .upload-destination { display:flex; align-items:center; gap:.65rem; margin:.75rem 0; }
 .upload-destination label { font-weight:700; }
 .upload-destination select { min-width:min(24rem,100%); }
@@ -222,7 +239,7 @@ tbody tr.selected-row { background:var(--color-accent-quiet); }
 .row-action { width:100%; padding:0; border:0; border-radius:.25rem; color:inherit; background:transparent;
   box-shadow:none; text-align:left; }
 .row-action:hover { border-color:transparent; }
-.row-action:focus-visible { outline:2px solid var(--color-accent); outline-offset:2px; }
+.row-action:focus-visible { outline:2px solid var(--color-focus); outline-offset:2px; }
 .tag { display:inline-flex; padding:.15rem .45rem; border-radius:999px;
   color:var(--color-text-muted); background:color-mix(in srgb, var(--color-text) 6%, transparent); font-size:.7rem; }
 .list-summary { display:flex; justify-content:flex-end; margin-top:.75rem; color:var(--color-text-muted); font-size:.72rem; }
@@ -242,10 +259,10 @@ tbody tr.selected-row { background:var(--color-accent-quiet); }
 .button { min-height:2.375rem; display:inline-flex; align-items:center; justify-content:center; gap:.4rem;
   padding:.45rem .8rem; border:1px solid var(--color-border); border-radius:var(--radius-control);
   color:var(--color-text); background:var(--color-surface); cursor:pointer; font-weight:680;
-  box-shadow:0 1px 2px rgb(24 34 28 / 5%); }
+  box-shadow:0 1px 2px color-mix(in srgb, var(--color-text) 5%, transparent); }
 .button:hover:not(:disabled) { border-color:color-mix(in srgb, var(--color-accent) 55%, var(--color-border)); }
-.button.primary { color:#fff; border-color:var(--color-accent); background:var(--color-accent);
-  box-shadow:0 5px 12px rgb(33 100 70 / 20%); }
+.button.primary { color:var(--color-primary-foreground); border-color:var(--color-accent); background:var(--color-accent);
+  box-shadow:0 5px 12px color-mix(in srgb, var(--color-accent) 20%, transparent); }
 .button.primary:hover:not(:disabled) { background:var(--color-accent-hover); }
 .button.ghost { border-color:transparent; background:transparent; box-shadow:none; }
 .button.danger { color:var(--color-danger); border-color:color-mix(in srgb, var(--color-danger) 26%, var(--color-border));
@@ -259,10 +276,10 @@ textarea { padding:.65rem; resize:vertical; }
 input:focus-visible, select:focus-visible, textarea:focus-visible { outline:0; border-color:var(--color-accent); box-shadow:var(--focus-ring); }
 #drawer { position:fixed; z-index:20; inset:0 0 0 auto; width:min(29rem, 100vw); height:100dvh;
   padding:0; overflow:auto; color:var(--color-text); background:var(--color-surface); border-left:1px solid var(--color-border);
-  box-shadow:-12px 0 36px rgb(18 30 22 / 16%); }
+  box-shadow:-12px 0 36px color-mix(in srgb, var(--color-text) 16%, transparent); }
 .drawer-backdrop { position:fixed; z-index:19; inset:0; margin:0; padding:0; border:0; border-radius:0;
-  background:rgb(18 30 22 / 24%); }
-.drawer-backdrop.pending-disabled { cursor:wait; background:rgb(18 30 22 / 32%); }
+  background:color-mix(in srgb, var(--color-text) 24%, transparent); }
+.drawer-backdrop.pending-disabled { cursor:wait; background:color-mix(in srgb, var(--color-text) 32%, transparent); }
 .confirmation-dialog { position:fixed; z-index:21; top:50%; left:50%; width:min(24rem, calc(100vw - 2rem));
   padding:1.25rem; transform:translate(-50%, -50%); border:1px solid var(--color-border); border-radius:var(--radius-surface);
   color:var(--color-text); background:var(--color-surface); box-shadow:var(--shadow-raised); }
@@ -276,8 +293,8 @@ input:focus-visible, select:focus-visible, textarea:focus-visible { outline:0; b
 .application-dialog h3 { margin:1.2rem 0 .5rem; font-size:.9rem; }
 .utility-sheet { position:fixed; z-index:21; inset:0 0 0 auto; width:min(30rem, 100vw); height:100dvh;
   display:grid; grid-template-rows:auto minmax(0, 1fr); overflow:hidden;
-  color:var(--color-text); background:var(--color-surface); border-left:3px solid #8bd2a8;
-  box-shadow:-12px 0 36px rgb(18 30 22 / 16%); animation:utility-sheet-enter .18s ease-out; }
+  color:var(--color-text); background:var(--color-surface); border-left:3px solid var(--color-accent);
+  box-shadow:-12px 0 36px color-mix(in srgb, var(--color-text) 16%, transparent); animation:utility-sheet-enter .18s ease-out; }
 @keyframes utility-sheet-enter { from { transform:translateX(1.25rem); opacity:.72; } }
 .utility-sheet-header { position:relative; z-index:1; display:flex; align-items:center;
   justify-content:space-between; gap:1rem; padding:1.15rem 1.25rem; border-bottom:1px solid var(--color-border);
@@ -295,7 +312,11 @@ input:focus-visible, select:focus-visible, textarea:focus-visible { outline:0; b
 .utility-group .form-field { margin:0; }
 .utility-reset { display:flex; align-items:center; justify-content:space-between; gap:1rem; }
 .utility-reset > div { flex:1; }
-.utility-live { display:block; min-height:1.25rem; color:var(--color-accent-hover); font-size:.75rem; }
+.utility-live { display:block; min-height:1.25rem; color:var(--color-accent-text-hover); font-size:.75rem; }
+.custom-theme-fieldset { margin:.75rem 0 0; padding:0; border:0; }
+.custom-theme-fieldset legend { padding:0 0 .35rem; font-size:.78rem; font-weight:680; }
+.custom-color-grid { display:grid; gap:.65rem; grid-template-columns:repeat(auto-fit, minmax(8rem, 1fr)); margin-bottom:.65rem; }
+.custom-color-grid input[aria-invalid="true"] { border-color:var(--color-danger); box-shadow:0 0 0 1px var(--color-danger); }
 .help-diagnostics dl { display:grid; grid-template-columns:max-content minmax(0, 1fr); gap:.4rem .7rem;
   margin:.65rem 0; font-size:.75rem; }
 .help-diagnostics dt { color:var(--color-text-muted); }
@@ -353,17 +374,17 @@ input:focus-visible, select:focus-visible, textarea:focus-visible { outline:0; b
 .attachment-list { list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:.35rem; }
 .attachment-list li { display:flex; align-items:center; justify-content:space-between; gap:.75rem; font-size:.82rem; }
 .attachment-link { display:inline-flex; align-items:center; gap:.4rem; min-width:0;
-  color:var(--color-accent); text-decoration:none; }
+  color:var(--color-accent-text); text-decoration:none; }
 .attachment-link span { overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
   text-decoration:underline; text-underline-offset:.18em; }
-.attachment-link:hover { color:var(--color-accent-hover); }
-.attachment-link:focus-visible { outline:2px solid var(--color-accent); outline-offset:2px; border-radius:.25rem; }
+.attachment-link:hover { color:var(--color-accent-text-hover); }
+.attachment-link:focus-visible { outline:2px solid var(--color-focus); outline-offset:2px; border-radius:.25rem; }
 .attachment-size { flex-shrink:0; color:var(--color-text-muted); font-size:.75rem; }
 .toolbar { display:flex; align-items:center; gap:.55rem; margin-bottom:.875rem; }
 .toolbar-spacer { flex:1; }
 .search-field { min-height:2.375rem; flex:1; display:flex; align-items:center; gap:.55rem; padding:0 .7rem;
   border:1px solid var(--color-border); border-radius:var(--radius-control); background:var(--color-surface);
-  box-shadow:0 1px 2px rgb(24 34 28 / 5%); }
+  box-shadow:0 1px 2px color-mix(in srgb, var(--color-text) 5%, transparent); }
 .search-field:focus-within { border-color:var(--color-accent); box-shadow:var(--focus-ring); }
 .search-field > .icon { color:var(--color-text-muted); }
 #search, #file-search { min-height:0; padding:0; border:0; border-radius:0; background:transparent; box-shadow:none; }
@@ -378,8 +399,8 @@ input:focus-visible, select:focus-visible, textarea:focus-visible { outline:0; b
 .button.compact { min-height:2.25rem; padding:.3rem .6rem; font-size:.75rem; }
 .bulk-toolbar { display:flex; flex-wrap:wrap; align-items:center; gap:.5rem; margin-bottom:.75rem; padding:.6rem .7rem;
   border:1px solid color-mix(in srgb, var(--color-accent) 32%, var(--color-border));
-  border-radius:.625rem; background:var(--color-accent-quiet); box-shadow:0 4px 12px rgb(33 76 50 / 6%); }
-.bulk-toolbar > span { min-width:6.5rem; color:var(--color-accent-hover); font-weight:700; }
+  border-radius:.625rem; background:var(--color-accent-quiet); box-shadow:0 4px 12px color-mix(in srgb, var(--color-accent) 6%, transparent); }
+.bulk-toolbar > span { min-width:6.5rem; color:var(--color-accent-text-hover); font-weight:700; }
 .bulk-toolbar input { min-width:10rem; flex:1; }
 tr.selected-row { background:color-mix(in srgb, var(--color-accent) 11%, transparent); }
 #dropzone { margin-bottom:1rem; padding:1.25rem; border:1.5px dashed color-mix(in srgb, var(--color-text-muted) 52%, var(--color-border));
@@ -389,18 +410,18 @@ tr.selected-row { background:color-mix(in srgb, var(--color-accent) 11%, transpa
 .dropzone-content strong, .dropzone-content small { display:block; }
 .dropzone-content strong { color:var(--color-text); }
 .dropzone-icon { width:2.4rem; height:2.4rem; display:grid; place-items:center; border-radius:.625rem;
-  color:var(--color-accent); background:var(--color-accent-quiet); }
-.linkish { min-height:2.25rem; display:inline-flex; align-items:center; padding:0; border:0; border-radius:0; color:var(--color-accent); background:transparent;
+  color:var(--color-accent-text); background:var(--color-accent-quiet); }
+.linkish { min-height:2.25rem; display:inline-flex; align-items:center; padding:0; border:0; border-radius:0; color:var(--color-accent-text); background:transparent;
   box-shadow:none; cursor:pointer; font-weight:inherit; text-decoration:underline; text-underline-offset:.15em; }
 .toast { position:fixed; z-index:30; right:1rem; bottom:1rem; left:auto; transform:none;
   display:flex; align-items:center; gap:.5rem;
   max-width:min(24rem, calc(100vw - 2rem));
   padding:.65rem .8rem; border:1px solid var(--color-border); border-radius:var(--radius-control);
-  background:var(--color-surface); box-shadow:0 10px 28px rgb(24 34 28 / 18%); }
-.toast.success { color:var(--color-accent-hover); border-color:color-mix(in srgb, var(--color-accent) 32%, var(--color-border)); }
+  background:var(--color-surface); box-shadow:0 10px 28px color-mix(in srgb, var(--color-text) 18%, transparent); }
+.toast.success { color:var(--color-accent-text-hover); border-color:color-mix(in srgb, var(--color-accent) 32%, var(--color-border)); }
 .action-notice { position:fixed; z-index:18; right:1rem; bottom:1rem; display:flex; align-items:center; gap:.55rem;
   max-width:min(34rem, calc(100vw - 2rem)); padding:.7rem .8rem; border:1px solid color-mix(in srgb, var(--color-accent) 32%, var(--color-border));
-  border-radius:var(--radius-control); color:var(--color-text); background:var(--color-surface); box-shadow:0 10px 28px rgb(24 34 28 / 18%); }
+  border-radius:var(--radius-control); color:var(--color-text); background:var(--color-surface); box-shadow:0 10px 28px color-mix(in srgb, var(--color-text) 18%, transparent); }
 .action-notice-message { flex:1; }
 .action-notice.error { border-color:color-mix(in srgb, var(--color-danger) 42%, var(--color-border)); }
 .trash-actions { display:flex; align-items:center; gap:.4rem; overflow:visible; }
@@ -419,59 +440,41 @@ tr.selected-row { background:color-mix(in srgb, var(--color-accent) 11%, transpa
   :root {
     --color-canvas:#121814;
     --color-surface:#19211c;
-    --color-surface-subtle:#202922;
+    --color-surface-subtle:#161d18;
     --color-text:#dce5df;
-    --color-text-muted:#9aa79e;
-    --color-border:#344138;
+    --color-text-muted:#878f8a;
+    --color-border:#646c67;
     --color-accent:#65c68e;
-    --color-accent-hover:#8ad9aa;
-    --color-accent-quiet:#1f3428;
+    --color-accent-hover:#81d0a2;
+    --color-accent-quiet:#1f2e25;
+    --color-accent-text:#65c68e;
+    --color-accent-text-hover:#7acc9d;
     --color-danger:#f18e85;
-    --color-danger-quiet:#321f1e;
-    --shadow-raised:0 14px 34px rgb(0 0 0 / 20%);
-    --focus-ring:0 0 0 3px rgb(101 198 142 / 22%);
+    --color-danger-quiet:#262822;
+    --color-primary-foreground:#000000;
+    --shadow-raised:0 14px 34px rgba(132, 137, 134, 0.28);
+    --color-focus:#65c68e;
+    --focus-ring:0 0 0 3px #65c68e;
+    --rail-bg:#2d5940;
+    --rail-border:#8ba496;
+    --rail-fg:#ffffff;
+    --rail-fg-muted:#b7c6bd;
+    --rail-accent:#65c68e;
+    --rail-accent-fg:#000000;
+    --rail-hover-bg:#426a53;
+    --rail-connection-ok:#9bdab6;
+    --rail-connection-bad:#f5b2ac;
+    --rail-error-bg:#6c403c;
+    --rail-error-border:#ac9391;
+    --rail-error-fg:#ffffff;
+    --rail-error-accent:#f6b6b0;
   }
-  .brand-mark, .button.primary { color:#102218; }
 }
-:root[data-theme="light"] {
-  color-scheme:light;
-  --color-canvas:#f3f1eb;
-  --color-surface:#ffffff;
-  --color-surface-subtle:#f8f8f5;
-  --color-text:#18221c;
-  --color-text-muted:#626c65;
-  --color-border:#d7dad5;
-  --color-accent:#216446;
-  --color-accent-hover:#174c36;
-  --color-accent-quiet:#e7f0e9;
-  --color-danger:#9f332e;
-  --color-danger-quiet:#fff8f7;
-  --shadow-raised:0 14px 34px rgb(37 54 43 / 8%);
-  --focus-ring:0 0 0 3px rgb(61 131 92 / 18%);
-}
-:root[data-theme="dark"] {
-  color-scheme:dark;
-  --color-canvas:#121814;
-  --color-surface:#19211c;
-  --color-surface-subtle:#202922;
-  --color-text:#dce5df;
-  --color-text-muted:#9aa79e;
-  --color-border:#344138;
-  --color-accent:#65c68e;
-  --color-accent-hover:#8ad9aa;
-  --color-accent-quiet:#1f3428;
-  --color-danger:#f18e85;
-  --color-danger-quiet:#321f1e;
-  --shadow-raised:0 14px 34px rgb(0 0 0 / 20%);
-  --focus-ring:0 0 0 3px rgb(101 198 142 / 22%);
-}
-:root[data-theme="dark"] .button.primary,
-:root[data-theme="dark"] .brand-mark { color:#102218; }
 :root[data-density="compact"] tbody td,
 :root[data-density="compact"] .stacked-item { padding-block:.42rem; }
 :root[data-density="compact"] td.tree-cell .tree-cell-inner { min-height:1.8rem; }
 button:focus-visible, .tab:focus-visible, [role="button"]:focus-visible, .linkish:focus-visible {
-  outline:2px solid var(--color-accent); outline-offset:2px;
+  outline:2px solid var(--color-focus); outline-offset:2px;
 }
 @media (max-width: 64rem) {
   .vault-workspace { display:block; }
@@ -481,7 +484,7 @@ button:focus-visible, .tab:focus-visible, [role="button"]:focus-visible, .linkis
   .group-editor .field-actions { grid-template-columns:1fr; }
   .workflow-actions .button { flex:1 1 auto; }
   body { display:block; }
-  .context-rail { position:relative; width:100%; height:auto; min-height:0; border-right:0; border-bottom:1px solid #365747; }
+  .context-rail { position:relative; width:100%; height:auto; min-height:0; border-right:0; border-bottom:1px solid var(--rail-border); }
   .context-actions { grid-template-columns:repeat(2, minmax(0, 1fr)); }
   .context-version { margin-top:0; }
   .app-header-inner { padding-inline:1rem; }

--- a/src/web/assets/theme.js
+++ b/src/web/assets/theme.js
@@ -1,0 +1,300 @@
+export const HEX_PATTERN = /^#[0-9a-fA-F]{6}$/;
+export const CONTRAST_MIN = 4.5;
+export const CUSTOM_COLOR_KEYS = Object.freeze(['canvas', 'surface', 'text', 'accent', 'danger']);
+export const PALETTE_NAMES = Object.freeze(['forest', 'nord', 'solarized', 'high-contrast']);
+
+const REQUIRED_CONTRAST_PAIRS = Object.freeze([
+  ['text', 'canvas'],
+  ['text', 'surface'],
+  ['accent', 'surface'],
+  ['danger', 'surface'],
+]);
+
+export function isValidHex(value) {
+  return typeof value === 'string' && HEX_PATTERN.test(value);
+}
+
+export function hexToRgb(hex) {
+  const value = hex.slice(1);
+  return {
+    r: parseInt(value.slice(0, 2), 16),
+    g: parseInt(value.slice(2, 4), 16),
+    b: parseInt(value.slice(4, 6), 16),
+  };
+}
+
+function componentToHex(component) {
+  return Math.max(0, Math.min(255, Math.round(component))).toString(16).padStart(2, '0');
+}
+
+export function rgbToHex({ r, g, b }) {
+  return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`;
+}
+
+export function mix(hexA, hexB, amount) {
+  const a = hexToRgb(hexA);
+  const b = hexToRgb(hexB);
+  const t = Math.max(0, Math.min(1, amount));
+  return rgbToHex({
+    r: a.r * (1 - t) + b.r * t,
+    g: a.g * (1 - t) + b.g * t,
+    b: a.b * (1 - t) + b.b * t,
+  });
+}
+
+function srgbToLinear(channel) {
+  const value = channel / 255;
+  return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+}
+
+export function relativeLuminance(hex) {
+  const { r, g, b } = hexToRgb(hex);
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+}
+
+export function contrastRatio(hexA, hexB) {
+  const lumA = relativeLuminance(hexA);
+  const lumB = relativeLuminance(hexB);
+  const lighter = Math.max(lumA, lumB);
+  const darker = Math.min(lumA, lumB);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+export function meetsContrast(hexA, hexB, minRatio = CONTRAST_MIN) {
+  return contrastRatio(hexA, hexB) >= minRatio;
+}
+
+function contrastingForeground(bgHex) {
+  const white = '#ffffff';
+  const black = '#000000';
+  return contrastRatio(bgHex, white) >= contrastRatio(bgHex, black) ? white : black;
+}
+
+const CONTRAST_SEARCH_STEPS = 256;
+
+// Finds the most muted (largest mix-toward-`driftTowards`) tone that still
+// meets minRatio against every background. `base` at weight 0 must already
+// pass every background, which callers guarantee via validated core tokens.
+function findMutedTone(base, driftTowards, backgrounds, minRatio = CONTRAST_MIN) {
+  for (let step = CONTRAST_SEARCH_STEPS; step >= 0; step -= 1) {
+    const candidate = mix(base, driftTowards, step / CONTRAST_SEARCH_STEPS);
+    if (backgrounds.every((bg) => contrastRatio(candidate, bg) >= minRatio)) return candidate;
+  }
+  return base;
+}
+
+// Finds the least aggressive mix-toward-`driftTowards` tone that meets
+// minRatio against every background. Falls back to `driftTowards` itself.
+function findAccessibleTone(base, driftTowards, backgrounds, minRatio = CONTRAST_MIN) {
+  for (let step = 0; step <= CONTRAST_SEARCH_STEPS; step += 1) {
+    const candidate = mix(base, driftTowards, step / CONTRAST_SEARCH_STEPS);
+    if (backgrounds.every((bg) => contrastRatio(candidate, bg) >= minRatio)) return candidate;
+  }
+  return driftTowards;
+}
+
+// Starts from a background already known to support the foreground(s), then
+// moves toward the desired tint only while every required contrast holds.
+function findAccessibleBackground(base, desired, foregrounds, minRatio = CONTRAST_MIN) {
+  for (let step = CONTRAST_SEARCH_STEPS; step >= 0; step -= 1) {
+    const candidate = mix(base, desired, step / CONTRAST_SEARCH_STEPS);
+    if (foregrounds.every((fg) => contrastRatio(fg, candidate) >= minRatio)) return candidate;
+  }
+  return base;
+}
+
+export const PALETTES = Object.freeze({
+  forest: Object.freeze({
+    light: Object.freeze({
+      canvas: '#f3f1eb',
+      surface: '#ffffff',
+      text: '#18221c',
+      accent: '#216446',
+      danger: '#9f332e',
+    }),
+    dark: Object.freeze({
+      canvas: '#121814',
+      surface: '#19211c',
+      text: '#dce5df',
+      accent: '#65c68e',
+      danger: '#f18e85',
+    }),
+  }),
+  nord: Object.freeze({
+    light: Object.freeze({
+      canvas: '#eceff4',
+      surface: '#fbfcfe',
+      text: '#2e3440',
+      accent: '#34506e',
+      danger: '#96323c',
+    }),
+    dark: Object.freeze({
+      canvas: '#2e3440',
+      surface: '#3b4252',
+      text: '#eceff4',
+      accent: '#88c0d0',
+      danger: '#e49da4',
+    }),
+  }),
+  solarized: Object.freeze({
+    light: Object.freeze({
+      canvas: '#fdf6e3',
+      surface: '#fefbef',
+      text: '#073642',
+      accent: '#1b6ea8',
+      danger: '#b8221f',
+    }),
+    dark: Object.freeze({
+      canvas: '#002b36',
+      surface: '#073642',
+      text: '#eee8d5',
+      accent: '#5bc3ba',
+      danger: '#ec847d',
+    }),
+  }),
+  'high-contrast': Object.freeze({
+    light: Object.freeze({
+      canvas: '#ffffff',
+      surface: '#ffffff',
+      text: '#000000',
+      accent: '#0033cc',
+      danger: '#b30000',
+    }),
+    dark: Object.freeze({
+      canvas: '#000000',
+      surface: '#000000',
+      text: '#ffffff',
+      accent: '#4d94ff',
+      danger: '#ff6666',
+    }),
+  }),
+});
+
+export function isValidCustomVariant(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  if (keys.length !== CUSTOM_COLOR_KEYS.length) return false;
+  return CUSTOM_COLOR_KEYS.every((key) => isValidHex(value[key]));
+}
+
+export function validateCustomVariantContrast(core) {
+  const failures = [];
+  for (const [foreground, background] of REQUIRED_CONTRAST_PAIRS) {
+    const ratio = contrastRatio(core[foreground], core[background]);
+    if (ratio < CONTRAST_MIN) {
+      failures.push({ pair: `${foreground}-${background}`, ratio, required: CONTRAST_MIN });
+    }
+  }
+  return { valid: failures.length === 0, failures };
+}
+
+export function deriveTokens(core, variant) {
+  const surfaceSubtle = findAccessibleBackground(
+    core.surface,
+    mix(core.surface, core.canvas, 0.5),
+    [core.text],
+  );
+  // Matches the translucent .app-header/.tab-list composite in style.css
+  // (surface 92% over canvas, then text 4% over that) so muted text stays
+  // readable on that rendered background too, not just the flat tokens.
+  const tabListBg = mix(mix(core.canvas, core.surface, 0.92), core.text, 0.04);
+  const textMuted = findMutedTone(
+    core.text,
+    core.surface,
+    [core.canvas, core.surface, surfaceSubtle, tabListBg],
+  );
+  const border = findAccessibleTone(
+    core.surface,
+    core.text,
+    [core.canvas, core.surface, surfaceSubtle],
+    3,
+  );
+  const primaryForeground = contrastingForeground(core.accent);
+  const desiredAccentHover = variant === 'dark'
+    ? mix(core.accent, '#ffffff', 0.18)
+    : mix(core.accent, '#000000', 0.18);
+  const accentHover = findAccessibleBackground(
+    core.accent,
+    desiredAccentHover,
+    [primaryForeground],
+  );
+  const accentQuiet = findAccessibleBackground(
+    core.surface,
+    mix(core.accent, core.surface, 0.92),
+    [core.text, core.accent],
+  );
+  const accentTextBackgrounds = [core.canvas, core.surface, surfaceSubtle, accentQuiet];
+  const accentText = findAccessibleTone(
+    core.accent,
+    core.text,
+    accentTextBackgrounds,
+  );
+  const accentTextHover = findAccessibleBackground(
+    accentText,
+    mix(accentText, core.text, 0.18),
+    accentTextBackgrounds,
+  );
+  const dangerQuiet = findAccessibleBackground(
+    core.surface,
+    mix(core.surface, core.danger, 0.06),
+    [core.danger],
+  );
+  const railBg = mix(core.accent, '#000000', 0.55);
+  const railFg = contrastingForeground(railBg);
+  const railBorder = findAccessibleTone(railBg, railFg, [railBg], 3);
+  const railFgMuted = findMutedTone(railFg, railBg, [railBg]);
+  const railAccent = core.accent;
+  const railAccentFg = contrastingForeground(railAccent);
+  const railHoverBg = findAccessibleBackground(
+    railBg,
+    mix(railBg, '#ffffff', 0.1),
+    [railFg],
+  );
+  const railConnectionOk = mix(core.accent, '#ffffff', 0.35);
+  const railConnectionBad = findAccessibleTone(core.danger, '#ffffff', [railBg]);
+  const railErrorBg = mix(core.danger, '#000000', 0.55);
+  const railErrorFg = contrastingForeground(railErrorBg);
+  const railErrorBorder = findAccessibleTone(railErrorBg, railErrorFg, [railErrorBg], 3);
+  const railErrorAccent = mix(core.danger, '#ffffff', 0.35);
+  const shadowTint = hexToRgb(mix(core.text, '#000000', 0.4));
+  const focusColor = findAccessibleTone(core.accent, core.text, [core.canvas, core.surface], 3);
+
+  return {
+    surfaceSubtle,
+    textMuted,
+    border,
+    accentHover,
+    accentQuiet,
+    accentText,
+    accentTextHover,
+    dangerQuiet,
+    primaryForeground,
+    railBg,
+    railBorder,
+    railFg,
+    railFgMuted,
+    railAccent,
+    railAccentFg,
+    railHoverBg,
+    railConnectionOk,
+    railConnectionBad,
+    railErrorBg,
+    railErrorBorder,
+    railErrorFg,
+    railErrorAccent,
+    focusColor,
+    focusRing: `0 0 0 3px ${focusColor}`,
+    shadowRaised: `0 14px 34px rgba(${shadowTint.r}, ${shadowTint.g}, ${shadowTint.b}, ${variant === 'dark' ? 0.28 : 0.1})`,
+  };
+}
+
+export function resolveTokens(paletteName, variantKind, customTheme) {
+  const variant = variantKind === 'dark' ? 'dark' : 'light';
+  let core;
+  if (paletteName === 'custom' && isValidCustomVariant(customTheme?.[variant])) {
+    core = customTheme[variant];
+  } else {
+    core = (PALETTES[paletteName] ?? PALETTES.forest)[variant];
+  }
+  return { ...core, ...deriveTokens(core, variant) };
+}

--- a/src/web/assets/theme.test.js
+++ b/src/web/assets/theme.test.js
@@ -1,0 +1,299 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CONTRAST_MIN,
+  CUSTOM_COLOR_KEYS,
+  HEX_PATTERN,
+  PALETTE_NAMES,
+  PALETTES,
+  contrastRatio,
+  deriveTokens,
+  isValidCustomVariant,
+  isValidHex,
+  meetsContrast,
+  mix,
+  resolveTokens,
+  validateCustomVariantContrast,
+} from './theme.js';
+
+test('HEX_PATTERN and isValidHex accept only strict six-digit hex', () => {
+  for (const good of ['#000000', '#ffffff', '#AbC123', '#216446']) {
+    assert.ok(HEX_PATTERN.test(good), good);
+    assert.equal(isValidHex(good), true, good);
+  }
+  for (const bad of ['#fff', '000000', '#12345', '#1234567', 'red', 'rgb(0,0,0)', '#gggggg', '', null, undefined, 42]) {
+    assert.equal(isValidHex(bad), false, String(bad));
+  }
+});
+
+test('contrastRatio matches known WCAG reference values', () => {
+  assert.equal(contrastRatio('#000000', '#ffffff'), 21);
+  assert.equal(contrastRatio('#ffffff', '#ffffff'), 1);
+  assert.equal(contrastRatio('#123456', '#654321'), contrastRatio('#654321', '#123456'));
+});
+
+test('meetsContrast enforces the WCAG AA 4.5 default threshold', () => {
+  assert.equal(CONTRAST_MIN, 4.5);
+  assert.equal(meetsContrast('#000000', '#ffffff'), true);
+  assert.equal(meetsContrast('#777777', '#888888'), false);
+  assert.equal(meetsContrast('#000000', '#ffffff', 21), true);
+  assert.equal(meetsContrast('#000000', '#ffffff', 21.1), false);
+});
+
+test('contrast validation does not round a borderline failure up to 4.5', () => {
+  const borderlineForeground = '#3eca1d';
+  const borderlineBackground = '#0e457a';
+  assert.ok(contrastRatio(borderlineForeground, borderlineBackground) < CONTRAST_MIN);
+
+  const result = validateCustomVariantContrast({
+    canvas: '#000000',
+    surface: borderlineBackground,
+    text: '#ffffff',
+    accent: borderlineForeground,
+    danger: '#ffffff',
+  });
+  assert.equal(result.valid, false);
+  assert.ok(result.failures.some(({ pair }) => pair === 'accent-surface'));
+});
+
+test('every built-in palette resolves light and dark variants with valid strict hex core tokens', () => {
+  assert.deepEqual([...PALETTE_NAMES].sort(), ['forest', 'high-contrast', 'nord', 'solarized'].sort());
+  for (const name of PALETTE_NAMES) {
+    const palette = PALETTES[name];
+    for (const variant of ['light', 'dark']) {
+      const core = palette[variant];
+      assert.ok(core, `${name}/${variant} missing`);
+      for (const key of CUSTOM_COLOR_KEYS) {
+        assert.ok(isValidHex(core[key]), `${name}/${variant}/${key} = ${core[key]}`);
+      }
+    }
+  }
+});
+
+test('Forest palette matches the exact current production colors', () => {
+  assert.deepEqual(PALETTES.forest.light, {
+    canvas: '#f3f1eb',
+    surface: '#ffffff',
+    text: '#18221c',
+    accent: '#216446',
+    danger: '#9f332e',
+  });
+  assert.deepEqual(PALETTES.forest.dark, {
+    canvas: '#121814',
+    surface: '#19211c',
+    text: '#dce5df',
+    accent: '#65c68e',
+    danger: '#f18e85',
+  });
+});
+
+test('built-in palettes satisfy the required contrast pairs in both variants', () => {
+  for (const name of PALETTE_NAMES) {
+    for (const variant of ['light', 'dark']) {
+      const core = PALETTES[name][variant];
+      const result = validateCustomVariantContrast(core);
+      assert.equal(result.valid, true, `${name}/${variant}: ${JSON.stringify(result.failures)}`);
+    }
+  }
+});
+
+test('isValidCustomVariant enforces exact shape and strict hex, rejecting extra or missing keys', () => {
+  const valid = { canvas: '#ffffff', surface: '#fafafa', text: '#000000', accent: '#123456', danger: '#654321' };
+  assert.equal(isValidCustomVariant(valid), true);
+  assert.equal(isValidCustomVariant({ ...valid, extra: '#000000' }), false);
+  const { canvas, ...missingCanvas } = valid;
+  assert.equal(isValidCustomVariant(missingCanvas), false);
+  assert.equal(isValidCustomVariant({ ...valid, accent: 'not-a-hex' }), false);
+  assert.equal(isValidCustomVariant({ ...valid, accent: 'rgb(0,0,0)' }), false);
+  assert.equal(isValidCustomVariant(null), false);
+  assert.equal(isValidCustomVariant('#ffffff'), false);
+  assert.equal(isValidCustomVariant([]), false);
+});
+
+test('validateCustomVariantContrast reports every failing required pair', () => {
+  const lowContrast = { canvas: '#808080', surface: '#888888', text: '#7a7a7a', accent: '#8a8a8a', danger: '#8f8f8f' };
+  const result = validateCustomVariantContrast(lowContrast);
+  assert.equal(result.valid, false);
+  assert.ok(result.failures.length > 0);
+  for (const failure of result.failures) {
+    assert.ok(['text-canvas', 'text-surface', 'accent-surface', 'danger-surface'].includes(failure.pair));
+    assert.ok(failure.ratio < CONTRAST_MIN);
+  }
+
+  const highContrast = { canvas: '#ffffff', surface: '#ffffff', text: '#000000', accent: '#003399', danger: '#a30000' };
+  const good = validateCustomVariantContrast(highContrast);
+  assert.equal(good.valid, true);
+  assert.deepEqual(good.failures, []);
+});
+
+test('deriveTokens produces a complete, valid-format secondary and rail token set', () => {
+  for (const name of PALETTE_NAMES) {
+    for (const variant of ['light', 'dark']) {
+      const tokens = deriveTokens(PALETTES[name][variant], variant);
+      for (const key of [
+        'surfaceSubtle', 'textMuted', 'border', 'accentHover', 'accentQuiet',
+        'accentText', 'accentTextHover',
+        'dangerQuiet', 'primaryForeground', 'railBg', 'railBorder', 'railFg',
+        'railFgMuted', 'railAccent', 'railAccentFg', 'railHoverBg',
+        'railConnectionOk', 'railConnectionBad', 'railErrorBg', 'railErrorBorder',
+        'railErrorFg', 'railErrorAccent', 'focusColor',
+      ]) {
+        assert.ok(isValidHex(tokens[key]), `${name}/${variant}/${key} = ${tokens[key]}`);
+      }
+      assert.equal(tokens.focusRing, `0 0 0 3px ${tokens.focusColor}`);
+      assert.match(tokens.shadowRaised, /^0 14px 34px rgba\(\d+, \d+, \d+, [0-9.]+\)$/);
+    }
+  }
+});
+
+test('deriveTokens picks a readable primary foreground against the accent for bright and dark accents', () => {
+  const brightAccent = deriveTokens({ canvas: '#ffffff', surface: '#ffffff', text: '#000000', accent: '#f5e642', danger: '#a30000' }, 'light');
+  assert.ok(meetsContrast(brightAccent.primaryForeground, '#f5e642', 3), 'bright accent should pick a dark foreground');
+
+  const darkAccent = deriveTokens({ canvas: '#000000', surface: '#000000', text: '#ffffff', accent: '#0a1a33', danger: '#a30000' }, 'dark');
+  assert.ok(meetsContrast(darkAccent.primaryForeground, '#0a1a33', 3), 'dark accent should pick a light foreground');
+});
+
+test('medium accepted accents choose true black when the near-black brand tone is not readable', () => {
+  const core = { canvas: '#000000', surface: '#000000', text: '#ffffff', accent: '#777777', danger: '#ff6666' };
+  assert.equal(validateCustomVariantContrast(core).valid, true);
+  const tokens = deriveTokens(core, 'dark');
+  assert.equal(tokens.primaryForeground, '#000000');
+  assert.equal(tokens.railAccentFg, '#000000');
+  assert.ok(meetsContrast(tokens.primaryForeground, core.accent));
+  assert.ok(meetsContrast(tokens.railAccentFg, tokens.railAccent));
+});
+
+test('accepted accents derive readable text colors for canvas and component surfaces', () => {
+  const core = {
+    canvas: '#767676', surface: '#ffffff', text: '#000000', accent: '#767676', danger: '#000000',
+  };
+  assert.equal(validateCustomVariantContrast(core).valid, true);
+  const tokens = deriveTokens(core, 'light');
+  assert.ok(meetsContrast(tokens.accentText, core.canvas));
+  assert.ok(meetsContrast(tokens.accentText, core.surface));
+  assert.notEqual(tokens.accentText, core.accent);
+});
+
+test('deriveTokens is deterministic: same input always produces the same output', () => {
+  const a = deriveTokens(PALETTES.nord.dark, 'dark');
+  const b = deriveTokens(PALETTES.nord.dark, 'dark');
+  assert.deepEqual(a, b);
+});
+
+test('resolveTokens merges core and derived tokens for a built-in palette', () => {
+  const tokens = resolveTokens('nord', 'light', null);
+  assert.equal(tokens.canvas, PALETTES.nord.light.canvas);
+  assert.equal(tokens.accent, PALETTES.nord.light.accent);
+  assert.ok(isValidHex(tokens.railBg));
+});
+
+test('resolveTokens uses the supplied custom theme when palette is custom', () => {
+  const customTheme = {
+    light: { canvas: '#ffffff', surface: '#fafafa', text: '#000000', accent: '#003399', danger: '#a30000' },
+    dark: { canvas: '#000000', surface: '#0a0a0a', text: '#ffffff', accent: '#3399ff', danger: '#ff5555' },
+  };
+  const light = resolveTokens('custom', 'light', customTheme);
+  assert.equal(light.canvas, '#ffffff');
+  assert.equal(light.accent, '#003399');
+  const dark = resolveTokens('custom', 'dark', customTheme);
+  assert.equal(dark.canvas, '#000000');
+  assert.equal(dark.accent, '#3399ff');
+});
+
+test('textMuted stays readable on the translucent .app-header/.tab-list composite background', () => {
+  for (const name of PALETTE_NAMES) {
+    for (const variant of ['light', 'dark']) {
+      const core = PALETTES[name][variant];
+      const tokens = deriveTokens(core, variant);
+      const tabListBg = mix(mix(core.canvas, core.surface, 0.92), core.text, 0.04);
+      assert.ok(
+        meetsContrast(tokens.textMuted, tabListBg),
+        `${name}/${variant}: ${tokens.textMuted} vs ${tabListBg} = ${contrastRatio(tokens.textMuted, tabListBg)}`,
+      );
+    }
+  }
+});
+
+test('resolveTokens falls back to Forest defaults for an unknown palette name', () => {
+  const tokens = resolveTokens('not-a-real-palette', 'light', null);
+  assert.equal(tokens.canvas, PALETTES.forest.light.canvas);
+});
+
+test('every derived foreground token meets 4.5:1 against every background it is rendered on', () => {
+  for (const name of PALETTE_NAMES) {
+    for (const variant of ['light', 'dark']) {
+      const core = PALETTES[name][variant];
+      const tokens = deriveTokens(core, variant);
+      const pairs = [
+        ['textMuted', tokens.textMuted, core.canvas],
+        ['textMuted', tokens.textMuted, core.surface],
+        ['primaryForeground', tokens.primaryForeground, core.accent],
+        ['railFg', tokens.railFg, tokens.railBg],
+        ['railFgMuted', tokens.railFgMuted, tokens.railBg],
+        ['railAccentFg', tokens.railAccentFg, tokens.railAccent],
+        ['railErrorFg', tokens.railErrorFg, tokens.railErrorBg],
+        ['railConnectionBad (button text)', tokens.railConnectionBad, tokens.railBg],
+      ];
+      for (const [label, fg, bg] of pairs) {
+        assert.ok(
+          meetsContrast(fg, bg),
+          `${name}/${variant} ${label}: ${fg} vs ${bg} = ${contrastRatio(fg, bg)}`,
+        );
+      }
+    }
+  }
+});
+
+test('derived text, danger, borders, and focus stay accessible for every valid core palette', () => {
+  const adversarial = [
+    { canvas: '#fbc98d', surface: '#14fc45', text: '#255b2d', accent: '#7e3072', danger: '#8f0ab3' },
+    { canvas: '#4101ed', surface: '#005126', text: '#c2e5a3', accent: '#96f595', danger: '#2ad615' },
+    { canvas: '#969a52', surface: '#77e7f4', text: '#0c3103', accent: '#990691', danger: '#6a563e' },
+    { canvas: '#532b47', surface: '#2b1fbb', text: '#d2b78b', accent: '#47d49f', danger: '#b1fc1c' },
+  ];
+  const cores = [
+    ...PALETTE_NAMES.flatMap((name) => ['light', 'dark'].map((variant) => ({
+      label: `${name}/${variant}`,
+      variant,
+      core: PALETTES[name][variant],
+    }))),
+    ...adversarial.map((core, index) => ({ label: `adversarial-${index}`, variant: 'light', core })),
+  ];
+
+  for (const { label, variant, core } of cores) {
+    assert.equal(validateCustomVariantContrast(core).valid, true, `${label} must be accepted by core validation`);
+    const tokens = deriveTokens(core, variant);
+    const checks = [
+      ['muted text on canvas', tokens.textMuted, core.canvas, 4.5],
+      ['muted text on surface', tokens.textMuted, core.surface, 4.5],
+      ['muted text on subtle surface', tokens.textMuted, tokens.surfaceSubtle, 4.5],
+      ['danger text on quiet danger surface', core.danger, tokens.dangerQuiet, 4.5],
+      ['border on surface', tokens.border, core.surface, 3],
+      ['border on canvas', tokens.border, core.canvas, 3],
+      ['border on subtle surface', tokens.border, tokens.surfaceSubtle, 3],
+      ['primary text on hover background', tokens.primaryForeground, tokens.accentHover, 4.5],
+      ['text on quiet accent surface', core.text, tokens.accentQuiet, 4.5],
+      ['accent on quiet accent surface', core.accent, tokens.accentQuiet, 4.5],
+      ['accent text on canvas', tokens.accentText, core.canvas, 4.5],
+      ['accent text on surface', tokens.accentText, core.surface, 4.5],
+      ['accent text on subtle surface', tokens.accentText, tokens.surfaceSubtle, 4.5],
+      ['accent text on quiet accent surface', tokens.accentText, tokens.accentQuiet, 4.5],
+      ['accent hover text on canvas', tokens.accentTextHover, core.canvas, 4.5],
+      ['accent hover text on surface', tokens.accentTextHover, core.surface, 4.5],
+      ['accent hover text on subtle surface', tokens.accentTextHover, tokens.surfaceSubtle, 4.5],
+      ['rail border on rail', tokens.railBorder, tokens.railBg, 3],
+      ['rail text on hover background', tokens.railFg, tokens.railHoverBg, 4.5],
+      ['error border on error surface', tokens.railErrorBorder, tokens.railErrorBg, 3],
+      ['focus on canvas', tokens.focusColor, core.canvas, 3],
+      ['focus on surface', tokens.focusColor, core.surface, 3],
+    ];
+    for (const [description, foreground, background, minimum] of checks) {
+      assert.ok(
+        foreground && meetsContrast(foreground, background, minimum),
+        `${label} ${description}: ${foreground ?? 'missing'} vs ${background}`,
+      );
+    }
+  }
+});

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -70,6 +70,7 @@ fn asset(path: &str) -> Option<(&'static str, &'static str)> {
             include_str!("assets/preferences.js"),
         )),
         "/settings.js" => Some(("application/javascript", include_str!("assets/settings.js"))),
+        "/theme.js" => Some(("application/javascript", include_str!("assets/theme.js"))),
         "/ui-model.js" => Some(("application/javascript", include_str!("assets/ui-model.js"))),
         "/tree-grid.js" => Some((
             "application/javascript",
@@ -559,6 +560,7 @@ mod tests {
             "/secrets.js",
             "/preferences.js",
             "/settings.js",
+            "/theme.js",
             "/commands.js",
             "/files.js",
             "/tree-grid.js",

--- a/src/web/preferences.rs
+++ b/src/web/preferences.rs
@@ -11,7 +11,9 @@ use crate::error::{CrosstacheError, Result};
 use super::api::ApiError;
 use super::WebState;
 
-const UI_PREFERENCES_VERSION: u64 = 1;
+const UI_PREFERENCES_VERSION: u64 = 2;
+const CONTRAST_MIN: f64 = 4.5;
+const PALETTE_VALUES: [&str; 5] = ["forest", "nord", "solarized", "high-contrast", "custom"];
 
 fn current_version() -> u64 {
     UI_PREFERENCES_VERSION
@@ -19,6 +21,10 @@ fn current_version() -> u64 {
 
 fn default_theme() -> String {
     "system".to_string()
+}
+
+fn default_palette() -> String {
+    "forest".to_string()
 }
 
 fn default_exposure_timeout_seconds() -> u64 {
@@ -31,6 +37,116 @@ fn default_density() -> String {
 
 fn default_folder_expansion() -> bool {
     true
+}
+
+fn is_valid_hex_color(value: &str) -> bool {
+    value.len() == 7
+        && value.starts_with('#')
+        && value.as_bytes()[1..].iter().all(u8::is_ascii_hexdigit)
+}
+
+fn hex_to_rgb(hex: &str) -> Option<(u8, u8, u8)> {
+    if !is_valid_hex_color(hex) {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[1..3], 16).ok()?;
+    let g = u8::from_str_radix(&hex[3..5], 16).ok()?;
+    let b = u8::from_str_radix(&hex[5..7], 16).ok()?;
+    Some((r, g, b))
+}
+
+fn srgb_channel_to_linear(channel: u8) -> f64 {
+    let value = f64::from(channel) / 255.0;
+    if value <= 0.03928 {
+        value / 12.92
+    } else {
+        ((value + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+fn relative_luminance(hex: &str) -> Option<f64> {
+    let (r, g, b) = hex_to_rgb(hex)?;
+    Some(
+        0.2126 * srgb_channel_to_linear(r)
+            + 0.7152 * srgb_channel_to_linear(g)
+            + 0.0722 * srgb_channel_to_linear(b),
+    )
+}
+
+fn contrast_ratio(hex_a: &str, hex_b: &str) -> Option<f64> {
+    let lum_a = relative_luminance(hex_a)?;
+    let lum_b = relative_luminance(hex_b)?;
+    let lighter = lum_a.max(lum_b);
+    let darker = lum_a.min(lum_b);
+    Some((lighter + 0.05) / (darker + 0.05))
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CustomColorVariant {
+    pub(crate) canvas: String,
+    pub(crate) surface: String,
+    pub(crate) text: String,
+    pub(crate) accent: String,
+    pub(crate) danger: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CustomTheme {
+    pub(crate) light: CustomColorVariant,
+    pub(crate) dark: CustomColorVariant,
+}
+
+impl Default for CustomTheme {
+    fn default() -> Self {
+        Self {
+            light: CustomColorVariant {
+                canvas: "#f3f1eb".to_string(),
+                surface: "#ffffff".to_string(),
+                text: "#18221c".to_string(),
+                accent: "#216446".to_string(),
+                danger: "#9f332e".to_string(),
+            },
+            dark: CustomColorVariant {
+                canvas: "#121814".to_string(),
+                surface: "#19211c".to_string(),
+                text: "#dce5df".to_string(),
+                accent: "#65c68e".to_string(),
+                danger: "#f18e85".to_string(),
+            },
+        }
+    }
+}
+
+fn validate_custom_variant(name: &str, variant: &CustomColorVariant) -> Result<()> {
+    for (field, value) in [
+        ("canvas", &variant.canvas),
+        ("surface", &variant.surface),
+        ("text", &variant.text),
+        ("accent", &variant.accent),
+        ("danger", &variant.danger),
+    ] {
+        if !is_valid_hex_color(value) {
+            return Err(CrosstacheError::invalid_argument(format!(
+                "UI preference custom_theme.{name}.{field} must be a strict six-digit hex color"
+            )));
+        }
+    }
+    for (foreground, background, pair) in [
+        (&variant.text, &variant.canvas, "text-canvas"),
+        (&variant.text, &variant.surface, "text-surface"),
+        (&variant.accent, &variant.surface, "accent-surface"),
+        (&variant.danger, &variant.surface, "danger-surface"),
+    ] {
+        let ratio = contrast_ratio(foreground, background).unwrap_or(0.0);
+        if ratio < CONTRAST_MIN {
+            return Err(CrosstacheError::invalid_argument(format!(
+                "UI preference custom_theme.{name} fails contrast for {pair} ({ratio:.2} < {CONTRAST_MIN})"
+            )));
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -56,6 +172,10 @@ pub(crate) struct UiPreferencesV1 {
     pub(crate) version: u64,
     #[serde(default = "default_theme")]
     pub(crate) theme: String,
+    #[serde(default = "default_palette")]
+    pub(crate) palette: String,
+    #[serde(default)]
+    pub(crate) custom_theme: CustomTheme,
     #[serde(default = "default_exposure_timeout_seconds")]
     pub(crate) exposure_timeout_seconds: u64,
     #[serde(default = "default_density")]
@@ -70,6 +190,8 @@ impl Default for UiPreferencesV1 {
         Self {
             version: UI_PREFERENCES_VERSION,
             theme: default_theme(),
+            palette: default_palette(),
+            custom_theme: CustomTheme::default(),
             exposure_timeout_seconds: default_exposure_timeout_seconds(),
             density: default_density(),
             folder_expansion: default_folder_expansion(),
@@ -79,7 +201,7 @@ impl Default for UiPreferencesV1 {
 }
 
 impl UiPreferencesV1 {
-    pub(crate) fn from_json(value: Value) -> Result<Self> {
+    pub(crate) fn from_json(mut value: Value) -> Result<Self> {
         reject_vault_data_keys(&value)?;
 
         let object = value.as_object().ok_or_else(|| {
@@ -90,6 +212,17 @@ impl UiPreferencesV1 {
             return Err(CrosstacheError::invalid_argument(format!(
                 "Unsupported UI preference version {version}"
             )));
+        }
+
+        // Palette and custom-theme fields did not exist before version 2.
+        // Treat same-named legacy extension data like any other unknown
+        // presentation field rather than reinterpreting it under a newer
+        // schema and rejecting an otherwise valid legacy preferences file.
+        if version < 2 {
+            if let Some(object) = value.as_object_mut() {
+                object.remove("palette");
+                object.remove("custom_theme");
+            }
         }
 
         let mut preferences: Self = serde_json::from_value(value)?;
@@ -109,6 +242,14 @@ impl UiPreferencesV1 {
                 "UI preference 'density' must be comfortable or compact",
             ));
         }
+        if !PALETTE_VALUES.contains(&self.palette.as_str()) {
+            return Err(CrosstacheError::invalid_argument(format!(
+                "UI preference 'palette' must be one of {}",
+                PALETTE_VALUES.join(", ")
+            )));
+        }
+        validate_custom_variant("light", &self.custom_theme.light)?;
+        validate_custom_variant("dark", &self.custom_theme.dark)?;
         validate_widths("secrets", &self.column_widths.secrets, 5)?;
         validate_widths("files", &self.column_widths.files, 4)?;
         Ok(())
@@ -303,7 +444,7 @@ mod tests {
     use crate::web::api::tests::get_json;
     use crate::web::testutil;
 
-    use super::{preference_path_for, PreferenceStore, UiPreferencesV1};
+    use super::{preference_path_for, CustomTheme, PreferenceStore, UiPreferencesV1};
 
     #[test]
     fn preferences_reject_vault_data_keys() {
@@ -352,7 +493,7 @@ mod tests {
         .unwrap();
 
         let canonical = serde_json::to_value(preferences).unwrap();
-        assert_eq!(canonical.as_object().unwrap().len(), 6);
+        assert_eq!(canonical.as_object().unwrap().len(), 8);
         assert!(canonical.get("design").is_none());
     }
 
@@ -378,8 +519,9 @@ mod tests {
     #[test]
     fn defaults_are_safe_and_versioned() {
         let preferences = UiPreferencesV1::default();
-        assert_eq!(preferences.version, 1);
+        assert_eq!(preferences.version, 2);
         assert_eq!(preferences.theme, "system");
+        assert_eq!(preferences.palette, "forest");
         assert_eq!(preferences.exposure_timeout_seconds, 30);
         assert_eq!(preferences.density, "comfortable");
         assert!(preferences.folder_expansion);
@@ -394,6 +536,22 @@ mod tests {
     }
 
     #[test]
+    fn custom_theme_defaults_match_forest_and_pass_validation() {
+        let preferences = UiPreferencesV1::default();
+        assert_eq!(preferences.custom_theme.light.canvas, "#f3f1eb");
+        assert_eq!(preferences.custom_theme.light.surface, "#ffffff");
+        assert_eq!(preferences.custom_theme.light.text, "#18221c");
+        assert_eq!(preferences.custom_theme.light.accent, "#216446");
+        assert_eq!(preferences.custom_theme.light.danger, "#9f332e");
+        assert_eq!(preferences.custom_theme.dark.canvas, "#121814");
+        assert_eq!(preferences.custom_theme.dark.surface, "#19211c");
+        assert_eq!(preferences.custom_theme.dark.text, "#dce5df");
+        assert_eq!(preferences.custom_theme.dark.accent, "#65c68e");
+        assert_eq!(preferences.custom_theme.dark.danger, "#f18e85");
+        assert!(preferences.validate().is_ok());
+    }
+
+    #[test]
     fn unversioned_preferences_migrate_and_unknown_presentation_fields_are_ignored() {
         let preferences = UiPreferencesV1::from_json(json!({
             "theme": "dark",
@@ -402,15 +560,112 @@ mod tests {
         }))
         .unwrap();
 
-        assert_eq!(preferences.version, 1);
+        assert_eq!(preferences.version, 2);
         assert_eq!(preferences.theme, "dark");
         assert_eq!(preferences.density, "compact");
         assert_eq!(preferences.exposure_timeout_seconds, 30);
+        assert_eq!(preferences.palette, "forest");
+        assert_eq!(preferences.custom_theme, CustomTheme::default());
+    }
+
+    #[test]
+    fn legacy_versions_ignore_fields_that_only_became_valid_in_version_two() {
+        let preferences = UiPreferencesV1::from_json(json!({
+            "version": 1,
+            "theme": "dark",
+            "palette": "legacy-extension-value",
+            "custom_theme": {"legacy": "unvalidated extension data"}
+        }))
+        .unwrap();
+
+        assert_eq!(preferences.version, 2);
+        assert_eq!(preferences.theme, "dark");
+        assert_eq!(preferences.palette, "forest");
+        assert_eq!(preferences.custom_theme, CustomTheme::default());
     }
 
     #[test]
     fn unsupported_versions_are_rejected_without_guessing_at_migration() {
-        assert!(UiPreferencesV1::from_json(json!({"version": 2})).is_err());
+        assert!(UiPreferencesV1::from_json(json!({"version": 3})).is_err());
+    }
+
+    #[test]
+    fn valid_custom_theme_roundtrips() {
+        let custom_theme = json!({
+            "light": {"canvas": "#ffffff", "surface": "#fafafa", "text": "#000000", "accent": "#003399", "danger": "#a30000"},
+            "dark": {"canvas": "#000000", "surface": "#0a0a0a", "text": "#ffffff", "accent": "#3399ff", "danger": "#ff5555"},
+        });
+        let preferences = UiPreferencesV1::from_json(json!({
+            "version": 2,
+            "palette": "custom",
+            "custom_theme": custom_theme,
+        }))
+        .unwrap();
+
+        assert_eq!(preferences.palette, "custom");
+        assert_eq!(preferences.custom_theme.light.accent, "#003399");
+        assert_eq!(preferences.custom_theme.dark.accent, "#3399ff");
+        let serialized = serde_json::to_value(&preferences).unwrap();
+        assert_eq!(serialized["custom_theme"]["light"]["accent"], "#003399");
+        assert_eq!(serialized["custom_theme"]["dark"]["accent"], "#3399ff");
+    }
+
+    #[test]
+    fn unknown_palette_values_are_rejected() {
+        assert!(
+            UiPreferencesV1::from_json(json!({"version": 2, "palette": "not-a-real-palette"}))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn malformed_custom_theme_hex_is_rejected() {
+        for accent in ["red", "#12345", "#1234567", "rgb(0,0,0)", "216446"] {
+            let value = json!({
+                "version": 2,
+                "custom_theme": {
+                    "light": {"canvas": "#ffffff", "surface": "#fafafa", "text": "#000000", "accent": accent, "danger": "#a30000"},
+                    "dark": {"canvas": "#000000", "surface": "#0a0a0a", "text": "#ffffff", "accent": "#3399ff", "danger": "#ff5555"},
+                }
+            });
+            assert!(
+                UiPreferencesV1::from_json(value).is_err(),
+                "accepted malformed hex {accent}"
+            );
+        }
+    }
+
+    #[test]
+    fn incomplete_or_extra_custom_theme_keys_are_rejected() {
+        let missing_danger = json!({
+            "version": 2,
+            "custom_theme": {
+                "light": {"canvas": "#ffffff", "surface": "#fafafa", "text": "#000000", "accent": "#003399"},
+                "dark": {"canvas": "#000000", "surface": "#0a0a0a", "text": "#ffffff", "accent": "#3399ff", "danger": "#ff5555"},
+            }
+        });
+        assert!(UiPreferencesV1::from_json(missing_danger).is_err());
+
+        let extra_key = json!({
+            "version": 2,
+            "custom_theme": {
+                "light": {"canvas": "#ffffff", "surface": "#fafafa", "text": "#000000", "accent": "#003399", "danger": "#a30000", "mystery": "#123456"},
+                "dark": {"canvas": "#000000", "surface": "#0a0a0a", "text": "#ffffff", "accent": "#3399ff", "danger": "#ff5555"},
+            }
+        });
+        assert!(UiPreferencesV1::from_json(extra_key).is_err());
+    }
+
+    #[test]
+    fn low_contrast_custom_colors_are_rejected() {
+        let value = json!({
+            "version": 2,
+            "custom_theme": {
+                "light": {"canvas": "#808080", "surface": "#888888", "text": "#7a7a7a", "accent": "#8a8a8a", "danger": "#8f8f8f"},
+                "dark": {"canvas": "#000000", "surface": "#0a0a0a", "text": "#ffffff", "accent": "#3399ff", "danger": "#ff5555"},
+            }
+        });
+        assert!(UiPreferencesV1::from_json(value).is_err());
     }
 
     #[tokio::test]
@@ -481,9 +736,10 @@ mod tests {
         .unwrap();
         let store = PreferenceStore::new(path.clone(), 20);
         let migrated = store.load().await.unwrap();
-        assert_eq!(migrated.version, 1);
+        assert_eq!(migrated.version, 2);
         assert_eq!(migrated.theme, "dark");
         assert_eq!(migrated.exposure_timeout_seconds, 20);
+        assert_eq!(migrated.palette, "forest");
 
         store
             .save_json(json!({
@@ -500,7 +756,7 @@ mod tests {
         assert_eq!(disk["theme"], "light");
         assert_eq!(disk["exposure_timeout_seconds"], 20);
         assert!(disk.get("future_presentation").is_none());
-        assert_eq!(disk.as_object().unwrap().len(), 6);
+        assert_eq!(disk.as_object().unwrap().len(), 8);
         assert!(std::fs::read_dir(temp.path()).unwrap().all(|entry| !entry
             .unwrap()
             .file_name()
@@ -533,8 +789,9 @@ mod tests {
 
         let (status, defaults) = get_json(app.clone(), "GET", "/api/preferences", None).await;
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(defaults["version"], 1);
+        assert_eq!(defaults["version"], 2);
         assert_eq!(defaults["theme"], "system");
+        assert_eq!(defaults["palette"], "forest");
         assert_eq!(defaults["exposure_timeout_seconds"], 10);
 
         let (status, saved) = get_json(

--- a/tests/web/ui-context.spec.js
+++ b/tests/web/ui-context.spec.js
@@ -1,4 +1,9 @@
 import { test, expect, expectNoSeriousOrCriticalAxeViolations } from './fixtures.js';
+import { PALETTES } from '../../src/web/assets/theme.js';
+
+async function rootVar(page, name) {
+  return page.evaluate((cssVar) => getComputedStyle(document.documentElement).getPropertyValue(cssVar).trim(), name);
+}
 
 async function createSecret(page, name) {
   await page.locator('#new-secret').click();
@@ -59,9 +64,9 @@ test('Commands, Help, and Settings are real keyboard-accessible surfaces', async
 
   await page.locator('#settings-open').click();
   const settings = page.getByRole('dialog', { name: 'Settings' });
-  await expect(settings.getByLabel('Theme')).toBeFocused();
+  await expect(settings.getByLabel('Mode')).toBeFocused();
   await expect(settings.locator('#settings-error')).toHaveCount(1);
-  await settings.getByLabel('Theme').selectOption('dark');
+  await settings.getByLabel('Mode').selectOption('dark');
   await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
   await expectNoSeriousOrCriticalAxeViolations(page);
   await page.keyboard.press('Escape');
@@ -312,7 +317,7 @@ test('Settings failures remain global after close and explicit Retry recovers sa
   await expect(page.locator('#settings-open')).not.toHaveAttribute('data-error', 'true');
 
   await page.locator('#settings-open').click();
-  await page.getByRole('dialog', { name: 'Settings' }).getByLabel('Theme').selectOption('dark');
+  await page.getByRole('dialog', { name: 'Settings' }).getByLabel('Mode').selectOption('dark');
   await page.keyboard.press('Escape');
   await expect(page.locator('#settings-open')).toBeFocused();
   await expect(status).toBeVisible();
@@ -429,4 +434,118 @@ test('committed capability loss clears Trash while a failed transition preserves
   await expect(page.getByText('old-deleted-secret')).toHaveCount(0);
   await expect(page.locator('#vault-tabs [role="tab"][aria-selected="true"]')).toHaveCount(1);
   await expect(page.locator('#vault-tabs [role="tab"][tabindex="0"]')).toHaveCount(1);
+});
+
+test('built-in palettes and mode combine, persist across reload, and stay axe-clean', async ({ page, baseURL }) => {
+  await page.goto(baseURL);
+  await page.locator('#settings-open').click();
+  const settings = page.getByRole('dialog', { name: 'Settings' });
+  await expect(settings.getByLabel('Mode')).toBeFocused();
+
+  await settings.getByLabel('Color palette').selectOption('nord');
+  await settings.getByLabel('Mode').selectOption('dark');
+  await expect(page.locator('html')).toHaveAttribute('data-palette', 'nord');
+  await expect(page.locator('html')).toHaveAttribute('data-effective-theme', 'dark');
+  await expect.poll(() => rootVar(page, '--color-canvas')).toBe(PALETTES.nord.dark.canvas);
+  await expectNoSeriousOrCriticalAxeViolations(page);
+
+  await page.reload();
+  await expect(page.locator('html')).toHaveAttribute('data-palette', 'nord');
+  await expect(page.locator('html')).toHaveAttribute('data-effective-theme', 'dark');
+  await expect.poll(() => rootVar(page, '--color-canvas')).toBe(PALETTES.nord.dark.canvas);
+});
+
+test('Custom palette: valid edits preview and persist, invalid contrast is blocked with a message, reset restores Forest', async ({ page, baseURL }) => {
+  await page.goto(baseURL);
+  await page.locator('#settings-open').click();
+  const settings = page.getByRole('dialog', { name: 'Settings' });
+
+  const paletteSaved = page.waitForRequest((request) => (
+    request.method() === 'PUT' && request.url().includes('/api/preferences')
+  ));
+  await settings.getByLabel('Color palette').selectOption('custom');
+  await expect(page.locator('#custom-theme-fieldset')).toBeVisible();
+  await expect(page.locator('html')).toHaveAttribute('data-palette', 'custom');
+  await paletteSaved;
+
+  const accentInput = page.locator('#custom-color-accent');
+  const accentSaved = page.waitForRequest((request) => (
+    request.method() === 'PUT' && request.url().includes('/api/preferences')
+  ));
+  await accentInput.fill('#003399');
+  await accentInput.dispatchEvent('input');
+  await expect.poll(() => rootVar(page, '--color-accent')).toBe('#003399');
+  await accentSaved;
+
+  const beforeInvalid = await rootVar(page, '--color-accent');
+  await accentInput.fill('#cccccc');
+  await accentInput.dispatchEvent('input');
+  await expect(page.locator('#custom-theme-status')).toContainText('accent vs surface');
+  await expect(page.locator('#settings-live')).toHaveText('');
+  await expect(accentInput).toHaveAttribute('aria-invalid', 'true');
+  expect(await rootVar(page, '--color-accent')).toBe(beforeInvalid);
+
+  const multiFieldSaved = page.waitForRequest((request) => (
+    request.method() === 'PUT' && request.url().includes('/api/preferences')
+  ));
+  for (const [key, value] of [
+    ['canvas', '#000000'],
+    ['surface', '#000000'],
+    ['text', '#ffffff'],
+    ['accent', '#ffffff'],
+    ['danger', '#ffffff'],
+  ]) {
+    await page.locator(`#custom-color-${key}`).fill(value);
+  }
+  await expect.poll(() => rootVar(page, '--color-canvas')).toBe('#000000');
+  await expect.poll(() => rootVar(page, '--color-accent')).toBe('#ffffff');
+  await multiFieldSaved;
+
+  await page.reload();
+  await page.locator('#settings-open').click();
+  await expect(page.locator('html')).toHaveAttribute('data-palette', 'custom');
+  await expect.poll(() => rootVar(page, '--color-canvas')).toBe('#000000');
+  await expect.poll(() => rootVar(page, '--color-accent')).toBe('#ffffff');
+  await expectNoSeriousOrCriticalAxeViolations(page);
+
+  await page.locator('#theme-select').selectOption('dark');
+  await page.locator('#custom-variant-select').selectOption('dark');
+  const darkSaved = page.waitForRequest((request) => (
+    request.method() === 'PUT' && request.url().includes('/api/preferences')
+  ));
+  await page.locator('#custom-color-accent').fill('#3399ff');
+  await expect.poll(() => rootVar(page, '--color-accent')).toBe('#3399ff');
+  await darkSaved;
+
+  const resetSaved = page.waitForRequest((request) => (
+    request.method() === 'PUT' && request.url().includes('/api/preferences')
+  ));
+  await page.locator('#custom-theme-reset').click();
+  await expect.poll(() => rootVar(page, '--color-accent')).toBe(PALETTES.forest.dark.accent);
+  await resetSaved;
+  await page.reload();
+  await expect(page.locator('html')).toHaveAttribute('data-palette', 'custom');
+  await expect(page.locator('html')).toHaveAttribute('data-effective-theme', 'dark');
+  await expect.poll(() => rootVar(page, '--color-accent')).toBe(PALETTES.forest.dark.accent);
+});
+
+test('accepted custom accents derive readable eyebrow text on the canvas', async ({ page, baseURL }) => {
+  await page.goto(baseURL);
+  await page.locator('#settings-open').click();
+  await page.locator('#palette-select').selectOption('custom');
+
+  for (const [key, value] of [
+    ['canvas', '#767676'],
+    ['text', '#000000'],
+    ['accent', '#767676'],
+    ['danger', '#000000'],
+  ]) {
+    await page.locator(`#custom-color-${key}`).fill(value);
+  }
+
+  await expect.poll(() => rootVar(page, '--color-canvas')).toBe('#767676');
+  await expect.poll(() => rootVar(page, '--color-accent')).toBe('#767676');
+  await expect.poll(() => rootVar(page, '--color-accent-text')).not.toBe('#767676');
+  await expect(page.locator('.eyebrow').first()).not.toHaveCSS('color', 'rgb(118, 118, 118)');
+  await expectNoSeriousOrCriticalAxeViolations(page);
 });


### PR DESCRIPTION
## Summary
- separate display mode from color palette with Forest, Nord, Solarized, High Contrast, and Custom choices
- add guided light/dark custom palette editing with strict persistence and WCAG contrast safeguards
- derive accessible semantic tokens for rails, controls, focus indicators, links, muted text, and initial fallbacks
- migrate UI preferences to version 2 while preserving legacy settings and rejecting unsafe/future shapes

## Verification
- `npm run test:unit` (255 passed)
- `cargo fmt --check`
- `cargo clippy --features ui -- -D warnings`
- `cargo test web:: --features ui`
- `npx playwright test tests/web/ui-context.spec.js --project=functional-chromium` (13 passed)
- independent accessibility, schema, security, and adversarial-color review: PASS

## Security
- custom values are restricted to exact six-digit hex colors and fixed nested keys
- no secrets or vault data are accepted in presentation preferences
- invalid or low-contrast drafts never replace the last valid preview or persisted theme

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches broad presentation and preference persistence (v2 migration) across client and API, but changes are scoped to UI theming with strict validation rather than vault or auth logic.
> 
> **Overview**
> Adds **separate display mode and color palette** choices in Settings (Forest, Nord, Solarized, High Contrast, Custom), with the former “Theme” control renamed to **Mode**.
> 
> A new **`theme.js`** layer resolves palettes into semantic CSS custom properties (including context-rail tokens) and applies them at runtime via **`settings.js`**, replacing duplicated `:root[data-theme=…]` blocks in **`style.css`** with JS-driven variables and accessible pre-JS Forest fallbacks.
> 
> **Custom** palettes get light/dark hex editors with live preview, per-variant drafts, contrast validation (4.5:1), and reset-to-Forest; invalid edits do not overwrite the last valid preview or persisted theme.
> 
> **UI preferences bump to version 2** (`palette`, `custom_theme`) on client and Rust **`/api/preferences`**, with legacy v0/v1 migration that ignores premature `palette`/`custom_theme` keys and server-side hex/contrast rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ca1569e0a811c899d00a01401559882d936d27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->