### PR TITLE
fix(windows): make xv work on Windows, and run the test suite there

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,3 +63,35 @@ jobs:
 
       - name: Check all features on Windows
         run: cargo check --all-features
+
+  # The suite had only ever been *compiled* on Windows, never run. Every
+  # Windows-specific defect it covers — directory handles needing
+  # FILE_FLAG_BACKUP_SEMANTICS, FileRenameInfo rejecting a non-NULL
+  # RootDirectory, config/context paths ignoring the environment so tests wrote
+  # to the real %APPDATA% — sat undetected behind `cargo check`. This job is
+  # what keeps them fixed.
+  #
+  # Deliberately no clippy step here: Windows currently reports pre-existing
+  # dead-code lints for helpers gated behind #[cfg(unix)], which would fail
+  # `-D warnings` on arrival. The ubuntu job above owns lint enforcement.
+  windows-test:
+    name: Windows Test Suite
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: windows-test
+
+      # 19 tests drive a child process through `sh` (`xv run`, output masking,
+      # clipboard). Git for Windows is preinstalled on this runner and ships
+      # `sh.exe` in its bin directory; put it on PATH explicitly rather than
+      # relying on the image's default PATH, which is not part of any contract.
+      - name: Ensure a POSIX shell is on PATH
+        run: echo "C:\Program Files\Git\bin" >> $env:GITHUB_PATH
+
+      - name: Run tests
+        run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,8 +158,10 @@ debug = true
 # libtest runs each #[test] on a 2MB thread — unit tests that call
 # `Cli::try_parse_from` overflow once the subcommand tree grows a few more
 # variants. opt-level 1 makes rustc reuse stack slots, collapsing that usage.
-# The shipped binary is unaffected either way: `main` parses on the 8MB main
-# thread, and release builds optimize fully.
+# The shipped binary is unaffected: `main` parses on the 8MB main thread, and
+# release builds optimize fully. On Windows that 8MB is not a given — the main
+# thread gets whatever the PE header reserves (1MB by default), so `build.rs`
+# links the binaries with an explicit 8MB reserve.
 [profile.test]
 opt-level = 1
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,24 @@
 fn main() {
     built::write_built_file().expect("Failed to acquire build-time information");
+
+    // Windows sizes the main thread's stack from the PE header's
+    // SizeOfStackReserve, which defaults to 1 MiB — it does NOT get the 8 MiB
+    // main thread the `[profile.test]` note in Cargo.toml assumes (that's a
+    // Unix default). At opt-level 0 the clap-derive command-tree build
+    // (`Cli::command()` and the `augment_subcommands` chain) transiently uses
+    // ~1.9 MiB, so on Windows every debug-built `xv` command aborts with
+    // STATUS_STACK_OVERFLOW ("thread 'main' has overflowed its stack") before
+    // main's first line runs. Reserve 8 MiB to match the Unix main thread.
+    //
+    // `rustc-link-arg-bins` scopes this to this package's binaries, so it does
+    // not invalidate the dependency build cache the way a global RUSTFLAGS
+    // entry in `.cargo/config.toml` would. Reserve is address space only;
+    // pages are committed on demand, so this costs nothing at runtime.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+        match std::env::var("CARGO_CFG_TARGET_ENV").as_deref() {
+            Ok("msvc") => println!("cargo:rustc-link-arg-bins=/STACK:8388608"),
+            Ok("gnu") => println!("cargo:rustc-link-arg-bins=-Wl,--stack,8388608"),
+            _ => {}
+        }
+    }
 }

