### PR TITLE
fix(windows): size FILE_RENAME_INFO buffer per the documented contract

### DIFF
--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -1634,6 +1634,21 @@ fn open_windows_atomic_parent(
     })
 }
 
+/// Byte size to allocate and report for a `FILE_RENAME_INFO` carrying a name
+/// of `name_bytes` bytes.
+///
+/// `sizeof(FILE_RENAME_INFO) + FileNameLength` is the size the API documents.
+/// Because the struct's trailing `FileName: [u16; 1]` and its padding are
+/// already counted by `size_of`, the result always leaves at least one zero
+/// `u16` past the copied name, which supplies the terminator for free given a
+/// zeroed buffer.
+#[cfg(windows)]
+fn windows_rename_info_size(name_bytes: usize) -> usize {
+    use windows_sys::Win32::Storage::FileSystem::FILE_RENAME_INFO;
+
+    std::mem::size_of::<FILE_RENAME_INFO>() + name_bytes
+}
+
 #[cfg(windows)]
 fn windows_rename_into_parent(
     file: &std::fs::File,
@@ -1646,10 +1661,17 @@ fn windows_rename_into_parent(
         FileRenameInfo, SetFileInformationByHandle, FILE_RENAME_INFO, FILE_RENAME_INFO_0,
     };
 
+    // Buffer sizing follows the documented contract for FileRenameInfo:
+    // `sizeof(FILE_RENAME_INFO) + FileNameLength`, with `FileNameLength`
+    // counting the name only (no terminator) while the buffer itself leaves
+    // room for one. Sizing from `offset_of(FileName)` instead understates the
+    // buffer by the trailing FileName[1] element plus its padding — 4 bytes on
+    // 64-bit — and SetFileInformationByHandle rejects the short buffer with
+    // ERROR_INVALID_PARAMETER (os error 87) rather than a size-specific error.
     let name: Vec<u16> = destination.encode_wide().collect();
     let name_bytes = name.len() * std::mem::size_of::<u16>();
     let name_offset = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
-    let byte_length = name_offset + name_bytes;
+    let byte_length = windows_rename_info_size(name_bytes);
     let word_length = byte_length.div_ceil(std::mem::size_of::<usize>());
     let mut buffer = vec![0usize; word_length];
     let information = buffer.as_mut_ptr().cast::<FILE_RENAME_INFO>();
@@ -2439,6 +2461,37 @@ pub fn glob_matches_either_name(
     original_name: &str,
 ) -> bool {
     matcher.is_match(name) || (!original_name.is_empty() && matcher.is_match(original_name))
+}
+
+#[cfg(all(test, windows))]
+mod windows_rename_tests {
+    use super::*;
+    use windows_sys::Win32::Storage::FileSystem::FILE_RENAME_INFO;
+
+    /// Regression: the buffer was sized from `offset_of(FileName)` rather than
+    /// `size_of::<FILE_RENAME_INFO>()`, understating it by the trailing
+    /// `FileName[1]` element and its padding (4 bytes on 64-bit).
+    /// `SetFileInformationByHandle` rejected the short buffer with
+    /// ERROR_INVALID_PARAMETER (os error 87), so every private atomic replace
+    /// failed on Windows: `xv context use`, config writes, and the web UI's
+    /// `ui.json` (which is why no appearance change ever persisted).
+    #[test]
+    fn rename_info_buffer_has_room_for_the_name_and_a_terminator() {
+        let offset = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
+        for name_bytes in [2usize, 14, 24, 512] {
+            let size = windows_rename_info_size(name_bytes);
+            assert_eq!(
+                size,
+                std::mem::size_of::<FILE_RENAME_INFO>() + name_bytes,
+                "must match the documented sizeof + FileNameLength contract"
+            );
+            assert!(
+                size >= offset + name_bytes + std::mem::size_of::<u16>(),
+                "buffer of {size} leaves no terminator after a {name_bytes}-byte name \
+                 at offset {offset}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## ⚠️ Not verified on Windows

Read this before approving. The fix is a one-line change I am confident in by construction, but **I could not execute a single line of it.** See *Verification* below — the honest state is "very likely correct, unconfirmed."

## Symptom

Reported on a Windows machine after upgrading to v0.36.0. `xv doctor` reported no problems, but changing the web UI appearance from `system` to `light` produced *"Settings need attention — the application configuration is invalid."* The config was valid; `xv doctor` was right.

Reproduced from the CLI, which prints the real error the web UI discards:

```
$ xv context use kv-private-sz3
error[xv-config-invalid]: Configuration error: Failed to atomically replace Windows
destination 'C:\Users\...\AppData\Roaming\xv\context': The parameter is incorrect. (os error 87)
```

## Root cause

`ERROR_INVALID_PARAMETER` from `SetFileInformationByHandle(FileRenameInfo)` in `windows_rename_into_parent` — the commit point of `atomic_write_file_no_follow`. The buffer and its reported size were computed from `offset_of(FILE_RENAME_INFO, FileName)` instead of `size_of::<FILE_RENAME_INFO>()`:

| | value |
|---|---|
| `offset_of(FileName)` | 20 |
| `size_of::<FILE_RENAME_INFO>()` | 24 |
| passed for a 7-char name | **34** |
| documented `sizeof + FileNameLength` | **38** |

The struct's trailing `FileName: [u16; 1]` and its padding are counted by `size_of` but not `offset_of`, so the call understated the buffer by 4 bytes and left no room for the terminating NUL. (Layout computed, not assumed.) Sizing from `size_of` also fixes 32-bit, where the struct is 16 bytes rather than 24 — the old arithmetic was wrong on both.

Since the buffer is zeroed, the extra room supplies the terminator with no extra copy.

## Blast radius — wider than the reported symptom

Every private atomic write on Windows was failing:

- `ui.json` — so **no appearance change has ever persisted**; there was no `ui.json` on the affected machine at all, and a missing file silently falls back to defaults, which is why this went unnoticed
- `xv context use`
- `save_config` — hence `xv config set` and `xv config edit`'s seeding of a missing config

**Not a v0.36.0 regression.** `windows_rename_into_parent` is byte-identical to v0.35.0; this has been broken since the handle-relative rename landed. The upgrade merely coincided with the first appearance change on that machine.

## Verification

- `cargo fmt --check` clean, `cargo clippy --all-targets` 0 errors, full suite green (the `test_detached_clear_process_clears_clipboard` flake is unrelated — it drives the real system clipboard, passes 3/3 in isolation, and the entire diff is Windows-gated so none of it compiles on macOS).
- **Not executed on Windows.** No `rustup` on the dev host (Homebrew Rust), so not even a cross `cargo check` was possible. CI's Windows job runs `cargo check --all-features` and **never runs tests**, so neither the bug nor this fix is reachable by the suite on any platform CI exercises — that is how it shipped.
- The added guard test is `cfg(all(test, windows))` and **will run nowhere** until Windows CI runs tests.

**To confirm:** on a Windows host, `cargo build` from this branch then `xv context use <vault>`. No os error 87 means fixed; the appearance toggle will work too, same helper.

## Follow-ups this exposed (not in this PR)

1. **Windows CI should run tests, not just `cargo check`.** Otherwise the next bug in this file is equally invisible.
2. **Write failures should not report `xv-config-invalid`.** Every failure in this path is wrapped in `CrosstacheError::config`, so a failed *file write* tells the user their configuration is invalid and to run `xv config show` — which sent the reporter to inspect a healthy file and made `xv doctor`'s clean result look contradictory. Fixing it changes a documented exit code (`docs/exit-codes.md`), so it is left as a deliberate decision.
3. **The web layer logs nothing.** `src/web/errors.rs` and `preferences.rs` have no tracing, so the underlying OS error is discarded before anyone can see it. Diagnosing this took code archaeology instead of reading an error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change is small and targets a documented Win32 contract, but it sits on the critical path for all Windows atomic config/UI writes; incorrect sizing would still break persistence broadly.
> 
> **Overview**
> Fixes **Windows private atomic file commits** that were failing with `ERROR_INVALID_PARAMETER` (os error 87) because the `FILE_RENAME_INFO` buffer passed to `SetFileInformationByHandle` was **4 bytes too small** on 64-bit (and wrong on 32-bit).
> 
> `windows_rename_into_parent` now sizes the buffer with a new **`windows_rename_info_size`** helper using **`sizeof(FILE_RENAME_INFO) + FileNameLength`**, replacing arithmetic based on **`offset_of(FileName)`**, which omitted the trailing `FileName[1]` field and padding. Inline comments document the API contract and why the old size was rejected.
> 
> That rename is the commit step for **`atomic_write_file_no_follow`** on Windows, so the bug broke **every** private atomic write: **`xv context use`**, config saves, and web UI persistence (e.g. **`ui.json`** / appearance settings).
> 
> A **`cfg(all(test, windows))`** regression test asserts the sizing contract and that the buffer leaves room for a UTF-16 terminator after the name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75b184c22054c50f8f229a2aed3639997e22afd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->