### PR TITLE
chore: bump version to 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.37.0 — Backend lifecycle (2026-08-11)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.36.2"
+version = "0.37.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.36.2"
+version = "0.37.0"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Version bump for the v0.37.0 release.

The bump has to land on main before tagging — `release.yml`'s `verify-version` job fails the release if `Cargo.toml` doesn't match the tag.

- `Cargo.toml` / `Cargo.lock`: 0.36.2 → 0.37.0
- `CHANGELOG.md`: `## Unreleased` → `## v0.37.0 — Backend lifecycle (2026-08-11)`

Minor rather than patch, per the repo's own convention: v0.36.0 was a feature release, v0.36.1/0.36.2 were fixes. This ships three new commands and a new config block.

Contents: #411 — backend lifecycle (`xv backend ls|add|rm [--purge]`), the `[azure]` config block, the additive `apply_backend` split, a `Prompter` test seam, and `xv init` preserving other configured backends.

Local gate: `cargo fmt --check` clean, `cargo clippy -- -D warnings` clean, `cargo test --lib` 1174 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no code or behavior changes.
> 
> **Overview**
> Bumps **crosstache** from `0.36.2` to `0.37.0` in `Cargo.toml`/`Cargo.lock`, and renames the changelog `## Unreleased` heading to `## v0.37.0 — Backend lifecycle (2026-08-11)`.
> 
> Required so `release.yml`'s `verify-version` job will accept the `v0.37.0` tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35f586b7c787d4fbda60538b79cdfbf26245799f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->