### PR TITLE
chore: bump version to 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## v0.36.0 — Bootstrap-safe config recovery (2026-08-08)
+
+### Added
 
 - **`xv doctor` provides bootstrap-safe configuration recovery.** It diagnoses
   invalid application configuration before normal config loading, automatically

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Version bump for the **v0.36.0** release, covering the bootstrap-safe `xv doctor` config recovery merged in #400.

- `Cargo.toml` 0.35.0 → 0.36.0 (the only version source)
- `Cargo.lock` resynced
- `CHANGELOG.md`: `## Unreleased` → `## v0.36.0 — Bootstrap-safe config recovery (2026-08-08)`, plus the house-style `### Added` category. The entry's wording is #400's author's, unchanged.

`release.yml`'s `verify-version` job fails the release when `Cargo.toml` doesn't match the tag, so this must land on `main` before `v0.36.0` is tagged.

### Release contents

One commit since v0.35.0: #400, adding `xv doctor` — it runs *before* normal config loading so recovery works when `xv.conf` is broken, repairs only deterministic schema omissions, writes a timestamped backup before changing anything, and exits 3 when manual fixes remain.

Minor bump: a feature addition, consistent with how 0.31–0.35 were each cut.

### Verification

Local gate on this branch: `cargo fmt --check` clean, `cargo clippy --all-targets` 0 errors, full `cargo test` 45 suites / 0 failures. Built binary reports `xv 0.36.0` and `xv doctor --help` resolves.

Main's CI was already green on `1776144` before this branch was cut.

### Note for the release decision

Two points carried over from #400's own description, not from my analysis:

- Its author marked it **medium risk** — it changes how the global config is read and atomically rewritten on disk, though scoped to `doctor`, with no changes to secret handling or auth.
- The **Windows ACL path was not executed locally**; it was source- and binding-reviewed, guarded by `cfg(windows)`. CI's Windows check passed, but that's compile-and-test, not a real ACL exercise. Worth a conscious call before publishing signed Windows binaries.

After merge: `git tag -a v0.36.0` on the merged commit, triggering `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no runtime behavior; risk is limited to release tagging or changelog accuracy, not secret handling or auth paths.
> 
> **Overview**
> Prepares the **v0.36.0** release by aligning package metadata and changelog with the already-merged `xv doctor` work (#400).
> 
> `Cargo.toml` moves **0.35.0 → 0.36.0** (the sole version source); `Cargo.lock` resyncs the `crosstache` crate entry. `CHANGELOG.md` replaces `## Unreleased` with **`## v0.36.0 — Bootstrap-safe config recovery (2026-08-08)`** under `### Added`, documenting bootstrap-safe config recovery via `xv doctor` (pre-load diagnosis, deterministic repairs, timestamped backup before edits, exit 3 when manual fixes remain).
> 
> No Rust source or feature code changes in this diff—only release bookkeeping so `release.yml` `verify-version` can match a `v0.36.0` tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2808eb6b6b35e283e807795480062959d0125b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->