### PR TITLE
fix(install): make Azure CLI optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,12 @@ curl -sSL https://raw.githubusercontent.com/bziobnic/crosstache/main/scripts/ins
 iwr -useb https://raw.githubusercontent.com/bziobnic/crosstache/main/scripts/install.ps1 | iex
 ```
 
+Azure CLI is not an installation or general runtime requirement. Local and AWS
+backends need no Azure tooling, and Azure supports environment credentials,
+managed identity, and OIDC directly. Install Azure CLI only if you want to use
+`--credential-type cli` or the Azure discovery and provisioning steps in the
+interactive `xv init` flow.
+
 ### Pre-built binaries
 
 [Releases page](https://github.com/bziobnic/crosstache/releases) — choose the right archive:

--- a/docs/superpowers/plans/2026-08-09-remove-az-installer-dependency.md
+++ b/docs/superpowers/plans/2026-08-09-remove-az-installer-dependency.md
@@ -1,0 +1,123 @@
+# Remove Azure CLI Installer Dependency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the generic crosstache installers from checking for or installing Azure CLI, because `xv` supports local, AWS, environment-credential, managed-identity, and OIDC operation without it.
+
+**Architecture:** Treat Azure CLI as an optional Azure credential and interactive-provisioning tool, not an installation prerequisite. Exercise the Unix installer end to end with a hermetic fake release and an `az` spy, then make both Unix and PowerShell installers backend-neutral while preserving their existing download, signature, checksum, extraction, and PATH behavior.
+
+**Tech Stack:** Rust integration tests, Bash, PowerShell, Markdown.
+
+## Global Constraints
+
+- Preserve Azure CLI authentication (`--credential-type cli`) as an optional supported mode.
+- Preserve the separate `xfunction` provisioning installer, whose design intentionally orchestrates Azure CLI commands.
+- Do not alter the user's existing `package-lock.json` modification.
+- Installer downloads must remain signature- and checksum-verified.
+
+---
+
+### Task 1: Prove the generic Unix installer has no Azure CLI prerequisite
+
+**Files:**
+- Create: `tests/installer_tests.rs`
+
+**Interfaces:**
+- Consumes: `scripts/install.sh`, `XDG_BIN_HOME`, `PATH`, and the installer's existing release-download contract.
+- Produces: `unix_installer_does_not_invoke_azure_cli`, an end-to-end regression test that fails if the installer executes `az`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create a Unix-only Rust integration test that builds a tiny signed-release fixture, places fake `curl`, `minisign`, and `az` commands first on `PATH`, runs `bash scripts/install.sh v-test`, and asserts that the fake binary was installed while the `az` spy marker was not created. The fake `az` returns a valid `az version` response so the current installer completes instead of prompting; the marker is the observable regression.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --test installer_tests unix_installer_does_not_invoke_azure_cli -- --exact --nocapture`
+
+Expected: FAIL because the current installer calls the fake `az version` command and creates the marker.
+
+- [ ] **Step 3: Keep the test fixture behavioral**
+
+The test must execute the installer and assert process effects. It must not inspect installer source text for removed function names or messages.
+
+### Task 2: Remove the mandatory Azure CLI work from both installers
+
+**Files:**
+- Modify: `scripts/install.sh`
+- Modify: `scripts/install.ps1`
+
+**Interfaces:**
+- Consumes: the existing platform detection and verified release installation flows.
+- Produces: non-interactive generic installation that never detects, prompts for, or installs Azure CLI.
+
+- [ ] **Step 1: Remove the Unix Azure CLI prerequisite**
+
+Delete `check_azure_cli`, `install_azure_cli`, and the Azure CLI check/prompt block in `main`. Change `show_usage` to recommend `xv init` and explain that backend-specific authentication is configured afterward.
+
+- [ ] **Step 2: Run the Unix regression test**
+
+Run: `cargo test --test installer_tests unix_installer_does_not_invoke_azure_cli -- --exact --nocapture`
+
+Expected: PASS; the release fixture installs and the `az` marker remains absent.
+
+- [ ] **Step 3: Remove the PowerShell Azure CLI prerequisite symmetrically**
+
+Delete `Test-AzureCLI`, `Install-AzureCLI`, and the Azure CLI check/prompt block in `Install-crosstache`. Change `Show-Usage` to the same backend-neutral next step as the Unix installer.
+
+- [ ] **Step 4: Validate installer syntax**
+
+Run: `bash -n scripts/install.sh`
+
+If `pwsh` is available, run: `pwsh -NoProfile -Command '$errors = $null; [void][System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path "scripts/install.ps1"), [ref]$null, [ref]$errors); if ($errors.Count) { $errors | ForEach-Object { Write-Error $_ }; exit 1 }'`
+
+Expected: both scripts parse without errors.
+
+### Task 3: Document the validated dependency boundary
+
+**Files:**
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: the authentication modes already documented in the Authentication section.
+- Produces: accurate installation guidance distinguishing optional Azure CLI auth from actual prerequisites.
+
+- [ ] **Step 1: Clarify installation requirements**
+
+Add a short note after Quick install: Azure CLI is not required to install or use crosstache with local, AWS, environment credentials, managed identity, or OIDC. It remains optional for `--credential-type cli` and for Azure discovery/provisioning in the interactive setup flow.
+
+- [ ] **Step 2: Verify documentation and source references are coherent**
+
+Run: `rg -n -S 'requires Azure CLI|Azure CLI \(az\) must be installed|crosstache will not work properly without Azure CLI' scripts README.md`
+
+Expected: no false universal-prerequisite claims remain in the generic installers or README.
+
+### Task 4: Full verification
+
+**Files:**
+- Verify only.
+
+**Interfaces:**
+- Consumes: all changes from Tasks 1-3.
+- Produces: evidence that the installer dependency was removed without regressing the Rust project.
+
+- [ ] **Step 1: Format and lint**
+
+Run: `cargo fmt -- --check`
+
+Run: `cargo clippy -- -D warnings`
+
+Expected: both pass.
+
+- [ ] **Step 2: Run the test suite**
+
+Run: `cargo test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Inspect the final diff and working tree**
+
+Run: `git diff --check`
+
+Run: `git status --short`
+
+Expected: only the installer dependency change, its behavioral test, README clarification, and this plan are new; the pre-existing `package-lock.json` modification remains untouched.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -59,80 +59,6 @@ function Write-Error {
     exit 1
 }
 
-# Check if Azure CLI is installed
-function Test-AzureCLI {
-    try {
-        $azVersion = az version --output json | ConvertFrom-Json
-        if ($azVersion.'azure-cli') {
-            Write-Info "Azure CLI is already installed (version: $($azVersion.'azure-cli'))"
-            return $true
-        }
-    }
-    catch {
-        return $false
-    }
-    return $false
-}
-
-# Install Azure CLI for Windows
-function Install-AzureCLI {
-    Write-Info "Installing Azure CLI..."
-    
-    # Check if running with administrator privileges
-    $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
-    $isAdmin = $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-    
-    try {
-        # Try to install via winget first (if available)
-        if (Get-Command winget -ErrorAction SilentlyContinue) {
-            Write-Info "Installing Azure CLI via winget..."
-            winget install Microsoft.AzureCLI --accept-source-agreements --accept-package-agreements
-        }
-        # Try chocolatey if available
-        elseif (Get-Command choco -ErrorAction SilentlyContinue) {
-            Write-Info "Installing Azure CLI via Chocolatey..."
-            choco install azure-cli -y
-        }
-        # Fall back to MSI installer
-        else {
-            Write-Info "Installing Azure CLI via MSI installer..."
-            $msiUrl = "https://aka.ms/installazurecliwindows"
-            $tempFile = "$env:TEMP\AzureCLI.msi"
-            
-            Write-Info "Downloading Azure CLI installer..."
-            Invoke-WebRequest -Uri $msiUrl -OutFile $tempFile
-            
-            if ($isAdmin) {
-                Write-Info "Installing Azure CLI (requires administrator privileges)..."
-                Start-Process msiexec.exe -ArgumentList "/i", $tempFile, "/quiet" -Wait
-            }
-            else {
-                Write-Warning "Administrator privileges required for installation."
-                Write-Warning "Please run as administrator or install Azure CLI manually."
-                Write-Warning "You can download it from: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-windows"
-                return $false
-            }
-            
-            # Clean up temp file
-            Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
-        }
-        
-        # Verify installation
-        if (Test-AzureCLI) {
-            Write-Success "Azure CLI installed successfully"
-            return $true
-        }
-        else {
-            Write-Error "Azure CLI installation failed. Please install it manually from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-windows"
-            return $false
-        }
-    }
-    catch {
-        Write-Error "Failed to install Azure CLI: $($_.Exception.Message)"
-        return $false
-    }
-}
-
 # Get latest version from GitHub API
 function Get-LatestVersion {
     try {
@@ -260,25 +186,8 @@ function Test-Installation {
 # Show usage information
 function Show-Usage {
     Write-Host ""
-    Write-Info "Quick Start:"
-    Write-Host "  First, authenticate with Azure:"
-    Write-Host "  az login" -ForegroundColor White
-    Write-Host ""
-    Write-Host "  Initialize with your Azure Key Vault:"
-    Write-Host "  xv init --vault-name my-vault" -ForegroundColor White
-    Write-Host ""
-    Write-Host "  Set a secret:"
-    Write-Host "  xv secret set secret-name `"secret-value`"" -ForegroundColor White
-    Write-Host ""
-    Write-Host "  Get a secret:"
-    Write-Host "  xv secret get secret-name" -ForegroundColor White
-    Write-Host ""
-    Write-Host "  List secrets:"
-    Write-Host "  xv secret list" -ForegroundColor White
-    Write-Host ""
-    Write-Info "Requirements:"
-    Write-Host "  - Azure CLI (az) must be installed and authenticated" -ForegroundColor White
-    Write-Host "  - Active Azure subscription with Key Vault access" -ForegroundColor White
+    Write-Info "Next step:"
+    Write-Host "  Run 'xv init' to choose a backend and configure its authentication." -ForegroundColor White
     Write-Host ""
     Write-Info "For more information:"
     Write-Host "  xv --help" -ForegroundColor White
