### PR TITLE
chore: prepare v0.33.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.33.0 — Custom web color themes (2026-08-02)
+
+### Added
+
+- **Customizable web color themes.** Display mode is now independent from the
+  selected palette, with built-in Forest, Nord, Solarized, and High Contrast
+  palettes plus guided light and dark custom color variants.
+- Custom palettes preview live, persist across reloads, support independent
+  light/dark editing and reset, and retain unfinished drafts without applying
+  or saving invalid combinations.
+
+### Security and accessibility
+
+- Custom presentation preferences accept only strict six-digit hex colors and
+  exact versioned fields; unknown, future, malformed, and low-contrast values
+  fail closed without retaining vault data or secret-bearing fields.
+- Semantic foreground, border, hover, danger, focus, rail, and accent-text
+  tokens are derived to preserve WCAG contrast, including before JavaScript
+  loads and for adversarial but otherwise valid custom palettes.
+
 ## v0.32.1 — Web editor field presentation (2026-08-01)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.32.1"
+version = "0.33.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
## Summary
- bump the Crosstache crate and lockfile from 0.32.1 to 0.33.0
- document customizable web color themes and their accessibility/security guarantees

## Verification
- `cargo build`
- `cargo fmt --check`
- `git diff --check`
- confirmed Cargo.toml and Cargo.lock both report 0.33.0

After merge, `v0.33.0` will be tagged from the merged main commit to trigger the release workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release housekeeping only: version bump and changelog text with no runtime code changes in the PR diff.
> 
> **Overview**
> Prepares the **v0.33.0** release by aligning the crate version in `Cargo.toml` and `Cargo.lock` (**0.32.1 → 0.33.0**).
> 
> Adds a new **CHANGELOG** section for v0.33.0 that documents **customizable web color themes** (display mode separate from palette, built-in and custom palettes, live preview and persistence) and notes **fail-closed** validation for custom colors plus **WCAG-oriented** derived semantic tokens. No application or library code changes appear in this diff—only version metadata and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e75b72b31b9c2fc09ea4086a66bbdf57b1e38e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->