### PR TITLE
chore: prepare v0.36.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.36.1 — Windows reliability and install portability (2026-08-09)
+
+### Fixed
+
+- **Windows builds now run reliably.** Shipped binaries reserve enough stack,
+  private atomic writes and local-backend filesystem operations use correct
+  Windows semantics, isolated config paths work in tests, Azure CLI discovery
+  recognizes `az.cmd`, and the full Windows test suite now runs in CI.
+- **The generic installers no longer require or install the Azure CLI.** Local
+  and AWS users can install `xv` without Azure tooling; `az` remains optional
+  for CLI-based Azure authentication and interactive Azure provisioning.
+- **Stale workspace entries now explain the actual repair.** Reads report the
+  missing named backend and direct users to remove the stale alias or restore
+  its configuration instead of suggesting an unrelated full reinitialization.
+
 ## v0.36.0 — Bootstrap-safe config recovery (2026-08-08)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
## Summary

- bump the crate and lockfile version to 0.36.1
- document the Windows reliability, installer portability, and workspace diagnostic fixes shipped since v0.36.0
- prepare main for the annotated v0.36.1 release tag

## Validation

- git diff --check
- cargo fmt --all -- --check
- cargo check --locked --all-features
- cargo test --locked -- --test-threads=1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only (version and changelog); no application code changes in this diff.
> 
> **Overview**
> Prepares the **v0.36.1** release on `main` by bumping `crosstache` from **0.36.0** to **0.36.1** in `Cargo.toml` and `Cargo.lock`, and adding a **CHANGELOG** section for **2026-08-09**.
> 
> The new changelog entry documents fixes already shipped since v0.36.0: **Windows** reliability (stack reserve, atomic writes, `az.cmd`, CI tests), **installers** that no longer require Azure CLI for local/AWS users, and **clearer errors** when a workspace alias points at a missing named backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b31679833de77b3003c13baca2b1f350d328f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->