### PR TITLE
fix(workspace): make a stale workspace entry say how to fix itself

### DIFF
--- a/src/backend/error.rs
+++ b/src/backend/error.rs
@@ -92,6 +92,18 @@ pub enum BackendError {
     #[error("decryption failed: {0}")]
     Decryption(String),
 
+    /// The named backend does not exist: it is neither a `named_backends` key
+    /// nor a built-in kind.
+    ///
+    /// Distinct from [`Internal`](Self::Internal) for the same reason
+    /// [`Decryption`](Self::Decryption) is: callers need to tell "this can
+    /// never work, the configuration is wrong" apart from "something went
+    /// wrong inside a backend that does exist". The workspace layer relies on
+    /// that distinction to name the actual remedy for a stale entry rather
+    /// than emitting a generic parse error about backend *kinds*.
+    #[error("backend '{name}' is not configured")]
+    UnknownBackend { name: String },
+
     /// An internal error inside the backend implementation.
     #[error("backend internal error: {0}")]
     Internal(String),
@@ -134,6 +146,14 @@ impl From<BackendError> for CrosstacheError {
                 CrosstacheError::RateLimited(detail)
             }
             BackendError::Network(msg) => CrosstacheError::NetworkError(msg),
+            // Not a config *parse* problem, so not ConfigError: the file is
+            // valid, it just names a backend that no longer exists. Callers with
+            // more context (the workspace layer) build a richer message naming
+            // the remedy; this is the fallback for everyone else.
+            BackendError::UnknownBackend { name } => CrosstacheError::BackendUnavailable {
+                reason: format!("no backend named '{name}' is configured"),
+                backend: name,
+            },
             BackendError::RenameIncomplete {
                 source,
                 destination,

--- a/src/backend/local/audit.rs
+++ b/src/backend/local/audit.rs
@@ -160,6 +160,11 @@ pub fn failure_status(err: &BackendError) -> &'static str {
         BackendError::Conflict(_) => "Conflict",
         BackendError::RateLimited { .. } => "RateLimited",
         BackendError::Network(_) => "NetworkError",
+        // A misconfiguration, not a fault of any backend that ran: the name
+        // resolves to nothing. Shares the InvalidArgument token rather than
+        // widening the closed vocabulary for a case the audit trail cannot
+        // meaningfully distinguish.
+        BackendError::UnknownBackend { .. } => "InvalidArgument",
         BackendError::RenameIncomplete { .. } => "RenameIncomplete",
         // Conditional-write guards: the caller's snapshot went stale, or the
         // rename destination already exists. Rejections, not faults.

--- a/src/backend/registry.rs
+++ b/src/backend/registry.rs
@@ -269,9 +269,16 @@ impl BackendRegistry {
             };
         }
 
+        // Neither a `named_backends` key (checked above) nor a built-in kind:
+        // the name does not exist at all. Report that as its own variant --
+        // "unknown backend kind: X. Valid options: azure, local, aws" reads as
+        // advice to correct a *kind*, when the caller most likely referenced a
+        // named backend that has since been removed from the config.
         let kind: BackendKind = name
             .parse()
-            .map_err(|e: String| BackendError::Internal(e))?;
+            .map_err(|_: String| BackendError::UnknownBackend {
+                name: name.to_string(),
+            })?;
 
         match kind {
             BackendKind::Azure => {

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -269,12 +269,9 @@ pub(crate) async fn resolve_vault_ref_with_workspace(
 ) -> Result<(Arc<dyn Backend>, String, String)> {
     if let (Some(ws), Some(ws_registry)) = (ws, ws_registry) {
         if let Some(entry) = ws.entry(raw) {
-            let backend = ws_registry.materialize(&entry.backend).map_err(|e| {
-                CrosstacheError::config(format!(
-                    "workspace vault '{}' (backend '{}') is unavailable: {e}",
-                    entry.alias, entry.backend
-                ))
-            })?;
+            let backend = ws_registry
+                .materialize(&entry.backend)
+                .map_err(|e| crate::workspace::resolve::entry_unavailable_error(entry, e))?;
             return Ok((backend, entry.backend.clone(), entry.vault.clone()));
         }
     }

--- a/src/cli/mv_ops.rs
+++ b/src/cli/mv_ops.rs
@@ -378,12 +378,7 @@ pub(crate) async fn execute_mv(
         let default_entry = ws.default_entry()?.clone();
         let backend = ws_registry
             .materialize(&default_entry.backend)
-            .map_err(|e| {
-                CrosstacheError::config(format!(
-                    "workspace vault '{}' (backend '{}') is unavailable: {e}",
-                    default_entry.alias, default_entry.backend
-                ))
-            })?;
+            .map_err(|e| crate::workspace::resolve::entry_unavailable_error(&default_entry, e))?;
         (default_entry.vault, default_entry.backend, backend)
     } else {
         let vault_name = resolve_vault_for_trait(&config, registry).await?;
@@ -498,18 +493,12 @@ async fn execute_cross_vault_alias_mv(
         }
     };
 
-    let src_backend = ws_registry.materialize(&src_entry.backend).map_err(|e| {
-        CrosstacheError::config(format!(
-            "workspace vault '{}' (backend '{}') is unavailable: {e}",
-            src_entry.alias, src_entry.backend
-        ))
-    })?;
-    let dst_backend = ws_registry.materialize(&dst_entry.backend).map_err(|e| {
-        CrosstacheError::config(format!(
-            "workspace vault '{}' (backend '{}') is unavailable: {e}",
-            dst_entry.alias, dst_entry.backend
-        ))
-    })?;
+    let src_backend = ws_registry
+        .materialize(&src_entry.backend)
+        .map_err(|e| crate::workspace::resolve::entry_unavailable_error(src_entry, e))?;
+    let dst_backend = ws_registry
+        .materialize(&dst_entry.backend)
+        .map_err(|e| crate::workspace::resolve::entry_unavailable_error(dst_entry, e))?;
 
     // Find the source secret by its qualified (folder, display-name) path —
     // same lookup `execute_secret_mv` uses for the same-vault case.

--- a/src/cli/secret_ops.rs
+++ b/src/cli/secret_ops.rs
@@ -2258,12 +2258,9 @@ async fn execute_deleted_secret_list_workspace(
     let show_vault = ws.entries.len() >= 2;
     let mut items: Vec<crate::secret::manager::DeletedSecretSummary> = Vec::new();
     for entry in &ws.entries {
-        let backend = ws_registry.materialize(&entry.backend).map_err(|e| {
-            CrosstacheError::config(format!(
-                "workspace vault '{}' (backend '{}') is unavailable: {e}",
-                entry.alias, entry.backend
-            ))
-        })?;
+        let backend = ws_registry
+            .materialize(&entry.backend)
+            .map_err(|e| crate::workspace::resolve::entry_unavailable_error(entry, e))?;
 
         if !backend.capabilities().has_soft_delete {
             eprintln!(
@@ -2381,12 +2378,9 @@ async fn execute_secret_list_workspace(
 
     let mut merged: Vec<crate::secret::manager::SecretSummary> = Vec::new();
     for entry in &ws.entries {
-        let backend = ws_registry.materialize(&entry.backend).map_err(|e| {
-            CrosstacheError::config(format!(
-                "workspace vault '{}' (backend '{}') is unavailable: {e}",
-                entry.alias, entry.backend
-            ))
-        })?;
+        let backend = ws_registry
+            .materialize(&entry.backend)
+            .map_err(|e| crate::workspace::resolve::entry_unavailable_error(entry, e))?;
 
         let cache_key = crate::cache::CacheKey::SecretsList {
             backend: entry.backend.clone(),
@@ -5287,12 +5281,9 @@ pub(crate) async fn execute_secret_find_direct(
             // `--all-vaults` vault-prefix style.
             let mut items: Vec<CandidateItem> = Vec::new();
             for entry in &ws.entries {
-                let backend = ws_registry.materialize(&entry.backend).map_err(|e| {
-                    CrosstacheError::config(format!(
-                        "workspace vault '{}' (backend '{}') is unavailable: {e}",
-                        entry.alias, entry.backend
-                    ))
-                })?;
+                let backend = ws_registry
+                    .materialize(&entry.backend)
+                    .map_err(|e| crate::workspace::resolve::entry_unavailable_error(entry, e))?;
                 let secrets = backend
                     .secrets()
                     .list_secrets(&entry.vault, None)
@@ -6079,12 +6070,9 @@ async fn resolve_uri_secret_workspace_aware(
     if backend_ref.backend.is_none() {
         if let (Some(ws), Some(ws_registry)) = (ws, ws_registry) {
             if let Some(entry) = ws.entry(&backend_ref.vault) {
-                let backend = ws_registry.materialize(&entry.backend).map_err(|e| {
-                    CrosstacheError::config(format!(
-                        "workspace vault '{}' (backend '{}') is unavailable: {e}",
-                        entry.alias, entry.backend
-                    ))
-                })?;
+                let backend = ws_registry
+                    .materialize(&entry.backend)
+                    .map_err(|e| crate::workspace::resolve::entry_unavailable_error(entry, e))?;
                 return backend
                     .secrets()
                     .get_secret(&entry.vault, secret_name, true)

--- a/src/utils/error_hints.rs
+++ b/src/utils/error_hints.rs
@@ -20,6 +20,9 @@ pub fn hint_for(code: &str) -> Option<&'static str> {
             "Check TLS configuration and any corporate proxy with TLS interception."
         }
         "xv-config-invalid" => "Run 'xv config show' to inspect, or 'xv init' to reinitialize.",
+        "xv-backend-unavailable" => {
+            "Run 'xv cx ls' to see attached workspace vaults and the backend each one uses."
+        }
         "xv-env-not-defined" => "Run 'xv env list' to see defined environments.",
         "xv-azure-api" => "Check Azure service status and your subscription quotas.",
         "xv-scan-leak-detected" => "Findings printed to stderr; review and remove the leak before committing. Use 'xv scan --hook' for CI integration.",
@@ -40,6 +43,7 @@ mod tests {
         assert!(hint_for("xv-config-invalid").is_some());
         assert!(hint_for("xv-env-not-defined").is_some());
         assert!(hint_for("xv-scan-leak-detected").is_some());
+        assert!(hint_for("xv-backend-unavailable").is_some());
     }
 
     #[test]
@@ -58,6 +62,7 @@ mod tests {
             "xv-config-invalid",
             "xv-env-not-defined",
             "xv-scan-leak-detected",
+            "xv-backend-unavailable",
         ] {
             let hint = hint_for(code).unwrap();
             assert!(

--- a/src/web/errors.rs
+++ b/src/web/errors.rs
@@ -333,6 +333,18 @@ pub(crate) fn backend_error(error: BackendError) -> (StatusCode, ApiErrorBody) {
             "The secret could not be decrypted.",
             "The configured age identity may not match this store, or the data may be damaged.",
         ),
+        // A workspace entry naming a backend that is not configured. Not
+        // transient, so deliberately not 503 "try again later" — it will never
+        // succeed until the config or the workspace changes. Carries the same
+        // code as the CLI so both surfaces name one failure, and the same
+        // remedy, since the UI is loopback-only and driven by the very user who
+        // can run `xv cx rm`.
+        UnknownBackend { .. } => generic(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "xv-backend-unavailable",
+            "A vault in this workspace points at a backend that is not configured.",
+            "Remove the stale entry with 'xv cx rm <alias>', or restore the backend in your config.",
+        ),
         Internal(_) | Other(_) => generic(
             StatusCode::INTERNAL_SERVER_ERROR,
             "xv-backend-internal",

--- a/src/workspace/resolve.rs
+++ b/src/workspace/resolve.rs
@@ -135,13 +135,49 @@ pub async fn resolve_secret_target(
     }
 }
 
-fn materialize(registry: &BackendRegistry, entry: &WorkspaceEntry) -> Result<Arc<dyn Backend>> {
-    registry.materialize(&entry.backend).map_err(|e| {
-        CrosstacheError::config(format!(
-            "workspace vault '{}' (backend '{}') is unavailable: {e}",
+/// Turn a failed materialization of a workspace entry into a user-facing error.
+///
+/// A *stale* entry — one whose backend is not configured at all — is not an
+/// outage. It can never resolve, and because unqualified reads and the union
+/// `ls` fan out across every attached vault, one stale entry blocks all of
+/// them until it is removed. It therefore needs to name its own remedy.
+///
+/// What used to surface instead was the registry's generic
+/// `unknown backend kind: X. Valid options: azure, local, aws`, wrapped as
+/// `xv-config-invalid`. That was wrong twice over: the backend *kind* is not
+/// what is broken, and `xv-config-invalid`'s hint recommends `xv init`, which
+/// would rebuild the user's entire configuration to fix one stale line.
+///
+/// Genuine failures of a backend that *does* exist (auth, network, a bad
+/// `[named_backends.x]` block) keep their original shape — the caller cannot
+/// tell whether the secret is there, so those must still fail loud.
+pub(crate) fn entry_unavailable_error(
+    entry: &WorkspaceEntry,
+    error: crate::backend::error::BackendError,
+) -> CrosstacheError {
+    match error {
+        crate::backend::error::BackendError::UnknownBackend { name } => {
+            CrosstacheError::BackendUnavailable {
+                reason: format!(
+                    "workspace alias '{}' points at it, but no backend by that name is \
+                     configured. Remove the stale entry with `xv cx rm {}`, or restore the \
+                     backend by adding a [named_backends.{}] section to your config.",
+                    entry.alias, entry.alias, name
+                ),
+                backend: name,
+            }
+        }
+        other => CrosstacheError::config(format!(
+            "workspace vault '{}' (backend '{}') is unavailable: {other}",
             entry.alias, entry.backend
-        ))
-    })
+        )),
+    }
+}
+
+fn materialize(registry: &BackendRegistry, entry: &WorkspaceEntry) -> Result<Arc<dyn Backend>> {
+    registry
+        .materialize(&entry.backend)
+        .map_err(|e| entry_unavailable_error(entry, e))
 }
 
 /// Materialize the workspace's effective default entry without probing any
@@ -204,6 +240,79 @@ async fn search_all(
         }
     }
     Ok(found)
+}
+
+#[cfg(test)]
+mod stale_entry_tests {
+    use super::*;
+    use crate::backend::error::BackendError;
+
+    fn entry(alias: &str, backend: &str) -> WorkspaceEntry {
+        WorkspaceEntry {
+            alias: alias.to_string(),
+            backend: backend.to_string(),
+            vault: "default".to_string(),
+            default: false,
+        }
+    }
+
+    /// A workspace entry pointing at a backend that no longer exists blocks
+    /// every unqualified read and the union `ls`. The error therefore has to
+    /// name the way out.
+    ///
+    /// It must NOT arrive as `xv-config-invalid`: that code's hint recommends
+    /// `xv init`, which would rebuild the user's whole configuration to fix a
+    /// single stale line. Nor should it repeat the registry's
+    /// "Valid options: azure, local, aws", which points at correcting a
+    /// backend *kind* — not what is wrong here.
+    #[test]
+    fn stale_entry_names_the_remedy() {
+        let error = entry_unavailable_error(
+            &entry("stale", "ghost-backend"),
+            BackendError::UnknownBackend {
+                name: "ghost-backend".to_string(),
+            },
+        );
+
+        assert_eq!(error.code(), "xv-backend-unavailable");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("xv cx rm stale"),
+            "must name the removal command: {rendered}"
+        );
+        assert!(
+            rendered.contains("[named_backends.ghost-backend]"),
+            "must name the restore path: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Valid options"),
+            "must not suggest correcting a backend kind: {rendered}"
+        );
+    }
+
+    /// The stale case is carved out of, not substituted for, fail-loud
+    /// behaviour. A backend that genuinely exists but failed — auth, network, a
+    /// malformed `[named_backends.x]` block — still aborts the operation with
+    /// its original shape, because the caller cannot tell whether the secret is
+    /// in there and must not be handed a partial answer.
+    #[test]
+    fn a_real_failure_of_an_existing_backend_is_unchanged() {
+        let error = entry_unavailable_error(
+            &entry("work", "local-a"),
+            BackendError::Network("connection timed out".to_string()),
+        );
+
+        assert_eq!(error.code(), "xv-config-invalid");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("workspace vault 'work' (backend 'local-a') is unavailable"),
+            "{rendered}"
+        );
+        assert!(
+            !rendered.contains("xv cx rm"),
+            "removing the entry is not the fix for a transient failure: {rendered}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/tests/e2e_workspaces.rs
+++ b/tests/e2e_workspaces.rs
@@ -16,6 +16,30 @@ use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
+/// Remove a whole `[named_backends.<name>]` block from a config, leaving any
+/// workspace entry that pointed at it dangling — which is exactly how a real
+/// stale entry comes about.
+fn strip_named_backend(config: &str, name: &str) -> String {
+    let header = format!("[named_backends.{name}]");
+    let mut out = String::new();
+    let mut skipping = false;
+    for line in config.lines() {
+        if line.trim() == header {
+            skipping = true;
+            continue;
+        }
+        // Any following section header ends the block.
+        if skipping && line.trim_start().starts_with('[') {
+            skipping = false;
+        }
+        if !skipping {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
 /// Render a path for interpolation into a **double-quoted** TOML string.
 ///
 /// TOML basic strings process backslash escapes, so an unescaped Windows path
@@ -3657,6 +3681,78 @@ fn uri_alias_precedence_over_raw_vault_of_same_name() {
         rendered.contains("qualified: raw-active-value"),
         "{rendered}"
     );
+}
+
+/// A workspace entry goes stale when the named backend it points at is removed
+/// from the config: the entry survives in the context file, referencing
+/// nothing. Unqualified reads and the union `ls` fan out across every attached
+/// vault, so one stale entry blocks all of them — correctly, since skipping it
+/// could hand back a wrong or incomplete answer. What it must not do is leave
+/// the user without a way out.
+///
+/// Regression: this used to surface as `xv-config-invalid` carrying the
+/// registry's `unknown backend kind: local-b. Valid options: azure, local,
+/// aws` — advice to correct a backend *kind*, when the entry simply points at
+/// one that is gone. `xv-config-invalid`'s TTY hint compounded it by
+/// recommending `xv init`, which would rebuild the entire configuration to fix
+/// a single stale line.
+#[test]
+fn stale_workspace_entry_names_its_remedy_and_cx_rm_recovers() {
+    let env = WorkspaceEnv::new();
+    env.ok(&[
+        "cx",
+        "add",
+        "default",
+        "--backend",
+        "local-a",
+        "--as",
+        "work",
+    ]);
+    env.ok(&[
+        "cx",
+        "add",
+        "default",
+        "--backend",
+        "local-b",
+        "--as",
+        "stage",
+    ]);
+    env.ok(&["set", "work:TOKEN", "--value", "v"]);
+    env.ok(&["list"]);
+
+    // Make `stage` stale by deleting the backend it points at.
+    let config_path = env.config_dir.join("xv").join("xv.conf");
+    let config = std::fs::read_to_string(&config_path).expect("read config");
+    let pruned = strip_named_backend(&config, "local-b");
+    assert!(
+        !pruned.contains("[named_backends.local-b]"),
+        "the block must actually be gone, or this test proves nothing"
+    );
+    assert!(
+        pruned.contains("[named_backends.local-a]"),
+        "only local-b should have been removed"
+    );
+    std::fs::write(&config_path, pruned).expect("write config");
+
+    let out = env.err(&["list"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("xv-backend-unavailable"),
+        "a stale entry is not a config-parse failure: {stderr}"
+    );
+    assert!(
+        stderr.contains("xv cx rm stage"),
+        "the error must name the command that fixes it: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Valid options"),
+        "must not read as advice to correct a backend kind: {stderr}"
+    );
+
+    // The remedy the message names has to actually work.
+    env.ok(&["cx", "rm", "stage"]);
+    env.ok(&["list"]);
+    env.ok(&["get", "work:TOKEN"]);
 }
 
 // ===========================================================================


### PR DESCRIPTION
## The bug

A workspace entry goes stale when the named backend it points at is removed from the config: the entry survives in the context file, referencing nothing. Unqualified reads and the union `ls` fan out across every attached vault, so **one stale entry blocks all of them**.

I hit this for real: a contaminated context file left an entry pointing at `local-a` after that backend was gone, and every `xv list` / `xv get` failed with:

```
error[xv-config-invalid]: Configuration error: workspace vault 'stale' (backend 'ghost') is
unavailable: backend internal error: unknown backend kind: ghost. Valid options: azure, local, aws
```

That message is wrong three times over:

- **The backend *kind* is not what is broken.** "Valid options: azure, local, aws" reads as advice to change `ghost` to `azure`, when the entry simply points at a named backend that no longer exists.
- **It is not a config *parse* failure**, so `xv-config-invalid` is the wrong code.
- **That code's TTY hint recommends `xv init`** — which would rebuild the user's entire configuration to repair one stale line.

## After

```
error[xv-backend-unavailable]: Backend 'ghost' is not available: workspace alias 'stale' points
at it, but no backend by that name is configured. Remove the stale entry with `xv cx rm stale`,
or restore the backend by adding a [named_backends.ghost] section to your config.
  hint: Run 'xv cx ls' to see attached workspace vaults and the backend each one uses.
```

## What did *not* change, deliberately

**Read semantics.** A stale entry still fails the operation rather than being skipped. Skipping is tempting — it would make `xv list` work again — but it would let an unqualified `xv get FOO` return *another* vault's `FOO`, and silently drop a vault from `ls` output. The fail-loud rule in `search_all` exists precisely to prevent that, and quietly weakening it to improve an error message would be a bad trade. Only the diagnosis and the remedy change.

Worth noting how much already worked, which is why this is a diagnosis bug rather than a lockout: qualified reads (`xv get alias:NAME`), all writes, and `xv cx ls` / `xv cx rm` were unaffected throughout. The one-command fix existed; nothing told the user about it.

If you'd rather `ls` degrade gracefully — skip stale vaults with a visible note, the way `--deleted` already skips backends without soft-delete — that's a reasonable but separate product decision, and I didn't want to make it unilaterally inside a bug fix.

## Implementation

`BackendError::UnknownBackend` is carved out of `Internal` — the same split `Decryption` already got, for the same reason: callers need to distinguish "this can never work, the config is wrong" from "something failed inside a backend that does exist". That makes the stale case detectable **by type rather than by matching message text**.

A genuine failure of a backend that *does* exist — auth, network, a malformed `[named_backends.x]` block — keeps its original shape and still fails loud, because the caller cannot tell whether the secret is in there.

The error text was also duplicated inline at **eight** call sites across `resolve.rs`, `helpers.rs`, `mv_ops.rs`, and `secret_ops.rs`, each free to drift. All now route through one `entry_unavailable_error`.

## Verification

- Reproduced the original failure from a hand-built stale context, confirmed the new message, and confirmed `xv cx rm` recovers
- New e2e test builds the stale state the way a user actually would — `cx add` a backend, then delete its `[named_backends.*]` block — and asserts the message names `xv cx rm stage`, does not say "Valid options", and that the named remedy works
- Two unit tests pin both halves: the stale case names the remedy; a network failure of a real backend is unchanged
- `cargo test` — 2828 passed, 0 failed, across 45 binaries, rebased onto current `main` (post-#403)
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` introduces no new lints vs. a stashed baseline

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches error classification and user messaging across many workspace fan-out CLI paths; behavior stays fail-loud (no skipping stale vaults), so misclassification could misdirect fixes but does not weaken secret resolution semantics.
> 
> **Overview**
> When a workspace alias points at a **named backend that no longer exists**, resolution no longer surfaces as `xv-config-invalid` with the registry’s misleading “unknown backend kind / Valid options: azure, local, aws” text. The registry now returns **`BackendError::UnknownBackend`**, mapped to **`xv-backend-unavailable`** with workspace-aware guidance (`xv cx rm <alias>` or restore `[named_backends.*]`).
> 
> **`entry_unavailable_error`** centralizes that mapping for workspace materialization; CLI paths in helpers, mv, and secret ops route through it instead of duplicating inline config errors. Real failures on backends that **do** exist (network, auth, bad named block) still use the previous unavailable/config shape.
> 
> The web API and TTY hint for **`xv-backend-unavailable`** align with the CLI remedy. Local audit maps unknown-backend to **`InvalidArgument`** without widening the status vocabulary. E2e and unit tests cover stale-entry messaging and unchanged behavior for transient failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65c684adb8cf4fe8f164651d14e21925b1754bf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->