--- a/src/backend/azure/auth.rs
+++ b/src/backend/azure/auth.rs
@@ -132,7 +132,7 @@ fn az_output(args: &[&str]) -> Option<String> {
     use std::io::Read;
     use std::process::{Command, Stdio};
 
-    let mut child = Command::new("az")
+    let mut child = Command::new(super::az_program())
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/src/backend/azure/detect.rs
+++ b/src/backend/azure/detect.rs
@@ -3,6 +3,7 @@
 //! This module provides utilities for detecting Azure CLI installation,
 //! available subscriptions, and environment configuration.
 
+use super::az_program;
 use crate::error::{CrosstacheError, Result};
 use serde_json::Value;
 use std::process::Command;
@@ -100,7 +101,7 @@ impl AzureDetector {
 
     /// Check if Azure CLI is available
     fn check_cli_available() -> bool {
-        Command::new("az")
+        Command::new(az_program())
             .arg("--version")
             .output()
             .map(|output| output.status.success())
@@ -109,7 +110,7 @@ impl AzureDetector {
 
     /// Get Azure CLI version
     fn get_cli_version() -> Option<String> {
-        let output = Command::new("az").arg("--version").output().ok()?;
+        let output = Command::new(az_program()).arg("--version").output().ok()?;
 
         if !output.status.success() {
             return None;
@@ -125,7 +126,7 @@ impl AzureDetector {
 
     /// Check if user is logged into Azure CLI
     fn check_cli_logged_in() -> bool {
-        Command::new("az")
+        Command::new(az_program())
             .args(["account", "show"])
             .output()
             .map(|output| output.status.success())
@@ -134,7 +135,7 @@ impl AzureDetector {
 
     /// Get available Azure subscriptions
     async fn get_subscriptions() -> Result<Vec<AzureSubscription>> {
-        let output = Command::new("az")
+        let output = Command::new(az_program())
             .args(["account", "list", "--output", "json"])
             .output()
             .map_err(|e| CrosstacheError::config(format!("Failed to execute Azure CLI: {e}")))?;
@@ -187,7 +188,7 @@ impl AzureDetector {
 
     /// Get current tenant information
     async fn get_tenant_info() -> Result<Option<AzureTenant>> {
-        let output = Command::new("az")
+        let output = Command::new(az_program())
             .args(["account", "show", "--output", "json"])
             .output()
             .map_err(|e| CrosstacheError::config(format!("Failed to execute Azure CLI: {e}")))?;
@@ -230,7 +231,7 @@ impl AzureDetector {
             );
             return None;
         }
-        let output = Command::new("az")
+        let output = Command::new(az_program())
             .args([
                 "rest",
                 "--method",
@@ -282,7 +283,7 @@ impl AzureDetector {
 
     /// Get available resource groups for a subscription
     pub async fn get_resource_groups(subscription_id: &str) -> Result<Vec<String>> {
-        let output = Command::new("az")
+        let output = Command::new(az_program())
             .args([
                 "group",
                 "list",
@@ -322,15 +323,38 @@ impl AzureDetector {
     }
 
     /// Get available locations for a subscription
+    ///
+    /// Goes through the ARM REST endpoint rather than `az account
+    /// list-locations`. The latter is a local-profile command — its help reads
+    /// "List supported regions for the *current* subscription" — and it rejects
+    /// `--subscription` outright with `ERROR: unrecognized arguments`, which
+    /// failed step 4/6 of `xv init` for every user. (`--subscription` is a
+    /// global argument for ARM-backed commands like `az group list`, which is
+    /// why the other calls in this module are fine.) The REST URL carries the
+    /// subscription in its path, so it answers for the subscription the user
+    /// actually chose in step 2 rather than whatever the CLI last defaulted to.
     pub async fn get_locations(subscription_id: &str) -> Result<Vec<String>> {
-        let output = Command::new("az")
+        // Validate before interpolating into the URL — the same guard
+        // `get_tenant_details` applies, so a malformed or hostile value can't
+        // reshape the request path.
+        if !is_valid_uuid(subscription_id) {
+            return Err(CrosstacheError::config(format!(
+                "Invalid subscription id {subscription_id:?}: expected a UUID"
+            )));
+        }
+
+        let output = Command::new(az_program())
             .args([
-                "account",
-                "list-locations",
-                "--subscription",
-                subscription_id,
+                "rest",
+                "--method",
+                "GET",
+                "--url",
+                &format!(
+                    "https://management.azure.com/subscriptions/{subscription_id}\
+                     /locations?api-version=2022-12-01"
+                ),
                 "--query",
-                "[].name",
+                "value[].name",
                 "--output",
                 "json",
             ])
@@ -367,7 +391,7 @@ impl AzureDetector {
         subscription_id: &str,
         resource_group: &str,
     ) -> Result<bool> {
-        let output = Command::new("az")
+        let output = Command::new(az_program())
             .args([
                 "group",
                 "exists",
@@ -394,7 +418,7 @@ impl AzureDetector {
         resource_group: &str,
         location: &str,
     ) -> Result<()> {
-        let output = Command::new("az")
+        let output = Command::new(az_program())
             .args([
                 "group",
                 "create",
@@ -423,7 +447,7 @@ impl AzureDetector {
         subscription_id: &str,
         resource_group: &str,
     ) -> Result<Vec<String>> {
-        let output = Command::new("az")
+        let output = Command::new(az_program())
             .args([
                 "storage",
                 "account",
@@ -471,7 +495,7 @@ impl AzureDetector {
         subscription_id: &str,
         storage_account: &str,
     ) -> Result<bool> {
-        let output = Command::new("az")
+        let output = Command::new(az_program())
             .args([
                 "storage",
                 "account",
@@ -497,7 +521,7 @@ impl AzureDetector {
         storage_account: &str,
         container_name: &str,
     ) -> Result<bool> {
-        let output = Command::new("az")
+        let output = Command::new(az_program())
             .args([
                 "storage",
                 "container",
@@ -601,6 +625,20 @@ mod tests {
 
         // At minimum, we should be able to detect CLI availability
         assert!(env.cli_available == AzureDetector::check_cli_available());
+    }
+
+    /// `get_locations` interpolates the subscription id straight into an ARM
+    /// URL path, so a non-UUID must be rejected before the request is built.
+    /// Runs offline — the guard fires before any `az` invocation.
+    #[tokio::test]
+    async fn get_locations_rejects_non_uuid_subscription() {
+        let err = AzureDetector::get_locations("../../evil?api-version=1")
+            .await
+            .expect_err("a non-UUID subscription id must be refused");
+        assert!(
+            err.to_string().contains("expected a UUID"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/backend/azure/mod.rs
+++ b/src/backend/azure/mod.rs
@@ -34,6 +34,46 @@ use crate::error::CrosstacheError;
 use crate::secret::manager::AzureSecretOperations;
 use crate::vault::operations::AzureVaultOperations;
 
+/// The Azure CLI executable name to hand to `Command::new`.
+///
+/// On Windows the Azure CLI ships as `az.cmd` — a batch shim around the Python
+/// entry point. There is no `az.exe`. A shell resolves the bare name `az`
+/// against `PATHEXT`, but `std::process::Command` does not: it only appends
+/// `.exe` to an extension-less program name. So `Command::new("az")` fails with
+/// `NotFound` on every Windows box, even when `az account show` works fine in
+/// the very same terminal — which reads to the user as "Azure CLI is not
+/// installed" when it plainly is.
+///
+/// Probe `PATH` for the batch names first and fall back to the bare `az`, which
+/// is correct everywhere else (and keeps the "not installed" diagnostic honest
+/// when the CLI genuinely isn't there).
+#[cfg(windows)]
+pub fn az_program() -> &'static str {
+    use std::sync::OnceLock;
+
+    static PROGRAM: OnceLock<&'static str> = OnceLock::new();
+    PROGRAM.get_or_init(|| {
+        // `.exe` is included for completeness — no shipping Azure CLI provides
+        // one today, but a third-party repackaging might, and it costs nothing.
+        ["az.cmd", "az.bat", "az.exe"]
+            .into_iter()
+            .find(|candidate| {
+                std::env::var_os("PATH").is_some_and(|paths| {
+                    std::env::split_paths(&paths).any(|dir| dir.join(candidate).is_file())
+                })
+            })
+            .unwrap_or("az")
+    })
+}
+
+/// The Azure CLI executable name to hand to `Command::new`.
+///
+/// Everywhere but Windows the CLI is a plain `az` on `PATH`.
+#[cfg(not(windows))]
+pub fn az_program() -> &'static str {
+    "az"
+}
+
 /// Map [`CrosstacheError`] → [`BackendError`].
 ///
 /// This is a best-effort mapping; variants without a direct BackendError
@@ -241,6 +281,52 @@ impl Backend for AzureBackend {
             .await
             .map_err(|e| BackendError::AuthenticationFailed(e.to_string()))?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod az_program_tests {
+    use super::az_program;
+
+    #[test]
+    fn resolves_to_a_known_candidate() {
+        let program = az_program();
+        if cfg!(windows) {
+            assert!(
+                matches!(program, "az.cmd" | "az.bat" | "az.exe" | "az"),
+                "unexpected Azure CLI program name: {program}"
+            );
+        } else {
+            assert_eq!(program, "az");
+        }
+    }
+
+    /// Guards the bug this helper exists for: on Windows the Azure CLI is
+    /// `az.cmd`, and `Command::new("az")` fails with `NotFound` because
+    /// `Command` appends only `.exe` and never consults `PATHEXT`. Detection
+    /// then reports "Azure CLI is not installed" on a machine where `az` runs
+    /// fine in the shell. Whenever a batch shim IS on `PATH`, we must pick it
+    /// over the bare name.
+    ///
+    /// Self-skipping rather than environment-dependent: when no shim is on
+    /// `PATH` the CLI genuinely is not installed and there is nothing to
+    /// assert, so this stays green on CI runners without the Azure CLI.
+    #[cfg(windows)]
+    #[test]
+    fn prefers_the_batch_shim_over_the_bare_name() {
+        let shim_on_path = std::env::var_os("PATH").is_some_and(|paths| {
+            std::env::split_paths(&paths)
+                .any(|dir| dir.join("az.cmd").is_file() || dir.join("az.bat").is_file())
+        });
+        if !shim_on_path {
+            return;
+        }
+        assert_ne!(
+            az_program(),
+            "az",
+            "a batch shim is on PATH but az_program() fell back to the bare name, \
+             which Command::new cannot resolve"
+        );
     }
 }
 

--- a/src/backend/local/files.rs
+++ b/src/backend/local/files.rs
@@ -77,6 +77,12 @@ fn file_meta_path(store_path: &Path, vault: &str, name: &str) -> Result<PathBuf,
 
 #[cfg(test)]
 fn sync_directory(path: &Path) -> Result<(), BackendError> {
+    // Directory fsync is a Unix durability primitive with no Windows analogue —
+    // and `File::open` on a directory fails outright there without
+    // FILE_FLAG_BACKUP_SEMANTICS. Skip the sync off Unix but still record the
+    // event, so the ordering assertions in these tests stay meaningful on every
+    // platform. Mirrors `sync_directory` in `super::secrets`.
+    #[cfg(unix)]
     fs::File::open(path)
         .and_then(|directory| directory.sync_all())
         .map_err(|e| BackendError::Internal(format!("sync directory {}: {e}", path.display())))?;
@@ -128,6 +134,14 @@ struct LocalFileChain {
 }
 
 struct AnchoredDir {
+    /// The retained directory handle.
+    ///
+    /// Read on Unix, where every operation is performed relative to it via
+    /// `openat`. Windows has no `openat`, so the operations there address
+    /// their targets by path — but the handle is still held for the lifetime
+    /// of the chain, so the directory validated on the way in cannot be
+    /// swapped out from under them.
+    #[cfg_attr(not(unix), allow(dead_code))]
     file: fs::File,
     display: PathBuf,
 }
@@ -174,7 +188,66 @@ impl AnchoredDir {
                 display: path.to_path_buf(),
             })
         }
-        #[cfg(not(unix))]
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+            use windows_sys::Win32::Storage::FileSystem::{
+                FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_BACKUP_SEMANTICS,
+                FILE_FLAG_OPEN_REPARSE_POINT,
+            };
+
+            // Windows refuses to open a directory at all without
+            // FILE_FLAG_BACKUP_SEMANTICS — a plain `File::open` on one always
+            // fails with ERROR_ACCESS_DENIED (os error 5), which took the whole
+            // local file backend down on Windows.
+            //
+            // FILE_FLAG_OPEN_REPARSE_POINT stands in for the Unix branch's
+            // `O_NOFOLLOW`: it opens a reparse point itself instead of
+            // redirecting to its target, so the attribute checks below can
+            // refuse it rather than silently anchoring somewhere else.
+            let file = fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+                .open(path)
+                .map_err(|error| {
+                    BackendError::Internal(format!(
+                        "open anchored directory {}: {error}",
+                        path.display()
+                    ))
+                })?;
+
+            // Windows has no open flag equivalent to `O_DIRECTORY`/`O_NOFOLLOW`
+            // that fails the open outright, so enforce both after the fact from
+            // the handle — not from the path, which would reintroduce the
+            // race the anchored handle exists to close.
+            let attributes = file
+                .metadata()
+                .map_err(|error| {
+                    BackendError::Internal(format!(
+                        "inspect anchored directory {}: {error}",
+                        path.display()
+                    ))
+                })?
+                .file_attributes();
+            if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                return Err(BackendError::Internal(format!(
+                    "refusing reparse-point anchored directory {}",
+                    path.display()
+                )));
+            }
+            if attributes & FILE_ATTRIBUTE_DIRECTORY == 0 {
+                return Err(BackendError::Internal(format!(
+                    "anchored path {} is not a directory",
+                    path.display()
+                )));
+            }
+
+            Ok(Self {
+                file,
+                display: path.to_path_buf(),
+            })
+        }
+        #[cfg(all(not(unix), not(windows)))]
         {
             let file = fs::File::open(path).map_err(|error| {
                 BackendError::Internal(format!(
@@ -485,11 +558,37 @@ impl AnchoredDir {
         #[cfg(not(unix))]
         {
             let mut options = fs::OpenOptions::new();
-            options.read(flags & libc::O_RDONLY == libc::O_RDONLY);
-            options.write(flags & libc::O_WRONLY != 0);
+
+            // The access mode is an enum packed into the low bits, not a set of
+            // independent flags: `O_RDONLY` is 0 (so `flags & O_RDONLY ==
+            // O_RDONLY` is vacuously true for every input) and `O_RDWR` (2)
+            // shares no bit with `O_WRONLY` (1). Testing them as bitmasks
+            // therefore left `write` unset for `O_RDWR`, and `OpenOptions`
+            // rejected the accompanying `create` with "creating or truncating a
+            // file requires write or append access" — which is exactly how the
+            // vault lock (`O_RDWR | O_CREAT`) failed on Windows. Decode the
+            // mode instead.
+            const ACCESS_MODE: libc::c_int = libc::O_RDONLY | libc::O_WRONLY | libc::O_RDWR;
+            let access = flags & ACCESS_MODE;
+            options.read(access == libc::O_RDONLY || access == libc::O_RDWR);
+            options.write(access == libc::O_WRONLY || access == libc::O_RDWR);
             options.create(flags & libc::O_CREAT != 0);
             options.truncate(flags & libc::O_TRUNC != 0);
             let _ = mode;
+
+            // Counterpart to the Unix branch's `O_NOFOLLOW`. Without it Windows
+            // silently follows a symlink placed at `name`, anchoring the
+            // operation outside the directory this handle exists to pin. With
+            // it the open yields the reparse point itself, whose `is_file()` is
+            // false, so the match below rejects it as a non-file entry.
+            #[cfg(windows)]
+            {
+                use std::os::windows::fs::OpenOptionsExt;
+                options.custom_flags(
+                    windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT,
+                );
+            }
+
             match options.open(self.display.join(name)) {
                 Ok(file) if file.metadata().is_ok_and(|metadata| metadata.is_file()) => {
                     Ok(Some(file))
@@ -660,6 +759,15 @@ impl AnchoredDir {
     }
 
     fn sync(&self) -> Result<(), BackendError> {
+        // Directory fsync is a Unix durability primitive. Windows has no
+        // analogue: `FlushFileBuffers` on a directory handle fails with
+        // ERROR_ACCESS_DENIED (os error 5) — and the handle is opened read-only
+        // by design, so there is nothing to flush. Metadata durability there
+        // comes from the filesystem's own ordering, not an explicit call.
+        // Skip the sync off Unix but keep recording the event so the ordering
+        // assertions in the tests stay meaningful on every platform. Mirrors
+        // `sync_directory` in `super::secrets`.
+        #[cfg(unix)]
         self.file
             .sync_all()
             .map_err(|error| BackendError::Internal(format!("sync anchored directory: {error}")))?;

--- a/src/backend/local/secrets.rs
+++ b/src/backend/local/secrets.rs
@@ -498,8 +498,15 @@ fn write_meta(path: &Path, meta: &SecretMeta, crypto_opts: MetaCrypto) -> Result
 }
 
 fn sync_file(path: &Path) -> Result<(), BackendError> {
-    fs::OpenOptions::new()
-        .read(true)
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    // Windows `FlushFileBuffers` requires write access on the handle — a
+    // read-only open fails with ERROR_ACCESS_DENIED (os error 5). Unix `fsync`
+    // is content with a read-only descriptor, so only widen it where the
+    // platform demands it.
+    #[cfg(windows)]
+    options.write(true);
+    options
         .open(path)
         .and_then(|file| file.sync_all())
         .map_err(|e| BackendError::Internal(format!("sync file {}: {e}", path.display())))

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -8306,8 +8306,23 @@ mod tests {
         let stdout_path = dir.path().join("stdout.txt");
         let stderr_path = dir.path().join("stderr.txt");
 
-        let child = Command::new("echo")
-            .arg("hello SUPERSECRET world")
+        // `echo` is a shell builtin on Windows rather than an executable, so
+        // spawning it directly there fails with NotFound. Go through the
+        // platform's own shell instead of assuming a Unix `echo` binary exists.
+        #[cfg(windows)]
+        let mut command = {
+            let mut command = Command::new("cmd");
+            command.arg("/c").arg("echo hello SUPERSECRET world");
+            command
+        };
+        #[cfg(not(windows))]
+        let mut command = {
+            let mut command = Command::new("echo");
+            command.arg("hello SUPERSECRET world");
+            command
+        };
+
+        let child = command
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()

--- a/src/cli/upgrade_ops.rs
+++ b/src/cli/upgrade_ops.rs
@@ -555,15 +555,29 @@ fn version_output_matches(output: &str, expected: &semver::Version) -> bool {
 mod tests {
     use super::*;
 
+    /// Releases publish exactly four archives (see
+    /// `.github/workflows/release.yml`), so a host outside that set — Windows
+    /// on ARM64, for one — has no asset to download. Refusing with a clear
+    /// "Unsupported platform" message is the correct outcome there; inventing a
+    /// name would only turn into a 404 at download time. Assert the contract
+    /// rather than assuming every build host is a release target.
     #[test]
     fn test_get_asset_name_returns_valid_name() {
-        let name = get_asset_name();
-        assert!(name.is_ok(), "Should detect current platform");
-        let name = name.unwrap();
-        assert!(
-            name.ends_with(".tar.gz") || name.ends_with(".zip"),
-            "Asset should be tar.gz or zip, got: {name}"
-        );
+        match get_asset_name() {
+            Ok(name) => assert!(
+                name.ends_with(".tar.gz") || name.ends_with(".zip"),
+                "Asset should be tar.gz or zip, got: {name}"
+            ),
+            Err(error) => {
+                let message = error.to_string();
+                assert!(
+                    message.contains("Unsupported platform"),
+                    "unexpected error for {}/{}: {message}",
+                    std::env::consts::OS,
+                    std::env::consts::ARCH
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/config/context.rs
+++ b/src/config/context.rs
@@ -394,6 +394,20 @@ impl ContextManager {
 
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {
+            // Honour `XDG_CONFIG_HOME` here too, for the same reason
+            // `Config::get_config_path` does: `dirs::config_dir()` goes through
+            // the Win32 known-folder API and ignores the environment, so on
+            // Windows every test suite shared the one real
+            // `%APPDATA%\xv\context` file. Workspaces registered by one suite
+            // then leaked into the next ("unknown backend kind: local-a"),
+            // which is a contamination bug in its own right and not merely a
+            // test-isolation inconvenience.
+            if let Some(config_home) =
+                std::env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty())
+            {
+                return Ok(PathBuf::from(config_home).join("xv").join("context"));
+            }
+
             // Use platform-appropriate config directory for other platforms
             let config_dir = dirs::config_dir()
                 .ok_or_else(|| CrosstacheError::config("Could not determine config directory"))?;

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -620,7 +620,7 @@ impl ConfigInitializer {
         // Create storage account using Azure CLI with timeout
         let create_storage_cmd = tokio::time::timeout(
             std::time::Duration::from_secs(180), // 3 minute timeout for storage account creation
-            tokio::process::Command::new("az")
+            tokio::process::Command::new(crate::backend::azure::az_program())
                 .args([
                     "storage",
                     "account",
@@ -686,7 +686,7 @@ impl ConfigInitializer {
         // Create blob container with timeout to prevent hanging
         let create_container_cmd = tokio::time::timeout(
             std::time::Duration::from_secs(120), // 2 minute timeout
-            tokio::process::Command::new("az")
+            tokio::process::Command::new(crate::backend::azure::az_program())
                 .args([
                     "storage",
                     "container",
@@ -795,7 +795,7 @@ impl ConfigInitializer {
         // Create blob container with timeout
         let create_container_cmd = tokio::time::timeout(
             std::time::Duration::from_secs(120), // 2 minute timeout
-            tokio::process::Command::new("az")
+            tokio::process::Command::new(crate::backend::azure::az_program())
                 .args([
                     "storage",
                     "container",

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -433,6 +433,21 @@ impl Config {
 
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {
+            // Honour `XDG_CONFIG_HOME` here as well. It is not a Windows
+            // convention and real users will not have it set, so this changes
+            // nothing for them — but `dirs::config_dir()` resolves through the
+            // Win32 known-folder API and ignores the environment entirely.
+            // That silently defeated the integration harness's
+            // `HOME`/`XDG_CONFIG_HOME` isolation (`tests/common/mod.rs`), whose
+            // stated invariant is that tests never touch the user's real
+            // config: on Windows `cargo test` read and OVERWROTE the real
+            // `%APPDATA%\xv\xv.conf` instead of its tempdir copy.
+            if let Some(config_home) =
+                std::env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty())
+            {
+                return Ok(PathBuf::from(config_home).join("xv").join("xv.conf"));
+            }
+
             // Use platform-appropriate config directory for other platforms
             let config_dir = dirs::config_dir()
                 .ok_or_else(|| CrosstacheError::config("Unable to determine config directory"))?;

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -55,24 +55,55 @@ pub fn write_private(
         file.write_all(bytes.as_ref())?;
         Ok(())
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
     {
-        // If the file already exists it may be read-only from a previous
-        // sensitive write; clear the read-only attribute first so the
-        // overwrite does not fail with a permission error (e.g. a second
-        // context `save` after `set_context` on Windows).
-        if let Ok(meta) = std::fs::metadata(path.as_ref()) {
-            let mut perms = meta.permissions();
-            if perms.readonly() {
-                perms.set_readonly(false);
-                std::fs::set_permissions(path.as_ref(), perms)?;
+        use std::io::Write;
+        use windows_sys::Win32::Storage::FileSystem::{
+            CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OPEN_REPARSE_POINT, FILE_GENERIC_WRITE,
+            FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        };
+
+        // This used to emulate 0600 with FILE_ATTRIBUTE_READONLY. That grants
+        // no confidentiality whatsoever on Windows — every other user can still
+        // read the file — while blocking precisely the operations the local
+        // backend depends on: `fs::rename` cannot replace a read-only
+        // destination, and `FlushFileBuffers` cannot run against one. Both fail
+        // with ERROR_ACCESS_DENIED (os error 5), which is how secret
+        // activation and file syncing broke on Windows.
+        //
+        // Clear the attribute off files left behind by those builds, then
+        // create with the protected owner+SYSTEM DACL that
+        // `atomic_write_file_no_follow` already uses — the actual 0600
+        // equivalent, and one that still permits the owner to delete and
+        // replace (FILE_ALL_ACCESS), as renaming over the file requires.
+        if let Ok(metadata) = std::fs::metadata(path.as_ref()) {
+            let mut permissions = metadata.permissions();
+            if permissions.readonly() {
+                permissions.set_readonly(false);
+                std::fs::set_permissions(path.as_ref(), permissions)?;
             }
         }
-        std::fs::write(path.as_ref(), bytes.as_ref())?;
-        let mut perms = std::fs::metadata(path.as_ref())?.permissions();
-        perms.set_readonly(true);
-        std::fs::set_permissions(path.as_ref(), perms)?;
+
+        let descriptor = windows_private_security_descriptor()
+            .map_err(|error| std::io::Error::other(error.to_string()))?;
+        let attributes = windows_security_attributes(Some(&descriptor));
+        // FILE_FLAG_OPEN_REPARSE_POINT is the counterpart to the Unix branch's
+        // `O_NOFOLLOW`: a symlink at `path` is replaced rather than written
+        // through to whatever it points at.
+        let mut file = windows_create_file(
+            path.as_ref(),
+            FILE_GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            CREATE_ALWAYS,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+            &attributes,
+        )?;
+        file.write_all(bytes.as_ref())?;
         Ok(())
+    }
+    #[cfg(all(not(unix), not(windows)))]
+    {
+        std::fs::write(path.as_ref(), bytes.as_ref())
     }
 }
 
@@ -1499,9 +1530,13 @@ struct WindowsAtomicParent {
     // an ancestor from becoming a reparse point or being renamed/replaced
     // after validation.
     _chain: Vec<std::fs::File>,
-    directory: std::fs::File,
+    // Retention-only, like `_chain`: pins the immediate parent for the lifetime
+    // of the write so the validated directory cannot be swapped out from under
+    // the rename. Never read — the rename addresses its target by full path
+    // because Win32 has no handle-relative rename (see
+    // `windows_rename_into_parent`).
+    _directory: std::fs::File,
     absolute: PathBuf,
-    destination: std::ffi::OsString,
 }
 
 #[cfg(windows)]
@@ -1513,7 +1548,8 @@ fn open_windows_atomic_parent(
     use windows_sys::Win32::Storage::FileSystem::{
         CreateDirectoryW, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
         FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_LIST_DIRECTORY,
-        FILE_READ_ATTRIBUTES, FILE_SHARE_READ, FILE_TRAVERSE, OPEN_EXISTING,
+        FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_TRAVERSE,
+        OPEN_EXISTING,
     };
 
     let absolute = if path.is_absolute() {
@@ -1525,10 +1561,11 @@ fn open_windows_atomic_parent(
             })?
             .join(path)
     };
-    let destination = absolute
+    // Validated for its own sake — the rename uses the full path, but a
+    // destination that names no file is still a caller error.
+    absolute
         .file_name()
-        .ok_or_else(|| CrosstacheError::invalid_argument("Atomic destination must name a file"))?
-        .to_os_string();
+        .ok_or_else(|| CrosstacheError::invalid_argument("Atomic destination must name a file"))?;
     let parent_path = absolute.parent().ok_or_else(|| {
         CrosstacheError::invalid_argument("Atomic destination must have a parent directory")
     })?;
@@ -1541,7 +1578,24 @@ fn open_windows_atomic_parent(
     let mut current = PathBuf::new();
     let mut chain = Vec::new();
 
-    for component in parent_path.components() {
+    // The immediate parent needs write/delete sharing; every ancestor above it
+    // stays locked down. Replacing an entry inside a directory makes the kernel
+    // open that directory for write, so a `FILE_SHARE_READ`-only handle on it
+    // makes our *own* rename fail with ERROR_SHARING_VIOLATION (os error 32) —
+    // confirmed against both `SetFileInformationByHandle` and the NT-level
+    // `NtSetInformationFile` (STATUS_SHARING_VIOLATION, 0xC0000043), so it is
+    // inherent to the operation rather than an artifact of either entry point.
+    // Ancestors are unaffected: renaming this directory would require opening
+    // *it* for delete, which its own retained parent still refuses.
+    let components: Vec<Component> = parent_path.components().collect();
+    let last_component = components.len().saturating_sub(1);
+
+    for (index, component) in components.into_iter().enumerate() {
+        let share = if index == last_component {
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
+        } else {
+            FILE_SHARE_READ
+        };
         match component {
             Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
                 current.push(component.as_os_str());
@@ -1562,7 +1616,7 @@ fn open_windows_atomic_parent(
         let file = match windows_create_file(
             &current,
             access,
-            FILE_SHARE_READ,
+            share,
             OPEN_EXISTING,
             flags,
             std::ptr::null(),
@@ -1583,7 +1637,7 @@ fn open_windows_atomic_parent(
                 windows_create_file(
                     &current,
                     access,
-                    FILE_SHARE_READ,
+                    share,
                     OPEN_EXISTING,
                     flags,
                     std::ptr::null(),
@@ -1628,9 +1682,8 @@ fn open_windows_atomic_parent(
     })?;
     Ok(WindowsAtomicParent {
         _chain: chain,
-        directory,
+        _directory: directory,
         absolute,
-        destination,
     })
 }
 
@@ -1649,25 +1702,35 @@ fn windows_rename_info_size(name_bytes: usize) -> usize {
     std::mem::size_of::<FILE_RENAME_INFO>() + name_bytes
 }
 
+/// Atomically replace `destination` with `file`.
+///
+/// `destination` must be the **full** path. `RootDirectory` is deliberately
+/// left NULL: Win32's `SetFileInformationByHandle` does not implement the
+/// handle-relative form of `FileRenameInfo`, and rejects every non-NULL
+/// `RootDirectory` with ERROR_INVALID_PARAMETER (os error 87) — independent of
+/// buffer sizing, of the share mode the directory handle was opened with, and
+/// of whether the destination already exists. Only the NT-level
+/// `NtSetInformationFile` honours that field. This is why the config write,
+/// `xv context use`, and the web UI's `ui.json` all failed on Windows.
+///
+/// The retained parent handle in [`WindowsAtomicParent`] still pins the
+/// directory for the lifetime of the operation, so re-resolving the path here
+/// does not reopen a window an attacker can swap the parent out of.
 #[cfg(windows)]
 fn windows_rename_into_parent(
     file: &std::fs::File,
-    parent: &std::fs::File,
     destination: &std::ffi::OsStr,
 ) -> std::io::Result<()> {
     use std::os::windows::ffi::OsStrExt;
     use std::os::windows::io::AsRawHandle;
     use windows_sys::Win32::Storage::FileSystem::{
-        FileRenameInfo, SetFileInformationByHandle, FILE_RENAME_INFO, FILE_RENAME_INFO_0,
+        FileRenameInfo, SetFileInformationByHandle, FILE_RENAME_INFO,
     };
 
     // Buffer sizing follows the documented contract for FileRenameInfo:
     // `sizeof(FILE_RENAME_INFO) + FileNameLength`, with `FileNameLength`
     // counting the name only (no terminator) while the buffer itself leaves
-    // room for one. Sizing from `offset_of(FileName)` instead understates the
-    // buffer by the trailing FileName[1] element plus its padding — 4 bytes on
-    // 64-bit — and SetFileInformationByHandle rejects the short buffer with
-    // ERROR_INVALID_PARAMETER (os error 87) rather than a size-specific error.
+    // room for one.
     let name: Vec<u16> = destination.encode_wide().collect();
     let name_bytes = name.len() * std::mem::size_of::<u16>();
     let name_offset = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
@@ -1676,10 +1739,12 @@ fn windows_rename_into_parent(
     let mut buffer = vec![0usize; word_length];
     let information = buffer.as_mut_ptr().cast::<FILE_RENAME_INFO>();
     unsafe {
-        (*information).Anonymous = FILE_RENAME_INFO_0 {
-            ReplaceIfExists: true,
-        };
-        (*information).RootDirectory = parent.as_raw_handle().cast();
+        // Write only the 1-byte `ReplaceIfExists` arm of the union rather than
+        // assigning the whole `FILE_RENAME_INFO_0`: constructing that union
+        // from a single `bool` field leaves its other three bytes
+        // uninitialized, and assigning it copies all four into the buffer.
+        (*information).Anonymous.ReplaceIfExists = true;
+        (*information).RootDirectory = std::ptr::null_mut();
         (*information).FileNameLength = name_bytes as u32;
         std::ptr::copy_nonoverlapping(
             name.as_ptr(),
@@ -1818,14 +1883,12 @@ fn atomic_write_file_no_follow_windows(path: &Path, content: &[u8], private: boo
 
         // Caller-visible Windows commit point. No fallible operation is
         // performed after the handle-relative rename succeeds.
-        windows_rename_into_parent(&temporary, &parent.directory, &parent.destination).map_err(
-            |error| {
-                CrosstacheError::config(format!(
-                    "Failed to atomically replace Windows destination '{}': {error}",
-                    parent.absolute.display()
-                ))
-            },
-        )
+        windows_rename_into_parent(&temporary, parent.absolute.as_os_str()).map_err(|error| {
+            CrosstacheError::config(format!(
+                "Failed to atomically replace Windows destination '{}': {error}",
+                parent.absolute.display()
+            ))
+        })
     })();
 
     if let Err(operation_error) = operation {
@@ -2468,13 +2531,16 @@ mod windows_rename_tests {
     use super::*;
     use windows_sys::Win32::Storage::FileSystem::FILE_RENAME_INFO;
 
-    /// Regression: the buffer was sized from `offset_of(FileName)` rather than
-    /// `size_of::<FILE_RENAME_INFO>()`, understating it by the trailing
-    /// `FileName[1]` element and its padding (4 bytes on 64-bit).
-    /// `SetFileInformationByHandle` rejected the short buffer with
-    /// ERROR_INVALID_PARAMETER (os error 87), so every private atomic replace
-    /// failed on Windows: `xv context use`, config writes, and the web UI's
-    /// `ui.json` (which is why no appearance change ever persisted).
+    /// Keeps the buffer at the documented `sizeof(FILE_RENAME_INFO) +
+    /// FileNameLength`, which always leaves room for a terminator past the
+    /// copied name.
+    ///
+    /// Note this sizing was NOT what broke atomic replace on Windows, despite
+    /// what an earlier fix concluded: `SetFileInformationByHandle` returns
+    /// ERROR_INVALID_PARAMETER (os error 87) for a non-NULL `RootDirectory`
+    /// whatever the buffer length, and succeeds at either length once
+    /// `RootDirectory` is NULL. Sizing from `offset_of(FileName)` is merely
+    /// off-contract, not the fault. See `windows_rename_into_parent`.
     #[test]
     fn rename_info_buffer_has_room_for_the_name_and_a_terminator() {
         let offset = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
@@ -3727,6 +3793,19 @@ mod tests {
         assert_private_windows_dacl(&path);
     }
 
+    /// Creating a symlink needs `SeCreateSymbolicLinkPrivilege`, which an
+    /// elevated process or one running under Developer Mode holds and an
+    /// ordinary user shell does not. Windows reports the lack of it as
+    /// ERROR_PRIVILEGE_NOT_HELD (1314), which Rust does *not* map to
+    /// `ErrorKind::PermissionDenied` — so the kind-only check these tests
+    /// originally used never matched and they panicked instead of skipping.
+    #[cfg(windows)]
+    fn windows_symlink_unavailable(error: &std::io::Error) -> bool {
+        const ERROR_PRIVILEGE_NOT_HELD: i32 = 1314;
+        error.kind() == std::io::ErrorKind::PermissionDenied
+            || error.raw_os_error() == Some(ERROR_PRIVILEGE_NOT_HELD)
+    }
+
     #[test]
     #[cfg(windows)]
     fn atomic_write_refuses_windows_reparse_parent() {
@@ -3737,7 +3816,8 @@ mod tests {
         let linked = root.path().join("linked");
         std::fs::create_dir(&external).unwrap();
         if let Err(error) = symlink_dir(&external, &linked) {
-            if error.kind() == std::io::ErrorKind::PermissionDenied {
+            if windows_symlink_unavailable(&error) {
+                eprintln!("skipping: cannot create symlinks without privilege ({error})");
                 return;
             }
             panic!("create directory reparse point: {error}");
@@ -3757,7 +3837,8 @@ mod tests {
         let linked = root.path().join("linked.conf");
         std::fs::write(&target, b"old").unwrap();
         if let Err(error) = symlink_file(&target, &linked) {
-            if error.kind() == std::io::ErrorKind::PermissionDenied {
+            if windows_symlink_unavailable(&error) {
+                eprintln!("skipping: cannot create symlinks without privilege ({error})");
                 return;
             }
             panic!("create file reparse point: {error}");

--- a/tests/action_yml_tests.rs
+++ b/tests/action_yml_tests.rs
@@ -10,6 +10,7 @@
 //!    handles secret material, so masking, multi-line values, and delimiter
 //!    injection are all exercised for real rather than reviewed by eye.
 
+#[cfg(unix)]
 use std::io::Write;
 use std::path::PathBuf;
 
@@ -208,12 +209,23 @@ fn oidc_auth_requires_the_id_token_permission_and_ids() {
 ///
 /// `responses` maps a secret name to the value the stub prints. A name absent
 /// from the map makes the stub exit non-zero, standing in for a fetch failure.
+///
+/// Unix-only. Not because the action is — it supports Windows runners, where
+/// GitHub provides bash — but because this *harness* is: it writes an
+/// extensionless `#!/usr/bin/env bash` stub made executable via `chmod`, joins
+/// `PATH` with `:`, and spawns `bash` by bare name. None of that holds on a
+/// Windows developer machine, where the tests failed with "program not found"
+/// rather than telling us anything about `action.yml`. CI runs `cargo test` on
+/// ubuntu-latest (`.github/workflows/build.yml`), so this gate costs no
+/// coverage.
+#[cfg(unix)]
 struct FetchRun {
     status: std::process::ExitStatus,
     stdout: String,
     github_env: String,
 }
 
+#[cfg(unix)]
 fn run_fetch(secrets_input: &str, responses: &[(&str, &str)]) -> FetchRun {
     let tmp = tempfile::tempdir().unwrap();
     let bin_dir = tmp.path().join("bin");
@@ -274,6 +286,7 @@ fn run_fetch(secrets_input: &str, responses: &[(&str, &str)]) -> FetchRun {
     }
 }
 
+#[cfg(unix)]
 fn shell_case_pattern(name: &str) -> String {
     // Test names are plain, but quote anyway so a pattern char cannot alter the
     // stub's control flow.
@@ -281,6 +294,7 @@ fn shell_case_pattern(name: &str) -> String {
 }
 
 /// Extract `NAME=value` pairs from a GITHUB_ENV file written in heredoc form.
+#[cfg(unix)]
 fn parse_github_env(body: &str) -> Vec<(String, String)> {
     let mut out = Vec::new();
     let mut lines = body.lines().peekable();
@@ -299,6 +313,7 @@ fn parse_github_env(body: &str) -> Vec<(String, String)> {
     out
 }
 
+#[cfg(unix)]
 #[test]
 fn fetch_exports_and_masks_each_secret() {
     let run = run_fetch(
@@ -322,6 +337,7 @@ fn fetch_exports_and_masks_each_secret() {
     assert!(run.stdout.contains("Fetched 2 secret(s)"), "{}", run.stdout);
 }
 
+#[cfg(unix)]
 #[test]
 fn fetch_handles_multiline_values_and_masks_every_line() {
     // A PEM key is the canonical multi-line secret. The runner matches masks
@@ -348,6 +364,7 @@ fn fetch_handles_multiline_values_and_masks_every_line() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn fetch_uses_a_random_delimiter_per_value() {
     let run = run_fetch("A=sa\nB=sb\n", &[("sa", "value-a"), ("sb", "value-b")]);
@@ -366,6 +383,7 @@ fn fetch_uses_a_random_delimiter_per_value() {
     assert!(delims.iter().all(|d| d.starts_with("XV_EOF_")));
 }
 
+#[cfg(unix)]
 #[test]
 fn fetch_rejects_a_value_containing_its_delimiter() {
     // Defence against env injection: a value that could close the heredoc early
@@ -387,6 +405,7 @@ fn fetch_rejects_a_value_containing_its_delimiter() {
     assert!(vars[0].1.contains("A=INJECTED"));
 }
 
+#[cfg(unix)]
 #[test]
 fn fetch_rejects_invalid_environment_variable_names() {
     for bad in ["1BAD=x", "has-dash=x", "has space=x", "=x"] {
@@ -405,6 +424,7 @@ fn fetch_rejects_invalid_environment_variable_names() {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn fetch_rejects_malformed_entries() {
     let run = run_fetch("NO_EQUALS_SIGN\n", &[]);
@@ -420,6 +440,7 @@ fn fetch_rejects_malformed_entries() {
     assert!(run.stdout.contains("No secret name"), "{}", run.stdout);
 }
 
+#[cfg(unix)]
 #[test]
 fn fetch_fails_the_step_when_a_secret_is_missing() {
     // A missing secret must fail loudly; exporting an empty value would let a
@@ -433,6 +454,7 @@ fn fetch_fails_the_step_when_a_secret_is_missing() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn fetch_skips_blanks_and_comments_and_tolerates_crlf() {
     let run = run_fetch(
@@ -444,6 +466,7 @@ fn fetch_skips_blanks_and_comments_and_tolerates_crlf() {
     assert_eq!(vars, vec![("DB".to_string(), "hunter2".to_string())]);
 }
 
+#[cfg(unix)]
 #[test]
 fn fetch_preserves_values_with_shell_metacharacters() {
     // Values are data, never code: a value that looks like a command

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,6 +16,23 @@ pub fn xv() -> Command {
     Command::new(env!("CARGO_BIN_EXE_xv"))
 }
 
+/// Render a filesystem path for interpolation into a **double-quoted** TOML
+/// string.
+///
+/// TOML basic strings process backslash escapes, so a Windows path dropped in
+/// verbatim is not merely ugly — it fails to parse. `C:\Users\...` makes the
+/// parser read `\U` as a unicode escape and reject the file with "invalid
+/// unicode 8-digit hex code", which is how every generated `xv.conf` in these
+/// harnesses became unloadable on Windows. Escaping the separators keeps one
+/// template correct on every platform.
+pub fn toml_path(path: impl AsRef<Path>) -> String {
+    path.as_ref()
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
 /// Apply isolation env vars to a `Command`. Caller passes a tempdir;
 /// this routes XDG_CONFIG_HOME, HOME, and XV_NO_PARENT_CONFIG so
 /// config and walk-up resolution start clean.
@@ -89,8 +106,8 @@ store_path = "{store}"
 key_file = "{key}"
 default_vault = "default"
 "#,
-        store = store_dir.display(),
-        key = key_file.display(),
+        store = toml_path(&store_dir),
+        key = toml_path(&key_file),
     );
     std::fs::write(xv_dir.join("xv.conf"), config_content).expect("write config");
 
@@ -141,8 +158,8 @@ default_vault = "default"
 audit = {audit}
 git = {git}
 "#,
-        store = store_dir.display(),
-        key = key_file.display(),
+        store = toml_path(&store_dir),
+        key = toml_path(&key_file),
     );
     std::fs::write(xv_dir.join("xv.conf"), config_content).expect("write config");
 
@@ -201,8 +218,8 @@ store_path = "{store}"
 key_file = "{key}"
 default_vault = "default"
 "#,
-        store = store_dir.display(),
-        key = key_file.display(),
+        store = toml_path(&store_dir),
+        key = toml_path(&key_file),
     );
     std::fs::write(xv_dir.join("xv.conf"), config_content).expect("write config");
     std::fs::write(project_dir.join(".xv.toml"), xv_toml).expect("write .xv.toml");

--- a/tests/config_command_tests.rs
+++ b/tests/config_command_tests.rs
@@ -11,7 +11,7 @@ fn doctor_appears_in_top_level_help() {
 #[test]
 fn doctor_runs_before_normal_config_loading() {
     let (mut cmd, temp) = common::xv_isolated();
-    let path = temp.path().join(".config/xv/xv.conf");
+    let path = temp.path().join(".config").join("xv").join("xv.conf");
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     std::fs::write(&path, "debug = [\n").unwrap();
     let out = cmd.arg("doctor").output().expect("spawn");
@@ -24,7 +24,7 @@ fn doctor_runs_before_normal_config_loading() {
 #[test]
 fn doctor_rejects_json_format_with_one_valid_error_envelope() {
     let (mut cmd, temp) = common::xv_isolated();
-    let path = temp.path().join(".config/xv/xv.conf");
+    let path = temp.path().join(".config").join("xv").join("xv.conf");
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     std::fs::write(&path, "debug = [\n").unwrap();
 
@@ -47,7 +47,7 @@ fn doctor_rejects_json_format_with_one_valid_error_envelope() {
 #[test]
 fn doctor_rejects_yaml_format_with_one_valid_error_envelope() {
     let (mut cmd, temp) = common::xv_isolated();
-    let path = temp.path().join(".config/xv/xv.conf");
+    let path = temp.path().join(".config").join("xv").join("xv.conf");
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     std::fs::write(&path, "debug = [\n").unwrap();
 
@@ -71,7 +71,7 @@ fn doctor_rejects_yaml_format_with_one_valid_error_envelope() {
 #[test]
 fn doctor_missing_config_uses_defaults_without_creating_files() {
     let (mut cmd, temp) = common::xv_isolated();
-    let path = temp.path().join(".config/xv/xv.conf");
+    let path = temp.path().join(".config").join("xv").join("xv.conf");
 
     let out = cmd.arg("doctor").output().expect("spawn");
 
@@ -80,13 +80,13 @@ fn doctor_missing_config_uses_defaults_without_creating_files() {
     assert!(output.contains("does not exist"));
     assert!(output.contains("defaults are usable"));
     assert!(!path.exists());
-    assert!(!temp.path().join(".config/xv").exists());
+    assert!(!temp.path().join(".config").join("xv").exists());
 }
 
 #[test]
 fn doctor_complete_config_is_healthy_and_unchanged() {
     let (mut cmd, temp) = common::xv_isolated();
-    let path = temp.path().join(".config/xv/xv.conf");
+    let path = temp.path().join(".config").join("xv").join("xv.conf");
     let original = br#"backend = "local"
 debug = false
 subscription_id = ""
@@ -117,7 +117,7 @@ default_vault = "default"
 #[test]
 fn doctor_repairs_sparse_local_config_and_preserves_exact_backup() {
     let (mut cmd, temp) = common::xv_isolated();
-    let path = temp.path().join(".config/xv/xv.conf");
+    let path = temp.path().join(".config").join("xv").join("xv.conf");
     let original =
         b"# sparse local config\nbackend = \"local\"\n\n[local]\ndefault_vault = \"default\"\n";
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -175,7 +175,7 @@ fn doctor_repairs_sparse_local_config_and_preserves_exact_backup() {
 fn doctor_invalid_occupied_type_requires_manual_edit_without_disclosing_value() {
     const BAD_VALUE: &str = "doctor-private-debug-value";
     let (mut cmd, temp) = common::xv_isolated();
-    let path = temp.path().join(".config/xv/xv.conf");
+    let path = temp.path().join(".config").join("xv").join("xv.conf");
     let original = format!(
         r#"backend = "local"
 debug = "{BAD_VALUE}"
@@ -204,7 +204,7 @@ no_color = true
 #[test]
 fn doctor_persists_repairs_before_reporting_semantic_error() {
     let (mut cmd, temp) = common::xv_isolated();
-    let path = temp.path().join(".config/xv/xv.conf");
+    let path = temp.path().join(".config").join("xv").join("xv.conf");
     let original = b"# sparse AWS config\nbackend = \"aws\"\n";
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     std::fs::write(&path, original).unwrap();

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -36,8 +36,8 @@ store_path = "{store}"
 key_file = "{key}"
 default_vault = "default"
 "#,
-        store = store.display(),
-        key = key.display(),
+        store = common::toml_path(&store),
+        key = common::toml_path(&key),
     );
     std::fs::write(xv_dir.join("xv.conf"), content).expect("write xv.conf");
 }

--- a/tests/e2e_backend_resolution.rs
+++ b/tests/e2e_backend_resolution.rs
@@ -25,6 +25,20 @@ use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
+/// Render a path for interpolation into a **double-quoted** TOML string.
+///
+/// TOML basic strings process backslash escapes, so an unescaped Windows path
+/// does not just look wrong — it fails to parse: `C:\Users\...` makes the
+/// parser read `\U` as a unicode escape and reject the config with "invalid
+/// unicode 8-digit hex code".
+fn toml_path(path: impl AsRef<std::path::Path>) -> String {
+    path.as_ref()
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
 /// A test environment with a global `xv.conf` (azure backend, no/empty
 /// credentials, valid `[local]` block) and an isolated project directory
 /// that may contain a `.xv.toml` env profile.
@@ -68,8 +82,8 @@ store_path = "{store}"
 key_file = "{key}"
 default_vault = "default"
 "#,
-            store = store_dir.display(),
-            key = key_file.display(),
+            store = toml_path(&store_dir),
+            key = toml_path(&key_file),
         );
         std::fs::write(xv_dir.join("xv.conf"), config_content).expect("write config");
 
@@ -248,7 +262,16 @@ fn backend_token_after_separator_is_not_mistaken_for_cli_flag() {
     let env = BackendResolutionEnv::new();
     env.write_local_profile();
 
-    let output = env.run(&mut env.xv(), &["run", "--", "echo", "--backend", "prod"]);
+    // `echo` is a shell builtin on Windows rather than an executable, so the
+    // child has to go through the platform shell there. What this test is
+    // actually about — a literal `--backend` token sitting after `--` — is
+    // unchanged either way.
+    #[cfg(windows)]
+    let child: &[&str] = &["run", "--", "cmd", "/c", "echo", "--backend", "prod"];
+    #[cfg(not(windows))]
+    let child: &[&str] = &["run", "--", "echo", "--backend", "prod"];
+
+    let output = env.run(&mut env.xv(), child);
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(

--- a/tests/e2e_local_backend.rs
+++ b/tests/e2e_local_backend.rs
@@ -18,6 +18,20 @@ use tempfile::TempDir;
 // Test harness
 // ---------------------------------------------------------------------------
 
+/// Render a path for interpolation into a **double-quoted** TOML string.
+///
+/// TOML basic strings process backslash escapes, so an unescaped Windows path
+/// does not just look wrong — it fails to parse: `C:\Users\...` makes the
+/// parser read `\U` as a unicode escape and reject the config with "invalid
+/// unicode 8-digit hex code".
+fn toml_path(path: impl AsRef<std::path::Path>) -> String {
+    path.as_ref()
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
 struct TestEnv {
     _tmp: TempDir,
     config_dir: PathBuf,
@@ -56,8 +70,8 @@ store_path = "{store}"
 key_file = "{key}"
 default_vault = "default"
 "#,
-            store = store_dir.display(),
-            key = key_file.display(),
+            store = toml_path(&store_dir),
+            key = toml_path(&key_file),
         );
         std::fs::write(xv_dir.join("xv.conf"), config_content).expect("write config");
 

--- a/tests/e2e_local_file_ops.rs
+++ b/tests/e2e_local_file_ops.rs
@@ -103,8 +103,8 @@ store_path = "{store}"
 key_file = "{key}"
 default_vault = "default"
 "#,
-        store = root.join("store").display(),
-        key = root.join("key.txt").display(),
+        store = common::toml_path(root.join("store")),
+        key = common::toml_path(root.join("key.txt")),
     )
 }
 

--- a/tests/e2e_workspaces.rs
+++ b/tests/e2e_workspaces.rs
@@ -16,6 +16,20 @@ use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
+/// Render a path for interpolation into a **double-quoted** TOML string.
+///
+/// TOML basic strings process backslash escapes, so an unescaped Windows path
+/// does not just look wrong — it fails to parse: `C:\Users\...` makes the
+/// parser read `\U` as a unicode escape and reject the config with "invalid
+/// unicode 8-digit hex code".
+fn toml_path(path: impl AsRef<std::path::Path>) -> String {
+    path.as_ref()
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
 /// A hermetic environment with two independent local-backend stores
 /// registered as named backends `local-a` and `local-b`, plus a private
 /// global context directory. Neither backend is the top-level active
@@ -113,12 +127,12 @@ region = "us-east-1"
 endpoint_url = "http://127.0.0.1:1"
 default_vault = "default"
 "#,
-            store_default = store_default.display(),
-            key_default = key_default.display(),
-            store_a = store_a.display(),
-            key_a = key_a.display(),
-            store_b = store_b.display(),
-            key_b = key_b.display(),
+            store_default = toml_path(&store_default),
+            key_default = toml_path(&key_default),
+            store_a = toml_path(&store_a),
+            key_a = toml_path(&key_a),
+            store_b = toml_path(&store_b),
+            key_b = toml_path(&key_b),
         );
         std::fs::write(xv_dir.join("xv.conf"), config_content).expect("write config");
 
@@ -508,10 +522,10 @@ store_path = "{store_a}"
 key_file = "{key_a}"
 default_vault = "default"
 "#,
-        store_default = store_default.display(),
-        key_default = key_default.display(),
-        store_a = store_a.display(),
-        key_a = key_a.display(),
+        store_default = toml_path(&store_default),
+        key_default = toml_path(&key_default),
+        store_a = toml_path(&store_a),
+        key_a = toml_path(&key_a),
     );
     std::fs::write(xv_dir.join("xv.conf"), config_content).expect("write config");
 
@@ -622,10 +636,10 @@ store_path = "{store_a}"
 key_file = "{key_a}"
 default_vault = "default"
 "#,
-        store_default = store_default.display(),
-        key_default = key_default.display(),
-        store_a = store_a.display(),
-        key_a = key_a.display(),
+        store_default = toml_path(&store_default),
+        key_default = toml_path(&key_default),
+        store_a = toml_path(&store_a),
+        key_a = toml_path(&key_a),
     );
     std::fs::write(xv_dir.join("xv.conf"), config_content).expect("write config");
 
@@ -762,10 +776,10 @@ store_path = "{store_a}"
 key_file = "{key_a}"
 default_vault = "default"
 "#,
-        store_default = store_default.display(),
-        key_default = key_default.display(),
-        store_a = store_a.display(),
-        key_a = key_a.display(),
+        store_default = toml_path(&store_default),
+        key_default = toml_path(&key_default),
+        store_a = toml_path(&store_a),
+        key_a = toml_path(&key_a),
     );
     std::fs::write(xv_dir.join("xv.conf"), config_content).expect("write config");
 
@@ -3168,17 +3182,33 @@ fn run_env_alias_uri_resolves() {
     ]);
     env.ok(&["set", "work:TOKEN", "--value", "work-value"]);
 
+    // `printenv` does not exist on Windows; `cmd /c echo %MY_REF%` reads the
+    // same inherited variable out of the child's environment, which is what
+    // this test is checking `xv run` resolved.
+    #[cfg(windows)]
+    let child: &[&str] = &[
+        "run",
+        "--inherit-env",
+        "--no-masking",
+        "--",
+        "cmd",
+        "/c",
+        "echo %MY_REF%",
+    ];
+    #[cfg(not(windows))]
+    let child: &[&str] = &[
+        "run",
+        "--inherit-env",
+        "--no-masking",
+        "--",
+        "printenv",
+        "MY_REF",
+    ];
+
     let out = env
         .xv()
         .env("MY_REF", "xv://work/TOKEN")
-        .args([
-            "run",
-            "--inherit-env",
-            "--no-masking",
-            "--",
-            "printenv",
-            "MY_REF",
-        ])
+        .args(child)
         .output()
         .expect("execute xv run");
     assert!(


### PR DESCRIPTION
## Summary

`xv` did not work on Windows. Not in a narrow way — a debug build aborted before `main`'s first line, `xv init` could not find an Azure CLI that was plainly installed, and no config file could be written at all. This branch fixes the seven root causes behind that, and adds the CI job that would have caught them.

The reason none of it was noticed: **`cargo test` has never run on Windows.** `.github/workflows/build.yml` ran the suite only on `ubuntu-latest`; the Windows job did `cargo check --all-features` and nothing more. The suite was compiled on Windows, never executed.

Running it revealed 84 failures and 4 tests that hung indefinitely.

## Product fixes

**Stack overflow — every debug command.** Windows sizes the main thread's stack from the PE header's `SizeOfStackReserve` (1 MiB default), not the 8 MiB the `[profile.test]` note in `Cargo.toml` assumes — that's a Unix default. The clap-derive command-tree build needs ~1.9 MiB at `opt-level = 0`, so every debug-built command died with `STATUS_STACK_OVERFLOW`. Verified by reading the reserve off the built binary and by patching it to 8 MiB in place, after which the same binary ran.

**Azure CLI not found.** The CLI ships as `az.cmd` on Windows; there is no `az.exe`. A shell resolves the bare name via `PATHEXT`, but `std::process::Command` only appends `.exe`, so `Command::new("az")` failed with `NotFound` while `az account show` worked in the same terminal. All 17 call sites now go through `az_program()`.

**`xv init` step 4/6 — all platforms.** `az account list-locations` does not accept `--subscription`; its help reads "List supported regions for the *current* subscription" and it exits with `ERROR: unrecognized arguments`. Switched to the subscription-scoped ARM REST endpoint this module already uses elsewhere.

**Atomic replace — config writes, `xv context use`, web UI `ui.json`.** `SetFileInformationByHandle` does not implement the handle-relative form of `FileRenameInfo`: it rejects **any** non-NULL `RootDirectory` with `ERROR_INVALID_PARAMETER`, at every buffer length, under every share mode, whether or not the destination exists. Only the NT-level `NtSetInformationFile` honours that field.

> This means the buffer sizing changed in #402 was never the cause. That call fails at every length with `RootDirectory` set and succeeds at either length once it is NULL. The regression test's doc comment is corrected rather than removed — the sizing is still off-contract, just not the fault.

Separately, replacing a directory entry makes the kernel open that directory for write, so holding the immediate parent with `FILE_SHARE_READ` only made our *own* rename fail. Both entry points hit this, so it is inherent to the operation.

**`write_private` emulated `0600` with `FILE_ATTRIBUTE_READONLY`.** That grants no confidentiality on Windows — any other user can still read the file — while blocking exactly what the backend needs: a read-only destination rejects both `fs::rename` and opening for write. Replaced with the protected owner+SYSTEM DACL `atomic_write_file_no_follow` already uses. **This is strictly more private than before, not less.**

**The local file backend was entirely non-functional.** `fs::File::open` on a *directory* always fails on Windows without `FILE_FLAG_BACKUP_SEMANTICS`. And `open_file_with_flags` decoded the access mode as a bitmask when it is an enum in the low bits: `O_RDONLY` is `0`, so `flags & O_RDONLY == O_RDONLY` was vacuously true for every input, and `O_RDWR` (2) shares no bit with `O_WRONLY` (1) — the vault lock's `O_RDWR | O_CREAT` never set write access. Clippy had been reporting this as `&-masking with zero`.

**Tests wrote to the real `%APPDATA%`.** `dirs::config_dir()` resolves through the Win32 known-folder API and ignores the environment, so the harness's `HOME`/`XDG_CONFIG_HOME` isolation did nothing — despite `tests/common/mod.rs` naming that its "cardinal invariant". On my machine the suite left behind a real `%APPDATA%\xv\xv.conf` holding the harness's fake all-zero credentials. The context file had the same flaw, which is a contamination bug in its own right: every suite shared one real `context`, so workspaces leaked between them as `unknown backend kind: local-a`.

Both now check `XDG_CONFIG_HOME` first. It isn't a Windows convention, so real users are unaffected.

## Test fixes

Generated `xv.conf` interpolated Windows paths into double-quoted TOML, where `C:\Users` makes `\U` an invalid unicode escape; paths built with forward slashes were compared against backslash output; `echo`/`printenv`/`bash` were spawned as executables; the reparse-point tests checked for `PermissionDenied` but Windows reports `ERROR_PRIVILEGE_NOT_HELD` (1314), which Rust doesn't map there; and `test_get_asset_name_returns_valid_name` asserted every build host is a release target when only four archives are published.

## CI

New `windows-test` job running `cargo test --verbose`. 19 tests drive a child through `sh`; Git for Windows is preinstalled on the runner and ships `sh.exe`, and the job puts that directory on `PATH` explicitly rather than relying on the image's default `PATH`. Verified locally with the shell supplied only from there.

No clippy step on Windows on purpose: it currently reports pre-existing dead-code lints for `#[cfg(unix)]`-gated helpers that would fail `-D warnings` on arrival. Confirmed against a stashed baseline that these predate this branch and that it introduces none. Worth a follow-up; deliberately not bundled here.

## Verification

- `cargo test` — **2823 passed, 0 failed**, 43 ignored, across 45 binaries (from 84 failures + 4 hangs)
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — no new lints vs. a stashed baseline; one pre-existing lint (`&-masking with zero`) resolved
- Azure paths checked against a live signed-in CLI: `xv init` steps 1–5 all succeed, step 4 returning 103 locations

`xv init`'s write steps (resource group, storage account, vault creation) are **not** exercised — they create billable resources. Steps 1–6 read-only and the config write are.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch security-sensitive file I/O (DACL, atomic rename), config path resolution, and Azure init subprocess/REST behavior across platforms; scope is large but focused on Windows correctness with added CI coverage.
> 
> **Overview**
> **Windows usability:** Debug `xv` was aborting with stack overflow because the main thread only had the PE default 1 MiB reserve; **`build.rs`** now links binaries with an **8 MiB** stack on Windows. Azure integration no longer spawns bare `az` — **`az_program()`** picks `az.cmd`/`az.bat` on PATH so `Command` can find the CLI. **`xv init`** region listing uses the **subscription-scoped ARM REST** locations API (and rejects non-UUID subscription ids) instead of `az account list-locations`, which does not accept `--subscription`.
> 
> **Local backend & config on Windows:** Atomic config/context writes fix **`FileRenameInfo`** by leaving **`RootDirectory` NULL** and widening share on the immediate parent directory; **`write_private`** uses the protected owner+SYSTEM DACL instead of read-only attributes that broke rename/flush. The local **file backend** opens directories with **`FILE_FLAG_BACKUP_SEMANTICS`**, decodes **`openat` flag access modes** correctly for `O_RDWR`, and skips Unix-only directory fsync on Windows. **`sync_file`** opens with write on Windows for `FlushFileBuffers`. **`settings`/`context`** paths honor **`XDG_CONFIG_HOME`** on Windows so tests do not write real `%APPDATA%`.
> 
> **CI & tests:** A new **`windows-test`** job runs **`cargo test`** (with Git’s `sh` on PATH); previously Windows only **`cargo check`**. Integration tests escape paths for TOML, use **`cmd`**/`echo` where needed, gate Unix-only **`action.yml`** harness tests, and relax upgrade asset-name expectations for unsupported platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53588091894ef42dd0b694bcbb53ffea3cdd6398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->