### PR TITLE
chore: bump version to 0.37.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.37.1 — Backend lifecycle fixes (2026-08-11)
+
+### Fixed
+
+- **`xv backend add azure` can select an existing vault.** Declining to create a
+  new vault ended the flow with "a vault is required for the azure backend"
+  instead of offering the vaults already in the chosen resource group. The
+  prompt now lists them, with entering a name by hand and creating a new one as
+  the other choices.
+- **`[azure]`-only configs pass validation.** A config with the credentials in
+  the `[azure]` block and the top-level fields left empty passed `xv backend ls`
+  but failed `xv list` with `Configuration error: Subscription ID is required`,
+  because validation read the top-level fields directly. It now resolves through
+  `azure_settings()` like every other caller. Note the block still takes
+  precedence as a whole, not field by field — a partial `[azure]` block shadows
+  the top-level fields entirely and is rejected at validation.
+- **Clipboard tests no longer corrupt the heap on Windows.** Tests touching the
+  real system clipboard now serialize on a lock in the test code. They had
+  relied on a `--test-threads=1` note that nothing enforced, so CI's plain
+  `cargo test` opened concurrent handles to the single global Win32 clipboard
+  and failed with `STATUS_HEAP_CORRUPTION` (`0xc0000374`).
+
 ## v0.37.0 — Backend lifecycle (2026-08-11)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.37.0"
+version = "0.37.1"
 edition = "2021"
 authors = ["crosstache Team"]
 description = "A comprehensive tool for managing secrets across Azure Key Vault, AWS Secrets Manager, and local age-encrypted storage"


### PR DESCRIPTION
Version bump and changelog for v0.37.1, a patch release covering the three fixes merged in #413.

- `xv backend add azure` can select an existing vault instead of dead-ending when you decline to create one
- `[azure]`-only configs pass validation
- Clipboard tests serialize, fixing the Windows `0xc0000374` heap corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no runtime code modifications.
> 
> **Overview**
> Bumps crosstache from **0.37.0** to **0.37.1** in `Cargo.toml`/`Cargo.lock` and adds the corresponding changelog entry.
> 
> The release notes cover three already-merged fixes: existing-vault selection in `xv backend add azure`, `[azure]`-only config validation via `azure_settings()`, and serialized clipboard tests to stop Windows heap corruption in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a32b6e6aa42be5a92355547ed0cc711a2221c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->