### PR TITLE
chore: bump version to 0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.38.0 — TOTP codes and UI connection monitoring (2026-08-15)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosstache"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crosstache"
-version = "0.37.1"
+version = "0.38.0"
 edition = "2021"
 rust-version = "1.88"
 authors = ["crosstache Team"]


### PR DESCRIPTION
## Summary

- bump the xv package version from `0.37.1` to `0.38.0`
- update the lockfile package version
- promote the current changelog entries into the dated `v0.38.0` release section

## Why

The merged TOTP code-generation feature and UI connection-monitoring improvement are ready for a minor release. The release workflow requires the package version and annotated tag to match.

## User impact

After this PR merges, tagging `v0.38.0` will trigger the release workflow to publish signed binaries for all supported platforms.

## Validation

- `cargo fmt -- --check`
- `cargo check --all-features`
- `cargo test`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version and changelog edits with no application logic changes.
> 
> **Overview**
> Prepares the **v0.38.0** minor release by aligning package metadata with the features already merged on `main`.
> 
> **`crosstache` / `xv`** moves from `0.37.1` to **`0.38.0`** in `Cargo.toml`, with the lockfile entry updated so builds and the release workflow see a single version. The changelog **Unreleased** section is retitled to **`v0.38.0 — TOTP codes and UI connection monitoring (2026-08-15)`**, documenting **`xv totp`** and **`xv ui`** connection health polling without changing runtime behavior in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e71b2697343d94892a98fd4814016dd723de7b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->