### PR TITLE
chore: bump version to 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.34.0 — Keeper Security import/export (2026-08-06)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Version bump for the **v0.34.0** release, covering the Keeper Security JSON import/export work merged in #396.

- `Cargo.toml` 0.33.0 → 0.34.0 (the only version source — build metadata is embedded by the `built` crate at compile time)
- `Cargo.lock` resynced
- `CHANGELOG.md`: `## Unreleased` → `## v0.34.0 — Keeper Security import/export (2026-08-06)`

`release.yml`'s `verify-version` job fails the release when `Cargo.toml` doesn't match the tag, so this has to land on `main` before `v0.34.0` is tagged.

### Release contents

**Added** — `xv vault import --fmt keeper` / `xv vault export --fmt keeper` for the [Keeper import format](https://docs.keeper.io/user-guides/import-records-1/import-json). Keeper logins become typed `login` records; `$oneTimeCode` is stored as encrypted secret material, never a listable tag. Unstorable records are refused individually with reasons and a non-zero exit rather than dropped.

**Fixed** — `xv vault export` / `xv vault import` now work on the local and AWS backends instead of erroring; this applies to the pre-existing `json`/`env`/`txt` formats too.

Two behavior changes to existing commands ride along and are worth noting in case they affect anyone's scripts: `vault export`/`import` becoming available on local/AWS, and `--dry-run` now exiting non-zero when a record can't be imported (so it works as a gate).

### Verification

`cargo fmt --check` clean, `cargo clippy --all-targets` 0 warnings, `cargo test --lib` 1091 passed / 0 failed. Built binary reports `xv 0.34.0`.

After merge: `git tag -a v0.34.0` on the merged commit, which triggers `release.yml` to build and attach the signed cross-platform artifacts that `xv upgrade` consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and changelog header changes with no runtime or security logic modified.
> 
> **Overview**
> Prepares the **v0.34.0** release by aligning the crate version and changelog header with the Keeper Security import/export work already on `main`.
> 
> `Cargo.toml` moves **0.33.0 → 0.34.0** (the sole version source for `built` at compile time), with `Cargo.lock` resynced for the `crosstache` package entry. `CHANGELOG.md` renames `## Unreleased` to **`## v0.34.0 — Keeper Security import/export (2026-08-06)`** without editing the release notes body.
> 
> This must land before tagging `v0.34.0` so `release.yml`'s `verify-version` job passes when the tag is pushed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8068c28e7133c695002d042b99ed11ad8709c4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->