### PR TITLE
fix(keeper): stop dropping key material and password-less records on import

### DIFF
--- a/docs/keeper.md
+++ b/docs/keeper.md
@@ -38,9 +38,10 @@ and its password is encrypted secret material.
 | `login`                      | `f.username` tag                      |
 | `password`                   | record envelope, primary field         |
 | `login_url`                  | `f.url` tag                           |
-| `notes`                      | `note` tag                            |
+| `notes` + `$note` fields     | `note` tag (merged)                   |
 | `folders[].folder`           | `folder` tag, `\` rewritten to `/`    |
-| `custom_fields`              | ordinary tags                         |
+| scalar `custom_fields`       | ordinary tags                         |
+| object `custom_fields`       | record envelope, one field per sub-key |
 | `custom_fields.$oneTimeCode` | record envelope, `one-time-code` field |
 
 A TOTP seed is a second authentication factor, so `$oneTimeCode` is stored as
@@ -54,28 +55,56 @@ Titles pass through `xv`'s usual name sanitization — `Dev Server 1` is stored
 under the secret name `Dev-Server-1` with the original title preserved in the
 `original_name` tag, so it still displays and round-trips as `Dev Server 1`.
 
-### Records without a login or password
+### Object fields hold the real secrets
 
-Not every Keeper record is a login, and none of these are dropped silently:
+Keeper stores its most sensitive values inside *object-valued* custom fields:
 
-| Keeper record has            | Result                                              |
-|------------------------------|-----------------------------------------------------|
-| `login` + `password`         | typed `login` record                                |
-| `password`, no `login`       | plain secret; the password is the value             |
-| `notes` only (a secure note) | plain secret; the notes are the value, with a warning |
-| neither                      | refused, and reported as a failure                  |
-| a `$oneTimeCode`, but not both `login` and `password` | refused, and reported as a failure |
+| Keeper field    | Contains                                        |
+|-----------------|-------------------------------------------------|
+| `$keyPair`      | `privateKey`, `publicKey`                       |
+| `$paymentCard`  | `cardNumber`, `cardSecurityCode`, expiry        |
+| `$passkey`      | `privateKey`, `credentialId`, …                 |
+| `$pamSettings`  | connection and port-forward settings            |
 
-A record with no `login` cannot become a typed `login` record, because that
-type requires a username. It degrades to a plain secret instead.
+Every sub-key is flattened into the **encrypted envelope**, never a tag —
+tags are unencrypted metadata capped at 256 characters, so a private key
+there would be both exposed and rejected by the backend:
 
-A `$oneTimeCode` is the exception to that degrading. A TOTP seed can only be
-kept as encrypted secret material, and the only shape with room for it is a
-typed `login` record — which needs *both* a `login` and a `password`. Every
-other shape is a plain secret whose single value slot is already taken, so the
-seed could only go into a plaintext tag. Rather than downgrade a second
-authentication factor or drop it quietly, such a record is refused with its
-reason. Add the missing field in Keeper, or import that record separately.
+```bash
+xv get "BMO SFTP key" --field private-key
+xv get "BMO SFTP key" --record        # every field as JSON
+```
+
+### Record types
+
+A record must have exactly one primary field, and most Keeper credentials
+have no password — so imports pick a type to suit:
+
+| Keeper record has        | xv type       | Primary field |
+|--------------------------|---------------|---------------|
+| a `$keyPair` private key | `ssh-key`     | `private-key` |
+| a `$paymentCard` number  | `payment-card`| `card-number` |
+| `login` + `password`     | `login`       | `password`    |
+| anything else storable   | `secure-note` | `content`     |
+
+For `secure-note` the primary is taken from the password, else the first
+secret field, else the notes. These are ordinary built-in types — usable from
+`xv set --type` independently of any import.
+
+### The only records that are refused
+
+A record is refused only when it is genuinely empty. In practice that means
+its content was a Keeper **file attachment**, which Keeper's JSON export does
+not include:
+
+```
+[error] Skipping record 'salesforce-private-key': has no password, notes, or
+        custom fields, so there is nothing to store (a Keeper record whose
+        content is a file attachment exports empty — download the attachment
+        from Keeper and add it with 'xv attach')
+```
+
+Download those from Keeper and attach them with `xv attach`.
 
 ## What does not carry over
 
@@ -97,25 +126,36 @@ principals are always named so you can reconstruct them.
 **Multiple folders per record.** A Keeper record can live in several folders at
 once; an `xv` secret has one. The first is used and the rest are reported.
 
-**Duplicate titles.** Legal in Keeper, where folders disambiguate. Two titles
-that resolve to the same secret name are refused rather than silently
-overwriting each other — rename one in Keeper and re-import.
+**Duplicate titles are renamed, not refused.** Legal in Keeper, where folders
+disambiguate. xv has one flat namespace per vault, so the second and later
+records are qualified by their folder where that distinguishes them, and
+otherwise get a numeric suffix. The original title is always preserved in the
+`original_name` tag.
 
-## Records that get refused
+```
+Finance/American Express -> Finance American Express
+same folder, 2x github   -> github.com, github.com 2
+```
 
-Refusals are per-record: everything else in the file still imports, the reason
-is printed, and the command exits non-zero so a scripted migration cannot
-silently lose secrets.
+## Oversized values
 
-- **Nothing storable** — no password and no notes.
-- **A name collision** with an earlier record in the same file.
-- **An unusable folder path** — `xv` caps folder names at 50 characters and
-  nesting at 10 levels.
-- **Too many tags for the backend.** Azure Key Vault allows 15 tags per secret,
-  and `xv`'s own bookkeeping uses some of them, so a record with many
-  `custom_fields` can exceed the cap. This is checked *before* any write, so it
-  fails cleanly instead of half-writing. The same file imports without
-  complaint into the local backend, which has no tag limit.
+Azure caps a tag value at 256 characters. A `note` or URL over that limit is
+stored as an **encrypted envelope field** instead of a tag, rather than failing
+the record:
+
+```
+[warn] Sendgrid BQM Data Jobs: note is 1495 characters, over the backend's
+       256-character tag limit; stored as an encrypted 'note' field instead
+       of listable metadata.
+```
+
+Nothing is lost or truncated; the value simply stops being listable in
+`xv ls`. This only happens where the backend actually requires it — the local
+backend has no tag cap, so the same file keeps its notes listable there.
+
+A record whose tag *count* would exceed the backend's limit (15 on Azure) is
+still refused, and that check runs **before** any write, so it fails cleanly
+rather than part-way through.
 
 ## Export notes
 

--- a/src/records/keeper.rs
+++ b/src/records/keeper.rs
@@ -6,28 +6,40 @@
 //!
 //! # Mapping
 //!
-//! A Keeper record maps onto an xv typed `login` record wherever it can:
+//! | Keeper                       | xv                                         |
+//! |------------------------------|--------------------------------------------|
+//! | `title`                      | secret name (sanitized; original in a tag) |
+//! | `login`                      | `f.username` tag                           |
+//! | `password`                   | envelope primary field                     |
+//! | `login_url`                  | `f.url` tag                                |
+//! | `notes`, `$note` fields      | `note` tag (merged)                        |
+//! | `folders[].folder`           | `folder` tag (`\` → `/`)                   |
+//! | scalar `custom_fields`       | user tags                                  |
+//! | `$secret:*`, `$oneTimeCode`  | envelope fields                            |
+//! | object `custom_fields`       | envelope fields, one per sub-key           |
 //!
-//! | Keeper                  | xv                                        |
-//! |-------------------------|-------------------------------------------|
-//! | `title`                 | secret name (sanitized; original in a tag) |
-//! | `login`                 | `f.username` tag                          |
-//! | `password`              | envelope primary field (`password`)        |
-//! | `login_url`             | `f.url` tag                               |
-//! | `notes`                 | `note` tag                                |
-//! | `folders[].folder`      | `folder` tag (`\` → `/`)                  |
-//! | `custom_fields`         | user tags                                 |
-//! | `custom_fields.$oneTimeCode` | envelope `one-time-code` field       |
+//! ## Why object fields are always envelope material
 //!
-//! Records that carry no `login` cannot satisfy the `login` type's required
-//! `username` field, so they degrade to a plain (untyped) secret rather than
-//! being dropped — see [`plan_import`].
+//! Keeper keeps its most sensitive values inside *object-valued* custom
+//! fields: `$keyPair` holds `privateKey`/`publicKey`, `$paymentCard` holds
+//! `cardNumber`/`cardSecurityCode`, `$passkey` holds a `privateKey`. Every
+//! sub-key is therefore flattened into the encrypted envelope, never a tag —
+//! tags are unencrypted metadata and capped at 256 characters, so a private
+//! key there would be both exposed and rejected. Over-protecting a
+//! `publicKey` costs nothing; under-protecting a `privateKey` is a leak.
 //!
-//! The one exception is a `$oneTimeCode`: a TOTP seed can only live in a
-//! record envelope, which requires the typed shape (both a `login` and a
-//! `password`). A record carrying a seed in any other shape is refused, since
-//! the alternatives are dropping a second authentication factor or writing it
-//! into a listable tag.
+//! ## Choosing a record type
+//!
+//! A record must have exactly one primary field, and most Keeper credentials
+//! have no password at all (in a 434-record production export, none of the 27
+//! SSH keypairs had a login and only 5 had a password). Type selection is, in
+//! order: `ssh-key` when a private key is present, `payment-card` when a card
+//! number is, `login` for a username/password pair, and `secure-note`
+//! otherwise — with the primary taken from password, then the first secret
+//! field, then the notes.
+//!
+//! Only a record with genuinely nothing in it is refused. That happens when
+//! its content was a Keeper *file attachment*, which the JSON export omits.
 //!
 //! # Deliberate gaps
 //!
@@ -194,24 +206,24 @@ pub fn plan_import(
     // can reconstruct the grants with `xv share`.
     warn_about_shared_folders(file, &mut plan.warnings);
 
-    let login_type = find_type(types, LOGIN_TYPE).ok_or_else(|| {
-        CrosstacheError::config(format!(
-            "record type '{LOGIN_TYPE}' is not defined; Keeper import needs it to store \
-             username/password records. Did a [types.{LOGIN_TYPE}] block in config override \
-             the built-in?"
-        ))
-    })?;
+    // Every type an import can select must exist before any record is
+    // translated, so a config block shadowing one fails the whole import with
+    // a clear message rather than a run of per-record refusals.
+    for required in [LOGIN_TYPE, "ssh-key", "payment-card", "secure-note"] {
+        if find_type(types, required).is_none() {
+            return Err(CrosstacheError::config(format!(
+                "record type '{required}' is not defined; Keeper import needs it. Did a \
+                 [types.{required}] block in config override the built-in?"
+            )));
+        }
+    }
 
-    // Collisions are tracked on the SANITIZED name, because that (not the
-    // raw title) is what the backend keys on: "My Server" and "My/Server"
-    // both sanitize to "My-Server" and the second would silently overwrite
-    // the first.
-    let mut used_names: HashSet<String> = HashSet::new();
+    let mut used_names = NameAllocator::default();
 
     for record in &file.records {
         match plan_record(
             record,
-            login_type,
+            types,
             caps,
             backend_kind,
             &mut used_names,
@@ -230,13 +242,294 @@ pub fn plan_import(
     Ok(plan)
 }
 
+/// Keeper encodes a custom-field key as `$<type>:<label>:<n>`, `$<type>::<n>`,
+/// or a bare `$<type>`; a user-named field carries no `$` at all. Returns the
+/// Keeper base type (when typed) and the label to store the value under.
+fn parse_field_key(key: &str) -> (Option<&str>, String) {
+    let Some(body) = key.strip_prefix('$') else {
+        return (None, key.to_string());
+    };
+    let mut parts = body.split(':');
+    let base = parts.next().unwrap_or("");
+    let label = parts.next().unwrap_or("").trim();
+    let display = if label.is_empty() { base } else { label };
+    (Some(base), display.to_string())
+}
+
+/// Keeper base types whose scalar value is secret material. Anything not
+/// listed (text, host, email, url, note, …) is ordinary listable metadata.
+const SECRET_BASE_TYPES: &[&str] = &[
+    "secret",
+    "password",
+    "oneTimeCode",
+    "trafficEncryptionSeed",
+    "pinCode",
+    "privateKey",
+    "keyPair",
+    "paymentCard",
+    "passkey",
+    "bankAccount",
+];
+
+/// camelCase / spaced / underscored -> kebab-case, matching the field-name
+/// charset `RecordType::validate` enforces.
+fn kebab(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = String::with_capacity(s.len() + 4);
+    for (i, &ch) in chars.iter().enumerate() {
+        if ch.is_ascii_uppercase() {
+            let prev = i.checked_sub(1).map(|p| chars[p]);
+            let next = chars.get(i + 1).copied();
+            // Split on a lower->upper boundary ("hostName"), and also at the
+            // end of an acronym run ("privatePEMKey" -> private-pem-key);
+            // without the second rule the acronym swallows the next word.
+            let after_word = prev.is_some_and(|p| p.is_ascii_lowercase() || p.is_ascii_digit());
+            let acronym_end = prev.is_some_and(|p| p.is_ascii_uppercase())
+                && next.is_some_and(|n| n.is_ascii_lowercase());
+            if after_word || acronym_end {
+                out.push('-');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else if ch.is_ascii_lowercase() || ch.is_ascii_digit() {
+            out.push(ch);
+        } else {
+            out.push('-');
+        }
+    }
+    // Collapse and trim separators so the result is a legal field name.
+    let mut collapsed = String::with_capacity(out.len());
+    for ch in out.chars() {
+        if ch == '-' && collapsed.ends_with('-') {
+            continue;
+        }
+        collapsed.push(ch);
+    }
+    collapsed.trim_matches('-').to_string()
+}
+
+/// Envelope field name for one sub-key of a Keeper object field.
+///
+/// The special cases are exactly the sub-keys the `ssh-key` and
+/// `payment-card` types declare, so a flattened object lands on its type's
+/// real fields rather than shadowing them with a near-duplicate name.
+fn object_field_name(base: &str, sub: &str) -> String {
+    match (base, sub) {
+        ("keyPair", "privateKey") => "private-key".to_string(),
+        ("keyPair", "publicKey") => "public-key".to_string(),
+        ("paymentCard", "cardNumber") => "card-number".to_string(),
+        ("paymentCard", "cardSecurityCode") => "card-security-code".to_string(),
+        ("paymentCard", "cardExpirationDate") => "card-expiration-date".to_string(),
+        _ => {
+            let b = kebab(base);
+            let s = kebab(sub);
+            if b.is_empty() {
+                s
+            } else if s.is_empty() {
+                b
+            } else {
+                format!("{b}-{s}")
+            }
+        }
+    }
+}
+
+/// A record's custom fields, split by where they can legally be stored.
+#[derive(Default)]
+struct Classified {
+    /// Listable metadata, destined for plain tags.
+    tags: BTreeMap<String, String>,
+    /// Encrypted envelope fields.
+    secrets: BTreeMap<String, String>,
+    /// Which Keeper object types were present, for type selection.
+    objects: BTreeMap<String, BTreeMap<String, String>>,
+    /// Text from Keeper `$note` fields, merged into the record's note.
+    notes: Vec<String>,
+    /// Keeper base type -> the tag label its scalar value was stored under.
+    /// Lets a record type claim a value by Keeper's *type* (`$host`) rather
+    /// than the user-chosen label ("Host", "Server", …), which varies.
+    by_base: BTreeMap<String, String>,
+}
+
+/// Splits `custom_fields` into tags and envelope material.
+///
+/// Every sub-key of an object-valued field becomes an envelope field: those
+/// objects are where Keeper keeps private keys, card numbers and passkeys, and
+/// a tag is both size-limited and unencrypted. Over-protecting a `publicKey`
+/// or a `city` costs nothing; under-protecting a `privateKey` is a leak.
+fn classify_custom_fields(
+    record: &KeeperRecord,
+    title: &str,
+    warnings: &mut Vec<String>,
+) -> Classified {
+    let mut out = Classified::default();
+
+    for (key, raw) in &record.custom_fields {
+        let (base, label) = parse_field_key(key);
+
+        if let Some(obj) = raw.as_object() {
+            // A user-named object field has no Keeper base type, so its own
+            // label is the parent name — otherwise its sub-keys would collide
+            // with any other object's identically-named sub-key.
+            let base_name = base.unwrap_or(label.as_str());
+            let mut flat = BTreeMap::new();
+            for (sub, val) in obj {
+                let text = match val {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Null => continue,
+                    // A nested object/array has no flat rendering; keep it as
+                    // JSON rather than drop it.
+                    other => other.to_string(),
+                };
+                if text.trim().is_empty() {
+                    continue;
+                }
+                flat.insert(sub.clone(), text.clone());
+                out.secrets.insert(object_field_name(base_name, sub), text);
+            }
+            if !flat.is_empty() {
+                out.objects.insert(base_name.to_string(), flat);
+            }
+            continue;
+        }
+
+        let Some(value) = stringify_custom_field(raw) else {
+            // Arrays remain unrepresentable as a single field.
+            warnings.push(format!(
+                "{title}: custom field '{key}' is a JSON {} and was dropped",
+                json_kind(raw)
+            ));
+            continue;
+        };
+        if value.trim().is_empty() {
+            continue;
+        }
+
+        if key == KEEPER_ONE_TIME_CODE {
+            out.secrets.insert(ONE_TIME_CODE_FIELD.to_string(), value);
+            continue;
+        }
+
+        // `$note` is Keeper's note *field type*, not a user field that happens
+        // to be called "note". It is frequently a record's only content, so
+        // treating it as a reserved-tag collision would discard the record
+        // entirely.
+        if base == Some("note") {
+            out.notes.push(value);
+            continue;
+        }
+
+        if base.is_some_and(|b| SECRET_BASE_TYPES.contains(&b)) {
+            out.secrets.insert(kebab(&label), value);
+            continue;
+        }
+
+        if let Some(reason) = reserved_tag_reason(&label) {
+            // Rename rather than drop: the name is unusable, the value is
+            // still the user's data.
+            let renamed = format!("keeper-{label}");
+            warnings.push(format!(
+                "{title}: custom field '{key}' {reason}; stored as '{renamed}' instead"
+            ));
+            out.tags.insert(renamed, value);
+            continue;
+        }
+        if let Some(b) = base {
+            out.by_base.entry(b.to_string()).or_insert(label.clone());
+        }
+        out.tags.insert(label, value);
+    }
+
+    out
+}
+
+impl Classified {
+    /// Removes and returns the scalar value Keeper stored under base type
+    /// `base`, whatever label the user gave it.
+    fn take_by_base(&mut self, base: &str) -> Option<String> {
+        let label = self.by_base.remove(base)?;
+        self.tags.remove(&label)
+    }
+}
+
+/// The record type a Keeper record maps onto, plus the field its primary
+/// value came from.
+struct TypeChoice {
+    type_name: &'static str,
+    primary_field: &'static str,
+    primary_value: String,
+}
+
+/// Chooses the record type. A record must have exactly one primary field, so
+/// this is also what decides whether a password-less record is storable at
+/// all.
+fn choose_type(
+    password: Option<&str>,
+    username: Option<&str>,
+    notes: Option<&str>,
+    class: &mut Classified,
+) -> Option<TypeChoice> {
+    // An SSH keypair: the private key is the record's reason to exist.
+    if let Some(pk) = class.secrets.get("private-key").cloned() {
+        if class.objects.contains_key("keyPair") {
+            class.secrets.remove("private-key");
+            return Some(TypeChoice {
+                type_name: "ssh-key",
+                primary_field: "private-key",
+                primary_value: pk,
+            });
+        }
+    }
+
+    // A payment card.
+    if let Some(num) = class.secrets.get("card-number").cloned() {
+        if class.objects.contains_key("paymentCard") {
+            class.secrets.remove("card-number");
+            return Some(TypeChoice {
+                type_name: "payment-card",
+                primary_field: "card-number",
+                primary_value: num,
+            });
+        }
+    }
+
+    // The classic case: a username/password login.
+    if let (Some(pw), Some(_)) = (password, username) {
+        return Some(TypeChoice {
+            type_name: LOGIN_TYPE,
+            primary_field: "password",
+            primary_value: pw.to_string(),
+        });
+    }
+
+    // Everything else that still carries secret material. Precedence puts the
+    // most credential-like value in the primary slot so plain `xv get` returns
+    // what the user most likely wants.
+    let content = password
+        .map(str::to_string)
+        .or_else(|| {
+            // The first remaining envelope field, deterministic by name.
+            class.secrets.keys().next().cloned().map(|k| {
+                let v = class.secrets.get(&k).cloned().unwrap_or_default();
+                class.secrets.remove(&k);
+                v
+            })
+        })
+        .or_else(|| notes.map(str::to_string))?;
+
+    Some(TypeChoice {
+        type_name: "secure-note",
+        primary_field: "content",
+        primary_value: content,
+    })
+}
+
 /// Translates one record. `Err` carries the human-readable refusal reason.
 fn plan_record(
     record: &KeeperRecord,
-    login_type: &RecordType,
+    types: &[RecordType],
     caps: &BackendCapabilities,
     backend_kind: BackendKind,
-    used_names: &mut HashSet<String>,
+    used_names: &mut NameAllocator,
     warnings: &mut Vec<String>,
 ) -> std::result::Result<Option<SecretRequest>, String> {
     let title = display_title(&record.title);
@@ -245,179 +538,179 @@ fn plan_record(
         return Err("record has no title, so it has no secret name to store under".to_string());
     }
 
-    // Resolve the secret name up front: a collision is a refusal, not an
-    // overwrite.
-    let name = unique_name(&record.title, used_names)?;
-
-    // Split custom fields: the TOTP seed is secret material, everything else
-    // is a listable tag.
-    let mut user_tags: BTreeMap<String, String> = BTreeMap::new();
-    let mut one_time_code: Option<String> = None;
-    for (key, raw) in &record.custom_fields {
-        let Some(value) = stringify_custom_field(raw) else {
-            warnings.push(format!(
-                "{title}: custom field '{key}' is a JSON {} and cannot be stored as a tag; dropped",
-                json_kind(raw)
-            ));
-            continue;
-        };
-        if key == KEEPER_ONE_TIME_CODE {
-            one_time_code = Some(value);
-            continue;
-        }
-        if let Some(reason) = reserved_tag_reason(key) {
-            warnings.push(format!(
-                "{title}: custom field '{key}' {reason}; dropped to avoid corrupting record \
-                 bookkeeping"
-            ));
-            continue;
-        }
-        user_tags.insert(key.clone(), value);
-    }
-
     let folder = resolve_folder(record, warnings, &title)?;
-    let note = record.notes.as_ref().and_then(|s| non_empty(s));
+    let mut class = classify_custom_fields(record, &title, warnings);
 
-    // A record needs *something* to store as its value. Password first; a
-    // password-less record (a Keeper secure note) falls back to its notes so
-    // it isn't dropped.
+    // Keeper's own `notes` plus any `$note` custom fields, which are often a
+    // record's only content.
+    let note = {
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(n) = record.notes.as_ref().and_then(|s| non_empty(s)) {
+            parts.push(n);
+        }
+        parts.extend(class.notes.iter().cloned());
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join("\n\n"))
+        }
+    };
     let password = record.password.as_ref().and_then(|s| non_empty(s));
     let username = record.login.as_ref().and_then(|s| non_empty(s));
 
-    // A TOTP seed can only be stored as secret material, and the only shape
-    // with room for it is a typed `login` record — which needs BOTH a password
-    // (the primary field) and a username (required by the type). Any other
-    // shape is a plain secret whose single value slot is already spoken for,
-    // so the seed could only land in a plaintext tag.
-    //
-    // This guard covers every such shape at once, deliberately: it previously
-    // lived inside the password-without-login arm alone, which let a
-    // password-less secure note carrying a `$oneTimeCode` through and dropped
-    // the seed silently.
-    if one_time_code.is_some() && !(password.is_some() && username.is_some()) {
-        return Err(format!(
-            "has a {KEEPER_ONE_TIME_CODE} TOTP seed, but without both a 'login' and a \
-             'password' it cannot be stored as a typed '{LOGIN_TYPE}' record, and a plain \
-             secret has nowhere to keep the seed except a plaintext tag; add the missing \
-             field in Keeper, or import this record separately"
-        ));
-    }
-
-    let (content_type, value, field_tags) = match (&password, &username) {
-        // Full login record: typed, with the password in the envelope.
-        (Some(password), Some(username)) => {
-            let mut metadata: BTreeMap<String, String> = BTreeMap::new();
-            metadata.insert("username".to_string(), username.clone());
-            if let Some(url) = record.login_url.as_ref().and_then(|s| non_empty(s)) {
-                metadata.insert("url".to_string(), url);
-            }
-
-            let mut envelope: BTreeMap<String, String> = BTreeMap::new();
-            envelope.insert(login_type.primary().name.clone(), password.clone());
-            if let Some(code) = &one_time_code {
-                envelope.insert(ONE_TIME_CODE_FIELD.to_string(), code.clone());
-            }
-
-            let field_tags: BTreeMap<String, String> = metadata
-                .iter()
-                .map(|(k, v)| (format!("{FIELD_TAG_PREFIX}{k}"), v.clone()))
-                .collect();
-
-            let reserved = predicted_reserved_tag_count(
-                backend_kind,
-                true, // xv-type
-                false,
-                note.is_some(),
-                folder.is_some(),
-                false,
-            );
-            check_tag_budget(caps, reserved, &field_tags, &user_tags).map_err(|e| e.to_string())?;
-
-            let envelope_value = encode_envelope(&envelope).map_err(|e| e.to_string())?;
-            (
-                Some(RECORD_CONTENT_TYPE.to_string()),
-                envelope_value,
-                field_tags,
-            )
-        }
-        // No username: the `login` type's required `username` can't be
-        // satisfied, so store a plain secret rather than an invalid record.
-        (Some(password), None) => {
-            let mut extra = user_tags.clone();
-            if let Some(url) = record.login_url.as_ref().and_then(|s| non_empty(s)) {
-                extra.insert("url".to_string(), url);
-            }
-            // A `$oneTimeCode` here was already refused by the guard above.
-            let reserved = predicted_reserved_tag_count(
-                backend_kind,
-                false,
-                false,
-                note.is_some(),
-                folder.is_some(),
-                false,
-            );
-            check_tag_budget(caps, reserved, &BTreeMap::new(), &extra)
-                .map_err(|e| e.to_string())?;
-            user_tags = extra;
-            (
-                Some("text/plain".to_string()),
-                password.clone(),
-                BTreeMap::new(),
-            )
-        }
-        // No password at all: keep the record only if its notes carry
-        // content, which is how Keeper stores secure notes.
-        (None, _) => {
-            let Some(notes) = note.clone() else {
-                return Err(
-                    "has neither a password nor notes, so there is nothing to store".to_string(),
-                );
-            };
-            let reserved = predicted_reserved_tag_count(
-                backend_kind,
-                false,
-                false,
-                false, // notes became the value, not the note tag
-                folder.is_some(),
-                false,
-            );
-            check_tag_budget(caps, reserved, &BTreeMap::new(), &user_tags)
-                .map_err(|e| e.to_string())?;
-            warnings.push(format!(
-                "{title}: no password; stored its notes as the secret value"
-            ));
-            return Ok(Some(SecretRequest {
-                name,
-                value: Zeroizing::new(notes),
-                content_type: Some("text/plain".to_string()),
-                enabled: Some(true),
-                expires_on: None,
-                not_before: None,
-                tags: Some(user_tags.into_iter().collect()),
-                groups: None,
-                note: None,
-                folder,
-            }));
-        }
+    let Some(choice) = choose_type(
+        password.as_deref(),
+        username.as_deref(),
+        note.as_deref(),
+        &mut class,
+    ) else {
+        // Typically a Keeper record whose content is a file attachment:
+        // Keeper's JSON export carries record fields only, so such a record
+        // arrives genuinely empty and no import can recover it.
+        return Err(
+            "has no password, notes, or custom fields, so there is nothing to store (a Keeper \
+             record whose content is a file attachment exports empty — download the attachment \
+             from Keeper and add it with 'xv attach')"
+                .to_string(),
+        );
     };
 
-    let mut tags: HashMap<String, String> = HashMap::new();
-    if content_type.as_deref() == Some(RECORD_CONTENT_TYPE) {
-        tags.insert(TYPE_TAG.to_string(), login_type.name.clone());
+    let record_type = find_type(types, choice.type_name).ok_or_else(|| {
+        format!(
+            "record type '{}' is not defined; a config [types.{}] block may be overriding the \
+             built-in",
+            choice.type_name, choice.type_name
+        )
+    })?;
+
+    // The name is allocated only once the record is known to be storable, so
+    // a refused record never consumes a name its successor could have used.
+    let name = used_names.allocate(&record.title, folder.as_deref(), warnings);
+
+    // Metadata fields declared by the chosen type.
+    let mut metadata: BTreeMap<String, String> = BTreeMap::new();
+    if let Some(u) = username.clone() {
+        if record_type.field("username").is_some() {
+            metadata.insert("username".to_string(), u);
+        }
     }
+    if let Some(url) = record.login_url.as_ref().and_then(|s| non_empty(s)) {
+        if record_type.field("url").is_some() {
+            metadata.insert("url".to_string(), url);
+        } else {
+            class.tags.insert("url".to_string(), url);
+        }
+    }
+    // Promote Keeper-typed scalars onto the declared fields of the chosen
+    // type, so `$host:Server:1` lands on `f.host` rather than a tag named
+    // after whatever label the user happened to pick.
+    for (base, declared) in [("host", "host"), ("text", "cardholder-name")] {
+        if record_type.field(declared).is_none() {
+            continue;
+        }
+        if base == "text" && declared == "cardholder-name" {
+            // Only the cardholder-name text field, not every $text field.
+            if class.by_base.get("text").map(String::as_str) != Some("cardholderName") {
+                continue;
+            }
+        }
+        if let Some(v) = class.take_by_base(base) {
+            metadata.insert(declared.to_string(), v);
+        }
+    }
+
+    // Envelope: the primary plus every remaining secret field.
+    let mut envelope: BTreeMap<String, String> = class.secrets.clone();
+    envelope.insert(
+        choice.primary_field.to_string(),
+        choice.primary_value.clone(),
+    );
+
+    // A note that became the primary value must not also be duplicated into a
+    // tag.
+    let note_is_primary = note
+        .as_deref()
+        .is_some_and(|n| n == choice.primary_value.as_str());
+    let mut note_tag = if note_is_primary { None } else { note.clone() };
+
+    // Anything too long for a tag moves into the envelope rather than failing
+    // at the backend. Only when it would actually be rejected, so a backend
+    // without a cap (local) keeps the value listable.
+    if let Some(max) = caps.max_tag_value_len {
+        if let Some(n) = note_tag.clone() {
+            if n.len() > max {
+                warnings.push(format!(
+                    "{title}: note is {} characters, over the backend's {max}-character tag \
+                     limit; stored as an encrypted 'note' field instead of listable metadata",
+                    n.len()
+                ));
+                envelope.insert("note".to_string(), n);
+                note_tag = None;
+            }
+        }
+        let oversized_meta: Vec<String> = metadata
+            .iter()
+            .filter(|(_, v)| v.len() > max)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for key in oversized_meta {
+            let value = metadata.remove(&key).unwrap_or_default();
+            warnings.push(format!(
+                "{title}: field '{key}' is {} characters, over the backend's {max}-character \
+                 tag limit; stored as an encrypted field instead of listable metadata",
+                value.len()
+            ));
+            envelope.insert(key, value);
+        }
+        let oversized_tags: Vec<String> = class
+            .tags
+            .iter()
+            .filter(|(_, v)| v.len() > max)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for key in oversized_tags {
+            let value = class.tags.remove(&key).unwrap_or_default();
+            warnings.push(format!(
+                "{title}: custom field '{key}' is {} characters, over the backend's \
+                 {max}-character tag limit; stored as an encrypted field instead of a tag",
+                value.len()
+            ));
+            envelope.insert(kebab(&key), value);
+        }
+    }
+
+    let field_tags: BTreeMap<String, String> = metadata
+        .iter()
+        .map(|(k, v)| (format!("{FIELD_TAG_PREFIX}{k}"), v.clone()))
+        .collect();
+
+    let reserved = predicted_reserved_tag_count(
+        backend_kind,
+        true, // xv-type
+        false,
+        note_tag.is_some(),
+        folder.is_some(),
+        false,
+    );
+    check_tag_budget(caps, reserved, &field_tags, &class.tags).map_err(|e| e.to_string())?;
+
+    let envelope_value = encode_envelope(&envelope).map_err(|e| e.to_string())?;
+
+    let mut tags: HashMap<String, String> = HashMap::new();
+    tags.insert(TYPE_TAG.to_string(), record_type.name.clone());
     tags.extend(field_tags);
-    tags.extend(user_tags);
+    tags.extend(class.tags.clone());
 
     Ok(Some(SecretRequest {
         name,
-        value: Zeroizing::new(value),
-        content_type,
+        value: Zeroizing::new(envelope_value),
+        content_type: Some(RECORD_CONTENT_TYPE.to_string()),
         enabled: Some(true),
         expires_on: None,
         not_before: None,
         tags: Some(tags),
         groups: None,
-        note,
+        note: note_tag,
         folder,
     }))
 }
@@ -525,23 +818,75 @@ fn warn_about_shared_folders(file: &KeeperFile, warnings: &mut Vec<String>) {
 }
 
 /// Returns the sanitized, collision-free secret name for a Keeper title.
-fn unique_name(title: &str, used: &mut HashSet<String>) -> std::result::Result<String, String> {
-    let sanitized = crate::utils::sanitizer::sanitize_secret_name(title)
-        .map_err(|e| format!("title cannot be turned into a secret name: {e}"))?;
+/// Hands out a unique secret name per record.
+///
+/// Duplicate titles are ordinary in Keeper — folders disambiguate them there,
+/// and a real export has many ("American Express" ×3, "github.com" ×2). xv has
+/// one flat namespace per vault, so a duplicate would silently overwrite its
+/// predecessor. Collisions are tracked on the *sanitized* name because that is
+/// what the backend keys on: "My Server" and "My/Server" both sanitize to
+/// "My-Server".
+#[derive(Default)]
+pub struct NameAllocator {
+    used: HashSet<String>,
+}
 
-    if used.insert(sanitized.clone()) {
-        // The raw title is returned, not the sanitized form: the backend
-        // sanitizes on write and preserves the original in `original_name`,
-        // so passing the title through keeps that round-trip intact.
-        return Ok(title.to_string());
+impl NameAllocator {
+    /// Returns a title guaranteed not to collide with one already handed out.
+    ///
+    /// Prefers qualifying with the record's folder, which keeps the name
+    /// meaningful ("Finance/American Express" -> "Finance-American-Express").
+    /// When the folder does not disambiguate either — common, since duplicates
+    /// often share a folder — falls back to a numeric suffix.
+    fn allocate(
+        &mut self,
+        title: &str,
+        folder: Option<&str>,
+        warnings: &mut Vec<String>,
+    ) -> String {
+        if self.try_take(title) {
+            return title.to_string();
+        }
+
+        if let Some(folder) = folder {
+            // Use the last path segment: the full nested path makes for very
+            // long names and the leaf is what distinguishes siblings.
+            let leaf = folder.rsplit('/').next().unwrap_or(folder);
+            let qualified = format!("{leaf} {title}");
+            if self.try_take(&qualified) {
+                warnings.push(format!(
+                    "{title}: title already used by an earlier record; imported as '{qualified}' \
+                     (original title kept in the original_name tag)"
+                ));
+                return qualified;
+            }
+        }
+
+        for n in 2..=1000 {
+            let candidate = format!("{title} {n}");
+            if self.try_take(&candidate) {
+                warnings.push(format!(
+                    "{title}: title already used by an earlier record; imported as '{candidate}' \
+                     (original title kept in the original_name tag)"
+                ));
+                return candidate;
+            }
+        }
+
+        // Unreachable in practice; fall back to the raw title rather than
+        // panicking, and let the backend's own conflict handling decide.
+        title.to_string()
     }
 
-    // A duplicate title is legal in Keeper (folders disambiguate) but would
-    // silently overwrite here. Refuse rather than guess.
-    Err(format!(
-        "title collides with an earlier record in this file (both resolve to the secret name \
-         '{sanitized}'); rename one in Keeper before importing"
-    ))
+    /// Claims `title`'s sanitized form if free.
+    fn try_take(&mut self, title: &str) -> bool {
+        match crate::utils::sanitizer::sanitize_secret_name(title) {
+            Ok(sanitized) => self.used.insert(sanitized),
+            // An unsanitizable title can't be deduplicated; let it through and
+            // let the backend reject it with a definitive error.
+            Err(_) => true,
+        }
+    }
 }
 
 /// Tags whose meaning xv owns; a Keeper custom field may not claim them.
@@ -927,17 +1272,23 @@ mod tests {
     }
 
     #[test]
-    fn a_record_without_a_login_degrades_to_a_plain_secret() {
+    fn a_record_without_a_login_becomes_a_secure_note() {
+        // No username means the `login` type's required field can't be met,
+        // but the password is still secret material and must stay encrypted.
         let json = r#"{"records":[
           {"title":"Wifi Key","password":"hunter2","notes":"guest network"}
         ]}"#;
         let plan = plan_for(json, local_caps(), BackendKind::Local);
-        assert_eq!(plan.requests.len(), 1);
+        assert_eq!(plan.requests.len(), 1, "{:?}", plan.rejected);
         let req = &plan.requests[0];
-        assert_eq!(req.content_type.as_deref(), Some("text/plain"));
-        assert_eq!(req.value.as_str(), "hunter2");
+        assert_eq!(req.content_type.as_deref(), Some(RECORD_CONTENT_TYPE));
+        assert_eq!(
+            req.tags.as_ref().unwrap().get(TYPE_TAG).map(String::as_str),
+            Some("secure-note")
+        );
+        let env = parse_envelope(&req.value).unwrap();
+        assert_eq!(env.get("content").map(String::as_str), Some("hunter2"));
         assert_eq!(req.note.as_deref(), Some("guest network"));
-        assert!(!req.tags.as_ref().unwrap().contains_key(TYPE_TAG));
     }
 
     #[test]
@@ -946,9 +1297,12 @@ mod tests {
           {"title":"Recovery Steps","notes":"call the bank first"}
         ]}"#;
         let plan = plan_for(json, local_caps(), BackendKind::Local);
-        assert_eq!(plan.requests.len(), 1);
-        assert_eq!(plan.requests[0].value.as_str(), "call the bank first");
-        assert!(plan.warnings.iter().any(|w| w.contains("no password")));
+        assert_eq!(plan.requests.len(), 1, "{:?}", plan.rejected);
+        let env = parse_envelope(&plan.requests[0].value).unwrap();
+        assert_eq!(
+            env.get("content").map(String::as_str),
+            Some("call the bank first")
+        );
     }
 
     #[test]
@@ -961,56 +1315,61 @@ mod tests {
         assert!(plan.rejected[0].1.contains("nothing to store"));
     }
 
-    /// Regression (PR #396 review): a password-less secure note carrying a
-    /// `$oneTimeCode` used to import successfully with the seed silently
-    /// dropped — the guard lived in the password-without-login arm only, and
-    /// this shape returns from a different arm.
+    /// Regression (PR #396 review): a password-less note carrying a
+    /// `$oneTimeCode` once imported with the seed silently dropped. It is no
+    /// longer refused either — `secure-note` gives the seed a real encrypted
+    /// home, which is strictly better than rejecting the record.
     #[test]
-    fn refuses_a_passwordless_note_carrying_a_totp_seed() {
+    fn a_passwordless_note_carrying_a_totp_seed_keeps_the_seed_encrypted() {
         let json = r#"{"records":[{"title":"Note","notes":"recovery info",
           "custom_fields":{"$oneTimeCode":"otpauth://totp/x?secret=JBSWY3DPEHPK3PXP"}}]}"#;
         let plan = plan_for(json, local_caps(), BackendKind::Local);
 
+        assert_eq!(plan.requests.len(), 1, "{:?}", plan.rejected);
+        let req = &plan.requests[0];
+        let env = parse_envelope(&req.value).unwrap();
         assert!(
-            plan.requests.is_empty(),
-            "must not import while dropping the seed: {:?}",
-            plan.requests
+            env.values().any(|v| v.contains("JBSWY3DPEHPK3PXP")),
+            "seed must survive in the envelope: {env:?}"
         );
-        assert_eq!(plan.rejected.len(), 1);
-        assert!(
-            plan.rejected[0].1.contains("TOTP seed"),
-            "{:?}",
-            plan.rejected
-        );
+        for (k, v) in req.tags.as_ref().unwrap() {
+            assert!(
+                !v.contains("JBSWY3DPEHPK3PXP"),
+                "seed leaked into tag '{k}'"
+            );
+        }
     }
 
-    /// The seed must not be lost to the "nothing to store" path either: with
-    /// no password and no notes, the accurate reason is the seed, not
-    /// emptiness.
+    /// A record whose only content is a seed is still worth importing.
     #[test]
-    fn a_record_carrying_only_a_totp_seed_is_refused_for_the_right_reason() {
+    fn a_record_carrying_only_a_totp_seed_is_stored_not_refused() {
         let json = r#"{"records":[{"title":"OnlyOtp",
           "custom_fields":{"$oneTimeCode":"otpauth://totp/x?secret=ABC"}}]}"#;
         let plan = plan_for(json, local_caps(), BackendKind::Local);
 
-        assert!(plan.requests.is_empty());
-        assert_eq!(plan.rejected.len(), 1);
-        assert!(
-            plan.rejected[0].1.contains("TOTP seed"),
-            "expected the seed to be named as the reason, got: {:?}",
-            plan.rejected
-        );
+        assert_eq!(plan.requests.len(), 1, "{:?}", plan.rejected);
+        let env = parse_envelope(&plan.requests[0].value).unwrap();
+        assert!(env.values().any(|v| v.contains("secret=ABC")), "{env:?}");
     }
 
-    /// No TOTP seed involved, so a secure note still imports normally — the
-    /// guard must not over-reach.
     #[test]
     fn a_passwordless_note_without_a_seed_still_imports() {
         let json = r#"{"records":[{"title":"Plain Note","notes":"just text",
           "custom_fields":{"Category":"personal"}}]}"#;
         let plan = plan_for(json, local_caps(), BackendKind::Local);
         assert_eq!(plan.requests.len(), 1, "{:?}", plan.rejected);
-        assert_eq!(plan.requests[0].value.as_str(), "just text");
+        let env = parse_envelope(&plan.requests[0].value).unwrap();
+        assert_eq!(env.get("content").map(String::as_str), Some("just text"));
+        // A plain user field stays listable metadata.
+        assert_eq!(
+            plan.requests[0]
+                .tags
+                .as_ref()
+                .unwrap()
+                .get("Category")
+                .map(String::as_str),
+            Some("personal")
+        );
     }
 
     /// Whatever the shape, a seed is never written into a tag.
@@ -1043,37 +1402,79 @@ mod tests {
     }
 
     #[test]
-    fn refuses_a_totp_seed_that_has_nowhere_safe_to_go() {
-        // No login => plain secret => the one value slot is the password,
-        // so the seed would have to become a plaintext tag. Refuse.
+    fn a_password_without_a_login_still_keeps_its_totp_seed() {
+        // Previously refused: with only `login` available as a typed shape,
+        // there was nowhere to put the seed. `secure-note` removes that
+        // constraint, so the record imports with both values encrypted.
         let json = r#"{"records":[{"title":"T","password":"p","custom_fields":{
           "$oneTimeCode":"otpauth://totp/x?secret=ABC"}}]}"#;
         let plan = plan_for(json, local_caps(), BackendKind::Local);
-        assert!(plan.requests.is_empty());
-        assert_eq!(plan.rejected.len(), 1);
+        assert_eq!(plan.requests.len(), 1, "{:?}", plan.rejected);
+        let env = parse_envelope(&plan.requests[0].value).unwrap();
+        assert_eq!(env.get("content").map(String::as_str), Some("p"));
         assert!(
-            plan.rejected[0].1.contains("TOTP seed"),
-            "{:?}",
-            plan.rejected
+            env.get(ONE_TIME_CODE_FIELD)
+                .is_some_and(|v| v.contains("secret=ABC")),
+            "{env:?}"
         );
     }
 
     #[test]
-    fn colliding_titles_are_rejected_rather_than_overwriting() {
-        // Both sanitize to "My-Server": the second must not clobber the first.
+    fn colliding_titles_are_disambiguated_rather_than_dropped() {
+        // Both sanitize to "My-Server". Neither may be lost, and the second
+        // must not clobber the first.
         let json = r#"{"records":[
           {"title":"My Server","login":"a","password":"1"},
           {"title":"My/Server","login":"b","password":"2"}
         ]}"#;
         let plan = plan_for(json, local_caps(), BackendKind::Local);
-        assert_eq!(plan.requests.len(), 1);
-        assert_eq!(plan.requests[0].name, "My Server");
-        assert_eq!(plan.rejected.len(), 1);
-        assert!(
-            plan.rejected[0].1.contains("collides"),
-            "{:?}",
-            plan.rejected
+        assert_eq!(plan.requests.len(), 2, "{:?}", plan.rejected);
+        assert!(plan.rejected.is_empty());
+
+        let sanitized: Vec<String> = plan
+            .requests
+            .iter()
+            .map(|r| crate::utils::sanitizer::sanitize_secret_name(&r.name).unwrap())
+            .collect();
+        assert_eq!(
+            sanitized.iter().collect::<HashSet<_>>().len(),
+            2,
+            "names must be distinct after sanitization: {sanitized:?}"
         );
+        assert!(plan.warnings.iter().any(|w| w.contains("already used")));
+    }
+
+    #[test]
+    fn a_colliding_title_is_qualified_by_its_folder_when_that_disambiguates() {
+        let json = r#"{"records":[
+          {"title":"American Express","login":"a","password":"1",
+           "folders":[{"folder":"Finance"}]},
+          {"title":"American Express","login":"b","password":"2",
+           "folders":[{"folder":"Cards"}]}
+        ]}"#;
+        let plan = plan_for(json, local_caps(), BackendKind::Local);
+        assert_eq!(plan.requests.len(), 2, "{:?}", plan.rejected);
+        let names: Vec<&str> = plan.requests.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(names[0], "American Express");
+        assert_eq!(
+            names[1], "Cards American Express",
+            "the folder should carry the disambiguation, not a bare counter"
+        );
+    }
+
+    #[test]
+    fn same_folder_collisions_fall_back_to_a_numeric_suffix() {
+        let json = r#"{"records":[
+          {"title":"github.com","login":"a","password":"1","folders":[{"folder":"Web"}]},
+          {"title":"github.com","login":"b","password":"2","folders":[{"folder":"Web"}]},
+          {"title":"github.com","login":"c","password":"3","folders":[{"folder":"Web"}]}
+        ]}"#;
+        let plan = plan_for(json, local_caps(), BackendKind::Local);
+        assert_eq!(plan.requests.len(), 3, "{:?}", plan.rejected);
+        let names: Vec<&str> = plan.requests.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(names[0], "github.com");
+        assert_eq!(names[1], "Web github.com");
+        assert_eq!(names[2], "github.com 2");
     }
 
     #[test]
@@ -1109,26 +1510,36 @@ mod tests {
         let tags = plan.requests[0].tags.as_ref().unwrap();
         assert_eq!(tags.get(TYPE_TAG).map(String::as_str), Some("login"));
         assert_eq!(tags.get("f.username").map(String::as_str), Some("a"));
+        // The reserved names keep their real meaning...
         assert!(!tags.contains_key("original_name"));
+        // ...but the user's values are renamed, not discarded.
+        assert_eq!(
+            tags.get("keeper-original_name").map(String::as_str),
+            Some("evil")
+        );
+        assert_eq!(tags.get("keeper-folder").map(String::as_str), Some("evil"));
         assert_eq!(
             plan.warnings
                 .iter()
-                .filter(|w| w.contains("dropped"))
+                .filter(|w| w.contains("stored as 'keeper-"))
                 .count(),
             4
         );
     }
 
     #[test]
-    fn non_string_custom_fields_are_coerced_and_containers_reported() {
+    fn non_string_custom_fields_are_coerced_and_objects_flattened() {
         let json = r#"{"records":[{"title":"X","login":"a","password":"p",
-          "custom_fields":{"port":8080,"active":true,"nested":{"a":1}}}]}"#;
+          "custom_fields":{"port":8080,"active":true,"nested":{"a":"1"}}}]}"#;
         let plan = plan_for(json, local_caps(), BackendKind::Local);
-        let tags = plan.requests[0].tags.as_ref().unwrap();
+        let req = &plan.requests[0];
+        let tags = req.tags.as_ref().unwrap();
         assert_eq!(tags.get("port").map(String::as_str), Some("8080"));
         assert_eq!(tags.get("active").map(String::as_str), Some("true"));
+        // An object is no longer dropped: its sub-keys become envelope fields.
         assert!(!tags.contains_key("nested"));
-        assert!(plan.warnings.iter().any(|w| w.contains("JSON object")));
+        let env = parse_envelope(&req.value).unwrap();
+        assert_eq!(env.get("nested-a").map(String::as_str), Some("1"));
     }
 
     #[test]
@@ -1182,6 +1593,279 @@ mod tests {
     fn rejects_json_with_no_recognized_arrays() {
         assert!(parse_keeper_file(r#"{"secrets":[]}"#).is_err());
         assert!(parse_keeper_file("not json").is_err());
+    }
+
+    // ── Real-world Keeper shapes (from a 434-record production export) ────
+
+    /// The single most important case: Keeper keeps SSH private keys inside a
+    /// `$keyPair` object, and none of the 27 in the source export had a login
+    /// or (mostly) a password. Dropping the object dropped the private key.
+    #[test]
+    fn a_keypair_record_becomes_an_ssh_key_with_the_private_key_encrypted() {
+        let json = r#"{"records":[{"title":"BMO SFTP key",
+          "custom_fields":{"$keyPair::1":{
+            "privateKey":"-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n",
+            "publicKey":"ssh-rsa AAAAB3Nza"},
+            "$host:Host:1":"sftp.example.com"}}]}"#;
+        let plan = plan_for(json, azure_caps(), BackendKind::Azure);
+        assert_eq!(plan.requests.len(), 1, "{:?}", plan.rejected);
+        let req = &plan.requests[0];
+
+        let tags = req.tags.as_ref().unwrap();
+        assert_eq!(tags.get(TYPE_TAG).map(String::as_str), Some("ssh-key"));
+
+        let env = parse_envelope(&req.value).unwrap();
+        assert!(env
+            .get("private-key")
+            .is_some_and(|v| v.contains("BEGIN OPENSSH")));
+        assert!(env
+            .get("public-key")
+            .is_some_and(|v| v.starts_with("ssh-rsa")));
+
+        // The key material must never appear in listable metadata.
+        for (k, v) in tags {
+            assert!(
+                !v.contains("BEGIN OPENSSH"),
+                "private key leaked into '{k}'"
+            );
+        }
+    }
+
+    /// A keypair with only a public key has no private key to be primary, so
+    /// it cannot be an `ssh-key`; it must still import rather than vanish.
+    #[test]
+    fn a_keypair_with_only_a_public_key_still_imports() {
+        let json = r#"{"records":[{"title":"pub only",
+          "custom_fields":{"$keyPair::1":{"publicKey":"ssh-rsa AAAA"}}}]}"#;
+        let plan = plan_for(json, local_caps(), BackendKind::Local);
+        assert_eq!(plan.requests.len(), 1, "{:?}", plan.rejected);
+        let env = parse_envelope(&plan.requests[0].value).unwrap();
+        assert!(env.values().any(|v| v.contains("ssh-rsa")), "{env:?}");
+    }
+
+    #[test]
+    fn a_payment_card_keeps_number_and_cvv_out_of_tags() {
+        let json = r#"{"records":[{"title":"Amex",
+          "custom_fields":{"$paymentCard::1":{
+             "cardNumber":"4111111111111111",
+             "cardSecurityCode":"123",
+             "cardExpirationDate":"01/2030"},
+             "$text:cardholderName:1":"A Person"}}]}"#;
+        let plan = plan_for(json, azure_caps(), BackendKind::Azure);
+        assert_eq!(plan.requests.len(), 1, "{:?}", plan.rejected);
+        let req = &plan.requests[0];
+        let tags = req.tags.as_ref().unwrap();
+        assert_eq!(tags.get(TYPE_TAG).map(String::as_str), Some("payment-card"));
+
+        let env = parse_envelope(&req.value).unwrap();
+        assert_eq!(
+            env.get("card-number").map(String::as_str),
+            Some("4111111111111111")
+        );
+        assert_eq!(
+            env.get("card-security-code").map(String::as_str),
+            Some("123")
+        );
+        for (k, v) in tags {
+            assert!(!v.contains("4111111111111111"), "PAN leaked into '{k}'");
+            assert!(
+                !v.contains("123") || k.starts_with('f'),
+                "CVV leaked into '{k}'"
+            );
+        }
+        // The cardholder name is not sensitive and stays listable.
+        assert_eq!(
+            tags.get("f.cardholder-name").map(String::as_str),
+            Some("A Person")
+        );
+    }
+
+    /// Keeper's `$type:Label:N` key encoding must be understood, or every
+    /// field name ends up mangled.
+    #[test]
+    fn parses_keeper_typed_field_key_encodings() {
+        assert_eq!(
+            parse_field_key("$keyPair::1"),
+            (Some("keyPair"), "keyPair".into())
+        );
+        assert_eq!(
+            parse_field_key("$text:Bit Strength:1"),
+            (Some("text"), "Bit Strength".into())
+        );
+        assert_eq!(parse_field_key("$note"), (Some("note"), "note".into()));
+        assert_eq!(
+            parse_field_key("Security Group"),
+            (None, "Security Group".into())
+        );
+    }
+
+    #[test]
+    fn kebab_produces_legal_field_names() {
+        assert_eq!(kebab("privateKey"), "private-key");
+        assert_eq!(kebab("privatePEMKey"), "private-pem-key");
+        assert_eq!(kebab("hostName"), "host-name");
+        assert_eq!(kebab("Bit Strength"), "bit-strength");
+        assert_eq!(kebab("card_expiration__date"), "card-expiration-date");
+        assert_eq!(kebab("  spaced  "), "spaced");
+    }
+
+    /// `$secret:` fields are secret material by Keeper's own declaration.
+    #[test]
+    fn keeper_secret_typed_scalars_go_to_the_envelope() {
+        let json = r#"{"records":[{"title":"S","login":"u","password":"p",
+          "custom_fields":{"$secret:privatePEMKey:1":"-----BEGIN RSA-----",
+                           "$trafficEncryptionSeed":"seed-value",
+                           "$host:Server:1":"host.example.com"}}]}"#;
+        let plan = plan_for(json, local_caps(), BackendKind::Local);
+        let req = &plan.requests[0];
+        let env = parse_envelope(&req.value).unwrap();
+        assert!(env.contains_key("private-pem-key"), "{env:?}");
+        assert!(env.contains_key("traffic-encryption-seed"), "{env:?}");
+        // A host is ordinary metadata.
+        let tags = req.tags.as_ref().unwrap();
+        assert!(
+            tags.values().any(|v| v == "host.example.com"),
+            "host should stay listable: {tags:?}"
+        );
+    }
+
+    /// The Azure failure mode from the production import: a note longer than
+    /// the 256-char tag cap reached the backend and came back as an opaque
+    /// HTTP 400.
+    #[test]
+    fn an_oversized_note_moves_into_the_envelope_instead_of_failing() {
+        let long = "x".repeat(1495);
+        let json = format!(
+            r#"{{"records":[{{"title":"Sendgrid","login":"u","password":"p","notes":"{long}"}}]}}"#
+        );
+        let plan = plan_for(&json, azure_caps(), BackendKind::Azure);
+        assert_eq!(plan.requests.len(), 1, "{:?}", plan.rejected);
+        let req = &plan.requests[0];
+        assert!(
+            req.note.is_none(),
+            "oversized note must not be sent as a tag"
+        );
+        let env = parse_envelope(&req.value).unwrap();
+        assert_eq!(env.get("note").map(String::len), Some(1495));
+        assert!(plan
+            .warnings
+            .iter()
+            .any(|w| w.contains("over the backend's")));
+    }
+
+    /// Same value on a backend with no tag cap keeps its listability.
+    #[test]
+    fn an_oversized_note_stays_a_tag_where_the_backend_allows_it() {
+        let long = "x".repeat(1495);
+        let json = format!(
+            r#"{{"records":[{{"title":"Sendgrid","login":"u","password":"p","notes":"{long}"}}]}}"#
+        );
+        let plan = plan_for(&json, local_caps(), BackendKind::Local);
+        assert_eq!(plan.requests[0].note.as_ref().map(String::len), Some(1495));
+    }
+
+    #[test]
+    fn an_oversized_url_moves_into_the_envelope() {
+        let long = format!("https://example.com/{}", "a".repeat(4000));
+        let json = format!(
+            r#"{{"records":[{{"title":"adobe.com","login":"u","password":"p","login_url":"{long}"}}]}}"#
+        );
+        let plan = plan_for(&json, azure_caps(), BackendKind::Azure);
+        assert_eq!(plan.requests.len(), 1, "{:?}", plan.rejected);
+        let req = &plan.requests[0];
+        assert!(!req.tags.as_ref().unwrap().contains_key("f.url"));
+        let env = parse_envelope(&req.value).unwrap();
+        assert!(env.get("url").is_some_and(|v| v.len() > 4000));
+    }
+
+    /// Keeper's `$note` is a field *type*, not a user field named "note".
+    /// In the source export it was 33 records' only content, and treating it
+    /// as a reserved-tag collision discarded every one of them.
+    #[test]
+    fn a_keeper_note_field_is_kept_not_dropped_as_a_reserved_tag() {
+        let json = r#"{"records":[{"title":"Adaxes License",
+          "custom_fields":{"$note::1":"license key: ABC-123"}}]}"#;
+        let plan = plan_for(json, azure_caps(), BackendKind::Azure);
+
+        assert_eq!(plan.requests.len(), 1, "{:?}", plan.rejected);
+        let req = &plan.requests[0];
+        let env = parse_envelope(&req.value).unwrap();
+        assert_eq!(
+            env.get("content").map(String::as_str),
+            Some("license key: ABC-123"),
+            "the $note text is the record's only content and must survive"
+        );
+        assert!(
+            !plan.warnings.iter().any(|w| w.contains("reserved")),
+            "a $note field is not a reserved-tag collision: {:?}",
+            plan.warnings
+        );
+    }
+
+    #[test]
+    fn a_keeper_note_field_merges_with_the_records_own_notes() {
+        let json = r#"{"records":[{"title":"N","login":"u","password":"p",
+          "notes":"first","custom_fields":{"$note::1":"second"}}]}"#;
+        let plan = plan_for(json, local_caps(), BackendKind::Local);
+        assert_eq!(plan.requests[0].note.as_deref(), Some("first\n\nsecond"));
+    }
+
+    /// A record whose content is a Keeper file attachment exports with no
+    /// fields at all. It cannot be recovered, so the reason must say why
+    /// rather than leaving the user hunting.
+    #[test]
+    fn an_attachment_only_record_is_refused_with_an_actionable_reason() {
+        let json = r#"{"records":[{"title":"salesforce-private-key"}]}"#;
+        let plan = plan_for(json, local_caps(), BackendKind::Local);
+        assert_eq!(plan.rejected.len(), 1);
+        assert!(
+            plan.rejected[0].1.contains("attachment"),
+            "{:?}",
+            plan.rejected
+        );
+    }
+
+    /// The invariant that matters most, asserted across every shape at once:
+    /// no import path may put key material, a TOTP seed, or an oversized
+    /// value into a listable tag, and no record may exceed Azure's tag cap.
+    #[test]
+    fn no_shape_leaks_secret_material_or_busts_the_tag_cap() {
+        let mut fields = String::new();
+        for i in 0..6 {
+            fields.push_str(&format!(r#""extra{i}":"v","#));
+        }
+        let shapes = [
+            r#"{"title":"A","login":"u","password":"p","custom_fields":{"$keyPair::1":{"privateKey":"-----BEGIN OPENSSH PRIVATE KEY-----x","publicKey":"ssh-rsa AAAA"}}}"#.to_string(),
+            r#"{"title":"B","custom_fields":{"$keyPair::1":{"privateKey":"-----BEGIN RSA PRIVATE KEY-----y"}}}"#.to_string(),
+            r#"{"title":"C","custom_fields":{"$paymentCard::1":{"cardNumber":"4111111111111111","cardSecurityCode":"999"}}}"#.to_string(),
+            r#"{"title":"D","login":"u","password":"p","custom_fields":{"$oneTimeCode":"otpauth://totp/x?secret=SEED"}}"#.to_string(),
+            format!(r#"{{"title":"E","login":"u","password":"p","notes":"{}","custom_fields":{{{}}}}}"#,
+                    "n".repeat(900), fields.trim_end_matches(',')),
+        ];
+        for shape in shapes {
+            let json = format!(r#"{{"records":[{shape}]}}"#);
+            let plan = plan_for(&json, azure_caps(), BackendKind::Azure);
+            assert_eq!(plan.requests.len(), 1, "{shape}\n{:?}", plan.rejected);
+            let req = &plan.requests[0];
+            let tags = req.tags.as_ref().unwrap();
+
+            assert!(tags.len() <= 15, "{} tags for {shape}", tags.len());
+            for (k, v) in tags {
+                assert!(v.len() <= 256, "tag '{k}' is {} chars", v.len());
+                for marker in [
+                    "PRIVATE KEY",
+                    "BEGIN OPENSSH",
+                    "BEGIN RSA",
+                    "otpauth://",
+                    "4111111111111111",
+                ] {
+                    assert!(!v.contains(marker), "tag '{k}' leaked {marker}");
+                }
+            }
+            if let Some(n) = &req.note {
+                assert!(n.len() <= 256, "note is {} chars", n.len());
+            }
+        }
     }
 
     // ── Export ────────────────────────────────────────────────────────────

--- a/src/records/types.rs
+++ b/src/records/types.rs
@@ -148,7 +148,15 @@ fn field(name: &str, kind: FieldKind, required: bool, primary: bool) -> FieldDef
     }
 }
 
-/// The built-in record types: `login`, `api-key`, `database`.
+/// The built-in record types: `login`, `api-key`, `database`, `ssh-key`,
+/// `payment-card`, `secure-note`.
+///
+/// The last three exist because not every credential has a password. An SSH
+/// keypair, a card, or a free-form secret note has no username/password pair
+/// to hang a `login` record on, and a record must have exactly one primary
+/// field — so without these there is nowhere to put such material except a
+/// plaintext tag, which is not an option for a private key. They are ordinary
+/// types, usable from `xv set --type` independently of any import.
 pub fn builtin_types() -> Vec<RecordType> {
     vec![
         RecordType {
@@ -179,6 +187,43 @@ pub fn builtin_types() -> Vec<RecordType> {
                 field("username", FieldKind::Metadata, false, false),
                 field("password", FieldKind::Secret, true, true),
                 field("connection-string", FieldKind::Secret, false, false),
+            ],
+        },
+        // An SSH keypair. The public key is declared `secret` rather than
+        // metadata not because it needs hiding, but because it routinely
+        // exceeds the 256-character tag-value cap Azure imposes on metadata —
+        // as a tag it would simply fail to write.
+        RecordType {
+            name: "ssh-key".to_string(),
+            source: TypeSource::Builtin,
+            fields: vec![
+                field("host", FieldKind::Metadata, false, false),
+                field("username", FieldKind::Metadata, false, false),
+                field("private-key", FieldKind::Secret, true, true),
+                field("public-key", FieldKind::Secret, false, false),
+                field("passphrase", FieldKind::Secret, false, false),
+            ],
+        },
+        // Every element of a card that can authorize a charge is `secret`;
+        // only the cardholder name is listable metadata.
+        RecordType {
+            name: "payment-card".to_string(),
+            source: TypeSource::Builtin,
+            fields: vec![
+                field("cardholder-name", FieldKind::Metadata, false, false),
+                field("card-number", FieldKind::Secret, true, true),
+                field("card-security-code", FieldKind::Secret, false, false),
+                field("card-expiration-date", FieldKind::Secret, false, false),
+            ],
+        },
+        // The catch-all for secret material with no more specific shape.
+        RecordType {
+            name: "secure-note".to_string(),
+            source: TypeSource::Builtin,
+            fields: vec![
+                field("url", FieldKind::Metadata, false, false),
+                field("username", FieldKind::Metadata, false, false),
+                field("content", FieldKind::Secret, true, true),
             ],
         },
     ]
@@ -321,10 +366,47 @@ mod tests {
     #[test]
     fn builtin_types_are_valid() {
         let types = builtin_types();
-        assert_eq!(types.len(), 3);
+        assert_eq!(types.len(), 6);
         for t in &types {
             t.validate().unwrap_or_else(|e| panic!("{}: {e}", t.name));
         }
+
+        // Names are stable API: `xv set --type <name>` and stored `xv-type`
+        // tags reference them, so a rename silently orphans existing records.
+        let mut names: Vec<&str> = types.iter().map(|t| t.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec![
+                "api-key",
+                "database",
+                "login",
+                "payment-card",
+                "secure-note",
+                "ssh-key"
+            ]
+        );
+
+        // The password-less types exist to give records without a
+        // username/password pair a legal primary field.
+        let ssh = types.iter().find(|t| t.name == "ssh-key").unwrap();
+        assert_eq!(ssh.primary().name, "private-key");
+        // A public key regularly exceeds Azure's 256-char tag cap, so it must
+        // be envelope material, not a metadata tag.
+        assert_eq!(ssh.field("public-key").unwrap().kind, FieldKind::Secret);
+
+        let card = types.iter().find(|t| t.name == "payment-card").unwrap();
+        assert_eq!(card.primary().name, "card-number");
+        for f in ["card-security-code", "card-expiration-date"] {
+            assert_eq!(
+                card.field(f).unwrap().kind,
+                FieldKind::Secret,
+                "{f} must not be listable metadata"
+            );
+        }
+
+        let note = types.iter().find(|t| t.name == "secure-note").unwrap();
+        assert_eq!(note.primary().name, "content");
 
         let login = types.iter().find(|t| t.name == "login").unwrap();
         assert_eq!(login.primary().name, "password");

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1444,8 +1444,15 @@ pub(crate) mod tests {
         assert_eq!(login["fields"][2]["name"], "password");
         assert_eq!(login["fields"][2]["kind"], "secret");
         assert_eq!(login["fields"][2]["primary"], true);
-        // all three builtins present
-        for name in ["login", "api-key", "database"] {
+        // every builtin present
+        for name in [
+            "login",
+            "api-key",
+            "database",
+            "ssh-key",
+            "payment-card",
+            "secure-note",
+        ] {
             assert!(types.iter().any(|t| t["name"] == name), "{name} missing");
         }
     }

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -2361,10 +2361,11 @@ fn keeper_import_reports_unapplied_shared_folder_permissions() {
 }
 
 #[test]
-fn keeper_import_rejects_unstorable_and_colliding_records_nonzero() {
+fn keeper_import_rejects_only_genuinely_empty_records_and_exits_nonzero() {
     let env = TestEnv::new();
-    // "Nothing Here" has no password and no notes; "A/B" and "A B" both
-    // sanitize to the same secret name, so the second must not clobber.
+    // "Nothing Here" is empty (in a real export, a file-attachment record).
+    // "A B" and "A/B" both sanitize to "A-B": neither may be lost, and the
+    // second must not clobber the first.
     let body = r#"{"records":[
       {"title":"Keeper Good","login":"u","password":"p"},
       {"title":"Nothing Here"},
@@ -2383,12 +2384,30 @@ fn keeper_import_rejects_unstorable_and_colliding_records_nonzero() {
         fixture.to_str().unwrap(),
     ]);
     let combined = format!("{stdout}{stderr}");
+    // The empty record is refused, and the reason names the likely cause.
     assert!(combined.contains("nothing to store"), "{combined}");
-    assert!(combined.contains("collides"), "{combined}");
+    assert!(combined.contains("attachment"), "{combined}");
 
-    // The importable records still landed; only the refused ones didn't.
+    // Colliding titles are renamed rather than dropped.
+    assert!(combined.contains("already used"), "{combined}");
     assert_eq!(env.get_raw("Keeper Good"), "p");
     assert_eq!(env.get_raw("A B"), "1");
+
+    // Both colliding records survive under distinct names, so no value was
+    // overwritten by its duplicate.
+    let json = env.xv_ok(&["ls", "--format", "json"]);
+    let listed: serde_json::Value = serde_json::from_str(&json).expect("ls json");
+    let names: Vec<&str> = listed
+        .as_array()
+        .expect("array")
+        .iter()
+        .filter_map(|s| s["original_name"].as_str())
+        .collect();
+    assert_eq!(
+        names.iter().filter(|n| n.starts_with("A")).count(),
+        2,
+        "both colliding records should exist: {names:?}"
+    );
 }
 
 #[test]
@@ -2475,4 +2494,73 @@ fn keeper_export_round_trips_an_imported_file() {
     let record = env.xv_ok(&["get", "Dev Server 1", "--record"]);
     assert!(record.contains("\"password\": \"123123123\""), "{record}");
     env.xv_ok(&["context", "use", "default", "--global"]);
+}
+
+/// End-to-end proof of the fix that mattered most: Keeper keeps SSH private
+/// keys inside a `$keyPair` object with no login and usually no password, so
+/// the object was dropped and the record then discarded as empty. Drives the
+/// real binary to confirm the key survives and stays out of listable metadata.
+#[test]
+fn keeper_import_stores_a_keypair_as_an_ssh_key_record() {
+    let env = TestEnv::new();
+    let body = r#"{"records":[
+      {"title":"BMO SFTP key",
+       "custom_fields":{
+         "$keyPair::1":{
+           "privateKey":"-----BEGIN OPENSSH PRIVATE KEY-----\nSECRETKEYBODY\n-----END OPENSSH PRIVATE KEY-----",
+           "publicKey":"ssh-rsa AAAAB3NzaC1yc2EPUBLIC"},
+         "$host:Host:1":"sftp.example.com"}}
+    ]}"#;
+    let fixture = write_keeper_fixture(&env, body);
+    env.xv_ok(&[
+        "vault",
+        "import",
+        "default",
+        "--fmt",
+        "keeper",
+        "-i",
+        fixture.to_str().unwrap(),
+    ]);
+
+    // Typed as ssh-key, with the private key as the primary value.
+    let json = env.xv_ok(&["ls", "--format", "json"]);
+    assert!(json.contains("\"record_type\": \"ssh-key\""), "{json}");
+    assert_eq!(
+        env.get_raw("BMO SFTP key"),
+        "-----BEGIN OPENSSH PRIVATE KEY-----\nSECRETKEYBODY\n-----END OPENSSH PRIVATE KEY-----"
+    );
+
+    // Both halves of the pair are reachable as named fields.
+    let record = env.xv_ok(&["get", "BMO SFTP key", "--record"]);
+    assert!(record.contains("SECRETKEYBODY"), "{record}");
+    assert!(record.contains("ssh-rsa AAAAB3NzaC1yc2EPUBLIC"), "{record}");
+
+    // The private key must never reach listable metadata.
+    assert!(
+        !json.contains("SECRETKEYBODY") && !json.contains("BEGIN OPENSSH"),
+        "private key leaked into listable metadata:\n{json}"
+    );
+    // The host is ordinary metadata and stays listable.
+    assert!(json.contains("sftp.example.com"), "{json}");
+}
+
+/// A Keeper `$note` field is frequently a record's only content. Treating it
+/// as a reserved-tag collision discarded 33 records in a real export.
+#[test]
+fn keeper_import_keeps_a_note_only_record() {
+    let env = TestEnv::new();
+    let body = r#"{"records":[
+      {"title":"Adaxes License","custom_fields":{"$note::1":"license key ABC-123"}}
+    ]}"#;
+    let fixture = write_keeper_fixture(&env, body);
+    env.xv_ok(&[
+        "vault",
+        "import",
+        "default",
+        "--fmt",
+        "keeper",
+        "-i",
+        fixture.to_str().unwrap(),
+    ]);
+    assert_eq!(env.get_raw("Adaxes License"), "license key ABC-123");
 }


### PR DESCRIPTION
Diagnosed from a real 434-record Keeper export that imported **332 records and failed 102**. It now imports **427 and refuses 7**, and the 7 are unrecoverable by any importer.

| | Before | After |
|---|---|---|
| Imported | 332 | **427** |
| Failed | 102 | **7** |

Five distinct causes. The first is the reason this is a `fix` and not a polish PR.

### 1. Object custom fields were dropped — with the secret material inside them

Keeper keeps its most sensitive values in *object-valued* custom fields:

| Field | Contains |
|---|---|
| `$keyPair` | `privateKey`, `publicKey` |
| `$paymentCard` | `cardNumber`, `cardSecurityCode` |
| `$passkey` | `privateKey`, `credentialId` |

Only scalars were handled, so **every SSH private key and card number in the file was silently discarded** — and the stripped record was then usually refused as empty. Each sub-key now flattens into the encrypted envelope. A tag was never an option: tags are unencrypted metadata capped at 256 chars, so a private key there would be both exposed and rejected.

### 2. Password-less records had no legal primary field

A record must have exactly one primary, and `login` requires a password — but **none of the 27 keypairs had a login and only 5 had a password**. Adds three builtin types, usable from `xv set --type` independently of import:

- `ssh-key` — primary `private-key`, plus `public-key`/`passphrase` (public keys routinely blow the 256-char tag cap, so they're envelope material too)
- `payment-card` — primary `card-number`; CVV and expiry also secret, only cardholder name listable
- `secure-note` — primary `content`

### 3. `$note` was discarded as a reserved-tag collision

It's Keeper's note *field type*, not a user field named "note" — and it was the **only content of 33 records**. Now merges into the record's note. Reserved-name collisions generally now rename to `keeper-<name>` instead of dropping the value.

### 4. Colliding titles were refused, losing 21 records

Keeper allows duplicate titles (three "American Express"); xv has one flat namespace. Now qualified by folder where that disambiguates, else a numeric suffix. Original title always kept in `original_name`.

### 5. Oversized values failed at the Azure API

Every `BadParameter` 400 in the log was a note over 256 chars becoming a tag. The pre-check validated `f.*` and user tags but **never `note`**, so these bypassed fail-before-write and died at the backend. Oversized notes and URLs now move into the envelope — and only where the backend requires it, so local keeps them listable.

Also: Keeper's `$<type>:<label>:<n>` key encoding is now parsed, so typed scalars match on base type rather than the user-chosen label (`$host:Server:1` and `$host:Host:1` both reach `f.host`).

### The 7 that still fail

Their content is a Keeper **file attachment**, which Keeper's JSON export omits — there is nothing in the file to import. The message now says so and points at `xv attach`.

### Verification

Checked against the real export with Azure's caps (15 tags / 256 chars): 427/434 planned, and **zero** of the 427 put key material, a TOTP seed, or an oversized value into a tag, or exceeded the tag cap. That harness read the file but never echoed a value and was deleted; the invariant is now a synthetic test (`no_shape_leaks_secret_material_or_busts_the_tag_cap`).

49 keeper tests (41 unit + 8 e2e driving the real binary). Full suite green — 44 suites, 0 failures, clippy and fmt clean.

### Worth a reviewer's attention

`secure-note` covers 75 records, and when there's no password its primary comes from the first secret field **sorted by name** — deterministic but arbitrary in meaning, so plain `xv get` on such a record returns whichever field sorts first. `--record` always shows everything, so nothing is lost, but the primary isn't semantically chosen the way it is for `ssh-key` or `login`.

Behavior changes to existing imports: colliding titles are now renamed rather than refused, and password-without-login records become `secure-note` records instead of plain secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret storage shape (envelopes vs plain text), adds stable built-in type names, and alters import outcomes for collisions and password-only records—high impact on migrations but bounded to Keeper import and new types with extensive tests.
> 
> **Overview**
> Keeper JSON import is reworked so production exports (e.g. 434 records) import most credentials instead of silently losing SSH keys, cards, and notes.
> 
> **Object `custom_fields`** (`$keyPair`, `$paymentCard`, etc.) are flattened into the **encrypted envelope** per sub-key, not dropped or stored as tags. **Three built-in types** are added: `ssh-key`, `payment-card`, and `secure-note`, so records without a login/password pair still get a legal primary field and typed envelopes instead of plain secrets or refusal.
> 
> **Type selection** follows ssh-key → payment-card → login → secure-note; TOTP seeds import into envelopes via `secure-note` rather than refusing records missing both login and password. **`$note`** fields merge with `notes` and are no longer treated as reserved-tag collisions. **Duplicate titles** are disambiguated with folder-qualified or numeric names (original title in `original_name`), not refused.
> 
> **Azure tag limits**: values over 256 characters (notes, URLs, custom fields) move into envelope fields with warnings; tag-count overflow is still refused before write. **Reserved custom-field names** rename to `keeper-*` instead of dropping values.
> 
> `docs/keeper.md` documents the new mapping, record types, oversized-value behavior, and refusal cases (empty attachment-only records).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 424571864af5779296af5abe5b5cc05f0c023a27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->