@@ -290,25 +199,6 @@ function Install-crosstache {
     Write-Info "crosstache Installer for Windows"
     Write-Info "Repository: https://github.com/$GitHubRepo"
     Write-Host ""
-    
-    # Check and install Azure CLI if needed
-    if (-not (Test-AzureCLI)) {
-        Write-Warning "Azure CLI is not installed. crosstache requires Azure CLI for authentication."
-        $response = Read-Host "Would you like to install Azure CLI now? (y/N)"
-        if ($response -match '^[yY]([eE][sS])?$') {
-            $installResult = Install-AzureCLI
-            if (-not $installResult) {
-                Write-Warning "Azure CLI installation failed or was skipped."
-                Write-Warning "Please install Azure CLI manually from: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-windows"
-                Write-Warning "crosstache will not work properly without Azure CLI."
-            }
-        }
-        else {
-            Write-Warning "Skipping Azure CLI installation."
-            Write-Warning "Please install Azure CLI manually from: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-windows"
-            Write-Warning "crosstache will not work properly without Azure CLI."
-        }
-    }
     
     # Determine version to install
     if ($Version -eq "latest") {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,102 +38,6 @@ error() {
     exit 1
 }
 
-# Check if Azure CLI is installed
-check_azure_cli() {
-    if command -v az >/dev/null 2>&1; then
-        local version=$(az version --output tsv --query '"azure-cli"' 2>/dev/null || echo "unknown")
-        info "Azure CLI is already installed (version: $version)"
-        return 0
-    else
-        return 1
-    fi
-}
-
-# Install Azure CLI for different platforms
-install_azure_cli() {
-    local os arch install_method
-    
-    os=$(uname -s | tr '[:upper:]' '[:lower:]')
-    arch=$(uname -m)
-    
-    info "Installing Azure CLI..."
-    
-    case "$os" in
-        linux*)
-            # Check for package managers
-            if command -v apt-get >/dev/null 2>&1; then
-                install_method="apt"
-            elif command -v yum >/dev/null 2>&1; then
-                install_method="yum"
-            elif command -v dnf >/dev/null 2>&1; then
-                install_method="dnf"
-            elif command -v zypper >/dev/null 2>&1; then
-                install_method="zypper"
-            else
-                install_method="script"
-            fi
-            
-            case "$install_method" in
-                apt)
-                    info "Installing Azure CLI via apt..."
-                    curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-                    ;;
-                yum)
-                    info "Installing Azure CLI via yum..."
-                    sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-                    sudo sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo'
-                    sudo yum install azure-cli
-                    ;;
-                dnf)
-                    info "Installing Azure CLI via dnf..."
-                    sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-                    sudo sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo'
-                    sudo dnf install azure-cli
-                    ;;
-                zypper)
-                    info "Installing Azure CLI via zypper..."
-                    sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-                    sudo zypper addrepo --name 'Azure CLI' --check https://packages.microsoft.com/yumrepos/azure-cli azure-cli
-                    sudo zypper install --from azure-cli azure-cli
-                    ;;
-                script)
-                    info "Installing Azure CLI via install script..."
-                    curl -L https://aka.ms/InstallAzureCli | bash
-                    ;;
-            esac
-            ;;
-        darwin*)
-            # macOS
-            if command -v brew >/dev/null 2>&1; then
-                info "Installing Azure CLI via Homebrew..."
-                brew install azure-cli
-            else
-                info "Homebrew not found. Installing Azure CLI via install script..."
-                curl -L https://aka.ms/InstallAzureCli | bash
-            fi
-            ;;
-        mingw*|msys*|cygwin*|windows_nt*)
-            if command -v winget.exe >/dev/null 2>&1; then
-                info "Installing Azure CLI via winget..."
-                winget.exe install --exact --id Microsoft.AzureCLI || error "winget installation failed. Install Azure CLI manually from https://learn.microsoft.com/cli/azure/install-azure-cli-windows"
-            else
-                error "Automatic Azure CLI installation requires winget. Install Azure CLI manually from https://learn.microsoft.com/cli/azure/install-azure-cli-windows"
-            fi
-            ;;
-        *)
-            error "Unsupported operating system for automatic Azure CLI installation: $os"
-            ;;
-    esac
-    
-    # Verify installation
-    if command -v az >/dev/null 2>&1; then
-        local version=$(az version --output tsv --query '"azure-cli"' 2>/dev/null || echo "unknown")
-        success "Azure CLI installed successfully (version: $version)"
-    else
-        error "Azure CLI installation failed. Please install it manually from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli"
-    fi
-}
-
 # Detect platform and architecture
 detect_platform() {
     local os arch
@@ -395,25 +299,8 @@ verify_installation() {
 # Display usage information
 show_usage() {
     echo ""
-    info "Quick Start:"
-    echo "  First, authenticate with Azure:"
-    echo "  az login"
-    echo ""
-    echo "  Initialize with your Azure Key Vault:"
-    echo "  $BINARY_NAME init --vault-name my-vault"
-    echo ""
-    echo "  Set a secret:"
-    echo "  $BINARY_NAME secret set secret-name \"secret-value\""
-    echo ""
-    echo "  Get a secret:"
-    echo "  $BINARY_NAME secret get secret-name"
-    echo ""
-    echo "  List secrets:"
-    echo "  $BINARY_NAME secret list"
-    echo ""
-    info "Requirements:"
-    echo "  - Azure CLI (az) must be installed and authenticated"
-    echo "  - Active Azure subscription with Key Vault access"
+    info "Next step:"
+    echo "  Run '$BINARY_NAME init' to choose a backend and configure its authentication."
     echo ""
     info "For more information:"
     echo "  $BINARY_NAME --help"
@@ -437,23 +324,6 @@ main() {
     
     if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
         error "Either curl or wget is required but neither is installed"
-    fi
-    
-    # Check and install Azure CLI if needed
-    if ! check_azure_cli; then
-        warning "Azure CLI is not installed. crosstache requires Azure CLI for authentication."
-        echo "Would you like to install Azure CLI now? (y/N)"
-        read -r response </dev/tty
-        case "$response" in
-            [yY][eE][sS]|[yY])
-                install_azure_cli
-                ;;
-            *)
-                warning "Skipping Azure CLI installation."
-                warning "Please install Azure CLI manually from: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli"
-                warning "crosstache will not work properly without Azure CLI."
-                ;;
-        esac
     fi
     
     # Perform installation

--- a/tests/installer_tests.rs
+++ b/tests/installer_tests.rs
@@ -1,0 +1,125 @@
+//! End-to-end tests for the standalone release installers.
+//!
+//! The fixtures replace network and signature tooling, but execute the real
+//! installer script. This protects installer behavior rather than its source
+//! layout or wording.
+
+#[cfg(unix)]
+mod unix {
+    use flate2::{write::GzEncoder, Compression};
+    use sha2::{Digest, Sha256};
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+    use std::process::Command;
+
+    fn write_executable(path: &Path, body: &str) {
+        fs::write(path, body).unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    fn create_release_archive(path: &Path) {
+        let file = fs::File::create(path).unwrap();
+        let encoder = GzEncoder::new(file, Compression::default());
+        let mut archive = tar::Builder::new(encoder);
+        let body = b"#!/bin/sh\nprintf '%s\\n' 'xv v-test'\n";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        archive.append_data(&mut header, "xv", &body[..]).unwrap();
+        archive.into_inner().unwrap().finish().unwrap();
+    }
+
+    #[test]
+    fn unix_installer_does_not_invoke_azure_cli() {
+        let temp = tempfile::tempdir().unwrap();
+        let fake_bin = temp.path().join("bin");
+        let fixture_dir = temp.path().join("fixtures");
+        let install_dir = temp.path().join("install");
+        let home_dir = temp.path().join("home");
+        fs::create_dir_all(&fake_bin).unwrap();
+        fs::create_dir_all(&fixture_dir).unwrap();
+        fs::create_dir_all(&home_dir).unwrap();
+
+        let archive_path = fixture_dir.join("xv.tar.gz");
+        create_release_archive(&archive_path);
+        let archive = fs::read(&archive_path).unwrap();
+        let checksum = hex::encode(Sha256::digest(&archive));
+        let checksum_path = fixture_dir.join("xv.tar.gz.sha256");
+        fs::write(&checksum_path, format!("{checksum}  xv.tar.gz\n")).unwrap();
+        let signature_path = fixture_dir.join("xv.tar.gz.minisig");
+        fs::write(
+            &signature_path,
+            "untrusted comment: test fixture\nplaceholder\ntrusted comment: crosstache v-test\n",
+        )
+        .unwrap();
+
+        let az_marker = temp.path().join("az-invoked");
+        write_executable(
+            &fake_bin.join("az"),
+            "#!/bin/sh\n: > \"$AZ_MARKER\"\nprintf '%s\\n' '{\"azure-cli\":\"9.9.9\"}'\n",
+        );
+        write_executable(&fake_bin.join("minisign"), "#!/bin/sh\nexit 0\n");
+        write_executable(
+            &fake_bin.join("curl"),
+            r#"#!/bin/sh
+out=
+url=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o)
+            out=$2
+            shift 2
+            ;;
+        -*)
+            shift
+            ;;
+        *)
+            url=$1
+            shift
+            ;;
+    esac
+done
+case "$url" in
+    *.sha256) cp -f "$FIXTURE_CHECKSUM" "$out" ;;
+    *.minisig) cp -f "$FIXTURE_SIGNATURE" "$out" ;;
+    *.tar.gz) cp -f "$FIXTURE_ARCHIVE" "$out" ;;
+    *) exit 64 ;;
+esac
+"#,
+        );
+
+        let inherited_path = std::env::var_os("PATH").unwrap_or_default();
+        let path = std::env::join_paths(
+            std::iter::once(fake_bin.clone()).chain(std::env::split_paths(&inherited_path)),
+        )
+        .unwrap();
+        let installer = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/install.sh");
+        let output = Command::new("bash")
+            .arg(installer)
+            .arg("v-test")
+            .env("PATH", path)
+            .env("HOME", &home_dir)
+            .env("SHELL", "/bin/bash")
+            .env("XDG_BIN_HOME", &install_dir)
+            .env("AZ_MARKER", &az_marker)
+            .env("FIXTURE_ARCHIVE", &archive_path)
+            .env("FIXTURE_CHECKSUM", &checksum_path)
+            .env("FIXTURE_SIGNATURE", &signature_path)
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "installer failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(install_dir.join("xv").is_file(), "xv was not installed");
+        assert!(
+            !az_marker.exists(),
+            "the generic installer must not invoke Azure CLI"
+        );
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Installer and documentation changes only; verified release install path is preserved and regression-tested on Unix. No runtime auth or secret-handling logic changes.
> 
> **Overview**
> Generic **Unix and Windows installers** no longer detect, prompt for, or install Azure CLI. They still download, verify (checksum + minisign), extract, and install `xv` the same way; post-install guidance now points to **`xv init`** for backend and auth setup instead of Azure-only quick start.
> 
> **README** clarifies that Azure CLI is optional—needed only for `--credential-type cli` and certain Azure steps in interactive `xv init`, not for local/AWS/env/managed identity/OIDC use.
> 
> A new **Unix integration test** (`unix_installer_does_not_invoke_azure_cli`) runs the real `install.sh` against a hermetic fake release and asserts `az` is never invoked while install succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9671e89ea78c8ab8540ca375fa595c662149997f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->