### PR TITLE
chore: bump version to 0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog
 
+## v0.35.0 — Keeper import fidelity (2026-08-07)
+
+Diagnosed from a real 434-record Keeper export that v0.34.0 imported with 332
+successes and 102 failures. The same file now imports 427 and refuses 7.
+
+### Added
+
+- **Three built-in record types**, usable from `xv set --type` independently of
+  any import: `ssh-key` (primary `private-key`, plus `public-key` and
+  `passphrase`), `payment-card` (primary `card-number`; security code and
+  expiry also secret, only the cardholder name listable), and `secure-note`
+  (primary `content`). They exist because a record must have exactly one
+  primary field and most credentials have no password — in the source export,
+  none of the 27 SSH keypairs had a login and only 5 had a password, so there
+  was nowhere legal to put them.
+
+### Fixed
+
+- **Keeper object custom fields were dropped, discarding secret material.**
+  `$keyPair` holds `privateKey`/`publicKey`, `$paymentCard` holds `cardNumber`
+  and `cardSecurityCode`, `$passkey` holds a `privateKey`. Only scalar fields
+  were handled, so every SSH private key and card number in an export was
+  silently discarded — and the stripped record was then usually refused as
+  empty. Each sub-key now flattens into the encrypted envelope. A tag was never
+  an option for these: tags are unencrypted metadata capped at 256 characters.
+
+- **`$note` fields were discarded as reserved-tag collisions.** `$note` is
+  Keeper's note *field type*, not a user field named "note", and it was the
+  only content of 33 records in the source export. It now merges into the
+  record's note. Reserved-name collisions generally now rename to
+  `keeper-<name>` rather than dropping the value.
+
+- **Oversized values failed at the Azure API** with an opaque
+  `BadParameter` 400. Every such failure was a note longer than Azure's
+  256-character tag limit; the pre-check validated `f.*` and user tags but
+  never `note`, so these bypassed fail-before-write entirely. An oversized note
+  or URL now moves into the encrypted envelope instead — and only where the
+  backend actually requires it, so the local backend keeps such values
+  listable.
+
+- **Keeper's `$<type>:<label>:<n>` key encoding is now parsed**, so a typed
+  scalar is matched on its base type rather than the user-chosen label
+  (`$host:Server:1` and `$host:Host:1` both reach `f.host`).
+
+### Changed
+
+- **Colliding titles are renamed rather than refused**, which previously lost
+  21 records. Keeper allows duplicate titles; xv has one flat namespace per
+  vault. Duplicates are now qualified by their folder where that distinguishes
+  them, else given a numeric suffix. The original title is always preserved in
+  the `original_name` tag.
+
+- **A record with a password but no login becomes a `secure-note` record**
+  rather than a plain secret, so its other secret fields have somewhere
+  encrypted to live. Re-importing a file imported under v0.34.0 will therefore
+  produce different record shapes.
+
+### Known limitation
+
+- A Keeper record whose content is a **file attachment** exports with no fields
+  at all — Keeper's JSON export omits attachments — so it cannot be imported by
+  any means. These are refused with a message saying so; retrieve the
+  attachment from Keeper and add it with `xv attach`.
+
 ## v0.34.0 — Keeper Security import/export (2026-08-06)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Version bump for the **v0.35.0** release, covering the Keeper import fidelity work merged in #398.

- `Cargo.toml` 0.34.0 → 0.35.0 (the only version source)
- `Cargo.lock` resynced
- `CHANGELOG.md`: adds the v0.35.0 entry — **#398 landed without one**

`release.yml`'s `verify-version` job fails the release when `Cargo.toml` doesn't match the tag, so this must land on `main` before `v0.35.0` is tagged.

### Why minor, not patch

#398 is titled `fix`, and repairing v0.34.0's import is why it exists. But it also:

- adds **three built-in record types** (`ssh-key`, `payment-card`, `secure-note`) that appear in `xv type list` and work with `xv set --type`, independently of any import; and
- **changes behavior** for anyone re-importing — colliding titles are renamed rather than refused, and password-without-login records become `secure-note` records instead of plain secrets.

A patch number would hide both.

### Release contents

Measured against a real 434-record Keeper export: **332 imported / 102 failed → 427 imported / 7 refused.**

The headline fix is that Keeper's object custom fields (`$keyPair`, `$paymentCard`, `$passkey`) were being dropped, silently discarding every SSH private key and card number in an export. The 7 remaining refusals are records whose content is a Keeper file attachment, which its JSON export omits — unrecoverable by any importer.

### Verification

`cargo fmt --check` clean, `cargo test --lib` 1106 passed / 0 failed, built binary reports `xv 0.35.0`.

After merge: `git tag -a v0.35.0` on the merged commit, triggering `release.yml` to build and attach the signed cross-platform artifacts that `xv upgrade` consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only (version, lockfile, changelog); no runtime or security logic changes in this diff.
> 
> **Overview**
> Prepares the **v0.35.0** release on `main` by bumping the crate version in `Cargo.toml` (0.34.0 → 0.35.0), resyncing `Cargo.lock`, and adding the **v0.35.0** section to `CHANGELOG.md` for the Keeper import fidelity work (#398).
> 
> The changelog entry documents the user-facing delta: three built-in record types (`ssh-key`, `payment-card`, `secure-note`), fixes for dropped Keeper object fields and `$note` handling, oversized notes/URLs moved into the encrypted envelope where backends require it, Keeper key encoding parsing, duplicate-title renaming, and password-without-login records becoming `secure-note` shapes on re-import.
> 
> This must land before tagging `v0.35.0` so `release.yml`'s `verify-version` job passes when the tag is pushed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd1b03466dcf7dffe39b6b78d03ae1aa02f88ca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->