### PR TITLE
chore: bump version to 0.36.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.36.2 — Drawer close box and readable muted text (2026-08-10)
+
+### Added
+
+- **The secret drawer has a close box.** The create/edit drawer can now be
+  dismissed from an `x` in the top-right corner, not just the Cancel button at
+  the bottom. It goes through the same discard confirmation, so unsaved edits
+  are still protected, and it disables during a pending save like the other
+  drawer controls.
+
+### Fixed
+
+- **Muted text now meets WCAG AA on tinted backgrounds.** Secondary text sitting
+  on selected rows and on tags measured 4.26–4.28:1 against the required 4.5:1.
+  Muted tones are now derived against those tinted composites — the accent wash
+  on selected rows, the text wash on tags, and both stacked — as well as the
+  flat surfaces, so all four palettes pass in both light and dark modes.
+
 ## v0.36.1 — Windows reliability and install portability (2026-08-09)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.36.1"
+version = "0.36.2"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.36.1"
+version = "0.36.2"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Version bump for the v0.36.2 release.

Per the repo's release process, the bump has to land on main before tagging — `release.yml`'s `verify-version` job fails the release if `Cargo.toml` doesn't match the tag.

- `Cargo.toml` / `Cargo.lock`: 0.36.1 → 0.36.2
- `CHANGELOG.md`: new v0.36.2 section

Contents of the release (both already merged to main):
- #407 — secret drawer close box, muted-text WCAG AA contrast fix, browser suite greened
- #409 — multi-backend `xv init` design spec (docs only, not yet implemented)

Local gate: `cargo fmt --check` clean, `cargo clippy -- -D warnings` clean, `cargo test --lib` 1153 passed. CI green on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only change with no runtime code; risk is limited to a mismatched tag if versioning drifts from the release process.
> 
> **Overview**
> Prepares the **v0.36.2** release on `main` by aligning package metadata with the tag the release workflow expects.
> 
> **`Cargo.toml`** and **`Cargo.lock`** move **0.36.1 → 0.36.2**. **`CHANGELOG.md`** gains a new **v0.36.2** section (drawer close control, WCAG AA muted text on tinted surfaces) documenting work already merged; this PR does not ship those UI changes itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 537bd5c6e139edf8bc2927d9149e3464da49b5bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->